### PR TITLE
naptár widget: figyelmeztetés régi böngészőben, ahol nem indul #425

### DIFF
--- a/webapp/templates/angularjs.twig
+++ b/webapp/templates/angularjs.twig
@@ -2,7 +2,42 @@
 
 {#calendar-app#}
 <mcal class="calendar-app">
-    <app-root></app-root>
+    <app-root>
+        {# #425: ha a böngészőben egyáltalán nem fut JS, ide nem ír semmit az Angular sem,
+           és a látogató csak azt látja, hogy "üres" a miserend. Ezzel legalább kap egy
+           jelzést. Modern böngészőben az Angular felülírja az <app-root> tartalmát. #}
+        <noscript>
+            <div class="alert alert-warning" role="alert" style="margin:8px 0">
+                A miserend naptár megjelenítéséhez JavaScript szükséges. Kérjük, engedélyezze a böngészőjében, majd töltse újra az oldalt.
+            </div>
+        </noscript>
+    </app-root>
+    {# #425: a polyfills és a main modulként (`type="module"`) töltődnek, így régi
+       böngésző (pl. IE11, vagy a 2018 előtti Edge/Firefox/Safari) szótlanul kihagyja
+       őket - a látogató pedig egy üres widget-helyet lát. A `nomodule` script viszont
+       épp ezekben a régi böngészőkben fut le, így be tudunk írni egy figyelmeztetést
+       oda, ahol a naptár lett volna. #}
+    <script nomodule>
+        (function () {
+            function showBrowserWarning() {
+                var appRoot = document.querySelector('mcal app-root');
+                if (!appRoot) return;
+                appRoot.innerHTML =
+                    '<div class="alert alert-warning" role="alert" style="margin:8px 0">' +
+                    '<strong>A miserend naptár ebben a böngészőben nem jelenik meg.</strong><br>' +
+                    'Sajnos az ön böngészője túl régi, és nem támogatja a JavaScript modulokat, ' +
+                    'amik a naptárhoz kellenek. Kérjük, frissítse a böngészőjét a Chrome, ' +
+                    'Firefox, Safari vagy Edge legújabb verziójára - utána a miserend is ' +
+                    'megjelenik majd.' +
+                    '</div>';
+            }
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', showBrowserWarning);
+            } else {
+                showBrowserWarning();
+            }
+        })();
+    </script>
     <script src="/js/mcal/{{ polyfills }}" type="module"></script>
     <script src="/js/mcal/{{ main }}" type="module"></script>
 </mcal>


### PR DESCRIPTION
Fixes #425

## Mi a baj?

A naptár widget bundle (`polyfills` + `main`) `<script type="module">`-ként töltődik. Azok a böngészők, amik nem támogatják az ES modulokat (IE11, 2018 előtti Edge / Safari / Firefox), szótlanul kihagyják mindkét scriptet — a látogató csak egy üres `<app-root>`-ot lát ott, ahol a miserend lett volna. Fogalma sincs, **miért „nincs miserend"**.

## Mi a megoldás?

Két rétegű fallback az `angularjs.twig`-ben — pure template változás, semmi JS-build-érintett kód:

**`<noscript>` az `<app-root>`-on belül**:
Ha a JS teljesen ki van kapcsolva, ez a tartalom jön elő. Modern böngészőben az Angular bootstrap felülírja az `<app-root>` tartalmát, így a noscript csak akkor látható, ha az Angular maga sem futott.

**`<script nomodule>`**:
Csak azokban a böngészőkben fut, amik nem támogatnak modulokat. Egyszerűen átírja az `<app-root>` innerHTML-jét egy magyar figyelmeztetésre, ami azt kéri, frissítsék a böngészőt Chrome/Firefox/Safari/Edge újabb verziójára. Modern böngésző figyelmen kívül hagyja a `nomodule` attribútumot, így nincs hatása.

## Tesztek

Nincs automatikus teszt — tisztán template-szintű változás, ami csak böngészőben próbálható ki.

## Mit érdemes manuálisan ellenőrizni

- **Modern böngésző (Chrome/Firefox/Safari/Edge)**: nincs figyelmeztetés, a naptár megjelenik
- **Régi böngésző**: figyelmeztetés látható ott, ahol a naptár lett volna. Olyan változat tesztelhető pl. Safari 10.1 / Firefox 60 alatt, vagy egy ES-modul-támogatás nélküli emulátorban
- **JS teljesen kikapcsolva**: a `<noscript>` szövege jön elő

Ismert edge-case: Safari 10.1 és Firefox 60–62 hibásan tölti be a `nomodule` scriptet még akkor is, ha támogatja a modulokat. Ezekben a böngészőkben tehát extra figyelmeztetést láthat a felhasználó — nem törő, de zajos. Ha ez gond, van bevett workaround (`nomodule` + speciális `src=""` trick), de azt csak akkor érdemes berakni, ha tényleg sok ilyen böngészővel találkoztok.
