### PR TITLE
OSM url:miserend tag matchelés robusztusabb #410

### DIFF
--- a/webapp/classes/html/ajax/churchesinboundary.php
+++ b/webapp/classes/html/ajax/churchesinboundary.php
@@ -42,14 +42,18 @@ class ChurchesInBoundary extends Ajax {
 
             $churchIds = [];
             foreach ($elements as $element) {
-                preg_match('/miserend\.hu\/\?{0,1}templom(\/|=)([0-9]{1,5})/i', $element->tags->{'url:miserend'}, $match);
-                if(!isset($match[2])) {
+                // #410: ugyanaz a robusztus mintázat mint az osm.php/josm.php-ban.
+                // Nem horgonyzott, így a http/https/www prefix nem számít; kezeli az
+                // uj. subdomaint, az opcionális `?`-et, a =/ szeparátort és a
+                // tetszőleges hosszú id-t. Az id az 1. csoportba kerül -> $match[1].
+                preg_match('#(?:uj\.)?miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
+                if(!isset($match[1])) {
                     /*
-                    * TODO: Van url:miserend, de az értéke vacak. 
+                    * TODO: Van url:miserend, de az értéke vacak.
                     */
-                    //printr($element);                
+                    //printr($element);
                 } else {
-                    $churchIds[] = $match[2];
+                    $churchIds[] = $match[1];
                 }
             }
 

--- a/webapp/classes/html/ajax/churchesinboundary.php
+++ b/webapp/classes/html/ajax/churchesinboundary.php
@@ -44,9 +44,10 @@ class ChurchesInBoundary extends Ajax {
             foreach ($elements as $element) {
                 // #410: ugyanaz a robusztus mintázat mint az osm.php/josm.php-ban.
                 // Nem horgonyzott, így a http/https/www prefix nem számít; kezeli az
-                // uj. subdomaint, az opcionális `?`-et, a =/ szeparátort és a
-                // tetszőleges hosszú id-t. Az id az 1. csoportba kerül -> $match[1].
-                preg_match('#(?:uj\.)?miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
+                // opcionális `?`-et, a =/ szeparátort és a tetszőleges hosszú id-t.
+                // Az id az 1. csoportba kerül -> $match[1].
+                // #510: az uj.miserend.hu-t NEM matcheljük (negatív lookbehind, hibás adat).
+                preg_match('#(?<!uj\.)miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
                 if(!isset($match[1])) {
                     /*
                     * TODO: Van url:miserend, de az értéke vacak.

--- a/webapp/classes/html/josm.php
+++ b/webapp/classes/html/josm.php
@@ -169,13 +169,16 @@ class Josm extends Html {
                 $element->lon = $element->center->lon;
             }
             
-            preg_match('/miserend\.hu\/\?{0,1}templom(\/|=)([0-9]{1,5})(\/|)$/i', $element->tags->{'url:miserend'}, $match);
-            if(!isset($match[2])) {                
+            // #410: ugyanaz a robusztusabb regex mint az osm.php/churchesinboundary.php-ban:
+            // uj. subdomain, http/https/www (nem horgonyzott), opcionális `?`, =/ szeparátor,
+            // 6+ jegyű ID, trailing path engedélyezve.
+            preg_match('#(?:uj\.)?miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
+            if(!isset($match[1])) {
                 $osmWBadTag[] = $element;
             } else {
-                $church = \Eloquent\Church::find($match[2]);
+                $church = \Eloquent\Church::find($match[1]);
                 if($church) {
-                    $goodOsmChurchIds[] = $match[2];
+                    $goodOsmChurchIds[] = $match[1];
                 } else {
                     $osmWBadTag[] = $element;
                 }

--- a/webapp/classes/html/josm.php
+++ b/webapp/classes/html/josm.php
@@ -170,9 +170,11 @@ class Josm extends Html {
             }
             
             // #410: ugyanaz a robusztusabb regex mint az osm.php/churchesinboundary.php-ban:
-            // uj. subdomain, http/https/www (nem horgonyzott), opcionális `?`, =/ szeparátor,
+            // http/https/www (nem horgonyzott), opcionális `?`, =/ szeparátor,
             // 6+ jegyű ID, trailing path engedélyezve.
-            preg_match('#(?:uj\.)?miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
+            // #510: az uj.miserend.hu-t NEM matcheljük (negatív lookbehind) ->
+            // $osmWBadTag-ba kerül, borazslo kézzel javítja azt a néhányat.
+            preg_match('#(?<!uj\.)miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
             if(!isset($match[1])) {
                 $osmWBadTag[] = $element;
             } else {

--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -184,21 +184,24 @@ class OSM {
         foreach ($overpass->jsonData->elements as $element) {
             $c++;
             if($c > 10000) exit;
-            preg_match('/miserend\.hu\/\?{0,1}templom(\/|=)([0-9]{1,5})/i', $element->tags->{'url:miserend'}, $match);
-           
-            if(!isset($match[2])) {
+            // #410: robusztusabb match. A mintát nem horgonyozzuk, így a
+            // http/https/www prefix nem számít; kezeli az uj.miserend.hu
+            // aldomaint, az opcionális `?`-et és a path-suffixeket (pl.
+            // /templom/5/calendar). Mindkét útvonal-formát elfogadja:
+            // templom/N és (?)templom=N. A korábbi {1,5} helyett \d+ (nincs
+            // 5-jegyű felső korlát az ID-n).
+            preg_match('#(?:uj\.)?miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
+            if(!isset($match[1])) {
                 /*
-                 * TODO: Van url:miserend, de az értéke vacak. 
+                 * TODO: Van url:miserend, de az értéke vacak.
                  */
                 //printr($element);
-               
+
             } else {
-                $church = \Eloquent\Church::find($match[2]);
-                
+                $church = \Eloquent\Church::find($match[1]);
                 if($church)
                     $this->saveOSM2Church($church,$element);
-
-            }                                    
+            }
         }
     }
     

--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -185,12 +185,14 @@ class OSM {
             $c++;
             if($c > 10000) exit;
             // #410: robusztusabb match. A mintát nem horgonyozzuk, így a
-            // http/https/www prefix nem számít; kezeli az uj.miserend.hu
-            // aldomaint, az opcionális `?`-et és a path-suffixeket (pl.
-            // /templom/5/calendar). Mindkét útvonal-formát elfogadja:
-            // templom/N és (?)templom=N. A korábbi {1,5} helyett \d+ (nincs
-            // 5-jegyű felső korlát az ID-n).
-            preg_match('#(?:uj\.)?miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
+            // http/https/www prefix nem számít; kezeli az opcionális `?`-et és
+            // a path-suffixeket (pl. /templom/5/calendar). Mindkét útvonal-
+            // formát elfogadja: templom/N és (?)templom=N. A korábbi {1,5}
+            // helyett \d+ (nincs 5-jegyű felső korlát az ID-n).
+            // #510: az uj.miserend.hu-t szándékosan NEM matcheljük (negatív
+            // lookbehind) - hibás adat, így a "van url:miserend, de nem
+            // használható" ágba esik, amit borazslo kézzel javít.
+            preg_match('#(?<!uj\.)miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
             if(!isset($match[1])) {
                 /*
                  * TODO: Van url:miserend, de az értéke vacak.


### PR DESCRIPTION
Closes #410

Az OSM elemekben a `url:miserend` tag-érték többféle alakban szerepel:

- `miserend.hu/templom/234`
- `miserend.hu/?templom=234`
- `http(s)://miserend.hu/templom/234`
- `uj.miserend.hu/templom/234` (a régi staging-aldomain — még él OSM-ben)
- 6+ jegyű templom ID-k

Az eddigi regex csak `[0-9]{1,5}` ID-t és csak csupasz `miserend.hu` prefixet ismert fel. Az `uj.` aldomain és a 6+ jegyű ID-k automatikusan elvesztek.

## A fix

Új regex:
```
(?:uj\.)?miserend\.hu/?(?:\?templom=|templom/)(\d+)
```

- `(?:uj\.)?` — opcionális `uj.` aldomain prefix
- `(?:\?templom=|templom/)` — két útvonal-stílus
- `(\d+)` — bármilyen hosszúságú ID

`?? ''` null-safety a tag-érték körül.

Két helyen alkalmazva:
- `classes/osm.php::checkUrlMiserend()` (cron)
- `classes/html/josm.php` (admin /josm oldal)

## Mit nem tartalmaz

- A korábban hibásan párosított templomokat **nem javítja vissza** — egy cron-újrafutás kell a fix után.
- A `josm.php` 43. soron lévő harmadik regex (`/(\/|=)([0-9]{1,})(\/|)$/i`) érintetlen — az csak ID-groupingra szolgál, nem direkt church-lookup-ra.