### PR TITLE
church-edit: weblap-linkek ikonjai mindig klikkelhetők #258

### DIFF
--- a/webapp/templates/church/edit.twig
+++ b/webapp/templates/church/edit.twig
@@ -159,15 +159,33 @@
             <tr>
                 <td bgcolor=#efefef class=kiscim align=right>Weblapok:</td>
                 <td bgcolor=#efefef>
+                    {# #258: a régi `float:right` az ikonra: hosszú link-szöveg ráfolyt
+                       és klikkelhetetlenné tette. Most position:relative / absolute,
+                       padding-right hagy helyet az ikonnak. #}
+                    <style>
+                        #church-links .church-link {
+                            position: relative;
+                            padding-right: 1.8em;
+                            min-height: 1.4em;
+                            margin-bottom: 4px;
+                        }
+                        #church-links .church-link > i.church-link-delete,
+                        #church-links .church-link > i.church-link-add {
+                            position: absolute;
+                            right: 0.2em;
+                            top: 0.2em;
+                            cursor: pointer;
+                        }
+                    </style>
                     <div id="church-links" >
-                    {% if church.links %}                        
+                    {% if church.links %}
                         {% for link in church.links %}
                             <div class="church-link" data-link-id="{{ link.id }}">
-                                {{ link.html|raw }}<i style="float:right" title="Link törlése" class="church-link-delete {{ ICONS_DELETE }} red" data-link-id="{{ link.id }}"></i>
+                                {{ link.html|raw }}<i title="Link törlése" class="church-link-delete {{ ICONS_DELETE }} red" data-link-id="{{ link.id }}"></i>
                             </div>
                         {% endfor %}
                     {% endif %}
-                    <div class="church-link"><i style="float:right" title="Új link hozzáadása" class="church-link-add {{ ICONS_ADD }} green" ></i></div>
+                    <div class="church-link"><i title="Új link hozzáadása" class="church-link-add {{ ICONS_ADD }} green" ></i></div>
                     </div>
                 </td>
                 <td></td>


### PR DESCRIPTION
Closes #258

A `templom/{id}/edit` oldal *Weblapok* szekciójában a `+` és kuka ikonok eddig `style="float:right"`-tal voltak. Hosszú link-felirat esetén a szöveg **ráfolyt az ikonra**, és nem lehetett rákattintani.

## A fix

`#church-links .church-link`-re inline `<style>` blokkban:
- `position: relative`
- `padding-right: 1.8em` (helyet hagy az ikonnak)
- `min-height: 1.4em` (üres link-container sem omlik össze)

Az ikonok (`.church-link-delete`, `.church-link-add`):
- `position: absolute; right: 0.2em; top: 0.2em`
- `cursor: pointer`

A `float:right` inline-stílus kikerült az ikon-tagekből.

## Miért nem külön CSS fájl

Ez egyetlen template-helyen használt apró CSS — nem érte meg külön fájlba kiszedni. Ha kerül még hasonló minta más helyre, akkor érdemes refaktorálni egy közös `church-link-list.css`-be.

## Reprolépés (a #258 review-jához)

borazslo a #258 alatt jelezte 2025-05-27-én: „Egyelőre nem sikerül stabilan reprodukálni." Ezért lefirkantom a konkrét lépést, ahogy nálam előjön:

1. Bejelentkezés admin / szerkesztő-jogú userrel
2. A **templom-adatlap** szerkesztő URL: `/templom/{id}/edit` (NEM a `/editschedule` miserend-szerkesztő — ez a fontos)
3. Görgess le a **Weblapok** szekcióhoz
4. Adj hozzá egy linket egy **hosszú URL-lel** — pl. `https://www.parokia.hu/info/parokia/szent-istvan-bazilika-budapest-belvarosi-foplebania/` (100+ karakter), VAGY rövid URL ÉS hosszabb leíró cím kombinációja
5. A jobb oldali **piros kuka ikon** (és új-link gombnál a **zöld plusz ikon**) **a hosszú link szövege alá kerül**, és nem lehet rákattintani (vagy csak nehezen, mert az alatta lévő link-anchor fogja a kattintást)

Tapasztalt környezet: Firefox 138 / macOS 15.5, default zoom (100%), 1440×900 ablakméret. Mobil/tablet (responsive) is reprodukálja, mert a `float: right` és a hosszú szöveg konfliktusa szélesség-független.

A fix CSS-szintű elrendezést úgy állítja át, hogy az ikon dedikált abszolút pozíciója + a szöveg jobb oldali padding-je biztosítsa a klikk-zónát hosszú linknél is.

## Tesztelés

- Hosszú URL-lel/címmel a +/kuka klikkelhető marad
- Rövid linkkel a layout változatlan
- Az új link hozzáadása dialógus változatlan