### PR TITLE
#515: régi-adat figyelmeztetés a misekereső találati listában

### DIFF
--- a/webapp/templates/search/resultsmasses.twig
+++ b/webapp/templates/search/resultsmasses.twig
@@ -20,6 +20,13 @@
             }
         });
     </script>
+    <style>
+        /* #515: régi-adat jelzés a találati listában (mint a templomoldalon) */
+        .mass-results-table tr.mass-row--stale td { text-decoration: line-through; opacity: .55; }
+        .mass-row-freshness { margin-left: 6px; cursor: help; }
+        .mass-row-freshness--stale { color: #b02a37; }
+        .mass-row-freshness--medium { color: #997404; }
+    </style>
 {% endblock %}
 
 
@@ -64,6 +71,9 @@
                 {% set rowCounter = 0 %}
                 {% for result in results %}
                     {% set church = result.church %}
+                    {# #515: régi-adat jelzés a templom frissítettsége alapján (mint a templomoldalon: 180 nap / 1825 nap) #}
+                    {% set freshTs = (church.frissites and church.frissites != '0000-00-00') ? church.frissites|date('U') : null %}
+                    {% set daysAgo = freshTs ? (("now"|date('U')) - freshTs) / 86400 : null %}
                     {% set currentDate = result.start_date|date('Y-m-d') %}
                     {% if previousDate is null or previousDate != currentDate %}
                         <tr class="date-header">
@@ -79,7 +89,10 @@
                         {% set previousDate = currentDate %}
                         {% set rowCounter = 0 %}
                     {% endif %}
-                    <tr{% if rowCounter % 2 == 1 %} class="table-light"{% endif %}>
+                    {% set rowClasses = [] %}
+                    {% if rowCounter % 2 == 1 %}{% set rowClasses = rowClasses|merge(['table-light']) %}{% endif %}
+                    {% if daysAgo is not null and daysAgo >= 1825 %}{% set rowClasses = rowClasses|merge(['mass-row--stale']) %}{% endif %}
+                    <tr{% if rowClasses|length %} class="{{ rowClasses|join(' ') }}"{% endif %}>
                         <td class="align-middle">
                             <span class="badge badge-primary">{{ "%02d:%02d"|format((result.start_minutes / 60)|round(0, 'floor'), (result.start_minutes % 60)) }}</span>
                         </td>
@@ -116,6 +129,11 @@
                             </a>
                             {% if church.alternative_names.0 %}
                                 <br/><span class="alap" style="margin-left: 20px; font-style: italic;" title="{{ church.alternative_names|slice(1)|join(', ') }}">{{ church.alternative_names.0 }}</span>
+                            {% endif %}
+                            {% if daysAgo is not null and daysAgo >= 1825 %}
+                                <i class="fas fa-exclamation-triangle mass-row-freshness mass-row-freshness--stale" title="Az adatok több mint 5 éve nem lettek frissítve – szinte biztosan megbízhatatlanok. Segíts: a templom oldalán szerkeszd a naptárat, vagy küldj észrevételt!"></i>
+                            {% elseif daysAgo is not null and daysAgo >= 180 %}
+                                <i class="fas fa-exclamation-circle mass-row-freshness mass-row-freshness--medium" title="Az adatok egy ideje nem lettek megerősítve. Segíts: a templom oldalán szerkeszd a naptárat, vagy küldj észrevételt!"></i>
                             {% endif %}
                         </td>
                         <td class="align-middle">


### PR DESCRIPTION
Zárja: #515.

A templom oldalán már van 3-szintű frissesség-jelzés (`church.twig`). Ezt viszem át a **szentmisekereső találati listájába** (`resultsmasses.twig`), a templom `frissites` mezője alapján, azonos küszöbökkel:

- **5+ év** (≥1825 nap): az egész sor **áthúzva** (`mass-row--stale`) + piros háromszög ikon.
- **6 hónap – 5 év** (≥180 nap): sárga figyelmeztető ikon.
- Mindkettőnél **tooltip**, ami elmondja hogyan lehet segíteni (naptár-szerkesztés / észrevétel).

Az adat elérhető: a `result.church` a teljes `Church::toArray()` (tartalmazza a `frissites`-t). Csak template-változás, PHP nem módosul.

Twig-et lokálisan nem rendereltem (üres vendor/), a szintaxis standard — review + staging a bizonyíték.