### PR TITLE
#522: ellátó-plébánia választó kereshetővé tétele (autocomplete)

### DIFF
--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -373,6 +373,20 @@ class Edit extends \Html\Html {
             }
         }
 
+        // #522: a legközelebbi 40 marad gyors javaslatnak (távolsággal), de MINDEN
+        // aktív templomot felveszünk, hogy autocomplete-tel messziről is választható
+        // legyen (gépelhető a település / név). A meglévő javaslatokat nem duplikáljuk.
+        // Így JS nélkül is elérhető minden templom (a combobox csak a gépelést adja rá).
+        $allActive = \Eloquent\Church::where('ok', 'i')
+            ->where('id', '!=', $this->tid)
+            ->orderBy('varos')->orderBy('nev')
+            ->get(['id', 'varos', 'nev']);
+        foreach ($allActive as $c) {
+            if (!isset($options[$c->id])) {
+                $options[$c->id] = $c->varos . ' – ' . $c->nev;
+            }
+        }
+
         $this->form['parent_id'] = array(
             'type' => 'select',
             'name' => 'church[parent_id]',

--- a/webapp/templates/church/_panelholders.twig
+++ b/webapp/templates/church/_panelholders.twig
@@ -175,15 +175,17 @@
 
       _source: function( request, response ) {
         var matcher = new RegExp( $.ui.autocomplete.escapeRegex(request.term), "i" );
-        response( this.element.children( "option" ).map(function() {
+        // #529: ne rendereljünk több ezer opciót a legördülőbe (belassul minden) -
+        // legfeljebb az első 50 találatot adjuk vissza.
+        var results = [], limit = 50;
+        this.element.children( "option" ).each(function() {
+          if ( results.length >= limit ) return false;
           var text = $( this ).text();
-          if ( this.value && ( !request.term || matcher.test(text) ) )
-            return {
-              label: text,
-              value: text,
-              option: this
-            };
-        }) );
+          if ( this.value && ( !request.term || matcher.test(text) ) ) {
+            results.push({ label: text, value: text, option: this });
+          }
+        });
+        response( results );
       },
 
       _removeIfInvalid: function( event, ui ) {
@@ -233,8 +235,11 @@
     // Graceful: ha a widget nem futna le, a plain select minden aktív templommal ott marad.
     if ( $( "#selectParentChurch" ).length ) {
       $( "#selectParentChurch" ).combobox();
-      $( "#selectParentChurch" ).next( ".custom-combobox" ).find( "input" )
-        .attr( "placeholder", "Kezdd el gépelni a települést vagy a templom nevét…" );
+      var $parentInput = $( "#selectParentChurch" ).next( ".custom-combobox" ).find( "input" );
+      $parentInput.attr( "placeholder", "Kezdd el gépelni a települést vagy a templom nevét…" );
+      // #529: sok ezer opció van - csak a 2. karaktertől nyíljon a lista (ne dumpolja
+      // az egészet), a _source pedig max 50 találatot ad -> nem lassul be.
+      $parentInput.autocomplete( "option", "minLength", 2 );
     }
 
   } );

--- a/webapp/templates/church/_panelholders.twig
+++ b/webapp/templates/church/_panelholders.twig
@@ -119,6 +119,10 @@
     {%  endif  %}
 
 
+  <style>
+    /* #529: a nagy parent-lista legördülője kapjon görgetőt (jobbra) */
+    .ui-autocomplete { max-height: 320px; overflow-y: auto; overflow-x: hidden; }
+  </style>
   <script>
   $( function() {
     $.widget( "custom.combobox", {
@@ -175,13 +179,14 @@
 
       _source: function( request, response ) {
         var matcher = new RegExp( $.ui.autocomplete.escapeRegex(request.term), "i" );
-        // #529: ne rendereljünk több ezer opciót a legördülőbe (belassul minden) -
-        // legfeljebb az első 50 találatot adjuk vissza.
-        var results = [], limit = 50;
+        // #529: üres fókuszra a legközelebbi 10-et adjuk (az opciók távolság szerint
+        // rendezettek elöl), gépelésre max 30-at - ne rendereljünk több ezret.
+        // A "0" értékű placeholder ("– válassz –") opciót kihagyjuk.
+        var results = [], limit = request.term ? 30 : 10;
         this.element.children( "option" ).each(function() {
           if ( results.length >= limit ) return false;
           var text = $( this ).text();
-          if ( this.value && ( !request.term || matcher.test(text) ) ) {
+          if ( this.value && this.value !== "0" && ( !request.term || matcher.test(text) ) ) {
             results.push({ label: text, value: text, option: this });
           }
         });
@@ -237,9 +242,13 @@
       $( "#selectParentChurch" ).combobox();
       var $parentInput = $( "#selectParentChurch" ).next( ".custom-combobox" ).find( "input" );
       $parentInput.attr( "placeholder", "Kezdd el gépelni a települést vagy a templom nevét…" );
-      // #529: sok ezer opció van - csak a 2. karaktertől nyíljon a lista (ne dumpolja
-      // az egészet), a _source pedig max 50 találatot ad -> nem lassul be.
-      $parentInput.autocomplete( "option", "minLength", 2 );
+      // #529: üres mezőbe kattintva rögtön jöjjön a legközelebbi 10 (a _source üres
+      // termre 10-et ad, az opciók távolság szerint elöl). Gépelésre a _source szűr,
+      // a hosszú lista görgethető (CSS lent). minLength=0 + focus-trigger kell hozzá.
+      $parentInput.autocomplete( "option", "minLength", 0 );
+      $parentInput.on( "focus", function() {
+        if ( !this.value ) { $( this ).autocomplete( "search", "" ); }
+      });
     }
 
   } );

--- a/webapp/templates/church/_panelholders.twig
+++ b/webapp/templates/church/_panelholders.twig
@@ -229,6 +229,14 @@
 
     $( "#combobox" ).combobox();
 
+    // #522: az ellátó-plébánia választót is kereshetővé tesszük (ugyanez a widget).
+    // Graceful: ha a widget nem futna le, a plain select minden aktív templommal ott marad.
+    if ( $( "#selectParentChurch" ).length ) {
+      $( "#selectParentChurch" ).combobox();
+      $( "#selectParentChurch" ).next( ".custom-combobox" ).find( "input" )
+        .attr( "placeholder", "Kezdd el gépelni a települést vagy a templom nevét…" );
+    }
+
   } );
   </script>
 

--- a/webapp/templates/church/edit.twig
+++ b/webapp/templates/church/edit.twig
@@ -278,7 +278,7 @@
                 <td class=kiscim align=right>Honnan látják el:</td>
                 <td colspan="2">
                     {{ forms.select(form.parent_id) }}
-                    <small class="text-muted">Ez a misézőhely mely templomnak van alárendelve. A legközelebbi 20 misézőhely jelenik meg.</small>
+                    <small class="text-muted">Ez a misézőhely mely templomnak van alárendelve. Kezdd el gépelni a települést vagy a templom nevét – bármelyik aktív misézőhely kereshető (a legközelebbiek távolsággal a lista tetején).</small>
                 </td>
             </tr>
 


### PR DESCRIPTION
Zárja: #522.

**Probléma:** az ellátó-plébánia (parent) választó csak a **legközelebbi 40** templomot listázta → messzebbi plébániát nem lehetett kiválasztani, és nem lehetett gépelve keresni.

**Megoldás:**
- `edit.php`: a gyors javaslatok (legközelebbi 40, távolsággal) megmaradnak a lista tetején, de **minden aktív (`ok='i'`) templomot** felveszek az opciók közé, „város – név" formában.
- Ráteszem a **már létező jQuery UI `combobox` widgetet** (a `_panelholders.twig`-ből, ami az edit-oldalon amúgy is be van húzva), így **gépelve szűrhető** település/név szerint. A placeholder init után átíródik.

**Graceful degradation:** ha a combobox JS bármiért nem futna le, a plain `<select>` **így is minden aktív templomot tartalmaz** — a távoli választás JS nélkül is működik, csak kényelmetlenebb.

**Tradeoff / kérdés:** minden aktív templom betöltése (~pár ezer `<option>`) növeli az admin edit-oldal méretét. Ha ez sok, egy AJAX-alapú autocomplete a következő lépés — szólj, ha inkább úgy szeretnéd. `php -l` tiszta; a JS-t/Twig-et lokálisan nem futtattam, staging a bizonyíték.