### PR TITLE
#523: token-süti Secure flag HTTPS-en (X-Forwarded-Proto tudatosan)

### DIFF
--- a/webapp/classes/token.php
+++ b/webapp/classes/token.php
@@ -18,7 +18,9 @@ class Token {
             ]);        
         $token->save();
 
-        setcookie('token', $token->name, strtotime($timeout),"/","", false, true);  // https?
+        // #523: HTTPS-en Secure süti (Caddy reverse-proxy mögött X-Forwarded-Proto alapján is);
+        // http://localhost dev-en marad false, hogy ne törje a belépést.
+        setcookie('token', $token->name, strtotime($timeout),"/","", self::isHttps(), true);
         $_COOKIE['token'] = $token->name;
 
         return $token->name;
@@ -28,11 +30,19 @@ class Token {
     static function delete() {
         if(isset($_COOKIE['token'])) {
             \Eloquent\Token::where('name',$_COOKIE['token'])->delete();
-            setcookie('token', "", strtotime("-1 year"),"/","", false, true);        
+            setcookie('token', "", strtotime("-1 year"),"/","", self::isHttps(), true);
             unset($_COOKIE['token']);
         }        
     }
      
+    // #523: a kérés HTTPS-e. Caddy/nginx reverse-proxy mögött a backend http-t lát,
+    // ezért az X-Forwarded-Proto fejlécet is nézzük. http://localhost dev-en false marad.
+    static function isHttps() {
+        return (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off')
+            || (($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https')
+            || (($_SERVER['SERVER_PORT'] ?? '') == '443');
+    }
+
     static function cleanOut() {
         \Eloquent\Token::where('timeout','<',date('Y-m-d H:i:s'))->delete();
     }


### PR DESCRIPTION
Kapcsolódik: #523.

A login-token süti eddig fixen `secure=false`-szal ment (a `token.php:21`-en egy beégetett `// https?` komment is jelezte a kételyt). `Secure` nélkül a böngésző a token-sütit sima HTTP-kérésben is elküldi — pl. a `http→https` redirect ELŐTTI első kérésnél, vagy egy beszúrt `http://` erőforrásnál — ahol egy hálózati lehallgató tisztán kiolvashatja. A `Secure` flag pont ezt tiltja: a sütit csak HTTPS-en engedi ki.

Bevezetem a `Token::isHttps()`-t, és a create/delete `setcookie` ezt kapja a hardcode-olt `false` helyett. A detektálás **Caddy/nginx reverse-proxy mögött is** helyes, mert az `X-Forwarded-Proto` fejlécet is nézi (a backend ilyenkor http-t lát).

Fontos: `http://localhost` dev-en `isHttps()` **false marad** → a süti nem lesz Secure → a lokális belépés nem törik. 5 esetre leteszteltem (localhost http, prod https proxy mögött, direkt :443, `HTTPS=off`, CLI).

@borazslo — egy dolgot erősíts meg: a Caddy `reverse_proxy` alapból küldi az `X-Forwarded-Proto`-t, szóval prod/dev HTTPS-en `true` lesz. Ha nálad valamiért nem menne át ez a fejléc, akkor a süti prod-on is `secure=false` maradna (regresszió nincs, csak a hardening nem lépne életbe) — de érdemes ellenőrizni merge előtt.