### PR TITLE
templomkereső: keyword megőrzése sessionStorage-ban #356

### DIFF
--- a/webapp/templates/_panelsearchforchurch.twig
+++ b/webapp/templates/_panelsearchforchurch.twig
@@ -28,6 +28,29 @@
                 var boundaryDataFromUrl = window.boundaryDataFromUrl || [];
                 BoundaryAutocomplete.init('#keyword', '#panel-search-church-form', boundaryDataFromUrl);
             }
+
+            // #356: ha a felhasználó az eredmény-oldalról elnavigál (pl. egy
+            // templom-oldalra) és visszatér a keresőre, a beírt kulcsszó
+            // maradjon meg a sessionre. Ha az inputot a PHP backend már
+            // megtöltötte (eredmény-oldal sidebarja), azt nem írjuk felül.
+            try {
+                var keyInput = document.getElementById('keyword');
+                var form = document.getElementById('panel-search-church-form');
+                if (!keyInput || !form) return;
+
+                if (!keyInput.value) {
+                    var stored = sessionStorage.getItem('miserend.lastSearchKulcsszo');
+                    if (stored) {
+                        keyInput.value = stored;
+                    }
+                }
+
+                form.addEventListener('submit', function () {
+                    try { sessionStorage.setItem('miserend.lastSearchKulcsszo', keyInput.value || ''); } catch (_) {}
+                });
+            } catch (_) {
+                // sessionStorage privát/inkognitó-módban dobhat - csendben nyeljük el.
+            }
         });
     })();
     </script>


### PR DESCRIPTION
Closes #356

A `_panelsearchforchurch.twig` (Új keresés sidebar) most a sessionStorage-ban tartja a beírt kulcsszót, hogy ne vesszen el ha a felhasználó elnavigál (pl. egy templom-oldalra) és visszajön a keresőre.

## A logika

1. Submit-kor a `kulcsszo` input értéke `sessionStorage`-ba kerül `miserend.lastSearchKulcsszo` kulccsal.
2. Page-load-kor, **ha az input épp üres** (azaz nincs URL-paraméter ami pre-fillezné), visszatöltjük a sessionStorage-ból.
3. Az eredmény-oldal sidebarja már `?kulcsszo=...` URL-paraméterből kapja, azt nem írjuk felül.

## Miért sessionStorage és nem localStorage?

- **Session-élet**: tab/ablak bezárása után törlődik — privacy-friendly default.
- **Nincs cross-tab szennyeződés**: egy másik tab keresése nem zavarja a jelenlegit.
- **Backward-compat**: ha kell perzisztens, könnyű átírni `localStorage`-ra.

## Try/catch

Inkognitó / privát mód néha dobhat `SecurityError`-t a sessionStorage-on — csendben elnyeljük (a kereső így is működik, csak nem perzisztál).

## #357 külön

A `#357` (fallback eredménytelen keresésnél) PHP-search-logika módosítást igényel (filter relaxation + UI heading) — kockázatosabb, kihagyom ebből a PR-ből. Külön PR-ben térünk vissza rá, ha jónak látod.