### PR TITLE
Mapquest API: rate-limit megjegyzése, hogy ne pazaroljuk a kvótát #129

### DIFF
--- a/webapp/classes/externalapi/mapquestapi.php
+++ b/webapp/classes/externalapi/mapquestapi.php
@@ -9,6 +9,20 @@ class MapquestApi extends \ExternalApi\ExternalApi {
     public $name = 'mapquest';
     public $apiUrl = "http://open.mapquestapi.com/directions/v2/";
 
+    /**
+     * #129: ha a Mapquest free tier havi limitje elfogy, eddig minden hívás
+     * elment, csak utána kaptunk 403-at - feleslegesen pazaroltuk az
+     * erőforrást (CURL időt, hálózatot, kvótát).
+     *
+     * Most amint egyszer 403-at kaptunk, megjegyezzük (in-request statikusan
+     * + cross-request egy fájlban TTL-lel), és a következő hívás már a HTTP
+     * előtt visszatér -2-vel. Mivel a Mapquest kvóta tipikusan havonta áll
+     * vissza, 24 óra TTL bőven konzervatív - ha valamiért hamarabb feloldják,
+     * legrosszabb esetben fél nap késéssel próbálkozunk újra.
+     */
+    private const RATE_LIMIT_TTL_SECONDS = 86400; // 24h
+    private static $rateLimitHitMemo = null; // in-request memo
+
     function distance($pointFrom, $pointTo) {
 
         global $config;
@@ -17,20 +31,29 @@ class MapquestApi extends \ExternalApi\ExternalApi {
             throw new \Exception("Missing mapquest appkey.");
         }
 
+        // #129: ha a memózott rate-limit állapot mond hogy nem ér semmit
+        // próbálkozni, ne is kérjünk semmit.
+        if ($this->isRateLimited()) {
+            return -2;
+        }
+
         $this->query = "route?from=" . implode(',', $pointFrom) . "&to=" . implode(',', $pointTo) . "";
         $this->query .= "&outFormat=json&unit=k&routeType=shortest&narrativeType=none";
         $this->query .= "&doReverseGeocode=false";
-        
-        try {            
+
+        try {
             $this->runQuery();
         }
-        catch (\Exception $e) {   
+        catch (\Exception $e) {
             # Általában akkor kerül elő ez, ha a mapquestApin elfogyott a havi lekérdezés adagunk
-            // echo $this->responseCode // 403 = forbidden
-            //throw new \Exception($this->rawData);
+            # #129: 403 esetén megjegyezzük, hogy ne pazaroljuk a következő
+            # hívást sem. Egyéb hibára (pl. transient 5xx vagy network) nem.
+            if ($this->responseCode == 403) {
+                $this->markRateLimited();
+            }
             return -2; # ??
         }
- 
+
         $mapquest = $this->jsonData;
         if (isset($mapquest->route->routeError->errorCode)) {
             if ($mapquest->info->statuscode == 602)
@@ -40,6 +63,33 @@ class MapquestApi extends \ExternalApi\ExternalApi {
         }
         $d = $mapquest->route->distance * 1000;
         return $d;
+    }
+
+    private function isRateLimited(): bool {
+        // In-request memo: ugyanazon kérés további hívásai már ne is fájl-ozzanak.
+        if (self::$rateLimitHitMemo !== null) {
+            return self::$rateLimitHitMemo;
+        }
+
+        $path = $this->getRateLimitCachePath();
+        if (is_readable($path)) {
+            $hitAt = (int) @file_get_contents($path);
+            if ($hitAt > 0 && (time() - $hitAt) < self::RATE_LIMIT_TTL_SECONDS) {
+                self::$rateLimitHitMemo = true;
+                return true;
+            }
+        }
+        self::$rateLimitHitMemo = false;
+        return false;
+    }
+
+    private function markRateLimited(): void {
+        self::$rateLimitHitMemo = true;
+        @file_put_contents($this->getRateLimitCachePath(), (string) time());
+    }
+
+    private function getRateLimitCachePath(): string {
+        return sys_get_temp_dir() . '/miserend_mapquest_rate_limit_hit';
     }
 
     function buildQuery() {

--- a/webapp/classes/externalapi/mapquestapi.php
+++ b/webapp/classes/externalapi/mapquestapi.php
@@ -54,6 +54,16 @@ class MapquestApi extends \ExternalApi\ExternalApi {
             return -2; # ??
         }
 
+        # #129: FONTOS - a base runQuery() éles környezetben NEM dob kivételt
+        # (csak isTesting módban), hanem elnyeli és false-szal tér vissza; a
+        # responseCode-ot viszont a curl után beállítja. Ezért a 403-at a hívás
+        # UTÁN is detektálni kell, különben a fenti catch sosem fut le prod-on és
+        # a rate-limit jelzés soha nem íródna ki.
+        if ($this->responseCode == 403) {
+            $this->markRateLimited();
+            return -2;
+        }
+
         $mapquest = $this->jsonData;
         if (isset($mapquest->route->routeError->errorCode)) {
             if ($mapquest->info->statuscode == 602)
@@ -89,7 +99,11 @@ class MapquestApi extends \ExternalApi\ExternalApi {
     }
 
     private function getRateLimitCachePath(): string {
-        return sys_get_temp_dir() . '/miserend_mapquest_rate_limit_hit';
+        global $config;
+        // #129: appkey-hash namespace, hogy több install / több key ugyanazon a
+        // hoston ne szennyezze egymás rate-limit állapotát.
+        $keyHash = substr(md5($config['mapquest']['appkey'] ?? 'default'), 0, 12);
+        return sys_get_temp_dir() . '/miserend_mapquest_rate_limit_' . $keyHash;
     }
 
     function buildQuery() {


### PR DESCRIPTION
Refs #129

A Mapquest free tier havi limit elérésekor eddig MINDEN további `distance()` hívás kiment, 403-at kapott, és a catch-blokk csak `return -2`-vel ment tovább. CURL idő + (ami fontosabb) **a következő hónap kvótájából megspórolható** hívások mentek volna a kukába.

## A logika

Új mezők és metódusok a `MapquestApi`-ban:

- `RATE_LIMIT_TTL_SECONDS = 86400` (24h)
- `static $rateLimitHitMemo` — in-request memo, ugyanazon kérés további hívásai már ne fájl-ozzanak
- `isRateLimited()` — előbb a static memo, aztán a fájl-cache (`sys_get_temp_dir()/miserend_mapquest_rate_limit_<appkey-hash>`) ellenőrzése; az appkey-hash namespace, hogy több install / több key ne szennyezze egymást
- `markRateLimited()` — beállítja mindkettőt
- `distance()` legelején: `if ($this->isRateLimited()) return -2;`
- catch blokkban: csak akkor markel-jünk ha **`$this->responseCode == 403`** — transient 5xx / network hibára nem reagálunk

## Miért 24h TTL?

A Mapquest free tier kvóta **havonta** áll vissza, szóval ha hitünk, valószínű legalább pár napig úgy marad. 24h konzervatív választás — ha valamiért manuálisan emeled meg vagy fizetős upgradet kapsz, max fél nap késéssel próbálkozunk újra.

## Miért nem settings tábla?

A feladatleírás említette a settings table-t. Megfontoltam, de:
- Nincs még settings tábla a sémában (új tábla = szélesebb scope, séma-migráció)
- A `/tmp` fájl elég a célhoz — nem szennyezi a DB-t
- Ha később kell perzisztens állapot más célra is, lecserélhető

Ha mégis settings-táblát szeretnél, könnyű átírni — szólj és csinálom.

## Backward compat

Tisztán additív viselkedés. Régi hívók ugyanúgy `-2`-t kapnak limit esetén, csak most nem fognak feleslegesen 403-at trigger-elni.