### PR TITLE
ne küldhessünk üres javaslatot #419

### DIFF
--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -957,6 +957,13 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
   }
 
   public onSendToApprove() {
+    const generatedSuggestions = SuggestionUtil.generateSuggestions(this.masses, this.changes, this.deletedMasses);
+
+    if (generatedSuggestions.length === 0) {
+      this.snackBarService.error('Üres javaslatot nem lehet beküldeni.');
+      return;
+    }
+
     this.spinnerService.show();
 
     const suggestionPackage: SuggestionPackage = {
@@ -965,7 +972,7 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       senderEmail: this.suggestionSenderEmail.value,
       senderUserId: this.suggestionSenderID.value,
       senderMessage: this.suggestionSenderMessage.value,
-      suggestions: SuggestionUtil.generateSuggestions(this.masses, this.changes, this.deletedMasses),
+      suggestions: generatedSuggestions,
       state: SuggestionState.PENDING,
       createdAt: new Date()
     }

--- a/calendar/src/app/util/suggestion-util.spec.ts
+++ b/calendar/src/app/util/suggestion-util.spec.ts
@@ -1,0 +1,86 @@
+import {SuggestionUtil} from './suggestion-util';
+import {Mass} from '../model/mass';
+import {Rite} from '../enum/rites';
+
+function makeMass(overrides: Partial<Mass> = {}): Mass {
+  return {
+    id: 1,
+    churchId: 100,
+    title: 'Szentmise',
+    rite: Rite.ROMAN_CATHOLIC,
+    startDate: '2026-03-01T07:00:00',
+    lang: 'hu',
+    ...overrides,
+  };
+}
+
+describe('SuggestionUtil.generateSuggestions', () => {
+
+  it('returns an empty array when there are no changes and no deletions', () => {
+    const masses = new Map<number, Mass>([[1, makeMass()]]);
+    const changes = new Map<number, Mass>();
+    const deletedMasses: number[] = [];
+
+    const result = SuggestionUtil.generateSuggestions(masses, changes, deletedMasses);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when changes contain only a no-op modification', () => {
+    // #419: if the user opens an edit dialog and saves without changing anything,
+    // the mass ends up in `changes` but its diff vs. the original is empty.
+    // generateSuggestions must drop it so the package is detectable as empty.
+    const original = makeMass({id: 42, title: 'Szentmise', startDate: '2026-03-01T07:00:00'});
+    const unchanged = makeMass({id: 42, title: 'Szentmise', startDate: '2026-03-01T07:00:00'});
+
+    const masses = new Map<number, Mass>([[42, original]]);
+    const changes = new Map<number, Mass>([[42, unchanged]]);
+
+    const result = SuggestionUtil.generateSuggestions(masses, changes, []);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns a MODIFIED suggestion when the changed mass actually differs', () => {
+    const original = makeMass({id: 42, startDate: '2026-03-01T07:00:00'});
+    const modified = makeMass({id: 42, startDate: '2026-03-01T08:00:00'});
+
+    const result = SuggestionUtil.generateSuggestions(
+      new Map([[42, original]]),
+      new Map([[42, modified]]),
+      [],
+    );
+
+    expect(result.length).toBe(1);
+    expect(result[0].massState).toBe('MODIFIED' as any);
+    expect(result[0].massId).toBe(42);
+    expect(result[0].changes['startDate']).toBe('2026-03-01T08:00:00');
+  });
+
+  it('returns a NEW suggestion when a change has a negative (tmp) id', () => {
+    const tmpId = -123;
+    const newMass = makeMass({id: tmpId, title: 'Új mise'});
+
+    const result = SuggestionUtil.generateSuggestions(
+      new Map(),
+      new Map([[tmpId, newMass]]),
+      [],
+    );
+
+    expect(result.length).toBe(1);
+    expect(result[0].massState).toBe('NEW' as any);
+    expect(result[0].changes.id).toBeUndefined();
+    expect(result[0].changes.title).toBe('Új mise');
+  });
+
+  it('returns a DELETED suggestion for each id in deletedMasses', () => {
+    const masses = new Map<number, Mass>([[7, makeMass({id: 7, periodId: 3})]]);
+
+    const result = SuggestionUtil.generateSuggestions(masses, new Map(), [7]);
+
+    expect(result.length).toBe(1);
+    expect(result[0].massState).toBe('DELETED' as any);
+    expect(result[0].massId).toBe(7);
+    expect(result[0].periodId).toBe(3);
+  });
+});


### PR DESCRIPTION
Fixes #419

## Mi a baj?

A `SuggestionUtil.generateSuggestions` üres tömböt is visszaadhat — pl. ha a felhasználó megnyitott egy szerkesztő dialógust, mentett, de semmin nem változtatott (a `changes` mapbe bekerül a mise, de a diff üres). Eddig akkor is elment a POST a `/suggestions/church/{id}`-re, és a maintainernek egy fantom „üres" javaslatot kellett elutasítania.

## Mi a megoldás?

`church-calendar.component.ts:onSendToApprove()`-ban:

1. Egyszer kiszámoljuk a `suggestions` tömböt.
2. Ha üres → snack-bar figyelmeztetés (*„Üres javaslatot nem lehet beküldeni."*), nem küldünk semmit.
3. Csak ezután építjük fel a `SuggestionPackage`-et, és újrahasznosítjuk a már kiszámolt tömböt.

## Tesztek

Új `suggestion-util.spec.ts` négy esettel, amik a fix viselkedésére támaszkodnak:

- üres `changes` + üres `deletedMasses` → `[]`
- no-op módosítás (a „változtatott" mise mindenben azonos az eredetivel) → `[]`
- valódi módosítás → egy `MODIFIED` suggestion
- `NEW` (negatív tmp id) és `DELETED` bejegyzés a megfelelő helyre kerül

`ng test --watch=false --browsers=ChromeHeadless` mind az 5 új tesztet zölden futtatja le. (A többi pre-existing stub spec továbbra is failel, mert nincs bennük TestBed provider mock — nem ez a PR scope-ja.)

## Mit érdemes manuálisan ellenőrizni

- Nyiss meg egy mise szerkesztő dialógust egy nyilvános templomon, mentsd el változtatás nélkül → a „Beküldés" gombra kattintva a régi viselkedés helyett snack-bar jelzi, hogy nincs mit beküldeni.
- Valódi módosítás (pl. mise időpont) után a beküldés továbbra is működik.

---

*Első contributor vagyok itt, nyitott vagyok bármilyen review észrevételre — kódstílus, megközelítés, üzenet szövege, bármi.* 🙏