### PR TITLE
#521: ellátó plébánia cseréje a szerkesztőben (nem halmozás)

### DIFF
--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -63,10 +63,17 @@ class Edit extends \Html\Html {
             $parentId = (int) $this->input['church']['parent_id'];
             // Kapcsolat csak akkor kerül mentésre, ha érvényes parent ID van és nem önmagára mutat
             if ($parentId !== 0 && $parentId !== (int)$this->tid) {
-                \Eloquent\ChurchRelationship::updateOrCreate(
-                    ['parent_church_id' => $parentId, 'child_church_id' => $this->tid],
-                    ['type' => 'subordinate'] // Alapértelmezett típus
-                );
+                // #521: egy templomnak egy ellátó plébániája (parent) van a formon
+                // keresztül. A korábbi updateOrCreate a (parent,child) PÁRRA matchelt,
+                // ezért új plébánia választásakor ÚJ sort hozott létre, a régit meghagyva
+                // ("hozzáadja, de nem cserél"). Előbb töröljük a meglévő parent-kapcsolatot,
+                // hogy a választás CSERÉLJEN (és a korábbi duplikátumok is kitakarodjanak).
+                \Eloquent\ChurchRelationship::where('child_church_id', $this->tid)->delete();
+                \Eloquent\ChurchRelationship::create([
+                    'parent_church_id' => $parentId,
+                    'child_church_id' => $this->tid,
+                    'type' => 'subordinate',
+                ]);
             }
         } else {
             // Ha üres a kiválasztás, törlődnek az összes parent kapcsolat


### PR DESCRIPTION
Zárja: #521.

**Bug:** a templom-szerkesztőben az ellátó plébánia (parent) választás nem cserél, hanem halmoz — „az újakat hozzáadja, csak megmarad a régi is".

**Ok:** a mentés `ChurchRelationship::updateOrCreate`-tel a **`(parent_church_id, child_church_id)` párra** matchelt. Új plébániánál nincs ilyen pár → új sort hoz létre, a régi `(régi_parent, child)` sor megmarad.

**Fix:** a modell egy-parent-per-child (az üres-választás ága is minden child-kapcsolatot töröl). Ezért **delete-then-create**: előbb törlöm a meglévő parent-kapcsolatot a childra, majd létrehozom az újat. Így cserél — és a korábbi bug által létrehozott duplikátumok is kitakarodnak az első mentéskor.

`php -l` tiszta. DB-mentés lévén lokálisan nem futtatom élesben; a logika egyértelmű, review + éles a bizonyíték.