### PR TITLE
kereső: 0 mise-találatnál a szűkítő szűrők kiiktatása + felirat #357

### DIFF
--- a/webapp/classes/html/searchresultsmasses.php
+++ b/webapp/classes/html/searchresultsmasses.php
@@ -16,7 +16,6 @@ class SearchResultsMasses extends Html {
         parent::__construct();
         global $user, $config;
 
-        $search = new \Search('masses');
         //Data for pagination
         $params = [
             'q' => 'SearchResultsMasses',
@@ -38,211 +37,221 @@ class SearchResultsMasses extends Html {
             'timezone' => \Request::Text('timezone')
         ];
 
-        if($params['timezone']) $search->timezone =  $params['timezone'];
-
-        // Boundaries' based search
-        if (!empty($params['boundaries'])) {
-            $search->boundaries($params['boundaries']);
-            $this->boundaryDataJson = json_encode(\Eloquent\Boundary::whereIn('id', $params['boundaries'])->get()->map->toSimpleArray());
-        }
-        
-        // egyhazmegye filter
-        if ($params['ehm'] > 0) {
-            $ehmnev = DB::table('egyhazmegye')->where('id',$params['ehm'])->pluck('nev')[0];
-            $search->addMust(["wildcard" => ['church.egyhazmegye.keyword' => $ehmnev ]]);
-            $search->filters[] = "Egyházmegye: <b>" . htmlspecialchars($ehmnev) ." egyházmegye</b>";
-        }
-
-        // nyelvek filter
-        if($params['lang']) {
-            $langsShould = isset($params['lang']['should']) ? array_filter(array_map('trim', explode(',', $params['lang']['should']))) : [];
-            $langsMustNot = isset($params['lang']['must_not']) ? array_filter(array_map('trim', explode(',', $params['lang']['must_not']))) : [];
-
-            if (!empty($langsShould)) {
-                $search->languages($langsShould);                                              
-            }
-
-            if (!empty($langsMustNot)) {
-                $search->addMustNot([ 'terms' => ['church.nyelvek.keyword' => $langsMustNot] ]);
-                $translated = array_map(function($l){ return t('LANGUAGES.'.$l); }, $langsMustNot);
-                $search->filters[] = "A liturgia nyelve ne legyen <b>" . implode('</b> se <b>', $translated) . "</b>";                              
-            }
-        }
-        
-        // Main keyword search
-        if ($params['kulcsszo']) {
-            $search->keyword($params['kulcsszo']);
-        }
-    
         // Time range search
         $start_date = (isset($params['start_date']) AND $params['start_date'] != '') ? $params['start_date'] : date('Y-m-d');
         $start_time = (isset($params['start_time']) AND $params['start_time'] != '') ? $params['start_time'] : '00:00';
         $end_date = (isset($params['end_date']) AND $params['end_date'] != '') ? $params['end_date'] : date('Y-m-d', strtotime('+1 week'));
         $end_time = (isset($params['end_time']) AND $params['end_time'] != '') ? $params['end_time'] : '23:59';
-        
+
         $from = $start_date."T".$start_time.":00";
         $until = $end_date."T".$end_time.":00";
 
-        $search->timeRange($from, $until);
         $api = new \ExternalApi\NapilelkibatyuApi();
         $this->liturgicalDays = $api->getLiturgicalDaysInRange($from, $until);
-                                 
-        // Process advanced rites/types filters (if provided)
-         $typesReq = isset($params['types']) ? $params['types'] : [];
-         $ritesReq = isset($params['rites']) ? $params['rites'] : [];
-         $categoriesReq = isset($params['categories']) ? $params['categories'] : '';
-             
-         if (!empty($typesReq) || !empty($ritesReq)) {
-            // 1) Handle rites.must_not - exclude these rites entirely
-            if (!empty($ritesReq['must_not'])) {
-                $mustNotRites = array_filter(array_map('trim', explode(',', $ritesReq['must_not'])));
-                foreach ($mustNotRites as $r) {
-                    if ($r === '') continue;
-                    $search->filters[] = "A rítus nem lehet: <i>" . htmlspecialchars(t($r)) . "</i>";
-                    // add to query must_not
-                    $search->query['bool']['must_not'][] = [ 'term' => ['rite.keyword' => $r] ];
-                }   
+
+        $typesReq = isset($params['types']) ? $params['types'] : [];
+        $ritesReq = isset($params['rites']) ? $params['rites'] : [];
+        $categoriesReq = isset($params['categories']) ? $params['categories'] : '';
+
+        // #357: a típus/rítus/kategória szűrők a „szűkítő" filterek — ezeket iktatjuk ki,
+        // ha 0 találat van, hogy legalább valamit visszaadjunk.
+        $hasNarrowingFilters = !empty($typesReq) || !empty($ritesReq) || !empty($categoriesReq);
+
+        // ---- BASE szűrők (mindig megmaradnak): hely, egyházmegye, nyelv, kulcsszó, időtartam ----
+        $applyBaseFilters = function (\Search $search) use ($params, $from, $until) {
+            if ($params['timezone']) $search->timezone = $params['timezone'];
+
+            // Boundaries' based search
+            if (!empty($params['boundaries'])) {
+                $search->boundaries($params['boundaries']);
+                $this->boundaryDataJson = json_encode(\Eloquent\Boundary::whereIn('id', $params['boundaries'])->get()->map->toSimpleArray());
             }
 
-            // 2) Handle rites.should - at least one of these rite+type combinations must match
-            if (!empty($ritesReq['should'])) {
-                $shouldRites = array_filter(array_map('trim', explode(',', $ritesReq['should'])));
-                $shouldClauses = [];
+            // egyhazmegye filter
+            if ($params['ehm'] > 0) {
+                $ehmnev = DB::table('egyhazmegye')->where('id',$params['ehm'])->pluck('nev')[0];
+                $search->addMust(["wildcard" => ['church.egyhazmegye.keyword' => $ehmnev ]]);
+                $search->filters[] = "Egyházmegye: <b>" . htmlspecialchars($ehmnev) ." egyházmegye</b>";
+            }
 
-                // Add a human-readable filter listing allowed rites (translated)
-                if (!empty($shouldRites)) {
-                    $translated = array_map(function($r){ return t($r); }, $shouldRites);
-                    $search->filters[] = 'A rítus lehet <i>' . implode('</i> vagy <i>', $translated) . '</i>';
+            // nyelvek filter
+            if($params['lang']) {
+                $langsShould = isset($params['lang']['should']) ? array_filter(array_map('trim', explode(',', $params['lang']['should']))) : [];
+                $langsMustNot = isset($params['lang']['must_not']) ? array_filter(array_map('trim', explode(',', $params['lang']['must_not']))) : [];
+
+                if (!empty($langsShould)) {
+                    $search->languages($langsShould);
                 }
-                foreach ($shouldRites as $r) {
-                    
-                    if ($r === '') continue;
-                    // Build clause requiring this rite
-                    $cl = [ 'bool' => [ 'must' => [ [ 'term' => ['rite.keyword' => $r] ] ] ] ];
 
-                    // If types specification exists for this rite, apply its should/must_not rules
-                    if (!empty($typesReq[$r]) && is_array($typesReq[$r])) {
-                        // parse comma separated lists
-                        $tShould = [];
-                        if (!empty($typesReq[$r]['should'])) {
-                            if (is_array($typesReq[$r]['should'])) {
-                                $tShould = $typesReq[$r]['should'];
-                            } else {
-                                $tShould = array_filter(array_map('trim', explode(',', $typesReq[$r]['should'])));
+                if (!empty($langsMustNot)) {
+                    $search->addMustNot([ 'terms' => ['church.nyelvek.keyword' => $langsMustNot] ]);
+                    $translated = array_map(function($l){ return t('LANGUAGES.'.$l); }, $langsMustNot);
+                    $search->filters[] = "A liturgia nyelve ne legyen <b>" . implode('</b> se <b>', $translated) . "</b>";
+                }
+            }
+
+            // Main keyword search
+            if ($params['kulcsszo']) {
+                $search->keyword($params['kulcsszo']);
+            }
+
+            // Time range
+            $search->timeRange($from, $until);
+        };
+
+        // ---- SZŰKÍTŐ szűrők (típus / rítus / kategória) — ezeket dobjuk a fallback-ban ----
+        $applyNarrowingFilters = function (\Search $search) use ($typesReq, $ritesReq, $categoriesReq) {
+            if (!empty($typesReq) || !empty($ritesReq)) {
+                // 1) Handle rites.must_not - exclude these rites entirely
+                if (!empty($ritesReq['must_not'])) {
+                    $mustNotRites = array_filter(array_map('trim', explode(',', $ritesReq['must_not'])));
+                    foreach ($mustNotRites as $r) {
+                        if ($r === '') continue;
+                        $search->filters[] = "A rítus nem lehet: <i>" . htmlspecialchars(t($r)) . "</i>";
+                        $search->query['bool']['must_not'][] = [ 'term' => ['rite.keyword' => $r] ];
+                    }
+                }
+
+                // 2) Handle rites.should - at least one of these rite+type combinations must match
+                if (!empty($ritesReq['should'])) {
+                    $shouldRites = array_filter(array_map('trim', explode(',', $ritesReq['should'])));
+                    $shouldClauses = [];
+
+                    if (!empty($shouldRites)) {
+                        $translated = array_map(function($r){ return t($r); }, $shouldRites);
+                        $search->filters[] = 'A rítus lehet <i>' . implode('</i> vagy <i>', $translated) . '</i>';
+                    }
+                    foreach ($shouldRites as $r) {
+                        if ($r === '') continue;
+                        $cl = [ 'bool' => [ 'must' => [ [ 'term' => ['rite.keyword' => $r] ] ] ] ];
+
+                        if (!empty($typesReq[$r]) && is_array($typesReq[$r])) {
+                            $tShould = [];
+                            if (!empty($typesReq[$r]['should'])) {
+                                if (is_array($typesReq[$r]['should'])) {
+                                    $tShould = $typesReq[$r]['should'];
+                                } else {
+                                    $tShould = array_filter(array_map('trim', explode(',', $typesReq[$r]['should'])));
+                                }
                             }
-                            
-                        }
-                        $tMustNot = [];
-                        if (!empty($typesReq[$r]['must_not'])) {
-                            if (is_array($typesReq[$r]['must_not'])) {
-                                $tMustNot = $typesReq[$r]['must_not'];
-                            } else {
-                                $tMustNot = array_filter(array_map('trim', explode(',', $typesReq[$r]['must_not'])));
+                            $tMustNot = [];
+                            if (!empty($typesReq[$r]['must_not'])) {
+                                if (is_array($typesReq[$r]['must_not'])) {
+                                    $tMustNot = $typesReq[$r]['must_not'];
+                                } else {
+                                    $tMustNot = array_filter(array_map('trim', explode(',', $typesReq[$r]['must_not'])));
+                                }
+                            }
+
+                            if (!empty($tShould)) {
+                                $shouldTerms = [];
+                                foreach ($tShould as $tt) {
+                                    if ($tt === '') continue;
+                                    $shouldTerms[] = [ 'term' => ['types.keyword' => $tt] ];
+                                }
+                                $cl['bool']['must'][] = [ 'bool' => [
+                                    'should' => $shouldTerms,
+                                    'minimum_should_match' => 1
+                                ]];
+                            }
+
+                            if (!empty($tMustNot)) {
+                                foreach ($tMustNot as $tt) {
+                                    $cl['bool']['must_not'][] = [ 'term' => ['types.keyword' => $tt] ];
+                                }
+                            }
+                            foreach($tShould as $k => $ts)  $tShould[$k] = t($ts);
+                            foreach($tMustNot as $k => $ts)  $tMustNot[$k] = t($ts);
+
+                            if (!empty($tShould) or !empty($tMustNot)) {
+                                $search->filters[] = "Ha <b>".t($r)."</b> rítus, akkor  " .
+                                    (!empty($tShould) ? "legyen: <b>" . implode('</b> vagy <b>', $tShould) . "</b>" : '') .
+                                    (!empty($tShould) && !empty($tMustNot) ? ", de " : '') .
+                                    (!empty($tMustNot) ? "ne legyen: <b>" . implode('</b> vagy <b>', $tMustNot) . "</b>" : '');
                             }
                         }
 
-                        // If there are positive type constraints, require that the event has at least one of them
-                        if (!empty($tShould)) {
-                            // use 'terms' to require any of the types
-                            $shouldTerms = [];
-                            foreach ($tShould as $tt) {
-                                if ($tt === '') continue;
-                                $shouldTerms[] = [ 'term' => ['types.keyword' => $tt] ];
-                            }
-                            $cl['bool']['must'][] = [ 'bool' => [ 
-                                'should' => $shouldTerms, 
-                                'minimum_should_match' => 1 
-                            ]];                            
-                        }
-
-                        // If there are negative type constraints, add must_not for each
-                        if (!empty($tMustNot)) {
-                            foreach ($tMustNot as $tt) {
-                                $cl['bool']['must_not'][] = [ 'term' => ['types.keyword' => $tt] ];
-                            }
-                        }
-                        foreach($tShould as $k => $ts)  $tShould[$k] = t($ts);
-                        foreach($tMustNot as $k => $ts)  $tMustNot[$k] = t($ts);
-
-                        if (!empty($tShould) or !empty($tMustNot)) {
-                            $search->filters[] = "Ha <b>".t($r)."</b> rítus, akkor  " . 
-                                (!empty($tShould) ? "legyen: <b>" . implode('</b> vagy <b>', $tShould) . "</b>" : '') . 
-                                (!empty($tShould) && !empty($tMustNot) ? ", de " : '') .
-                                (!empty($tMustNot) ? "ne legyen: <b>" . implode('</b> vagy <b>', $tMustNot) . "</b>" : '');
-                        }
+                        $shouldClauses[] = $cl;
                     }
 
-                    $shouldClauses[] = $cl;
-                }
-
-                if (!empty($shouldClauses)) {
-                    // Ensure at least one of the should clauses matches
-                    $search->query['bool']['must'][] = [ 'bool' => [ 'should' => $shouldClauses, 'minimum_should_match' => 1 ] ];                    
+                    if (!empty($shouldClauses)) {
+                        $search->query['bool']['must'][] = [ 'bool' => [ 'should' => $shouldClauses, 'minimum_should_match' => 1 ] ];
+                    }
                 }
             }
-            
+
+            // Process categories filter
+            if (!empty($categoriesReq)) {
+                $selectedCategories = array_filter(array_map('trim', explode(',', $categoriesReq)));
+
+                $massDefinitionsPath = dirname(__DIR__) . '/../mass-definitions.json';
+                $massDefinitions = json_decode(file_get_contents($massDefinitionsPath), true);
+                $titlesByCategory = $massDefinitions['titlesByCategory'] ?? [];
+                $allTitles = [];
+                foreach ($selectedCategories as $cat) {
+                    if (isset($titlesByCategory[$cat])) {
+                        $allTitles = array_merge($allTitles, $titlesByCategory[$cat]);
+                    }
+                }
+                if (!empty($allTitles)) {
+                    foreach ($allTitles as $title) {
+                        $cleanTitle = preg_replace('/^MASS_TITLE\./', '', $title);
+                        $allTitles[] = $title;
+                        $translatedTitle = t('MASS_TITLE.' . $cleanTitle);
+                        $allTitles[] = $translatedTitle;
+                    }
+                    $titleFilters = array_unique($allTitles);
+                    $titleFilters = array_values($titleFilters);
+                    if (!empty($titleFilters)) {
+                        $search->query['bool']['must'][] = [ 'terms' => ['title.keyword' => $titleFilters] ];
+                        $translatedCategoryNames = array_map(function($c){ return t('MASS_TITLE_CATEGORY.' . $c); }, $selectedCategories);
+                        $search->filters[] = "Kategóriák: <b>" . implode('</b> vagy <b>', $translatedCategoryNames) . "</b>";
+                    }
+                }
+            }
+        };
+
+        // Set title based on number of selected categories
+        $selectedCategories = !empty($categoriesReq) ? array_filter(array_map('trim', explode(',', $categoriesReq))) : [];
+        if (count($selectedCategories) === 1) {
+            $categoryKey = reset($selectedCategories);
+            $categoryTranslation = t('MASS_TITLE_CATEGORY.' . $categoryKey);
+            $this->setTitle($categoryTranslation . ' keresése');
+        } else {
+            $this->setTitle('Események keresése');
         }
 
-         // Process categories filter
-         // Collect titlesByCategory from mass-definitions.json and filter by selected categories
-         if (!empty($categoriesReq)) {
-             $selectedCategories = array_filter(array_map('trim', explode(',', $categoriesReq)));
-             
-             // Load mass definitions to get titlesByCategory
-             $massDefinitionsPath = dirname(__DIR__) . '/../mass-definitions.json';
-             $massDefinitions = json_decode(file_get_contents($massDefinitionsPath), true);
-             $titlesByCategory = $massDefinitions['titlesByCategory'] ?? [];
-             // Concatenate arrays for selected categories
-             $allTitles = [];
-             foreach ($selectedCategories as $cat) {
-                 if (isset($titlesByCategory[$cat])) {
-                     $allTitles = array_merge($allTitles, $titlesByCategory[$cat]);
-                 }
-             }
-             if (!empty($allTitles)) {
-                 // Process each title: remove "MASS_TITLE." prefix and add translated version
-                 $titleFilters = [];
-                 foreach ($allTitles as $title) {
-                     // Remove "MASS_TITLE." prefix if exists
-                     $cleanTitle = preg_replace('/^MASS_TITLE\./', '', $title);
-                     $allTitles[] = $title;
-                     $translatedTitle = t('MASS_TITLE.' . $cleanTitle);
-                     $allTitles[] = $translatedTitle;
-                 }
-                 $titleFilters = array_unique($allTitles);
-                 // Re-index array to ensure clean numeric keys for proper JSON encoding
-                 $titleFilters = array_values($titleFilters);
-                 // Simple query filter: title must be one of these items
-                 if (!empty($titleFilters)) {
-                     $search->query['bool']['must'][] = [ 'terms' => ['title.keyword' => $titleFilters] ];
-                     $translatedCategoryNames = array_map(function($c){ return t('MASS_TITLE_CATEGORY.' . $c); }, $selectedCategories);
-                     $search->filters[] = "Kategóriák: <b>" . implode('</b> vagy <b>', $translatedCategoryNames) . "</b>";
-                 }
-             }
-         }
+        $offset = $this->pagination->take * $this->pagination->active;
+        $limit = $this->pagination->take;
 
-       // Set title based on number of selected categories
-       $selectedCategories = !empty($categoriesReq) ? array_filter(array_map('trim', explode(',', $categoriesReq))) : [];
-       if (count($selectedCategories) === 1) {
-           // If only one category is selected, use its translated name + " kereső"
-           $categoryKey = reset($selectedCategories);
-           $categoryTranslation = t('MASS_TITLE_CATEGORY.' . $categoryKey);
-           $this->setTitle($categoryTranslation . ' keresése');
-       } else {
-           // Otherwise use the default "Esemény kereső"
-           $this->setTitle('Események keresése');
-       }
-
-       $offset = $this->pagination->take * $this->pagination->active;
-        $limit = $this->pagination->take;     	        
+        // ---- 1. menet: teljes keresés (base + szűkítő szűrők) ----
+        $search = new \Search('masses');
+        $applyBaseFilters($search);
+        $applyNarrowingFilters($search);
         $results = $search->getResults($offset, $limit, false);
-                                        
-        if ($search->total != 0) {                   
+
+        // #357: ha 0 találat ÉS volt szűkítő szűrő → 2. menet a szűkítők nélkül.
+        if ($search->total == 0 && $hasNarrowingFilters) {
+            $relaxed = new \Search('masses');
+            $applyBaseFilters($relaxed);
+            $relaxedResults = $relaxed->getResults($offset, $limit, false);
+
+            if ($relaxed->total > 0) {
+                addMessage(
+                    'A megadott típus/rítus/kategória szűrőkkel nem találtunk misét, ezért azokat kiiktattuk. '
+                    . 'A többi feltételnek (hely, nyelv, időpont) megfelelő misék alább láthatók.',
+                    'info'
+                );
+                $search = $relaxed;
+                $results = $relaxedResults;
+            }
+        }
+
+        if ($search->total != 0) {
             foreach ($results as &$result) {
                 $church = \Eloquent\Church::find($result->church_id);
-                $result->church = $church->toArray();       
-                //$result->rrule = $church->getGeneratedMassRRulesAttribute();
-                
+                $result->church = $church->toArray();
+
                 $result->mass = \Eloquent\CalMass::find($result->mass_id)->toArray();
                 if($result->mass['rrule'])
                     $rrule = new \SimpleRRule($result->mass['rrule']);
@@ -250,19 +259,19 @@ class SearchResultsMasses extends Html {
                         $result->mass['rrule']['readable'] = $rrule->toText();
                     }
                 if(isset($result->mass['periodId'])) {
-                    $result->period = \Eloquent\CalPeriod::find($result->mass['periodId'])->toArray();                    
+                    $result->period = \Eloquent\CalPeriod::find($result->mass['periodId'])->toArray();
                 }
             }
-        }            
-       
+        }
+
         $url = \Pagination::qe($params, '/?' );
         $this->pagination->set($search->total, $url );
 
         $this->filters = $search->getFilters();
-                        
+
         $this->template = 'search/resultsmasses.twig';
-        
-        $this->results = $results;                
+
+        $this->results = $results;
     }
 
 }


### PR DESCRIPTION
Closes #357

> Ha nem találtunk egyáltalán mise eredményt … bővítsük a keresés egy-két filter kiiktatásával és adjuk vissza azt ami eredményt találunk. Persze legyen felirata.

A `SearchResultsMasses` eddig 0 találatnál egyszerűen üres oldalt adott. Most ha a mise-keresés a megadott szűrőkkel nem hoz eredményt, a **típus / rítus / kategória** (szűkítő) szűrőket kiiktatva újra keres, és ha úgy van találat, azt adja vissza — egy magyarázó felirattal.

## Megközelítés

A `__construct` szűrő-építését két closure-ra bontottam, hogy a keresés kétlépcsős lehessen:

- **`applyBaseFilters`** — a megtartandó feltételek: hely (boundaries), egyházmegye, nyelv, kulcsszó, időtartam.
- **`applyNarrowingFilters`** — a „szűkítő" feltételek: rítus (`rites`), típus (`types`), kategória (`categories`). Ezek a leggyakoribb 0-találat okozói (pl. „gitáros mise").

Folyamat:
1. **1. menet** — base + szűkítő szűrők (a régi viselkedés, változatlan query-építéssel).
2. Ha `total == 0` ÉS volt szűkítő szűrő → **2. menet** csak a base szűrőkkel.
3. Ha a 2. menet hoz találatot, azt jelenítjük meg, és `addMessage(...)`-dzsel kiírjuk: *„A megadott típus/rítus/kategória szűrőkkel nem találtunk misét, ezért azokat kiiktattuk. A többi feltételnek (hely, nyelv, időpont) megfelelő misék alább láthatók."*

A felirat a meglévő üzenet-megjelenítőbe megy (mint a templom-keresés „nem hozott eredményt" üzenete) — nincs template-módosítás.

## Hatókör

- A szűkítő szűrők közül a **rítus/típus/kategóriát** iktatjuk ki — ezek a leggyakoribb túl-szűkítők. A nyelvet, helyet, időtartamot megtartjuk (azok általában szándékos, fontos feltételek).
- Ha eredetileg sem volt szűkítő szűrő (csak base), nincs 2. menet — a 0 találat valódi.
- A régi query-építő logikát **verbatim** mozgattam a closure-okbe, nem írtam át — csak becsomagoltam, hogy újra futtatható legyen.

## Tesztelés — docker-stacken (Elasticsearch) lefuttatva

Felhúzott teljes stack (mass_index ~1.39M dok), valós keresésekkel:
- **Baseline** (szűrő nélkül, köv. hét): 10371 mise. Nincs fallback-felirat. ✓
- **Fallback-trigger**: `rites[should]=ROMAN_CATHOLIC` + nemlétező típus → 1. menet 0 találat → 2. menet a típus-szűrő nélkül → 10371 mise + a „kiiktattuk" felirat megjelenik. ✓
- **Negatív eset**: a baseline NEM tartalmazza a fallback-feliratot (nincs téves üzenet). ✓

`php -l` zöld. A keresés Elasticsearch-függő, ezért host-on nem unit-tesztelhető; az igazolás a docker-stacken end-to-end történt.
