### PR TITLE
#172: szomszédság-számítás visszaélesztése (Mapquest-függés nélkül)

### DIFF
--- a/webapp/classes/distance.php
+++ b/webapp/classes/distance.php
@@ -78,10 +78,12 @@ class Distance {
                     if ($rawDistance < $maxDistance AND $rawDistance > 0) {
                         // #172: nem dőlünk el a Mapquesten - road-distance ha van,
                         // egyébként a légvonalbeli (haversine) rawDistance.
-                        $distanceToSave = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
-                        $processingDistance->distance = $distanceToSave;
-                        if ($distanceToSave > $highestDistance)
-                            $highestDistance = $distanceToSave;
+                        $resolved = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
+                        $processingDistance->distance = $resolved['distance'];
+                        // #526: légvonal-fallback -> toupdate=1 (később útvonalra frissítendő); road -> 0.
+                        $processingDistance->toupdate = $resolved['road'] ? 0 : 1;
+                        if ($resolved['distance'] > $highestDistance)
+                            $highestDistance = $resolved['distance'];
                         $processingDistance->save();
                     } else {
                         //Pontatlant inkább soha senem mentünk el.
@@ -127,7 +129,9 @@ class Distance {
 
                             if ($rawDistance < $maxDistance AND $rawDistance > 0) {
                                 // #172: road-distance ha elérhető, egyébként légvonal.
-                                $processingDistance->distance = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
+                                $resolved = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
+                                $processingDistance->distance = $resolved['distance'];
+                                $processingDistance->toupdate = $resolved['road'] ? 0 : 1; // #526
                                 $processingDistance->save();
                             } else {
                                 //Pontatlant inkább soha senem mentünk el.
@@ -146,17 +150,20 @@ class Distance {
     // elérhető (van kulcs, nincs rate-limit), azt adjuk vissza; egyébként a
     // légvonalbeli (haversine) rawDistance-re esünk vissza. Így a feature mindig
     // frissül, a Mapquest csak opcionális felminősítés.
+    // #526: visszaadja a távolságot ÉS a minőségét ('road' => true, ha Mapquest
+    // útvonal-távolság; false, ha csak légvonal). A hívó ez alapján állítja a
+    // distances.toupdate flaget (1 = később útvonalra frissítendő).
     function resolveDistance($pointFrom, $pointTo, $rawDistance) {
         try {
             $mapquest = new \ExternalApi\MapquestApi();
             $mapquestDistance = $mapquest->distance($pointFrom, $pointTo);
             if ($mapquestDistance > 0) {
-                return $mapquestDistance;
+                return ['distance' => $mapquestDistance, 'road' => true];
             }
         } catch (\Throwable $e) {
             // nincs Mapquest-kulcs vagy bármilyen hiba -> marad a légvonal
         }
-        return $rawDistance;
+        return ['distance' => $rawDistance, 'road' => false];
     }
 
     function getRawDistance($pointFrom, $pointTo) {

--- a/webapp/classes/distance.php
+++ b/webapp/classes/distance.php
@@ -76,16 +76,13 @@ class Distance {
                     $pointTo = ['lat' => $churchTo->location->lat, 'lon' => $churchTo->location->lon];
                     $rawDistance = $this->getRawDistance($pointFrom, $pointTo);
                     if ($rawDistance < $maxDistance AND $rawDistance > 0) {
-                        $mapquest = new \ExternalApi\MapquestApi();
-                        $mapquestDistance = $mapquest->distance($pointFrom, $pointTo);
-                        if ($mapquestDistance == -2) {
-                            return;
-                        } elseif ($mapquestDistance > 0) {
-                            $processingDistance->distance = $mapquestDistance;
-                            if($mapquestDistance > $highestDistance)
-                                $highestDistance = $mapquestDistance;
-                            $processingDistance->save();
-                        }
+                        // #172: nem dőlünk el a Mapquesten - road-distance ha van,
+                        // egyébként a légvonalbeli (haversine) rawDistance.
+                        $distanceToSave = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
+                        $processingDistance->distance = $distanceToSave;
+                        if ($distanceToSave > $highestDistance)
+                            $highestDistance = $distanceToSave;
+                        $processingDistance->save();
                     } else {
                         //Pontatlant inkább soha senem mentünk el.
                         //$processingDistance->distance = $rawDistance;
@@ -122,21 +119,16 @@ class Distance {
                         }
                         $highestDistance = 0;
                         if ($churchFrom->updated_at > $processingDistance->updated_at
-                                OR $churchTo->updated_at > $processingDistance->updated_at OR 4 == 4) {
+                                OR $churchTo->updated_at > $processingDistance->updated_at) {
 
                             $pointFrom = ['lat' => $churchFrom->location->lat, 'lon' => $churchFrom->location->lon];
                             $pointTo = ['lat' => $churchTo->location->lat, 'lon' => $churchTo->location->lon];
                             $rawDistance = $this->getRawDistance($pointFrom, $pointTo);
 
                             if ($rawDistance < $maxDistance AND $rawDistance > 0) {
-                                $mapquest = new \ExternalApi\MapquestApi();
-                                $mapquestDistance = $mapquest->distance($pointFrom, $pointTo);
-                                if ($mapquestDistance == -2) {
-                                    return;
-                                } elseif ($mapquestDistance > 0) {
-                                    $processingDistance->distance = $mapquestDistance;
-                                    $processingDistance->save();
-                                }
+                                // #172: road-distance ha elérhető, egyébként légvonal.
+                                $processingDistance->distance = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
+                                $processingDistance->save();
                             } else {
                                 //Pontatlant inkább soha senem mentünk el.
                                 //$processingDistance->distance = $rawDistance;
@@ -148,6 +140,23 @@ class Distance {
                 
             }
             return $counter;
+    }
+
+    // #172: a szomszédság-számítás ne dőljön el a Mapquesten. Ha a road-distance
+    // elérhető (van kulcs, nincs rate-limit), azt adjuk vissza; egyébként a
+    // légvonalbeli (haversine) rawDistance-re esünk vissza. Így a feature mindig
+    // frissül, a Mapquest csak opcionális felminősítés.
+    function resolveDistance($pointFrom, $pointTo, $rawDistance) {
+        try {
+            $mapquest = new \ExternalApi\MapquestApi();
+            $mapquestDistance = $mapquest->distance($pointFrom, $pointTo);
+            if ($mapquestDistance > 0) {
+                return $mapquestDistance;
+            }
+        } catch (\Throwable $e) {
+            // nincs Mapquest-kulcs vagy bármilyen hiba -> marad a légvonal
+        }
+        return $rawDistance;
     }
 
     function getRawDistance($pointFrom, $pointTo) {

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -678,9 +678,10 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     }
 
     public function updateNeighbours() {
-        //TODO: Does not work! 
-        // "Call to undefined method Illuminate\Database\Query\Builder::MupdateChurch()"
-        $distance = new Distance();        
+        // #172: a globális \Distance kell (azon van a MupdateChurch). Az Eloquent
+        // névtérben a sima `new Distance()` a modellt (\Eloquent\Distance) hozná,
+        // ami nem ismeri a metódust -> "Call to undefined method MupdateChurch()".
+        $distance = new \Distance();
         $distance->MupdateChurch($this);
     }
     

--- a/webapp/tests/Unit/DistanceTest.php
+++ b/webapp/tests/Unit/DistanceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once PATH . 'classes/distance.php';
+
+/**
+ * #172: a szomszédság (distances) számító-motor tiszta geometriája + a
+ * Mapquest-független visszaesés. A DB-orchestrációt (MupdateChurch) nem itt
+ * teszteljük - az integrációs terep -, de a számítás magját igen.
+ */
+class DistanceTest extends TestCase {
+
+    private function d(): \Distance {
+        return new \Distance();
+    }
+
+    public function testGetRawDistanceForOneHundredthDegreeLatitude() {
+        // 0.01° szélesség-különbség ~ 1112 m légvonalban.
+        $from = ['lat' => 47.4979, 'lon' => 19.0402];
+        $to   = ['lat' => 47.5079, 'lon' => 19.0402];
+        $this->assertEqualsWithDelta(1112, $this->d()->getRawDistance($from, $to), 8);
+    }
+
+    public function testGetRawDistanceForIdenticalPointIsZero() {
+        $p = ['lat' => 47.4979, 'lon' => 19.0402];
+        $this->assertSame(0, $this->d()->getRawDistance($p, $p));
+    }
+
+    public function testGetBBoxContainsCenterPoint() {
+        $p = ['lat' => 47.4979, 'lon' => 19.0402];
+        $bbox = $this->d()->getBBox($p, 5000);
+        $this->assertGreaterThan($bbox['latMin'], $p['lat']);
+        $this->assertLessThan($bbox['latMax'], $p['lat']);
+        $this->assertGreaterThan($bbox['lonMin'], $p['lon']);
+        $this->assertLessThan($bbox['lonMax'], $p['lon']);
+    }
+
+    public function testGetBBoxHalfWidthMatchesRadius() {
+        // 5 km sugár ~ 0.045° szélességi félszélesség.
+        $p = ['lat' => 47.4979, 'lon' => 19.0402];
+        $bbox = $this->d()->getBBox($p, 5000);
+        $this->assertEqualsWithDelta(0.0449, $bbox['latMax'] - $p['lat'], 0.005);
+    }
+
+    public function testResolveDistanceFallsBackToStraightLineWhenMapquestUnavailable() {
+        // #172 lényege: Mapquest-kulcs nélkül (mint a CI-ban) a distance() eldob,
+        // és a resolveDistance a légvonalbeli (haversine) értékre esik vissza -
+        // így a szomszédság-frissítés sosem áll le csendben.
+        $from = ['lat' => 47.4979, 'lon' => 19.0402];
+        $to   = ['lat' => 47.5079, 'lon' => 19.0402];
+        $raw  = $this->d()->getRawDistance($from, $to);
+        $this->assertSame($raw, $this->d()->resolveDistance($from, $to, $raw));
+    }
+}

--- a/webapp/tests/Unit/DistanceTest.php
+++ b/webapp/tests/Unit/DistanceTest.php
@@ -50,6 +50,9 @@ class DistanceTest extends TestCase {
         $from = ['lat' => 47.4979, 'lon' => 19.0402];
         $to   = ['lat' => 47.5079, 'lon' => 19.0402];
         $raw  = $this->d()->getRawDistance($from, $to);
-        $this->assertSame($raw, $this->d()->resolveDistance($from, $to, $raw));
+        $resolved = $this->d()->resolveDistance($from, $to, $raw);
+        // #526: légvonalra esik vissza, és jelzi a minőséget (road=false -> toupdate=1).
+        $this->assertSame($raw, $resolved['distance']);
+        $this->assertFalse($resolved['road']);
     }
 }


### PR DESCRIPTION
Kapcsolódik: #172.

## A baj
A „szomszédos templomok" panel **megjelenik** élesben (a `distances` táblából olvas), de a **számító-motor halott** 2023 óta — az adat beragadt, új/áthelyezett templom nem kap szomszédot. Négy különálló törés:

1. **Kemény Mapquest-függés.** A `MupdateChurch` minden párnál a Mapquest road-distance-ét kérte; az kulcs nélkül `throw`-ol (`appkey=='***'`), rate-limitnél/403-nál `-2`-t ad → a metódus `return`-öl, az egész leáll. A haversine távolságot kiszámolta, de eldobta.
2. **Namespace-bug** a `Church::updateNeighbours()`-ben: `new Distance()` az Eloquent névtérben a **modellt** hozza (`\Eloquent\Distance`), nem a globális `\Distance`-t → „Call to undefined method `MupdateChurch()`" (a kód meg is jegyezte: `//TODO: Does not work!`).
3. **`OR 4 == 4`** debug-hack.
4. Csak `updated_at`-változáskor számol újra — a régi hibás értékek sosem javulnak.

## A fix
- **`resolveDistance()`**: Mapquest ha elérhető, azt vesszük (road-distance); egyébként a **légvonalbeli (haversine)** értékre esünk vissza. Nincs több abort → a frissítés mindig lefut. A Mapquest csak opcionális felminősítés.
- `updateNeighbours()`: `new Distance()` → `new \Distance()`.
- `OR 4 == 4` kivéve.
- Unit teszt: `getRawDistance`, `getBBox`, és a Mapquest-mentes fallback.

## Tudatos tradeoff (kérlek nézd meg)
Ez felülírja a korábbi „csak pontosat (road-distance) mentünk" elvet — de az pont a halál oka volt. „Közeli templomok"-hoz a légvonal tökéletes rendezés; a Mapquest marad felminősítésként, ha van kvóta. Ha inkább csak road-distance-t akarsz, szólj.

## Verifikáció
A tiszta geometriát és a fallbacket harness + unit teszt igazolja (a `MupdateChurch` DB-orchestrációját lokálisan nem tudom futtatni — az integrációs/éles terep). Egy kérés: **a `#19`-es cron (`\Distance::updateSome`) engedélyezve van-e** a prod DB-ben? Ha le van tiltva, ez a fix önmagában nem indítja újra.