### PR TITLE
angular: ng test CI workflow + xdescribe stub konvenció + CONTRIBUTING.md #436

### DIFF
--- a/.github/workflows/ng-test.yml
+++ b/.github/workflows/ng-test.yml
@@ -1,0 +1,39 @@
+name: Angular tests
+
+on:
+  pull_request:
+    paths:
+      - 'calendar/**'
+      - '.github/workflows/ng-test.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'calendar/**'
+      - '.github/workflows/ng-test.yml'
+  workflow_dispatch:
+
+jobs:
+  ng-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: calendar
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: calendar/package-lock.json
+
+      - name: npm ci
+        run: npm ci
+
+      - name: ng test (ChromeHeadlessCI)
+        env:
+          # A GitHub Actions ubuntu-latest runner-en a Chromium ide települ.
+          CHROME_BIN: /usr/bin/google-chrome
+        run: npx ng test --watch=false --browsers=ChromeHeadlessCI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,177 @@
+# 🙏 Közreműködés a miserend.hu fejlesztésében
+
+Köszi hogy itt vagy! Ez a fájl a hozzájárulás gyakorlati részleteit gyűjti egybe — a fejlesztői környezet telepítése és a hozzá tartozó kvázi-szabályok a [README.md](README.md)-ben vannak.
+
+## Tartalom
+
+1. [Általános folyamat](#általános-folyamat)
+2. [PHP rész](#-php-rész-webapp)
+3. [Angular naptár](#-angular-naptár-calendar)
+4. [Egyéb hasznos](#egyéb-hasznos)
+
+---
+
+## Általános folyamat
+
+1. **Fork-old a `szentjozsefhackathon/miserend.hu` repót** a saját GitHub fiókodba.
+2. **Klónozd** a forkodat lokálisan és add hozzá az upstream remote-ot:
+   ```sh
+   git clone https://github.com/<te-neved>/miserend.hu.git
+   cd miserend.hu
+   git remote add upstream https://github.com/szentjozsefhackathon/miserend.hu.git
+   ```
+3. **Új branch** minden témára külön: `git checkout -b fix/leírás-vagy-issue-szám`.
+4. **Commit** apró logikai egységekben, magyarul (a projekt többi commit-üzenete is ilyen).
+5. **Push** a saját forkodra: `git push -u origin <branch>`.
+6. **Pull Request** a `szentjozsefhackathon/miserend.hu` `master` ellen.
+7. Reagálj a review-megjegyzésekre, ha kell, push extra commitokat ugyanarra a branchre.
+
+> Nem kell minden PR-t a maintainerrel előre egyeztetni — a kis bugfix-eket vagy egyértelmű enhancement-eket csak küldd be. Nagyobb feature-nél (új komponens, séma-változás) inkább előbb egy issue-ban beszéljük át.
+
+---
+
+## 🐘 PHP rész (`webapp/`)
+
+A backend tisztán PHP, Twig templatekkel és egy Eloquent-alapú adatréteggel. Bootstrap + jQuery a frontenden, ami ide tartozik.
+
+### Tesztek (PHPUnit)
+
+```sh
+# Minden teszt
+bash scripts/docker-test.sh
+
+# Csak egy testsuite
+bash scripts/docker-test.sh --testsuite api
+bash scripts/docker-test.sh --testsuite simple
+
+# Coverage report
+bash scripts/docker-coverage.sh
+```
+
+A coverage report a `webapp/tests/coverage/html/index.html`-ban érhető el.
+
+### Tesztstruktúra
+
+```
+webapp/tests/
+├── bootstrap.php              # tesztkörnyezet inicializálása
+├── phpunit.xml                # PHPUnit konfiguráció
+├── Unit/                      # egységtesztek
+├── Api/                       # API tesztek
+├── Request/                   # request helper tesztek
+├── Rules/                     # szabálykezelő tesztek
+├── Integration/               # integrációs tesztek
+└── Functional/                # böngészős funkcionális tesztek
+```
+
+### Konvenciók
+
+- **Fájl-elnevezés**: `<TesztelendőOsztály>Test.php`
+- **Metódus-elnevezés**: `test`-tel kezdődik, pl. `testAddFavoriteAcceptsValidChurchId()`
+- **Új tesztet** új fájlba a megfelelő mappába, `extends PHPUnit\Framework\TestCase`
+- Docker-izolált környezetben fut, nem érinti a fejlesztői gépet
+
+### Mit érdemes tesztelni
+
+Prioritás szerint:
+1. **API validáció és autentikáció** — biztonsági kritikus
+2. **Pure functions** — könnyen tesztelhető, kevés mock
+3. **Üzleti logika** — komplex döntés, számítás
+4. **Edge case-ek** — határérték, hibakezelés
+
+Amit *nem* érdemes:
+- Framework / library kód (már tesztelt)
+- Triviális getter/setter
+- UI / template renderelés (inkább E2E)
+
+---
+
+## 🅰️ Angular naptár (`calendar/`)
+
+A naptárnézet és naptár-szerkesztő Angular 19 alkalmazás, FullCalendar + Angular Material alapokon. A `miserend` PHP konténerba a `webapp/js/mcal/` alá kerül buildelve.
+
+### Tesztek (Karma + Jasmine)
+
+```sh
+cd calendar
+npx ng test --watch=false --browsers=ChromeHeadless
+```
+
+CI ugyanezt futtatja, csak `--browsers=ChromeHeadlessCI` (a `karma.conf.js`-ben definiált `--no-sandbox` flagekkel).
+
+### Konvenciók
+
+#### `xdescribe` — pendingben tartott stub spec
+
+Az `ng generate component|service` automatikusan generál `*.spec.ts`-t egyetlen `should create` teszttel — de a TestBed providerek nélkül ezek a stubok futtatáskor **DI-hibára esnek** (No provider for ActivatedRoute / MatDialogRef / TranslateStore / stb.). Hogy a `ng test` ne legyen krónikusan piros, **az ilyen stubokat `xdescribe`-bal pendingbe tesszük** addig, amíg valaki rendesen ki nem egészíti őket TestBed mock-okkal.
+
+**Promóció `describe`-bá**:
+1. Add hozzá a hiányzó providereket (`MAT_DIALOG_DATA`, `MatDialogRef`, `TranslateModule.forRoot()`, mock service-ek)
+2. Cseréld `xdescribe` → `describe`
+3. Töröld a TODO kommentet a tetejéről
+4. Adj valódi assertion-öket — nem csak `expect(component).toBeTruthy()`
+
+#### Új teszt írása
+
+- **Pure utility tesztek** (`src/app/util/*.spec.ts`): nem kell TestBed, csak importáld az osztályt és teszteld. Ezek a leggyorsabbak, legmegbízhatóbbak.
+- **Komponens tesztek**: használj `TestBed.configureTestingModule()`-t a komponens import-jával és minden DI providerrel, amit a komponens injectál.
+
+#### CI viselkedés
+
+A `.github/workflows/ng-test.yml` workflow automatikusan fut minden `calendar/**`-t érintő PR-en. **A workflow akkor és csak akkor zöld, ha minden NEM-xdescribe-os teszt zöld.** Új teszt írása nem igényel workflow-módosítást.
+
+### Naptár fejlesztése (build / deploy)
+
+```sh
+cd calendar
+npm install      # ha még nem volt
+ng build --configuration=localProd
+npm run start:integrated
+```
+
+A `npm run start:integrated` watch módban indul: a forrás-változás után újrabuildel, majd egy Python script (`docker/miserend/calendar_deploy.py`) a kimenetet a `webapp/js/mcal/` alá másolja, ahonnan a PHP a `<script>` tag-eken keresztül betölti.
+
+### Éles / staging build
+
+```sh
+cd calendar
+ng build --configuration=production
+python ../docker/miserend/calendar_deploy.py
+```
+
+---
+
+## Egyéb hasznos
+
+### Branching stratégia
+
+- `master` ➜ staging környezet (`staging.miserend.hu`)
+- `production` ➜ éles honlap (`miserend.hu`)
+
+### Konténerekbe belépés
+
+```sh
+docker exec -it [mysql|mailcatcher|miserend] bash
+```
+
+### Composer használata
+
+```sh
+docker exec miserend composer install|require|update
+```
+
+### Helyi image build
+
+```sh
+docker build -t miserend:latest -f docker/miserend/Dockerfile .
+```
+
+Ha tesztelni szeretnéd, állítsd át a `docker/compose.dev.yml`-ben a `miserend` service `image` attribútumát `localhost/miserend:latest`-re.
+
+### Dump
+
+Adatbázis dump-hoz: `docker/mysql/dump.sh`. A szkript elején lévő változókat env-ben lehet felülbírálni — kényes adatokat előre takarít.
+
+---
+
+Ha bármi kérdésed van vagy elakadnál, nyiss issue-t bátran. Köszi az időt és a munkát! 🙏

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ docker-compose  -f docker/compose.yml  -f docker/compose.test.yml up
 
 Máris elérhető a http://localhost:8000 címen a miserend alkalmazás. Az `admin` felhasználóval be is lehet lépni az alapérelmezett jelszóval: `miserend`.
 
+## 🤝 Közreműködés
+
+Kapcsolódj be a fejlesztésbe! A fork → branch → PR folyamat, a teszt-konvenciók és a komponensenkénti (PHP / Angular) részletek itt:
+
+📖 **[CONTRIBUTING.md](CONTRIBUTING.md)**
+
 
 # ⚙️ Fejlesztői környezet telepítése
 
@@ -112,35 +118,17 @@ A http://localhost:8000 címen érhető el. Az admin / miserend az első felhasz
 
 ## Naptár frontend (Angular)
 
-A naptárnézet és naptár szerkesztő felület egy különállóm Angular alap projekt, mely a `miserend` konténerban van szintén.
-
-A `calendar` könyvtárban található Angular alkalmazás forrása.
+A naptárnézet és naptár szerkesztő felület egy különálló Angular alap projekt, mely a `miserend` konténerben van szintén. A forrása a `calendar/` könyvtárban.
 
 ### 📆 Naptárnézet
+
 - Első alkalommal le kell generálni az időszakokat:
 - Admin joggal, az `/periodyeareditor` felületen
 - A minta adatok idővel elévülhetnek, fontos az aktualizálásuk!
 
-### Naptárnézet fejlesztése
-Amennyiben a naptár alkalmazáson dolgozunk, az npm build után a `docker/miserend/calendar_deploy.py` szkript futtatásával lehet az alkalmazásba integrálni.
+### Naptár fejlesztése, build / deploy, tesztek
 
-
-A `/calendar` könyvtárban az alábbi parancsokat futtassuk:
-
-Ha még nem volt, akkor:
-
-```sh
-npm install
-```
-
-```sh
-ng build --configuration=localProd
-npm run start:integrated
-```
-
-- Ezzel egyrészt elérjük, hogy fejlesztői legyen a naptár
-- Másrészt elérjük, hogy ha valamit módosítunk, az szinte egyből érvényre jusson
-- Ilyenkor egy python script a `/calendar` mappában buildeli az Angularos projektet, majd a megfelelő helyre átmásolja a legenerált fájlokat
+A részletek (build / `start:integrated` / Karma teszt / CI workflow / `xdescribe` konvenció) a [CONTRIBUTING.md Angular fejezetében](CONTRIBUTING.md#-angular-naptár-calendar) találhatók.
 
 
 # 📅 RRULE Definícióik dokumentációja
@@ -221,101 +209,7 @@ docker exec miserend composer install|require|update
 
 ## 🧪 Tesztelés
 
-A projekt PHPUnit alapú unit teszteket használ a kód minőségének biztosítására és a regressziók elkerülésére.
-
-### Unit tesztek futtatása
-
-**Gyors futtatás (minden teszt):**
-```sh
-bash scripts/docker-test.sh
-```
-
-**Csak egy testsuite futtatása:**
-```sh
-bash scripts/docker-test.sh --testsuite api
-bash scripts/docker-test.sh --testsuite simple
-```
-
-**Code coverage generálása:**
-```sh
-bash scripts/docker-coverage.sh
-```
-
-A coverage report HTML formátumban a `webapp/tests/coverage/html/index.html` fájlban érhető el.
-
-### Teszt struktúra
-
-A tesztek a `webapp/tests/` könyvtárban találhatók, és a futtatott PHPUnit suite-ok szerint vannak csoportosítva:
-
-```
-webapp/tests/
-├── bootstrap.php              # Test környezet inicializálása
-├── functional-bootstrap.php   # Funkcionális tesztek bootstrapja
-├── phpunit.xml                # PHPUnit konfiguráció
-├── phpunit.functional.xml     # Funkcionális PHPUnit konfiguráció
-├── Unit/                      # Egységtesztek
-│   ├── SimpleFunctionsTest.php
-│   └── UtilityFunctionsTest.php
-├── Api/                       # API tesztek
-│   ├── ApiEndpointsTest.php
-│   ├── ApiTest.php
-│   └── LoginTest.php
-├── Request/                   # Request helper tesztek
-│   └── RequestTest.php
-├── Rules/                     # Szabálykezelő tesztek
-│   ├── SimplerruleTest.php
-│   └── DSTSimplerruleTest.php
-├── Integration/               # Integrációs tesztek
-│   └── UserTest.php
-└── Functional/                # Böngészős funkcionális tesztek
-    └── HomepageLogoTest.php
-```
-
-### Fontos tudnivalók
-
-- **Test naming convention**: A test fájlok neve megegyezik a tesztelt osztály nevével + `Test.php` végződés
-- **Test methods**: Minden teszt metódus `test` prefixszel kezdődik, pl. `testValidateVersionMainAcceptsVersion1()`
-- **Docker izolált környezet**: A tesztek Docker konténerben futnak, így nem befolyásolják a fejlesztői környezetet
-- **Coverage driver**: PCOV extension biztosítja a code coverage-t
-
-### Új tesztek írása
-
-1. **Hozz létre egy új test fájlt** a megfelelő helyen (pl. `webapp/tests/Api/FavoritesTest.php`)
-2. **Extend PHPUnit TestCase**: `class FavoritesTest extends TestCase`
-3. **Írj teszteket** a kritikus funkcionalitáshoz
-4. **Futtasd a teszteket** a fenti parancsokkal
-5. **Ellenőrizd a coverage-t** hogy minden fontos ág le legyen fedve
-
-**Példa teszt:**
-```php
-<?php
-
-use PHPUnit\Framework\TestCase;
-use Api\Favorites;
-
-class FavoritesTest extends TestCase {
-    
-    public function testAddFavoriteAcceptsValidChurchId() {
-        $favorites = new Favorites([]);
-        
-        // Test implementation
-        $this->assertTrue(true);
-    }
-}
-```
-
-### Mit érdemes tesztelni?
-
-**Prioritás szerint:**
-1. **API validáció és autentikáció** - kritikus biztonsági funkciók
-2. **Pure functions** - nincs side effect, könnyen tesztelhető
-3. **Üzleti logika** - komplex számítások, döntési fák
-4. **Edge case-ek** - határértékek, hibakezelés
-
-**Mit NEM kell tesztelni:**
-- Framework/library kód (már tesztelt)
-- Triviális getter/setter metódusok
-- UI/template renderelés (inkább E2E tesztek)
+A projekt PHPUnit (PHP) és Karma + Jasmine (Angular) teszteket használ. A futtatási parancsok, struktúra és konvenciók (köztük az Angular `xdescribe`-konvenció) a [CONTRIBUTING.md tesztelési fejezeteiben](CONTRIBUTING.md#-php-rész-webapp) találhatók.
 
 ## 🌳 Branching stratégia
 

--- a/calendar/angular.json
+++ b/calendar/angular.json
@@ -122,6 +122,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
+            "karmaConfig": "karma.conf.js",
             "polyfills": [
               "zone.js",
               "zone.js/testing"

--- a/calendar/karma.conf.js
+++ b/calendar/karma.conf.js
@@ -1,0 +1,46 @@
+// Karma konfiguráció - korábban az Angular CLI implicit készítette.
+// #436: ezt explicit kihúzzuk, hogy hozzá tudjunk adni egy ChromeHeadlessCI
+// launchert. A GitHub Actions konténerben a default ChromeHeadless `--no-sandbox`
+// nélkül nem indul, ezért külön launcher kell.
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/mcal'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu']
+      }
+    },
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/calendar/src/app/app.component.spec.ts
+++ b/calendar/src/app/app.component.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
-describe('AppComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],

--- a/calendar/src/app/components/add-message-dialog/add-message-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-message-dialog/add-message-dialog.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AddMessageDialogComponent } from './add-message-dialog.component';
 
-describe('EventEditDialogComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('EventEditDialogComponent', () => {
   let component: AddMessageDialogComponent;
   let fixture: ComponentFixture<AddMessageDialogComponent>;
 

--- a/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AddSimpleEventDialogComponent } from './add-simple-event-dialog.component';
 
-describe('AddSimpleEventDialogComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('AddSimpleEventDialogComponent', () => {
   let component: AddSimpleEventDialogComponent;
   let fixture: ComponentFixture<AddSimpleEventDialogComponent>;
 

--- a/calendar/src/app/components/church-calendar/church-calendar.component.spec.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ChurchCalendarComponent } from './church-calendar.component';
 
-describe('ChurchCalendarComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('ChurchCalendarComponent', () => {
   let component: ChurchCalendarComponent;
   let fixture: ComponentFixture<ChurchCalendarComponent>;
 

--- a/calendar/src/app/components/church/church.component.spec.ts
+++ b/calendar/src/app/components/church/church.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ChurchComponent } from './church.component';
 
-describe('ChurchComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('ChurchComponent', () => {
   let component: ChurchComponent;
   let fixture: ComponentFixture<ChurchComponent>;
 

--- a/calendar/src/app/components/copy-period-dialog/copy-period-dialog.component.spec.ts
+++ b/calendar/src/app/components/copy-period-dialog/copy-period-dialog.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CopyPeriodDialogComponent } from './copy-period-dialog.component';
 
-describe('CopyPeriodDialogComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('CopyPeriodDialogComponent', () => {
   let component: CopyPeriodDialogComponent;
   let fixture: ComponentFixture<CopyPeriodDialogComponent>;
 

--- a/calendar/src/app/components/delete-period-dialog/delete-period-dialog.component.spec.ts
+++ b/calendar/src/app/components/delete-period-dialog/delete-period-dialog.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DeletePeriodDialogComponent } from './delete-period-dialog.component';
 
-describe('DeletePeriodDialogComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('DeletePeriodDialogComponent', () => {
   let component: DeletePeriodDialogComponent;
   let fixture: ComponentFixture<DeletePeriodDialogComponent>;
 

--- a/calendar/src/app/components/delete-warning-dialog/delete-warning-dialog.component.spec.ts
+++ b/calendar/src/app/components/delete-warning-dialog/delete-warning-dialog.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DeleteWarningDialogComponent } from './delete-warning-dialog.component';
 
-describe('EventEditDialogComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('EventEditDialogComponent', () => {
   let component: DeleteWarningDialogComponent;
   let fixture: ComponentFixture<DeleteWarningDialogComponent>;
 

--- a/calendar/src/app/components/edit-schedule/edit-schedule.component.spec.ts
+++ b/calendar/src/app/components/edit-schedule/edit-schedule.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EditScheduleComponent } from './edit-schedule.component';
 
-describe('EditScheduleComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('EditScheduleComponent', () => {
   let component: EditScheduleComponent;
   let fixture: ComponentFixture<EditScheduleComponent>;
 

--- a/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.spec.ts
+++ b/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EventViewerDialogComponent } from './event-viewer-dialog.component';
 
-describe('EventViewerDialogComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('EventViewerDialogComponent', () => {
   let component: EventViewerDialogComponent;
   let fixture: ComponentFixture<EventViewerDialogComponent>;
 

--- a/calendar/src/app/components/mass-row/mass-row.component.spec.ts
+++ b/calendar/src/app/components/mass-row/mass-row.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MassRowComponent } from './mass-row.component';
 
-describe('MassRowComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('MassRowComponent', () => {
   let component: MassRowComponent;
   let fixture: ComponentFixture<MassRowComponent>;
 

--- a/calendar/src/app/components/masses-diff/masses-diff.component.spec.ts
+++ b/calendar/src/app/components/masses-diff/masses-diff.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MassesDiffComponent } from './masses-diff.component';
 
-describe('MassesDiffComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('MassesDiffComponent', () => {
   let component: MassesDiffComponent;
   let fixture: ComponentFixture<MassesDiffComponent>;
 

--- a/calendar/src/app/components/period-exclusion-dialog/period-exclusion-dialog.component.spec.ts
+++ b/calendar/src/app/components/period-exclusion-dialog/period-exclusion-dialog.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PeriodExclusionDialogComponent } from './period-exclusion-dialog.component';
 
-describe('PeriodExclusionDialogComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('PeriodExclusionDialogComponent', () => {
   let component: PeriodExclusionDialogComponent;
   let fixture: ComponentFixture<PeriodExclusionDialogComponent>;
 

--- a/calendar/src/app/components/period-year-editor/period-year-editor.component.spec.ts
+++ b/calendar/src/app/components/period-year-editor/period-year-editor.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PeriodYearEditorComponent } from './period-year-editor.component';
 
-describe('PeriodYearEditorComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('PeriodYearEditorComponent', () => {
   let component: PeriodYearEditorComponent;
   let fixture: ComponentFixture<PeriodYearEditorComponent>;
 

--- a/calendar/src/app/components/search/search.component.spec.ts
+++ b/calendar/src/app/components/search/search.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SearchComponent } from './search.component';
 
-describe('SearchComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('SearchComponent', () => {
   let component: SearchComponent;
   let fixture: ComponentFixture<SearchComponent>;
 

--- a/calendar/src/app/components/suggestions/suggestions.component.spec.ts
+++ b/calendar/src/app/components/suggestions/suggestions.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SuggestionsComponent } from './suggestions.component';
 
-describe('SuggestionsComponent', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('SuggestionsComponent', () => {
   let component: SuggestionsComponent;
   let fixture: ComponentFixture<SuggestionsComponent>;
 

--- a/calendar/src/app/event.service.spec.ts
+++ b/calendar/src/app/event.service.spec.ts
@@ -2,7 +2,10 @@ import { TestBed } from '@angular/core/testing';
 
 import { EventService } from './event.service';
 
-describe('EventService', () => {
+// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
+// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
+// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
+xdescribe('EventService', () => {
   let service: EventService;
 
   beforeEach(() => {


### PR DESCRIPTION
Fixes #436 (a #435 follow-up issue)

## Mi van benne

1. **Új workflow** (`.github/workflows/ng-test.yml`) ami minden `calendar/**`-érintő PR-en futtatja a Karma tesztet (`npx ng test --watch=false --browsers=ChromeHeadlessCI`).
2. **Új `karma.conf.js`** egy `ChromeHeadlessCI` launcherrel (`--no-sandbox --disable-gpu`) — a default `ChromeHeadless` ezek nélkül a flagek nélkül nem indul a GitHub Actions ubuntu konténerben. `angular.json` test config most explicit erre a config fájlra mutat (eddig az Angular CLI implicit készítette).
3. **17 stub spec `xdescribe`-olása** — a `should create` auto-generált spec-ek mind hibára estek (No provider for ActivatedRoute / MatDialogRef / TranslateStore / stb.). Pendingbe tesszük őket, hogy a `ng test` ne miattuk legyen krónikusan piros. Promóció: TestBed providerek hozzáadása + vissza `describe`-bá.
4. **Új `CONTRIBUTING.md`** PHP és Angular külön fejezetekkel: fork → branch → PR folyamat, PHP-oldal (PHPUnit + struktúra + konvenciók), Angular-oldal (Karma + `xdescribe`-konvenció + új teszt írása + CI viselkedés + build/deploy).
5. **README pointerek** a CONTRIBUTING megfelelő fejezeteire — a részletes Angular dev / teszt szakaszok helyén most pointer van, a tartalom átkerült a CONTRIBUTING-ba.

## Lokál ellenőrzés

```sh
cd calendar
npx ng test --watch=false --browsers=ChromeHeadlessCI
```

Eredmény (mac, Chrome 148):
```
TOTAL: 14 SUCCESS (33-ból 19 xdescribe-bal kihagyva)
```

CI-ban ugyanez kell hogy lefusson.

## Filozófia (te is megírtad a #436-on)

> *„Inkább kevesebb teszt legyen ... de ha pirosra futunk akkor ott tényleg hibánk legyen."*

Ezzel a PR-ral pont ez áll be: 14 valódi teszt fut + 19 stub pendingbe kerül, és a CI minden új PR előtt láthatóan zöld vagy piros lesz. Új teszt írása nem igényel workflow-módosítást — a karma a teljes `src/`-ből szed össze spec-eket, és minden `describe` (nem `xdescribe`) automatikusan beleesik.

## Mit nem tartalmaz (külön PR-ek)

- A 19 stub „valódi" tesztté fejlesztése — ezt a következő lépésekben prioritás szerint, leggyakrabban szerkesztett komponensekkel kezdve
- Coverage report a workflow-ba (egyelőre nincs benne, könnyen hozzáadható)

---

*Ha bármilyen módosítást szeretnél (más threshold, más Node verzió, más Chrome flag), boldogan átírom.* 🙏
