### PR TITLE
séma: PRIMARY KEY a megye táblán #174

### DIFF
--- a/docker/mysql/initdb.d/02-schema.sql
+++ b/docker/mysql/initdb.d/02-schema.sql
@@ -495,7 +495,7 @@ CREATE TABLE IF NOT EXISTS `megye` (
   `megyenev` varchar(50) NOT NULL DEFAULT '',
   `orszag` int(2) NOT NULL DEFAULT 12,
   `egyeb` varchar(255) NOT NULL DEFAULT '',
-  UNIQUE KEY `id` (`id`)
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=22 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
A #174 (sémakisimítás) egyik pontja: a `megye` tábla nem tartalmazott PRIMARY KEY-t. Az `id` AUTO_INCREMENT oszlopon a `UNIQUE KEY`-t `PRIMARY KEY`-re cseréltem.

Verifikálva: a tábla helyben betöltődik, az `id` kulcs `PRI` lesz.

Megjegyzés: az eredeti branch az `osm_tags` táblát is érintette (PK hozzáadás), de időközben eldobtad az `osm_tags`-ot a masteren (51de48a9), így az a rész okafogyott — ez a PR már csak a `megye` PRIMARY KEY-t adja.