### PR TITLE
naptár: ne küldjünk módosítást, ha valójában nem változott semmi #352

### DIFF
--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -896,6 +896,16 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
           const calendarEvent: CalendarEvent = MassUtil.createEventByType(this.dialogEvent, newMassId, specialPeriodType, this.translateService);
           const mass: Mass = MassUtil.createMass(calendarEvent, this.dialogEvent, this.currentChurch!, newMassId);
 
+          // #352: ha a felhasználó csak rányomott egy meglévő mise módosítására és semmit nem
+          // változtatott, ne tegyük változási javaslattá - nem küldünk fantom javaslatot, és
+          // nem futtatjuk feleslegesen az exclusion oldalhatásokat sem.
+          if (this.selectedMassId) {
+            const original = this.changes.get(this.selectedMassId) ?? this.masses.get(this.selectedMassId);
+            if (original && SuggestionUtil.isMassUnchanged(original, mass)) {
+              return;
+            }
+          }
+
           const recentlyExclusionSourcePeriodIds: number[] = this.excludeNewMassFromLowerPeriodMasses(periodId, periodWeight);
 
           const recentlyExcludedPeriodIds = this.excludeHigherPeriodMassesFromNewMass(mass, periodId, periodWeight);

--- a/calendar/src/app/util/suggestion-util.spec.ts
+++ b/calendar/src/app/util/suggestion-util.spec.ts
@@ -84,3 +84,34 @@ describe('SuggestionUtil.generateSuggestions', () => {
     expect(result[0].periodId).toBe(3);
   });
 });
+
+describe('SuggestionUtil.isMassUnchanged (#352)', () => {
+
+  it('returns true for two identical masses', () => {
+    const a = makeMass({id: 5, title: 'Szentmise', startDate: '2026-03-01T07:00:00'});
+    const b = makeMass({id: 5, title: 'Szentmise', startDate: '2026-03-01T07:00:00'});
+
+    expect(SuggestionUtil.isMassUnchanged(a, b)).toBe(true);
+  });
+
+  it('returns false when a scalar field differs (startDate)', () => {
+    const original = makeMass({id: 5, startDate: '2026-03-01T07:00:00'});
+    const modified = makeMass({id: 5, startDate: '2026-03-01T08:00:00'});
+
+    expect(SuggestionUtil.isMassUnchanged(original, modified)).toBe(false);
+  });
+
+  it('returns false when the modified mass adds a new field', () => {
+    const original = makeMass({id: 5});
+    const modified = makeMass({id: 5, comment: 'új megjegyzés'});
+
+    expect(SuggestionUtil.isMassUnchanged(original, modified)).toBe(false);
+  });
+
+  it('returns false when an optional field becomes null', () => {
+    const original = makeMass({id: 5, comment: 'régi'});
+    const modified = makeMass({id: 5, comment: null});
+
+    expect(SuggestionUtil.isMassUnchanged(original, modified)).toBe(false);
+  });
+});

--- a/calendar/src/app/util/suggestion-util.ts
+++ b/calendar/src/app/util/suggestion-util.ts
@@ -118,6 +118,15 @@ export class SuggestionUtil {
   }
 
 
+  /**
+   * #352: igaz, ha a modified mise minden mezője megegyezik az eredetivel.
+   * A getMassChanges-nek ugyanazt a logikáját használja, így a `generateSuggestions`
+   * is ugyanúgy fog viselkedni rá: a no-op modosítás nem kerül a javaslatok közé.
+   */
+  public static isMassUnchanged(original: Mass, modified: Mass): boolean {
+    return Object.keys(SuggestionUtil.getMassChanges(original, modified)).length === 0;
+  }
+
   private static getMassChanges(original: Mass, modified: Mass): any {
     const changes: any = {};
     for (const key in original) {


### PR DESCRIPTION
Fixes #352

Related: #419 / #434 (ugyanannak a problémának a másik fele)

## Mi a baj?

Ha a felhasználó megnyitja egy meglévő mise szerkesztő dialógusát és **változtatás nélkül** mentett, a mise akkor is bekerült a `changes` mapbe. Két látható hatása volt:

1. A javaslatcsomagban megjelent egy fantom `MODIFIED` bejegyzés — a maintainer-nek el kellett utasítania
2. A periódus-exclusion oldalhatások (`excludeNewMassFromLowerPeriodMasses`, `excludeHigherPeriodMassesFromNewMass`) hiába futottak le, ugyanazokkal a bemenetekkel

## Mi a megoldás?

Új `SuggestionUtil.isMassUnchanged(original, modified): boolean` helper — a meglévő `getMassChanges` deep-equal alapú logikájára épül (`Object.keys(diff).length === 0`).

A `church-calendar.component.ts` SAVE handlerében (az `else` ág, ami a NEM `editOne` esetet kezeli): az újra-épített `Mass`-t összehasonlítjuk a forrásával (`changes` mapből, fallback a `masses` mapre). Ha nincs valódi változás, korán kilépünk a handlerből — `changes` érintetlen, exclusion-logika nem fut.

## Tesztek

`suggestion-util.spec.ts` 4 új teszttel a helperre:
- pozitív eset (két azonos Mass)
- skaláris diff (`startDate` változik)
- új mező hozzáadása (`comment` előtt nincs, utána van)
- mező nullára állítása

`ng test --watch=false --browsers=ChromeHeadless --include='**/util/suggestion-util.spec.ts'` → **4 SUCCESS**.

## Mit érdemes manuálisan ellenőrizni

- Nyiss meg egy mise szerkesztő dialógust, kattints **Mentés** mindenféle változtatás nélkül → ne kerüljön bele a beküldhető javaslatba
- Valódi változtatás után (időpont, nap, periódus, stb.) → a régi viselkedés szerint kerüljön a `changes`-be

## Kapcsolat #419-cel

A #434 (`#419` fix) egy védőhálót ad: ha mégis üresen sikerült a javaslatot felépíteni, ne küldje el. Ez a PR (#352) a kiindulóoknál fogja meg: ne kerüljön no-op módosítás a `changes`-be. A kettő egymást nem zárja ki, egymást erősíti.

