### PR TITLE
naptár: havi n. napja recurrence napjának visszatöltése szerkesztéskor #453

### DIFF
--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
@@ -246,3 +246,69 @@ describe('AddFullEventDialogComponent (#450 egyszeri alkalom nem kap időszakot)
     expect(component.periodCtr.value).toBeNull();
   });
 });
+
+describe('AddFullEventDialogComponent (#453 havi-n.-napja nap visszatöltése)', () => {
+  let component: AddFullEventDialogComponent;
+  let fixture: ComponentFixture<AddFullEventDialogComponent>;
+
+  // #453: létező mise szerkesztéskor a selectedDays a mentett byweekday TÖMBJÉBŐL
+  // jön. A teszt-data ezt szimulálja egy adott renum + selectedDays párral.
+  function dataWith(renum: Renum, selectedDays: any) {
+    return {
+      title: 'EDIT_MASS',
+      existingPeriodIds: [],
+      event: {
+        period: null,
+        rite: Rite.ROMAN_CATHOLIC,
+        types: [],
+        title: 'Szentmise',
+        start: new Date('2026-03-15T10:00:00'),
+        duration: {hours: 1},
+        language: LanguageCode.HU,
+        renum,
+        selectedDays,
+        comment: '',
+        editOne: false,
+      },
+    };
+  }
+
+  async function setup(data: any) {
+    const periodServiceMock = {
+      getSelectableGeneratedPeriodsByDate: jasmine.createSpy().and.returnValue(of([])),
+      getPeriodById: jasmine.createSpy().and.returnValue(null),
+      getSpecialPeriodType: jasmine.createSpy().and.returnValue(null),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AddFullEventDialogComponent, TranslateModule.forRoot()],
+      providers: [
+        {provide: MAT_DIALOG_DATA, useValue: data},
+        {provide: MatDialogRef, useValue: {close: jasmine.createSpy()}},
+        {provide: PeriodService, useValue: periodServiceMock},
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddFullEventDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  // #453: havi n. napja (FOURTH_WEEK) — a byweekday tömbből (['MO']) a single-day
+  // mat-select EGYETLEN 'MO'-ra normalizálódik, így a mező nem marad üresen.
+  it('normalizes selectedDays from array to single value for a monthly nth-weekday recurrence', async () => {
+    await setup(dataWith(Renum.FOURTH_WEEK, [Day.MO]));
+
+    expect(Array.isArray(component.selectedDays)).toBeFalse();
+    expect(component.selectedDays).toBe(Day.MO);
+  });
+
+  // #453 regresszió-védelem: heti (több napos) misénél a tömb ÉRINTETLEN marad
+  // — a normalizálás nem dobhat el napokat.
+  it('keeps the array intact for a weekly multi-day recurrence', async () => {
+    await setup(dataWith(Renum.EVERY_WEEK, [Day.MO, Day.WE]));
+
+    expect(Array.isArray(component.selectedDays)).toBeTrue();
+    expect(component.selectedDays).toEqual([Day.MO, Day.WE]);
+  });
+});

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -103,6 +103,16 @@ export class AddFullEventDialogComponent {
     readonly translateService: TranslateService,
     readonly cdr: ChangeDetectorRef,
   ) {
+    // #453: létező mise szerkesztésekor a selectedDays a mentett rrule.byweekday
+    // TÖMBJÉBŐL jön (pl. ['MO']). A havi-n.-napja (FIRST_WEEK..FIFTH_WEEK,
+    // LAST_DAY_OF_MONTH) és minden single-day renum template-je viszont EGYETLEN
+    // Day-t vár (mat-select multiple nélkül) — egy tömb ott nem talál egyezést,
+    // ezért üresen maradt az „Ezen a napon" mező újranyitáskor. Init-kor a
+    // betöltött renum multiDays-e szerint normalizáljuk: single-day esetén
+    // tömb→első elem; multi-day esetén a tömböt érintetlenül hagyjuk (nem
+    // veszítünk napokat, mint az onRenumChange transition-logikája tenné).
+    this.normalizeSelectedDaysForLoadedRenum();
+
     const hasPeriodId = !!(this.data.event.period && (this.data.event.period as any).periodId);
 
     // A választható időszakokat furcsa sorrendben jelenítjük meg direkt.
@@ -235,6 +245,29 @@ export class AddFullEventDialogComponent {
 
   onNoClick(): void {
     this.dialogRef.close();
+  }
+
+  /**
+   * #453: a betöltött renum multiDays-e szerint hozza összhangba a selectedDays
+   * alakját (tömb vs. egyetlen Day), ADATVESZTÉS NÉLKÜL. Az onRenumChange a
+   * felhasználói VÁLTÁSKOR szándékosan egyetlen napra redukál — ez init-kor
+   * hibás lenne (egy meglévő heti több-napos misénél eldobná a napokat), ezért
+   * külön, óvatos normalizáló az induló állapothoz.
+   */
+  private normalizeSelectedDaysForLoadedRenum(): void {
+    const renum = this.data.event.renum;
+    if (ScriptUtil.isNull(renum) || ScriptUtil.isNull(recurrences[renum])) {
+      return;
+    }
+    const multiDays = recurrences[renum].multiDays;
+
+    if (!multiDays && Array.isArray(this.selectedDays)) {
+      // single-day renum (pl. havi n. napja): tömb → első elem (vagy üres).
+      this.selectedDays = this.selectedDays.length > 0 ? this.selectedDays[0] : [];
+    } else if (multiDays && !Array.isArray(this.selectedDays) && ScriptUtil.isNotNull(this.selectedDays)) {
+      // multi-day renum, de egyetlen érték jött: csomagoljuk tömbbe.
+      this.selectedDays = [this.selectedDays];
+    }
   }
 
   onRenumChange() {


### PR DESCRIPTION
Closes #453

A bejelentés: ha „Hónap n. megadott napján" ismétlődő eseményt készítünk, az „Ezen a napon" (hét napja) értéket jól menti el, de **újranyitáskor a mező üresen marad**, és újra ki kell választani.

## Gyökér-ok

A `selectedDays` mező init-kor a mentett `rrule.byweekday`-ből jön (`MassUtil.massToDialogEvent`), ami **tömb** (pl. `['MO']`).

A dialógus template a recurrence típusától függően kétféle nap-választót rajzol:
- `recurrences[renum].multiDays === true` (heti) → `mat-select multiple`, tömböt vár
- `multiDays === false` (havi n. napja, hó utolsó napja) → **egyetlen** `mat-select`, EGYETLEN Day-t vár

Egy single-day recurrence-nél a `['MO']` tömb nem talál egyezést az egy-értékes mat-select-ben → üres mező.

Az `onRenumChange()` normalizálja a tömb↔egyérték alakot, de az **csak felhasználói renum-váltáskor** fut — init-kor (létező mise betöltésekor) nem.

## A fix

`add-full-event-dialog.component.ts` — init-kor (konstruktorban) egy óvatos normalizáló fut a betöltött renum `multiDays`-e szerint:
- single-day renum + tömb → első elem (`['MO']` → `'MO'`)
- multi-day renum + egyetlen érték → tömbbe csomagolva

**Fontos:** ez NEM az `onRenumChange` transition-logikáját hívja, mert az egy meglévő **heti, több-napos** misénél eldobná a napokat (csak az elsőt tartaná meg). A normalizáló a multi-day tömböt érintetlenül hagyja — nincs adatvesztés.

## Tesztelés

`add-full-event-dialog.component.spec.ts`, 2 unit-teszt:
- havi n. napja (`FOURTH_WEEK`) + `['MO']` → `selectedDays === 'MO'` (egyérték, nem tömb)
- heti (`EVERY_WEEK`) + `['MO','WE']` → a tömb érintetlen marad (regresszió-védelem)

**Bizonyíték:** a fix nélküli komponensen a havi-teszt elhasal (`Expected ['MO'] to be 'MO'`), a fix-szel mindkettő zöld. Teljes dialógus-suite: 13/13.
