### PR TITLE
észrevétel form: tipp a naptár-szerkesztőre miserend-változásnál #314

### DIFF
--- a/webapp/templates/remark_form.twig
+++ b/webapp/templates/remark_form.twig
@@ -10,10 +10,9 @@
        a free-text észrevételnél. #}
     <div class="alert alert-info" role="alert" style="margin-bottom:1em">
         <strong>Tipp:</strong> ha a <em>miserend</em> változott (új mise, módosított időpont, kimaradt alkalom),
-        akkor a <a href="/templom/{{ church.id }}/editschedule"><strong>naptár-szerkesztő</strong></a>
-        pontosabb és gyorsabb mint a szöveges észrevétel.
-        Ott a változtatás után „Beküldés"-re kattintva ugyanúgy javaslatként megy a karbantartóknak.
-        <br/><small>(Bejelentkezés szükséges. Ha nincs hozzáférésed, lent az észrevétel-formot használd nyugodtan.)</small>
+        a templom oldalán található naptárban is tudsz közvetlenül módosítani! Csak kattints rá egy misére,
+        vagy egy üres helyre a heti/hónapos nézetben, és máris szerkesztheted. Ha kész vagy,
+        az egészet beküldheted javaslatcsomagként a karbantartóknak – és nem kell sem bejelentkezésed sem a szöveges forma.
     </div>
 
     <form method=post action="/remark/add/{{ church.id }}">

--- a/webapp/templates/remark_form.twig
+++ b/webapp/templates/remark_form.twig
@@ -4,7 +4,18 @@
 {% set pageDescription = "Javítások, változások bejelentése a templom adataival, miserenddel, kapcsolódó információkkal (szentségimádás, rózsafüzér, hittan, stb.) kapcsolatban." %}
 
  {% block content %}
-<div>  
+<div>
+    {# #314: ha kifejezetten a miserend (időpontok / új mise / módosítás) miatt
+       jött a felhasználó, a naptár-szerkesztő közvetlenebb és pontosabb csatorna
+       a free-text észrevételnél. #}
+    <div class="alert alert-info" role="alert" style="margin-bottom:1em">
+        <strong>Tipp:</strong> ha a <em>miserend</em> változott (új mise, módosított időpont, kimaradt alkalom),
+        akkor a <a href="/templom/{{ church.id }}/editschedule"><strong>naptár-szerkesztő</strong></a>
+        pontosabb és gyorsabb mint a szöveges észrevétel.
+        Ott a változtatás után „Beküldés"-re kattintva ugyanúgy javaslatként megy a karbantartóknak.
+        <br/><small>(Bejelentkezés szükséges. Ha nincs hozzáférésed, lent az észrevétel-formot használd nyugodtan.)</small>
+    </div>
+
     <form method=post action="/remark/add/{{ church.id }}">
         <input type=hidden name=tid value='{{ church.id }}'>
         {% if not user.loggedin %}


### PR DESCRIPTION
Closes #314

A `remark_form.twig` (észrevétel beküldő űrlap) tetejére egy `alert-info` doboz került, ami a felhasználó figyelmét a **naptár-szerkesztőre** tereli, ha a jelzendő dolog ténylegesen miserend-változás (új mise, módosított időpont, kimaradt alkalom).

## A logika

A szöveges észrevétel sok esetben olyan információ, amit a karbantartónak utána manuálisan át kell vinnie a naptár-szerkesztőbe. Közvetlenebb ha a felhasználó eleve a `/templom/{id}/editschedule`-on dolgozik, és onnan küldi javaslatként — pontosabb, gyorsabb, és a karbantartó egy kattintással elfogadhatja.

A tipp tartalmaz egy `<small>` figyelmeztetést is, hogy bejelentkezés kell — ha nincs hozzáférése, a lent lévő szöveges form marad az út.

## Ami nem fért bele

- **Nagyobb „naptár módosítása" gomb** a `_panelaskingremark`-on (a kérés másik fele): ez UI/design-döntés, és nehéz volt visszafogottan csinálni anélkül, hogy belerondítsak az oldal layout-jába. Külön issue / PR-ben megnézem ha jónak látod.
