### PR TITLE
tesztek: #308 default-period spec igazítása a #450 fix-hez

### DIFF
--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
@@ -24,9 +24,15 @@ function makeGeneratedPeriod(overrides: Partial<GeneratedPeriod> = {}): Generate
   };
 }
 
+// #450: a komponens a `renum === Renum.NONE` alapján dönti el, hogy egyszeri
+// alkalomról van-e szó (`singleEvent`). Egyszeri alkalomhoz NEM rendelünk
+// alapértelmezett időszakot (ez volt a #450 bug). Ezért a #308 default-period
+// teszteknek ismétlődő misét (EVERY_WEEK) kell használniuk — különben a
+// singleEvent-ág kihagyja a period-választást és null marad.
 function makeDialogData(
   periodOverride: GeneratedPeriod | null = null,
   existingPeriodIds: number[] = [],
+  renum: Renum = Renum.EVERY_WEEK,
 ) {
   return {
     title: 'ADD_NEW_MASS',
@@ -39,7 +45,7 @@ function makeDialogData(
       start: new Date('2026-03-15T10:00:00'),
       duration: {hours: 1},
       language: LanguageCode.HU,
-      renum: Renum.NONE,
+      renum,
       selectedDays: [Day.SU],
       comment: '',
       editOne: false,
@@ -160,7 +166,8 @@ describe('AddFullEventDialogComponent (#308 default period)', () => {
   it('handles missing existingPeriodIds (undefined) like an empty list — fallback to [0]', async () => {
     const p10 = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
 
-    // DialogData without existingPeriodIds key at all (legacy callers / safety net)
+    // DialogData without existingPeriodIds key at all (legacy callers / safety net).
+    // #450: ismétlődő mise (EVERY_WEEK), hogy a default-period ág lefusson.
     const data = {
       title: 'ADD_NEW_MASS',
       event: {
@@ -171,7 +178,7 @@ describe('AddFullEventDialogComponent (#308 default period)', () => {
         start: new Date('2026-03-15T10:00:00'),
         duration: {hours: 1},
         language: LanguageCode.HU,
-        renum: Renum.NONE,
+        renum: Renum.EVERY_WEEK,
         selectedDays: [Day.SU],
         comment: '',
         editOne: false,
@@ -181,5 +188,61 @@ describe('AddFullEventDialogComponent (#308 default period)', () => {
     await setup([p10], data as any);
 
     expect(component.periodCtr.value).toEqual(p10);
+  });
+});
+
+describe('AddFullEventDialogComponent (#450 egyszeri alkalom nem kap időszakot)', () => {
+  let component: AddFullEventDialogComponent;
+  let fixture: ComponentFixture<AddFullEventDialogComponent>;
+  let periodServiceMock: { getSelectableGeneratedPeriodsByDate: jasmine.Spy; getPeriodById: jasmine.Spy; getSpecialPeriodType: jasmine.Spy };
+
+  async function setup(periods: GeneratedPeriod[], data: any) {
+    periodServiceMock = {
+      getSelectableGeneratedPeriodsByDate: jasmine.createSpy().and.returnValue(of(periods)),
+      getPeriodById: jasmine.createSpy().and.returnValue(null),
+      getSpecialPeriodType: jasmine.createSpy().and.returnValue(null),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AddFullEventDialogComponent, TranslateModule.forRoot()],
+      providers: [
+        {provide: MAT_DIALOG_DATA, useValue: data},
+        {provide: MatDialogRef, useValue: {close: jasmine.createSpy()}},
+        {provide: PeriodService, useValue: periodServiceMock},
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddFullEventDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  // #450: egyszeri alkalomnál (renum === NONE) NEM szabad alapértelmezett
+  // időszakot rendelni — ez okozta, hogy az időszak első napjára került az esemény.
+  it('does NOT assign a default period for a single event (renum NONE), even if periods exist', async () => {
+    const evkozi = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
+
+    await setup([evkozi], makeDialogData(null, [10], Renum.NONE));
+
+    expect(component.singleEvent).toBeTrue();
+    expect(component.periodCtr.value).toBeNull();
+    expect(component.data.event.period).toBeFalsy();
+  });
+
+  // #450: ha a felhasználó ismétlődőről egyszerire vált (onRecurrenceModChange),
+  // a korábban beállított időszakot ki kell üríteni.
+  it('clears the period when switching from recurring to single (onRecurrenceModChange)', async () => {
+    const evkozi = makeGeneratedPeriod({id: 1, periodId: 10, name: 'Iskolaidő'});
+
+    // Ismétlődőként indul → kap default period-ot.
+    await setup([evkozi], makeDialogData(null, [10], Renum.EVERY_WEEK));
+    expect(component.periodCtr.value).toEqual(evkozi);
+
+    // A felhasználó egyszerire vált.
+    component.singleEvent = true;
+    component.onRecurrenceModChange();
+
+    expect(component.data.event.period).toBeNull();
+    expect(component.periodCtr.value).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #450 (teszt-oldal)

A `56f75ac8` (fix #450) helyesen oldotta meg a hibát: egyszeri alkalmaknál (`singleEvent`, azaz `renum === Renum.NONE`) többé NEM rendelünk alapértelmezett időszakot — ez okozta hogy az esemény az időszak első napjára (pl. 01.01.) került.

Viszont ezzel a #308-as default-period tesztjeim (amiket a #435-ben adtam hozzá) elhasaltak: a fixture-jük `Renum.NONE`-t használt, ami a fix után `singleEvent=true`-nak minősül, így a default-period ág kihagyódik és `periodCtr.value` null marad → 7 teszt piros.

Ez a PR a teszteket igazítja a helyes (fix utáni) viselkedéshez. @borazslo @krisek — ez a válasz a „a tesztek elhasalnak" kérdésre.

## Változások

`add-full-event-dialog.component.spec.ts`:

1. **`makeDialogData()` default `renum` → `Renum.EVERY_WEEK`** (+ opcionális 3. paraméter). A #308 default-period tesztek logikailag ismétlődő misékről szólnak (azoknak VAN időszaka), ezért most ismétlődő fixture-rel futnak. Az egy inline data-objektumos teszt is `EVERY_WEEK`-re vált.

2. **Új describe: `#450 egyszeri alkalom nem kap időszakot`** — két teszt ami a fix-et validálja:
   - egyszeri alkalom (`Renum.NONE`) → `singleEvent=true`, `periodCtr.value` null, `data.event.period` falsy — akkor is, ha van elérhető időszak
   - ismétlődő→egyszeri váltás (`onRecurrenceModChange`) → a korábban beállított period ürül

## Eredmény

- A 7 piros #308-teszt újra zöld
- +2 új teszt ami a #450 regressziót a jövőben kifogja (regression guard)
- Teljes suite: 20/20 SUCCESS

## Megjegyzés

Tisztán teszt-fájl változás — a `56f75ac8` komponens-fix-et NEM módosítom, az helyes. A tesztek eddig egy olyan viselkedést rögzítettek (egyszeri alkalom is kap időszakot), ami valójában a #450 bug volt; most a helyes viselkedést rögzítik.
