### PR TITLE
naptár: figyelmeztető banner ha hiányzik a húsvét/karácsony miserend #323

### DIFF
--- a/calendar/src/app/components/church-calendar/church-calendar.component.html
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.html
@@ -22,6 +22,21 @@
     </div>
   </div>
 }
+@if (missingEasterMassWarning || missingChristmasMassWarning) {
+  <div class="special-period-warning"
+       style="margin: 8px 0; padding: 10px 14px; border-left: 4px solid #f5a623; background: #fff7e6; color: #663c00; border-radius: 4px;">
+    <mat-icon style="vertical-align: middle; margin-right: 6px; color: #f5a623;">warning</mat-icon>
+    <strong>Figyelem:</strong>
+    @if (missingEasterMassWarning && missingChristmasMassWarning) {
+      ennek a templomnak nincs sem <em>húsvéti</em>, sem <em>karácsonyi</em> időszakú miséje, pedig a látható nézet érinti mindkettőt.
+    } @else if (missingEasterMassWarning) {
+      ennek a templomnak nincs <em>húsvéti</em> időszakú miséje, pedig a látható nézet érinti a húsvéti időszakot.
+    } @else {
+      ennek a templomnak nincs <em>karácsonyi</em> időszakú miséje, pedig a látható nézet érinti a karácsonyi időszakot.
+    }
+    <br/><small>Valószínű, hogy a miserend hiányos ezen ünnep(ek)re. Érdemes ellenőrizni a szerkesztőben.</small>
+  </div>
+}
 <full-calendar
   #calendar
   [options]="calendarOptions"

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -50,6 +50,7 @@ import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
 import {SearchService} from '../../services/search.service';
 import {GeneratedPeriod} from "../../model/generated-period";
+import {SpecialType} from "../../model/period";
 import { eventListTemplate, EventListTemplateVars } from './event-list-template';
 import {EditConfirmationService} from '../../services/edit-confirmation.service';
 import {CopyPeriodDialogComponent, CopyPeriodDialogData} from '../copy-period-dialog/copy-period-dialog.component';
@@ -1141,15 +1142,70 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
     this.calendarComponent.getApi().changeView(view as any);
   }
 
+  // #323: ha a látható nézet húsvét/karácsony időszakot is tartalmaz, és a
+  // templomnak nincs ilyen periódusú miséje, valószínű hibás/hiányos a
+  // miserend. UI flag-ek a template banner-éhez.
+  public missingEasterMassWarning = false;
+  public missingChristmasMassWarning = false;
+
   private onDatesSet(arg : any) {
     const title: string = arg.view.title;
     this.datesSet.emit(title);
     this.setCalendarsTitle(title);
-    
+
     // Fetch liturgical days for the current view date range
     const start = arg.view.currentStart;
     const end = arg.view.currentEnd;
     this.fetchLiturgicalDays(start, end);
+
+    // #323: ellenőrizzük, hogy a nézet érint-e karácsonyi vagy húsvéti
+    // periódust, és a templomnak van-e ilyen mise. Ha érinti, de nincs
+    // mise → warning banner.
+    this.checkSpecialPeriodCoverage(start, end);
+  }
+
+  private checkSpecialPeriodCoverage(viewStart: Date, viewEnd: Date): void {
+    // Csak ott jelezzünk, ahol értelmes (a felhasználó éppen szerkeszti vagy
+    // megnézi a templomot - suggestion review pl. nem).
+    if (ScriptUtil.isNull(this.currentChurch)) {
+      this.missingEasterMassWarning = false;
+      this.missingChristmasMassWarning = false;
+      return;
+    }
+
+    const normalize = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    const vStart = normalize(viewStart);
+    const vEnd = normalize(viewEnd);
+
+    let viewIntersectsEaster = false;
+    let viewIntersectsChristmas = false;
+
+    for (const gp of this.periodService['generatedPeriods$'].getValue()) {
+      const specialType = this.periodService.getSpecialPeriodType(gp.periodId);
+      if (specialType !== SpecialType.EASTER && specialType !== SpecialType.CHRISTMAS) {
+        continue;
+      }
+      const gpStart = normalize(new Date(gp.startDate));
+      const gpEnd = normalize(new Date(gp.endDate));
+      // intervallum-átfedés: nem (vEnd < gpStart vagy gpEnd < vStart)
+      if (vEnd < gpStart || gpEnd < vStart) {
+        continue;
+      }
+      if (specialType === SpecialType.EASTER) viewIntersectsEaster = true;
+      if (specialType === SpecialType.CHRISTMAS) viewIntersectsChristmas = true;
+    }
+
+    let churchHasEasterMass = false;
+    let churchHasChristmasMass = false;
+    for (const m of this.masses.values()) {
+      if (ScriptUtil.isNull(m.periodId)) continue;
+      if (this.periodService.isEasterPeriod(m.periodId)) churchHasEasterMass = true;
+      if (this.periodService.isChristmasPeriod(m.periodId)) churchHasChristmasMass = true;
+      if (churchHasEasterMass && churchHasChristmasMass) break;
+    }
+
+    this.missingEasterMassWarning = viewIntersectsEaster && !churchHasEasterMass;
+    this.missingChristmasMassWarning = viewIntersectsChristmas && !churchHasChristmasMass;
   }
 
   private fetchLiturgicalDays(start: Date, end: Date): void {


### PR DESCRIPTION
Closes #323

> *„A naptár nézetben ha húsvét vagy karácsony időszakhoz érkezünk, és az éppen megjelenített templomnak nincsen ilyen időszaka, mutassunk valami jelzést/figyelmeztetést, hogy valószínű hibás a miserend. Hmm. De pontosan hol és mit jelöljünk?"*

## A választott UX

**Hol**: sárga warning-banner a naptár fölött, közvetlenül a header alatt.

**Mit**: egyértelmű magyar szöveg, ami pontosan megmondja melyik ünnep érintett (húsvét, karácsony, vagy mindkettő), és hogy érdemes ellenőrizni a szerkesztőben.

3 ágra:
- csak húsvét érintve, nincs húsvéti mise
- csak karácsony érintve, nincs karácsonyi mise
- mindkettő érintve, egyik se megvan

## A logika

`onDatesSet`-ből új `checkSpecialPeriodCoverage(start, end)` hívás. A metódus:

1. Iterál `periodService.generatedPeriods$`-on, megnézi melyek érintik a látható tartományt és `specialType=EASTER` vagy `CHRISTMAS`
2. Iterál `this.masses`-en, megnézi van-e már mise easter / christmas periódusra
3. Ha (látható-tartomány-tartalmaz-easter ÉS nincs-easter-mise) → `missingEasterMassWarning = true`
4. Ugyanaz christmas-ra

A flag-ek public property-k a template `@if`-jeihez.

## Mit nem csinál

- **Suggestion-review oldal**: ha `currentChurch == null`, a flag-ek false-ra állnak — ott értelmetlen lenne a jelzés
- **Csak a következő ünnepekre néz**, nem évek múlva — a `generatedPeriods` listája az aktuális év / következő évre van generálva
- **Nincs „elrejtem ezt a warning-ot"** opció — minden new view-ra újraszámolódik. Ha sok, jelezz és bekapcsolható dismiss-elés.

## Tesztelhetőség

A logika `periodService.generatedPeriods$` BehaviorSubject-en + `this.masses` Map-en alapul. Karma-tesztben mockolható, de a TestBed setup nem-triviális (PeriodService teljes mock kell + masses input). A logikát átköltöztetni `MassUtil`-be pure-function-ként és azt tesztelni opció, ha kérnél — most jelen fix a meglévő mintát követi (PeriodService-t injectálva használja).