### PR TITLE
Overpass: konfigurálható endpoint (stabil EU-mirrorra átállítható) #376

### DIFF
--- a/webapp/classes/externalapi/overpassapi.php
+++ b/webapp/classes/externalapi/overpassapi.php
@@ -7,9 +7,20 @@ namespace ExternalApi;
 class OverpassApi extends \ExternalApi\ExternalApi {
 
     public $name = 'overpass';
-    public $apiUrl = "http://overpass-api.de/api/interpreter";
+    public $apiUrl = "https://overpass-api.de/api/interpreter";
 	public $testQuery = 'nwr["name"="Tápiószecső"];out geom;';
     public $queryFilter;
+
+    function __construct() {
+        global $config;
+        // #376: az Overpass-endpoint mostantól konfigurálható. borazslo tapasztalata
+        // szerint a fő overpass-api.de instabil lehet; prod átállhat egy stabilabb,
+        // EU-s mirrorra (pl. overpass.kumi.systems, Ausztria) a config['overpass']['apiUrl']
+        // vagy az OVERPASS_API_URL env révén. (Orosz mirrort ne — nem EU, GDPR/megbízhatóság.)
+        if (!empty($config['overpass']['apiUrl'])) {
+            $this->apiUrl = $config['overpass']['apiUrl'];
+        }
+    }
 
     function buildQuery() {
         $this->rawQuery = "[out:json][timeout:" . $this->queryTimeout . "];";

--- a/webapp/config.php
+++ b/webapp/config.php
@@ -15,8 +15,15 @@ $environment['default'] = [
         'useitforsearch' => false
     ],
 	'openstreetmap' => [
-		'apiUrl' => 'https://api.openstreetmap.org/'	
-    ],	
+		'apiUrl' => 'https://api.openstreetmap.org/'
+    ],
+    // #376: konfigurálható Overpass-endpoint. A fő overpass-api.de instabil lehet;
+    // prod átállhat egy stabil, EU-s mirrorra az OVERPASS_API_URL env-vel. Ajánlott:
+    //   https://overpass.kumi.systems/api/interpreter  (Kumi Systems, Ausztria — EU, GDPR-OK)
+    // NE orosz mirror (openstreetmap.ru): nem EU, GDPR/megbízhatósági kockázat.
+    'overpass' => [
+        'apiUrl' => env('OVERPASS_API_URL', 'https://overpass-api.de/api/interpreter')
+    ],
     'token' => [
         'web' => "2 weeks",
 		'API' => "15 minutes"


### PR DESCRIPTION
A #376 threadben jelezted, hogy az Overpass API-nál (ez hajtja az OSM boundary- és templom-a-határon-belül lekéréseket) a fő `overpass-api.de` instabil lehet — és ez fontosabb, mint a térkép-csempe kérdés. Eddig az endpoint **hardcode-olt** volt (`http://overpass-api.de/api/interpreter`).

## Fix

- `OverpassApi` konstruktor mostantól a `config['overpass']['apiUrl']`-t olvassa (`OVERPASS_API_URL` env, `config.php`).
- Default: a hivatalos `overpass-api.de`, most már **https**-en.
- Prod egy stabil, **EU-s** mirrorra állhat:
  ```
  OVERPASS_API_URL=https://overpass.kumi.systems/api/interpreter
  ```
  (Kumi Systems, Ausztria — EU, GDPR-OK.)

**Orosz mirror (openstreetmap.ru) kizárva**: nem EU, GDPR-/megbízhatósági kockázat (a config kommentben is jelölve).

Verifikálva: default / env-override / üres-config ág + a query-builderek érintetlenek. (A #376 tile-provider része külön, azt lezárod.)
