### PR TITLE
API: templom honlapjai a minimal response-ban is #112

### DIFF
--- a/webapp/classes/api/church.php
+++ b/webapp/classes/api/church.php
@@ -46,6 +46,7 @@ class Church extends Api {
             <li>„varos”</li>
             <li>„lat”</li>
             <li>„lon”</li>
+            <li>„links” (<em>string[]</em>): a templom honlapjai (üres tömb ha nincs)</li>
             <li>„tavolsag” (<em>integer</em>): távolság méterben</li>
             <li>„misek”: az adott napi szentmisék listája
                 <ul>

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -450,6 +450,10 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                 'koordinatak' => [ (float) $this->lat, (float) $this->lon ],
                 'lat' => (float) $this->lat,
                 'lon' =>(float) $this->lon,
+                // #112: a templom honlapja(i) a minimal response-ban is - a /nearby
+                // API alapból minimal-t ad vissza, és a mobil alkalmazásnak
+                // (KAPP) szüksége van rá.
+                'links' => $this->links->pluck('href')->toArray(),
                 'tavolsag' => (int) $this->distance
             ];
             return $return;


### PR DESCRIPTION
Closes #112

A templom honlapja(i) eddig csak a `toAPIArray()` **medium** és **full** válaszában szerepelt a `links` kulcs alatt. A **minimal** változatban nem — pedig a `/api/nearby` alapból minimal-t ad vissza, és a mobil alkalmazás (KAPP) erre épít.

## A változás

`Eloquent\Church::toAPIArray()` minimal-blokkjába egy sor:

```php
'links' => $this->links->pluck('href')->toArray(),
```

Üres tömböt ad vissza ha nincs egy weblap se → konzisztens a medium/full viselkedésével.

A `/api/church` doc-blokkjában is feltüntetve a kulcs.

## Mit NEM csinál

- Új mező nem jön be — csak az eddig is létező `links` reláció kerül ki a minimal válaszba.
- Az adatbázis séma változatlan.

## Backward compat

Tisztán additív változás. Régi kliens (ami nem várja a `links`-et) figyelmen kívül hagyja. Új kliens (KAPP) számít rá.