### PR TITLE
naptár: szerkesztéskor ne találgasson dátum-alapú időszakot #458

### DIFF
--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.spec.ts
@@ -312,3 +312,72 @@ describe('AddFullEventDialogComponent (#453 havi-n.-napja nap visszatöltése)',
     expect(component.selectedDays).toEqual([Day.MO, Day.WE]);
   });
 });
+
+describe('AddFullEventDialogComponent (#458 szerkesztéskor nincs dátum-alapú default időszak)', () => {
+  let component: AddFullEventDialogComponent;
+  let fixture: ComponentFixture<AddFullEventDialogComponent>;
+
+  function editData(title: string) {
+    return {
+      title,
+      existingPeriodIds: [],
+      event: {
+        period: null,                 // a hívó nem oldotta fel (generatedPeriods$-ban épp nincs)
+        rite: Rite.ROMAN_CATHOLIC,
+        types: [],
+        title: 'Szentmise',
+        start: new Date('2026-01-01T08:00:00'),
+        duration: {hours: 1},
+        language: LanguageCode.HU,
+        renum: Renum.EVERY_WEEK,       // ismétlődő → NEM singleEvent
+        selectedDays: [Day.TU, Day.TH],
+        comment: '',
+        editOne: false,
+      },
+    };
+  }
+
+  async function setup(periods: GeneratedPeriod[], data: any) {
+    const periodServiceMock = {
+      getSelectableGeneratedPeriodsByDate: jasmine.createSpy().and.returnValue(of(periods)),
+      getPeriodById: jasmine.createSpy().and.returnValue(null),
+      getSpecialPeriodType: jasmine.createSpy().and.returnValue(null),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AddFullEventDialogComponent, TranslateModule.forRoot()],
+      providers: [
+        {provide: MAT_DIALOG_DATA, useValue: data},
+        {provide: MatDialogRef, useValue: {close: jasmine.createSpy()}},
+        {provide: PeriodService, useValue: periodServiceMock},
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddFullEventDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  // #458: létező mise szerkesztésekor (EDIT_MASS) NEM szabad dátum-alapú default
+  // időszakot találgatni, ha a period nincs feloldva — különben pl. a „Téli idő"
+  // jelenik meg egy egész-éves mise helyett.
+  it('does NOT auto-pick a date-based period when editing an existing mass (EDIT_MASS)', async () => {
+    const teli = makeGeneratedPeriod({id: 7, periodId: 7, name: 'Téli időszak', weight: 5});
+    const evesEv = makeGeneratedPeriod({id: 10, periodId: 10, name: 'Egész évben', weight: 1});
+
+    await setup([teli, evesEv], editData('EDIT_MASS'));
+
+    expect(component.periodCtr.value).toBeNull();
+    expect(component.data.event.period).toBeFalsy();
+  });
+
+  // Kontroll: ÚJ mise létrehozásakor (ADD_NEW_MASS) az auto-default továbbra is fut
+  // — a #458 fix nem rontja el a #308 viselkedést.
+  it('still auto-picks a default period when creating a NEW mass (ADD_NEW_MASS)', async () => {
+    const teli = makeGeneratedPeriod({id: 7, periodId: 7, name: 'Téli időszak', weight: 5});
+
+    await setup([teli], editData('ADD_NEW_MASS'));
+
+    expect(component.periodCtr.value).toEqual(teli);
+  });
+});

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -132,7 +132,16 @@ export class AddFullEventDialogComponent {
       // Ha nincs egyezés (új templom, vagy soha nem volt mise ilyen időszakra),
       // marad a régi viselkedés: [0]. elem.
       // Do NOT set default period for single events
-      if (!this.data.event.period && !this.singleEvent && generatedPeriods.length > 0) {
+      //
+      // #458: az auto-default CSAK ÚJ mise létrehozásakor fusson. Létező mise
+      // szerkesztésekor (EDIT_MASS) a periódust a hívó (church-calendar) a mise
+      // tárolt periodId-jából állítja be; ha az valamiért nem oldódik fel
+      // (a generatedPeriods$-ban épp nincs meg a megfelelő évi példány), AKKOR
+      // SEM szabad dátum-alapú defaultot (pl. „Téli időszak") találgatni egy
+      // létező misére — inkább maradjon üres, hogy a hiba látszódjon, ne pedig
+      // hibás időszakot mentsünk. (Ez ugyanaz a hibafajta mint a #450.)
+      const isEditingExisting = this.data.title === 'EDIT_MASS';
+      if (!this.data.event.period && !this.singleEvent && !isEditingExisting && generatedPeriods.length > 0) {
         const existingPeriodIds = new Set(this.data.existingPeriodIds ?? []);
         const matched = existingPeriodIds.size > 0
           ? generatedPeriods.find(p => existingPeriodIds.has(p.periodId))

--- a/calendar/src/app/services/period.service.spec.ts
+++ b/calendar/src/app/services/period.service.spec.ts
@@ -1,0 +1,83 @@
+import {TestBed} from '@angular/core/testing';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+
+import {PeriodService} from './period.service';
+import {MatSnackBarService} from './mat-snack-bar.service';
+import {GeneratedPeriod} from '../model/generated-period';
+
+function gp(overrides: Partial<GeneratedPeriod> = {}): GeneratedPeriod {
+  return {
+    id: 1,
+    periodId: 10,
+    name: 'Egész évben',
+    weight: 1,
+    startDate: '2026-01-01',
+    endDate: '2027-01-01',
+    color: '#ccc',
+    ...overrides,
+  };
+}
+
+describe('PeriodService.getCurrentGeneratedPeriodByPeriodId (#458)', () => {
+  let service: PeriodService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        PeriodService,
+        {provide: MatSnackBarService, useValue: {error: jasmine.createSpy(), success: jasmine.createSpy()}},
+      ],
+    });
+    service = TestBed.inject(PeriodService);
+  });
+
+  it('returns the date-matching generated period when one exists', () => {
+    const p2026 = gp({id: 1, periodId: 10, startDate: '2026-01-01', endDate: '2027-01-01'});
+    service.generatedPeriods$.next([p2026]);
+
+    const result = service.getCurrentGeneratedPeriodByPeriodId(10, new Date('2026-06-15'));
+
+    expect(result).toBe(p2026);
+  });
+
+  // #458: ha az adott dátumra NINCS találat (a periodId megfelelő évi példánya
+  // nincs betöltve), létező mise szerkesztésekor a periodId-hoz tartozó periódust
+  // kell visszaadni — NEM null-t (különben a dialógus rossz időszakot defaultol
+  // vagy a mentés blokkolódik).
+  it('falls back to a same-periodId instance when no instance matches the date', () => {
+    const p2026 = gp({id: 1, periodId: 10, startDate: '2026-01-01', endDate: '2027-01-01'});
+    service.generatedPeriods$.next([p2026]);
+
+    // 2030 — semmilyen betöltött példány nem fedi, de a periodId létezik.
+    const result = service.getCurrentGeneratedPeriodByPeriodId(10, new Date('2030-03-01'));
+
+    expect(result).not.toBeNull();
+    expect(result!.periodId).toBe(10);
+  });
+
+  it('picks the closest-start instance among multiple same-periodId fallbacks', () => {
+    const p2025 = gp({id: 1, periodId: 10, startDate: '2025-01-01', endDate: '2026-01-01'});
+    const p2027 = gp({id: 3, periodId: 10, startDate: '2027-01-01', endDate: '2028-01-01'});
+    service.generatedPeriods$.next([p2025, p2027]);
+
+    // 2026-12 — egyik tartomány sem fedi (2025 vége 2026-01-01, 2027 kezdete 2027-01-01),
+    // a legközelebbi kezdetű a 2027-es.
+    const result = service.getCurrentGeneratedPeriodByPeriodId(10, new Date('2026-12-15'));
+
+    expect(result).toBe(p2027);
+  });
+
+  it('returns null when the periodId is not present at all', () => {
+    service.generatedPeriods$.next([gp({periodId: 10})]);
+
+    const result = service.getCurrentGeneratedPeriodByPeriodId(99, new Date('2026-06-15'));
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for null inputs', () => {
+    expect(service.getCurrentGeneratedPeriodByPeriodId(null, new Date())).toBeNull();
+    expect(service.getCurrentGeneratedPeriodByPeriodId(10, null as any)).toBeNull();
+  });
+});

--- a/calendar/src/app/services/period.service.ts
+++ b/calendar/src/app/services/period.service.ts
@@ -167,19 +167,40 @@ export class PeriodService {
     const normalizeDate = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
     const targetDate = normalizeDate(localDate);
 
-    const generatedPeriods = this.generatedPeriods$
-      .getValue()
-      .filter(p => {
-        const start = normalizeDate(new Date(p.startDate));
-        const end = normalizeDate(new Date(p.endDate));
-        return (
-          p.periodId === periodId &&
-          start <= targetDate &&
-          end >= targetDate //Egy napos eseményeknél ha csak sima ">" akkor nem talál semmit
-        );
-      });
+    const all = this.generatedPeriods$.getValue();
 
-    return generatedPeriods.length > 0 ? generatedPeriods[0] : null;
+    const generatedPeriods = all.filter(p => {
+      const start = normalizeDate(new Date(p.startDate));
+      const end = normalizeDate(new Date(p.endDate));
+      return (
+        p.periodId === periodId &&
+        start <= targetDate &&
+        end >= targetDate //Egy napos eseményeknél ha csak sima ">" akkor nem talál semmit
+      );
+    });
+
+    if (generatedPeriods.length > 0) {
+      return generatedPeriods[0];
+    }
+
+    // #458: ha az adott DÁTUMRA nincs találat (pl. a generatedPeriods$-ban épp nincs
+    // betöltve a periodId megfelelő évi példánya), létező mise szerkesztésekor akkor
+    // is a mise VALÓDI periódusát kell visszaadni — nem null-t. A null ugyanis a
+    // dialógusban vagy hibás dátum-alapú defaulthoz (Téli időszak), vagy blokkolt
+    // mentéshez vezetett. A mentés a periodId-t tárolja, így bármelyik azonos
+    // periodId-jú példány helyes; a legközelebbi kezdetűt választjuk a targetDate-hez.
+    const samePeriodId = all.filter(p => p.periodId === periodId);
+    if (samePeriodId.length > 0) {
+      return samePeriodId
+        .slice()
+        .sort((a, b) => {
+          const da = Math.abs(normalizeDate(new Date(a.startDate)).getTime() - targetDate.getTime());
+          const db = Math.abs(normalizeDate(new Date(b.startDate)).getTime() - targetDate.getTime());
+          return da - db;
+        })[0];
+    }
+
+    return null;
   }
 
   public saveData(periodYears: PeriodYear[]): Observable<any> {


### PR DESCRIPTION
Closes #458

A bejelentés (church 2747): az API a helyes mise-adatokat adja, de egy kedd-csütörtöki mise „összes elemének" szerkesztésekor az időszaknál „Téli időszak" jelenik meg, holott a mise valódi periódusa más (pl. „Egész évben"). Mentésnél a viselkedés bizonytalan volt.

## Gyökér-ok (docker-stacken kivizsgálva)

Két, egymást erősítő hiba az `add-full-event-dialog` periódus-kezelésében:

1. **A periódus-feloldás néha null.** A `PeriodService.getCurrentGeneratedPeriodByPeriodId(periodId, date)` csak akkor adott vissza periódust, ha a `generatedPeriods$`-ban volt a `periodId`-hoz egy a DÁTUMOT lefedő generált példány. Ha épp nem volt betöltve a megfelelő évi példány, `null`-t adott.

2. **A #308 auto-default beugrott szerkesztéskor.** Ha a period null lett, a dialógus a #308 logikával dátum-alapú alapértelmezést választott. Fontos részlet: a `matched` keresés a `getSelectableGeneratedPeriodsByDate` SZŰRT listáján fut (selectable + adott évre szűrve), NEM közvetlenül az `existingPeriodIds`-en. Ezért hiába tartalmazza a templom létező miséi közt a mise saját periódusát, ha az kiesik a szűrt listából (rossz év a régi startDate miatt), a `matched` nem talál → `generatedPeriods[0]` = a legnagyobb súlyú, dátum-illeszkedő = „Téli időszak".

**Mentéskor** (`onSave`): a rosszul beállított „Téli" period átment a validáción → `dialogRef.close(SAVE)` → a mise periódusa **felülíródott** volna „Téli"-re (adat-korrupció). Ha viszont a period null maradt, a mentés `required` hibával **blokkolódott**. Egyik sem jó.

**Miért nem reprodukálható minden misén:** ha a mise `startDate`-je beleesik a periódus aktuálisan generált ablakába (pl. egy idei mise), a feloldás sikerül és nincs hiba. A bug a régi/horgony `startDate`-ű (vagy év-/periódus-határon lévő) miséknél jön elő, ahol a dátum-ablak nem fed.

## A fix (2 réteg)

### 1. `PeriodService.getCurrentGeneratedPeriodByPeriodId` — robusztus feloldás
Ha a dátumra nincs találat, visszaesik a `periodId`-hoz tartozó legközelebbi kezdetű generált példányra (nem null). A mentés a `periodId`-t tárolja, így bármelyik azonos `periodId`-jú példány helyes. → szerkesztéskor a mise VALÓDI időszaka jelenik meg, és a mentés azt is őrzi meg.

### 2. Dialógus auto-default gate (#458)
A #308 auto-default CSAK új misénél (`ADD_NEW_MASS` / `COPY_NEW_MASS`) fut, `EDIT_MASS`-nál nem. Biztonsági háló: ha a period valamiért mégsem oldódik fel, akkor sem találunk ki dátum-alapú időszakot egy létező misére — inkább üres marad (a mentés `required`-del jelez), semmint hibás periódust mentsünk. (Ugyanaz a hibafajta mint a #450.)

## Tesztelés (docker-stacken + unit)

- **Docker-stack** (church 2747, period_id=10 „Egész évben"): a save-út kivizsgálva — fix nélkül a „Téli" átmenne a mentésen (korrupció).
- **Dialógus unit-tesztek**: EDIT_MASS + feloldatlan period → NEM választ „Téli"-t (null marad); ADD_NEW_MASS → az auto-default továbbra is fut. Fix nélkül bizonyítottan elhasal (a Téli-t választja).
- **PeriodService unit-tesztek** (új `period.service.spec.ts`, 5 teszt): dátum-egyezés; dátum-nélküli fallback a periodId-ra; legközelebbi-kezdet választás; ismeretlen periodId → null; null input.
- Teljes Angular suite: 29 SUCCESS.
