### PR TITLE
nearby API: 0,0 user-helyzet elutasítása + 0,0 templom kizárás (5000km+ bug) #94

### DIFF
--- a/webapp/classes/api/nearby.php
+++ b/webapp/classes/api/nearby.php
@@ -85,14 +85,33 @@ class NearBy extends Api {
 		
         $this->getInputJson();
 		$limit = isset($this->input['limit']) ? $this->input['limit'] : 10;
-		
+
+		// #94: a tényleges hiba forrása — a kliens (Android app) GPS-fix nélkül
+		// (0,0)-t küld, és erre minden magyar templom ~5000+ km-re jön vissza
+		// (error:0-val, mintha érvényes találat lenne). A 0,0 a Guineai-öbölben
+		// van, ott nincs katolikus misézőhely; kezeljük „nincs érvényes helyzet"-
+		// ként és adjunk vissza hibát a szemét 5000 km-es lista helyett.
+		if ((float) $this->input['lat'] === 0.0 && (float) $this->input['lon'] === 0.0) {
+			$this->return['error'] = 1;
+			$this->return['text'] = 'Érvénytelen helyzet (0,0) — nem sikerült meghatározni a pozíciót.';
+			$this->return['templomok'] = [];
+			return;
+		}
+
 		$this->return['templomok'] = \Eloquent\Church::select()
 				->addSelect(DB::raw("ST_distance_sphere( ST_GeomFromText('POINT ( ".$this->input['lat']." ".$this->input['lon']." )', 4326), ST_GeomFromText(CONCAT('POINT ( ',lat,' ', lon, ')'), 4326) ) as distance"))
                 ->where('ok','i')
+				// #94 (másodlagos, defenzív): a koordináta nélküli templomok a
+				// templomok.lat/lon DEFAULT 0.0/0.0 értékén ülnek. Ezeket a meglévő
+				// `lat <> ''` szűrő DECIMAL-coercion révén (''→0) már kizárja, de ez
+				// törékeny/rejtett — explicit `NOT (lat=0 AND lon=0)`-val biztosítjuk,
+				// hogy egy 0,0 templom akkor se szivárogjon be, ha a szűrő változik.
 				->where('lat','<>','')
+				->where('lon','<>','')
+				->whereRaw('NOT (lat = 0 AND lon = 0)')
                 ->orderBy('distance', 'ASC')
 				->limit($limit)
-                ->get()->map->toAPIArray( 
+                ->get()->map->toAPIArray(
 					isset($this->input['response_length']) ? $this->input['response_length'] : (  $this->fields['response_length']['default'] ? $this->fields['response_length']['default'] : false ), 
 					isset($this->input["whenMass"]) ? $this->input["whenMass"] : (  $this->fields['whenMass']['default'] ? $this->fields['whenMass']['default'] : false ));
 				

--- a/webapp/tests/Api/ApiEndpointsTest.php
+++ b/webapp/tests/Api/ApiEndpointsTest.php
@@ -425,33 +425,57 @@ class ApiEndpointsTest extends TestCase {
 
     /**
      * #94: a koordináta nélküli templomok (templomok.lat/lon DEFAULT 0.0/0.0,
-     * a Guineai-öböl) NEM jelenhetnek meg a nearby-keresésben — korábban ezeket
-     * a usertől ~5000+ km-re írta ki, mert csak az üres stringet szűrtük, a 0.0-t
-     * nem. Egy budapesti koordinátára indított keresés egyetlen találatának sem
-     * lehet abszurd (3000 km feletti) távolsága.
+     * a Guineai-öböl) NEM jelenhetnek meg a nearby-keresésben — a 0,0 „unknown
+     * location", nem valódi hely.
+     *
+     * A bugot a 0,0 KÖZELÉBE indított lekérdezés triggereli: ott a 0,0-templom a
+     * legközelebbi, így a top-N-be kerül. (Budapestről nézve a ~5000 km-es szellem
+     * az ORDER BY distance ASC LIMIT N miatt a lista végére esik, nem buknék ki —
+     * ezért kell direkt a 0,0 közelébe kérdezni.) A javítás (üres ÉS 0,0 kizárása)
+     * előtt a 0,0-templom itt megjelent; utána nem.
      */
     public function testApiNearbyExcludesZeroCoordinates(): void {
+        // A Guineai-öböl közelébe kérdezünk, ahol a 0,0-koordinátájú rekord lenne
+        // a legközelebbi találat, ha nem szűrnénk ki.
         $response = $this->apiRequest('/api/v4/nearby', [
-            'lat' => 47.497913,
-            'lon' => 19.040236,
-            'limit' => 20,
+            'lat' => 1.0,
+            'lon' => 1.0,
+            'limit' => 10,
         ]);
 
         $this->assertArrayHasKey('templomok', $response);
         $this->assertIsArray($response['templomok']);
 
-        // 3000 km méteres küszöb: Magyarország legtávolabbi temploma is jóval
-        // ezalatt van, így bármi efölött a 0,0-bug szellem-találata lenne.
-        $absurdDistanceMeters = 3_000_000;
         foreach ($response['templomok'] as $templom) {
-            $this->assertArrayHasKey('tavolsag', $templom);
-            $this->assertLessThan(
-                $absurdDistanceMeters,
-                $templom['tavolsag'],
-                "#94 regresszió: '{$templom['nev']}' (id={$templom['id']}) abszurd távolságra "
-                . "({$templom['tavolsag']} m) — valószínűleg 0,0 koordinátán ül."
+            $lat = isset($templom['lat']) ? (float) $templom['lat'] : null;
+            $lon = isset($templom['lon']) ? (float) $templom['lon'] : null;
+            $this->assertFalse(
+                $lat === 0.0 && $lon === 0.0,
+                "#94 regresszió: 0,0 koordinátájú templom megjelent a nearby-ben: "
+                . "'{$templom['nev']}' (id={$templom['id']})."
             );
         }
+    }
+
+    /**
+     * #94 (a tényleges hiba): a kliens GPS-fix nélkül (0,0)-t küld. Korábban erre
+     * a nearby `error:0`-val ~5000+ km-es magyar templomokat adott vissza, mintha
+     * érvényes találat lenne (ez volt a 2018-as „5000km+" bejelentés). A javítás
+     * után a (0,0) user-input hibát ad, nem szemét listát.
+     */
+    public function testApiNearbyRejectsZeroUserLocation(): void {
+        $response = $this->apiRequest('/api/v4/nearby', [
+            'lat' => 0.0,
+            'lon' => 0.0,
+            'limit' => 5,
+        ]);
+
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals(1, $response['error'], '#94: a (0,0) user-helyzetre hibát kell adni.');
+        $this->assertEmpty(
+            $response['templomok'] ?? [],
+            '#94: a (0,0) user-helyzetre nem szabad templomokat (5000 km-es szemét) visszaadni.'
+        );
     }
 
 }

--- a/webapp/tests/Api/ApiEndpointsTest.php
+++ b/webapp/tests/Api/ApiEndpointsTest.php
@@ -423,5 +423,35 @@ class ApiEndpointsTest extends TestCase {
         ];
     }
 
+    /**
+     * #94: a koordináta nélküli templomok (templomok.lat/lon DEFAULT 0.0/0.0,
+     * a Guineai-öböl) NEM jelenhetnek meg a nearby-keresésben — korábban ezeket
+     * a usertől ~5000+ km-re írta ki, mert csak az üres stringet szűrtük, a 0.0-t
+     * nem. Egy budapesti koordinátára indított keresés egyetlen találatának sem
+     * lehet abszurd (3000 km feletti) távolsága.
+     */
+    public function testApiNearbyExcludesZeroCoordinates(): void {
+        $response = $this->apiRequest('/api/v4/nearby', [
+            'lat' => 47.497913,
+            'lon' => 19.040236,
+            'limit' => 20,
+        ]);
+
+        $this->assertArrayHasKey('templomok', $response);
+        $this->assertIsArray($response['templomok']);
+
+        // 3000 km méteres küszöb: Magyarország legtávolabbi temploma is jóval
+        // ezalatt van, így bármi efölött a 0,0-bug szellem-találata lenne.
+        $absurdDistanceMeters = 3_000_000;
+        foreach ($response['templomok'] as $templom) {
+            $this->assertArrayHasKey('tavolsag', $templom);
+            $this->assertLessThan(
+                $absurdDistanceMeters,
+                $templom['tavolsag'],
+                "#94 regresszió: '{$templom['nev']}' (id={$templom['id']}) abszurd távolságra "
+                . "({$templom['tavolsag']} m) — valószínűleg 0,0 koordinátán ül."
+            );
+        }
+    }
 
 }


### PR DESCRIPTION
Closes #94

A 2018-as bejelentés: a komáromi Kistemplomot az Android app 5000+ km-re írta ki, a `0.0, 0.0` koordinátához mérve.

## A tényleges gyökér-ok (docker-stacken kivizsgálva)

Először azt hittem, hogy a 0,0 **koordinátájú templomok** nincsenek kiszűrve a nearby-ből. A docker-stacken lefuttatva kiderült: **ez nem így van.** A `templomok.lat` `decimal(11,7)`, és a meglévő `WHERE lat <> ''` szűrő a MariaDB DECIMAL-coercion révén (`''` → `0`) valójában `lat <> 0`-ként fut → a 0,0 templomokat **már most kizárja**. (Ellenőrizve: a seedben 1 db 0,0 templom van, és nem jelenik meg a nearby-ben.)

A valódi hiba a **kliens oldali (0,0) input**: ha az Android appban nincs GPS-fix, a kliens `lat=0, lon=0`-t küld. Erre a nearby `error:0`-val az összes magyar templomot ~5000+ km-re adta vissza, mintha érvényes találat lenne — pontosan a bejelentett „5000km+" tünet. (Reprodukálva: `{"lat":0,"lon":0}` → error:0 + 5335 km, 5377 km…)

## A fix

`webapp/classes/api/nearby.php`:

1. **Elsődleges:** a (0,0) user-input elutasítása. A 0,0 a Guineai-öbölben van, ott nincs misézőhely → „nincs érvényes helyzet", `error:1` + üres lista a szemét 5000 km-es lista helyett.
2. **Másodlagos, defenzív:** explicit `whereRaw('NOT (lat = 0 AND lon = 0)')`. A 0,0 templomokat a `lat <> ''` coercion már kizárja, de ez törékeny/rejtett — explicit guarddal robusztus, ha a szűrő valaha változik.

## Tesztelés — docker-stacken lefuttatva (nem csak php -l)

`webapp/tests/Api/ApiEndpointsTest.php`, 2 integrációs teszt a valódi seedelt DB ellen:

- `testApiNearbyRejectsZeroUserLocation` — (0,0) user-input → `error:1` + üres lista.
  **Bizonyíték:** a master (fix nélküli) kódon ELHASAL (`error:0`, 5335 km), a fix-szel ZÖLD.
- `testApiNearbyExcludesZeroCoordinates` — a 0,0 közelébe kérdezve nem jön vissza 0,0-koordinátájú templom (defenzív guard).

Futtatás (a CI receptje szerint):
```
docker compose -f docker/compose.yml -f docker/compose.test.yml up -d
docker compose ... exec -T miserend vendor/bin/phpunit -c tests/phpunit.xml --filter testApiNearby
```
Eredmény fix-szel: `Tests: 2, OK`. Master kódon: `Failures: 1` (a reject-teszt).

## Megjegyzés

A kliens (Android app) oldalán is érdemes lehet a GPS-fix bevárása mielőtt nearby-t hív — de az másik repó. Ez a PR a szerver-oldalt teszi védetté: rossz input → értelmes hiba, nem szemét.
