### PR TITLE
naptár: új mise alapértelmezett időszaka a napra érvényes legyen #308

### DIFF
--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
@@ -1,23 +1,96 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {of} from 'rxjs';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {TranslateModule} from '@ngx-translate/core';
 
-import { AddFullEventDialogComponent } from './add-full-event-dialog.component';
+import {AddFullEventDialogComponent} from './add-full-event-dialog.component';
+import {PeriodService} from '../../services/period.service';
+import {GeneratedPeriod} from '../../model/generated-period';
+import {Rite} from '../../enum/rites';
+import {LanguageCode} from '../../enum/language-code';
+import {Renum} from '../../enum/recurrence';
+import {Day} from '../../enum/day';
 
-describe('EventEditDialogComponent', () => {
+function makeGeneratedPeriod(overrides: Partial<GeneratedPeriod> = {}): GeneratedPeriod {
+  return {
+    id: 1,
+    periodId: 10,
+    name: 'Évközi idő',
+    weight: 1,
+    startDate: '2026-01-01',
+    endDate: '2026-12-31',
+    color: '#ccc',
+    ...overrides,
+  };
+}
+
+function makeDialogData(periodOverride: GeneratedPeriod | null = null) {
+  return {
+    title: 'ADD_NEW_MASS',
+    event: {
+      period: periodOverride,
+      rite: Rite.ROMAN_CATHOLIC,
+      types: [],
+      title: 'Szentmise',
+      start: new Date('2026-03-15T10:00:00'),
+      duration: {hours: 1},
+      language: LanguageCode.HU,
+      renum: Renum.NONE,
+      selectedDays: [Day.SU],
+      comment: '',
+      editOne: false,
+    },
+  };
+}
+
+describe('AddFullEventDialogComponent (#308 default period)', () => {
   let component: AddFullEventDialogComponent;
   let fixture: ComponentFixture<AddFullEventDialogComponent>;
+  let periodServiceMock: { getSelectableGeneratedPeriodsByDate: jasmine.Spy; getPeriodById: jasmine.Spy; getSpecialPeriodType: jasmine.Spy };
 
-  beforeEach(async () => {
+  async function setup(periods: GeneratedPeriod[], data = makeDialogData()) {
+    periodServiceMock = {
+      getSelectableGeneratedPeriodsByDate: jasmine.createSpy().and.returnValue(of(periods)),
+      getPeriodById: jasmine.createSpy().and.returnValue(null),
+      getSpecialPeriodType: jasmine.createSpy().and.returnValue(null),
+    };
+
     await TestBed.configureTestingModule({
-      imports: [AddFullEventDialogComponent]
-    })
-    .compileComponents();
+      imports: [AddFullEventDialogComponent, TranslateModule.forRoot()],
+      providers: [
+        {provide: MAT_DIALOG_DATA, useValue: data},
+        {provide: MatDialogRef, useValue: {close: jasmine.createSpy()}},
+        {provide: PeriodService, useValue: periodServiceMock},
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddFullEventDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  it('pre-fills periodCtr with the first (most relevant) period when none is set', async () => {
+    const relevant = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
+    const other = makeGeneratedPeriod({id: 2, periodId: 11, name: 'Nyári szünet'});
+
+    await setup([relevant, other]);
+
+    expect(periodServiceMock.getSelectableGeneratedPeriodsByDate).toHaveBeenCalled();
+    expect(component.periodCtr.value).toEqual(relevant);
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('does not overwrite an existing period selection (edit flow)', async () => {
+    const preselected = makeGeneratedPeriod({id: 5, periodId: 50, name: 'Húsvéti idő'});
+    const fromServer = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
+
+    await setup([fromServer], makeDialogData(preselected));
+
+    expect(component.periodCtr.value).toEqual(preselected);
+  });
+
+  it('leaves periodCtr null when no selectable periods exist', async () => {
+    await setup([]);
+
+    expect(component.periodCtr.value).toBeNull();
   });
 });

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
@@ -24,9 +24,13 @@ function makeGeneratedPeriod(overrides: Partial<GeneratedPeriod> = {}): Generate
   };
 }
 
-function makeDialogData(periodOverride: GeneratedPeriod | null = null) {
+function makeDialogData(
+  periodOverride: GeneratedPeriod | null = null,
+  existingPeriodIds: number[] = [],
+) {
   return {
     title: 'ADD_NEW_MASS',
+    existingPeriodIds,
     event: {
       period: periodOverride,
       rite: Rite.ROMAN_CATHOLIC,
@@ -69,7 +73,7 @@ describe('AddFullEventDialogComponent (#308 default period)', () => {
     fixture.detectChanges();
   }
 
-  it('pre-fills periodCtr with the first (most relevant) period when none is set', async () => {
+  it('falls back to [0] when the church has no existing masses (new church / no overlap)', async () => {
     const relevant = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
     const other = makeGeneratedPeriod({id: 2, periodId: 11, name: 'Nyári szünet'});
 
@@ -83,7 +87,7 @@ describe('AddFullEventDialogComponent (#308 default period)', () => {
     const preselected = makeGeneratedPeriod({id: 5, periodId: 50, name: 'Húsvéti idő'});
     const fromServer = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
 
-    await setup([fromServer], makeDialogData(preselected));
+    await setup([fromServer], makeDialogData(preselected, [10]));
 
     expect(component.periodCtr.value).toEqual(preselected);
   });
@@ -92,5 +96,68 @@ describe('AddFullEventDialogComponent (#308 default period)', () => {
     await setup([]);
 
     expect(component.periodCtr.value).toBeNull();
+  });
+
+  // #308 (borazslo review):
+  it('prefers a sortable period the church already has a mass for, over the first sorted period', async () => {
+    // Order from PeriodService reflects "May day weight": "Húsvéti idő" first (highest weight
+    // for a date in the easter range), then "Iskolaidő" (school time, lower weight but valid).
+    const easter      = makeGeneratedPeriod({id: 1, periodId: 50, name: 'Húsvéti idő',      weight: 10});
+    const schoolTime  = makeGeneratedPeriod({id: 2, periodId: 10, name: 'Iskolaidő',        weight: 1});
+    const summerBreak = makeGeneratedPeriod({id: 3, periodId: 11, name: 'Nyári szünet',     weight: 1});
+
+    // The church already has a Iskolaidő (10) mass — Wednesday addition should default to
+    // Iskolaidő, NOT Húsvéti idő, even though Húsvéti idő is the first in the sorted list.
+    await setup([easter, schoolTime, summerBreak], makeDialogData(null, [10]));
+
+    expect(component.periodCtr.value).toEqual(schoolTime);
+  });
+
+  it('walks the sorted list in order: picks the first existing period, not the highest existingPeriodId', async () => {
+    // existingPeriodIds includes both 50 and 11, but the sorted order is [10, 11, 50].
+    // We must pick 11, the FIRST existing in sort order, NOT 50.
+    const p10 = makeGeneratedPeriod({id: 1, periodId: 10, name: 'A',  weight: 3});
+    const p11 = makeGeneratedPeriod({id: 2, periodId: 11, name: 'B',  weight: 2});
+    const p50 = makeGeneratedPeriod({id: 3, periodId: 50, name: 'C',  weight: 1});
+
+    await setup([p10, p11, p50], makeDialogData(null, [50, 11]));
+
+    expect(component.periodCtr.value).toEqual(p11);
+  });
+
+  it('falls back to [0] when none of the existing periods match the sorted list', async () => {
+    // The church has miséket period 999, but 999 isn't in this day's selectable list.
+    // Should fall back to the original behaviour: [0].
+    const fromServer = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
+
+    await setup([fromServer], makeDialogData(null, [999]));
+
+    expect(component.periodCtr.value).toEqual(fromServer);
+  });
+
+  it('handles missing existingPeriodIds (undefined) like an empty list — fallback to [0]', async () => {
+    const p10 = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
+
+    // DialogData without existingPeriodIds key at all (legacy callers / safety net)
+    const data = {
+      title: 'ADD_NEW_MASS',
+      event: {
+        period: null,
+        rite: Rite.ROMAN_CATHOLIC,
+        types: [],
+        title: 'Szentmise',
+        start: new Date('2026-03-15T10:00:00'),
+        duration: {hours: 1},
+        language: LanguageCode.HU,
+        renum: Renum.NONE,
+        selectedDays: [Day.SU],
+        comment: '',
+        editOne: false,
+      },
+    };
+
+    await setup([p10], data as any);
+
+    expect(component.periodCtr.value).toEqual(p10);
   });
 });

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
@@ -135,6 +135,28 @@ describe('AddFullEventDialogComponent (#308 default period)', () => {
     expect(component.periodCtr.value).toEqual(fromServer);
   });
 
+  it('synchronously syncs data.event.period when prefilling (avoids save-race)', async () => {
+    const evkozi = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
+
+    await setup([evkozi]);
+
+    expect(component.periodCtr.value).toEqual(evkozi);
+    expect(component.data.event.period).toEqual(evkozi as any);
+  });
+
+  it('onSave defensively syncs data.event.period from periodCtr if they drifted apart', async () => {
+    const evkozi = makeGeneratedPeriod({id: 1, periodId: 10});
+    await setup([evkozi]);
+
+    (component.data.event as any).period = null;
+    component.singleEvent = false;
+
+    component.onSave();
+
+    expect(component.data.event.period).toEqual(evkozi as any);
+    expect(component.dialogRef.close).toHaveBeenCalled();
+  });
+
   it('handles missing existingPeriodIds (undefined) like an empty list — fallback to [0]', async () => {
     const p10 = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
 

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -125,7 +125,10 @@ export class AddFullEventDialogComponent {
         const matched = existingPeriodIds.size > 0
           ? generatedPeriods.find(p => existingPeriodIds.has(p.periodId))
           : null;
-        this.periodCtr.setValue(matched ?? generatedPeriods[0]);
+        const selectedPeriod = matched ?? generatedPeriods[0];
+        // Immediately sync to data.event.period to avoid async race condition with validation
+        this.data.event.period = selectedPeriod;
+        this.periodCtr.setValue(selectedPeriod);
       }
     });
 
@@ -177,6 +180,11 @@ export class AddFullEventDialogComponent {
   }
 
   onSave(): void {
+    // Ensure data.event.period is synced from FormControl if needed
+    if (this.data.event.period === null && this.periodCtr.value !== null) {
+      this.data.event.period = this.periodCtr.value;
+    }
+    
     if (!this.singleEvent && ScriptUtil.isNull(this.data.event.period)) {
       this.periodCtr.setErrors({required: true});
       return;

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -107,11 +107,25 @@ export class AddFullEventDialogComponent {
     // A választható időszakokat furcsa sorrendben jelenítjük meg direkt.
     periodService.getSelectableGeneratedPeriodsByDate(this.data.event.start).subscribe(generatedPeriods => {
       this.selectableGenPeriods = generatedPeriods;
-      // Új mise létrehozásánál a választott napra érvényes/várható időszak az alapértelmezett.
-      // A getSelectableGeneratedPeriodsByDate az aktuális dátum szerint sorba rendezve adja vissza,
-      // így a lista első eleme a leginkább releváns időszak.
+      // #308 (borazslo review): új mise létrehozásánál próbáljuk a templom már
+      // meglévő miserend-mintájához illeszteni az alapértelmezést.
+      // A getSelectableGeneratedPeriodsByDate súly szerint rendezi a periódusokat,
+      // így először a magas-súlyú (pl. húsvét, karácsony) jönnek, aztán a normál
+      // (pl. évközi / tanítási idő).
+      //
+      // Ha a templomnak vannak már miséi, és valamelyiknek a periódusa
+      // szerepel a sorrendben, AZT vegyük első ajánlatra - így egy szerdai
+      // májusi kattintás inkább "tanítási idő"-t ajánl, nem "húsvét"-ot vagy
+      // "május 1."-et.
+      //
+      // Ha nincs egyezés (új templom, vagy soha nem volt mise ilyen időszakra),
+      // marad a régi viselkedés: [0]. elem.
       if (!this.data.event.period && generatedPeriods.length > 0) {
-        this.periodCtr.setValue(generatedPeriods[0]);
+        const existingPeriodIds = new Set(this.data.existingPeriodIds ?? []);
+        const matched = existingPeriodIds.size > 0
+          ? generatedPeriods.find(p => existingPeriodIds.has(p.periodId))
+          : null;
+        this.periodCtr.setValue(matched ?? generatedPeriods[0]);
       }
     });
 

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -104,9 +104,15 @@ export class AddFullEventDialogComponent {
   ) {
     const hasPeriodId = !!(this.data.event.period && (this.data.event.period as any).periodId);
 
-    // A választható időszakokat furcsa sorrendben jelenítjük meg direkt. 
+    // A választható időszakokat furcsa sorrendben jelenítjük meg direkt.
     periodService.getSelectableGeneratedPeriodsByDate(this.data.event.start).subscribe(generatedPeriods => {
       this.selectableGenPeriods = generatedPeriods;
+      // Új mise létrehozásánál a választott napra érvényes/várható időszak az alapértelmezett.
+      // A getSelectableGeneratedPeriodsByDate az aktuális dátum szerint sorba rendezve adja vissza,
+      // így a lista első eleme a leginkább releváns időszak.
+      if (!this.data.event.period && generatedPeriods.length > 0) {
+        this.periodCtr.setValue(generatedPeriods[0]);
+      }
     });
 
     this.periodCtr.valueChanges.subscribe(value => {

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -79,6 +79,12 @@ export interface DeleteDialogData {
 export interface DialogData {
   title: string;
   event: DialogEvent;
+  // #308 (borazslo review): a templom már létező miséinek periódus-azonosítói
+  // (a betöltött + a folyamatban lévő változások egyesítve, deduplikálva).
+  // A dialog az alapértelmezett periódus-választás során előnyben részesíti
+  // ezeket: olyan miséhez ne ajánljunk új időszakot (pl. húsvét), ha a
+  // templomnak van már „illeszthető" rendszeres miserendje (pl. tanítási idő).
+  existingPeriodIds?: number[];
 }
 
 @Component({
@@ -816,8 +822,27 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       this.dialogEvent!.start = date;
     }
 
+    // #308 (borazslo review): a templom már létező miséinek periódusait
+    // előnyben részesítjük az alapértelmezett periódus-választáskor.
+    // A betöltött masses + folyamatban lévő changes összesítve, hogy a
+    // még el nem mentett új miserend is számítson.
+    const existingPeriodIds: number[] = [];
+    const seenPeriodIds = new Set<number>();
+    const addPeriodId = (periodId?: number | null) => {
+      if (ScriptUtil.isNotNull(periodId) && !seenPeriodIds.has(periodId)) {
+        seenPeriodIds.add(periodId);
+        existingPeriodIds.push(periodId);
+      }
+    };
+    for (const m of this.masses.values()) {
+      addPeriodId(m.periodId);
+    }
+    for (const m of this.changes.values()) {
+      addPeriodId(m.periodId);
+    }
+
     const dialogRef = this.dialog.open(AddFullEventDialogComponent, {
-      data: {title: title, event: this.dialogEvent}
+      data: {title: title, event: this.dialogEvent, existingPeriodIds: existingPeriodIds}
     });
 
     dialogRef.afterClosed().subscribe(result => {


### PR DESCRIPTION
Fixes #308

## Mi a baj?

Amikor a felhasználó egy naptári napra kattintva új visszatérő misét hoz létre és a *„részletek"* dialógusban köt ki, az időszak (period) dropdown eddig üres volt. Át kellett pörgetni a listát, megkeresni, melyik időszak fedi le az adott napot.

## Mi a megoldás?

A `PeriodService.getSelectableGeneratedPeriodsByDate` már relevancia szerint rendezi a periódusokat (átfedés > súly > legrövidebb), így a `[0]` elem a megfelelő alapértelmezett.

`AddFullEventDialogComponent` konstruktorában: amikor megérkezik a periódus-lista, ha `data.event.period == null` (= új mise flow), beállítjuk a `periodCtr`-t az első elemre. Szerkesztés esetén (= már van kiválasztott periódus) érintetlenül hagyjuk.

## Tesztek

Az `add-full-event-dialog.component.spec.ts` auto-generált stubot lecseréltem három esetre:

- pre-fill a legrelevánsabb (`PeriodService` által visszaadott első) periódussal
- nem írja felül a már meglévő kiválasztást (szerkesztés / suggestion review)
- üres marad, ha a service nem ad vissza választható periódust

`ng test --watch=false --browsers=ChromeHeadless --include='**/add-full-event-dialog/*.spec.ts'` → **3 SUCCESS**.

## Mit érdemes manuálisan ellenőrizni

- Hozz létre új visszatérő misét egy nyári és egy iskolai napra → a periódus dropdown mindkettő esetben az adott napra érvényes periódussal van előre kitöltve.
- Szerkessz egy meglévő misét → a már beállított periódus változatlan marad.

---

*Első contributor vagyok itt, nyitott vagyok bármilyen review észrevételre.* 🙏