### PR TITLE
docs: kimenő hálózati kapcsolatok listája #214

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Máris elérhető a http://localhost:8000 címen a miserend alkalmazás. Az `adm
 
 Az alkalmazás öt komponensből áll.
 
+> 🌐 A szerver által fut-időben használt **külső és belső hálózati kapcsolatok** (host\:port) teljes listája — hasznos firewall / egress-allow-list beállításhoz — a [Kimenő hálózati kapcsolatok](docs/outgoing-connections.md) dokumentumban található.
+
 ## 🛢️ MySQL konténer azaz az adatbázis
 
 Az adatbázis egyszerű MySQL / MariaDB. Megőrzi az adatokat újraindítás esetén is.  

--- a/docs/outgoing-connections.md
+++ b/docs/outgoing-connections.md
@@ -9,14 +9,14 @@
 
 | Cél | Host | Port | Mire kell | Forrás (osztály) |
 |---|---|---|---|---|
-| **OSM Nominatim** | `nominatim.openstreetmap.org` | 443 | Cím → koordináta keresés (geocoding) | `\ExternalApi\NominatimApi` |
+| **OSM Nominatim** | `nominatim.openstreetmap.org` | 443 | Cím vagy terület neve → koordináta keresés (geocoding) | `\ExternalApi\NominatimApi` |
 | **OSM Overpass** | `overpass-api.de` | 80 | Templom-elemek és határok lekérése OSM-ből (`url:miserend` tag) | `\ExternalApi\OverpassApi` |
 | **OSM opening_hours evaluator** | `openingh.openstreetmap.de` | 443 | `opening_hours` mező parse / evaluate | `\ExternalApi\OpeninghApi` |
-| **OSM OAuth** | `master.apis.dev.openstreetmap.org` | 443 | OSM OAuth flow (admin) | `\ExternalApi\OpenStreetMapApi` |
+| **OSM OAuth** | fejlesztéshez `master.apis.dev.openstreetmap.org`, élesen:  `api.openstreetmap.org` | 443 | OSM adatok módosítása | `\ExternalApi\OpenStreetMapApi` |
 | **Mapquest Directions** | `open.mapquestapi.com` | 80 | Útvonal-távolság számítás templomok között (cron) | `\ExternalApi\MapquestApi` |
 | **Közösségek API** | `kozossegek.hu` | 443 | Templomhoz tartozó közösségek lekérése | `\ExternalApi\KozossegekApi` |
-| **Szentségimádások** | `szentsegimadas.hu` | 443 | Adoráció / szentségimádás-időpontok | `\ExternalApi\SzentsegimadasApi` |
-| **Napi lelki batyu** | `szentjozsefhackathon.github.io` | 443 | Napi lelki batyu (idézet / olvasmány) | `\ExternalApi\NapiLelkibatyuApi` |
+| **Szentségimádások** | `szentsegimadas.hu` | 443 | Szentségimádás-időpontok (elavulóban) | `\ExternalApi\SzentsegimadasApi` |
+| **Napi lelki batyu** | `szentjozsefhackathon.github.io` | 443 | Napi lelki batyu: a liturgikus naptár érkezik innen | `\ExternalApi\NapiLelkibatyuApi` |
 
 ## Belső szolgáltatások (Docker compose network)
 

--- a/docs/outgoing-connections.md
+++ b/docs/outgoing-connections.md
@@ -1,0 +1,65 @@
+# Kimenő hálózati kapcsolatok
+
+> Ez a lista azokat a külső host:port-okat foglalja össze, amikre a miserend.hu szerver fut-időben rácsatlakozik.
+> Hasznos szerver-firewall, kimenő-allow-list, container egress-policy beállítások előtt — egyenként engedélyezős környezetben ezek hiányában a telepítés ripityára esik.
+>
+> Tracker: #214
+
+## Külső API-k
+
+| Cél | Host | Port | Mire kell | Forrás (osztály) |
+|---|---|---|---|---|
+| **OSM Nominatim** | `nominatim.openstreetmap.org` | 443 | Cím → koordináta keresés (geocoding) | `\ExternalApi\NominatimApi` |
+| **OSM Overpass** | `overpass-api.de` | 80 | Templom-elemek és határok lekérése OSM-ből (`url:miserend` tag) | `\ExternalApi\OverpassApi` |
+| **OSM opening_hours evaluator** | `openingh.openstreetmap.de` | 443 | `opening_hours` mező parse / evaluate | `\ExternalApi\OpeninghApi` |
+| **OSM OAuth** | `master.apis.dev.openstreetmap.org` | 443 | OSM OAuth flow (admin) | `\ExternalApi\OpenStreetMapApi` |
+| **Mapquest Directions** | `open.mapquestapi.com` | 80 | Útvonal-távolság számítás templomok között (cron) | `\ExternalApi\MapquestApi` |
+| **Közösségek API** | `kozossegek.hu` | 443 | Templomhoz tartozó közösségek lekérése | `\ExternalApi\KozossegekApi` |
+| **Szentségimádások** | `szentsegimadas.hu` | 443 | Adoráció / szentségimádás-időpontok | `\ExternalApi\SzentsegimadasApi` |
+| **Napi lelki batyu** | `szentjozsefhackathon.github.io` | 443 | Napi lelki batyu (idézet / olvasmány) | `\ExternalApi\NapiLelkibatyuApi` |
+
+## Belső szolgáltatások (Docker compose network)
+
+| Cél | Host | Port | Mire kell |
+|---|---|---|---|
+| **Elasticsearch** | `elasticsearch` | 9200 | Mise / templom kereső index |
+| **MariaDB** | `mysql` | 3306 | Fő adatbázis |
+| **Mailcatcher** | `mailcatcher` | 1025 (SMTP) / 1080 (web) | Dev környezetben email-elfogás |
+
+## SMTP (production)
+
+Production-ben a SMTP a `.env` `SMTP_HOST` / `SMTP_PORT` szerint (config.php `production` ág). Engedélyezni kell:
+
+| Cél | Host | Port |
+|---|---|---|
+| SMTP relay | (config-tól függ) | 25 / 465 / 587 |
+
+## Container image registry-k
+
+Build / pull időben kellhet:
+
+| Cél | Host | Port | Mire kell |
+|---|---|---|---|
+| GitHub Container Registry | `ghcr.io` | 443 | A `miserend.hu` image pull |
+| Docker Hub | `registry-1.docker.io`, `auth.docker.io` | 443 | `mariadb`, `node`, `busybox`, `dockage/mailcatcher` |
+| Elastic Registry | `docker.elastic.co` | 443 | ES image pull |
+
+## Build-time (csak fejlesztői gépen)
+
+| Cél | Host | Port | Mire kell |
+|---|---|---|---|
+| npm registry | `registry.npmjs.org` | 443 | Angular dep (`calendar/`) |
+| Packagist | `packagist.org`, `repo.packagist.org` | 443 | Composer dep |
+| nodejs.org | `nodejs.org` | 443 | Node binary (Docker build esetén) |
+| GitHub | `github.com`, `api.github.com`, `codeload.github.com` | 443 | git clone / composer github source |
+
+---
+
+## Karbantartás
+
+Ha új külső API integrációt vezetsz be:
+1. Vedd fel ide a host-ot és a célt
+2. A `\ExternalApi\...` osztály implementációja a `webapp/classes/externalapi/` alatt szokott lenni
+3. Production-allow-list frissítéséhez küldj jelzést a szerver-üzemeltetőnek
+
+Hiányzik valami? Nézd át a `webapp/classes/externalapi/` mappa fájljait, a `$apiUrl` mezőket — ez a lista azokból generálódott.


### PR DESCRIPTION
Closes #214

Új doksi: `docs/outgoing-connections.md` — tiszta lista az összes külső host:port-ról, amire a miserend.hu szerver futás közben rácsatlakozik, plusz a build-time függőségek.

## Mit fed le

- **8 külső API** (OSM Nominatim / Overpass / opening_hours / OAuth, Mapquest, Közösségek, Szentségimádások, Napi lelki batyu)
- **3 belső docker-network szolgáltatás** (ES, MariaDB, Mailcatcher)
- **SMTP relay** (config-függő)
- **Container registry-k** (ghcr.io, dockerhub, docker.elastic.co)
- **Build-time hosts** (npm registry, packagist, nodejs.org, github)

Minden bejegyzéshez: cél / host / port / mire kell / forrásosztály ha van.

## Forrás

A `webapp/classes/externalapi/*.php`-ben szereplő `$apiUrl` mezőket grepeltem ki és kategorizáltam. A docker compose YAML-okból a belső szolgáltatásokat.

## Karbantartás

A doksi végén egy rövid „karbantartás" szekció: új ExternalApi osztály bekerülésekor mit kell hozzátenni.