### PR TITLE
javaslattétel: email-értesítés + emberi-olvasható változások #307

### DIFF
--- a/webapp/classes/eloquent/calsuggestionpackage.php
+++ b/webapp/classes/eloquent/calsuggestionpackage.php
@@ -3,6 +3,7 @@ namespace Eloquent;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Capsule\Manager as DB;
 
 class CalSuggestionPackage extends CalModel
 {
@@ -46,4 +47,86 @@ class CalSuggestionPackage extends CalModel
         return null;
     }
 
+    /**
+     * #307: email-értesítés a beérkező javaslat-csomagról.
+     *
+     * Ugyanazt a 3 címzett-csoportot értesíti, mint a \Eloquent\Remark::emails():
+     *   - miserend adminok (jogok LIKE '%miserend%')
+     *   - egyházmegyei felelős (a templom egyházmegyéje alapján)
+     *   - templom-feltöltésre jogosult felhasználók
+     *
+     * A `notifications=1` flag-et tiszteletben tartja minden felhasználónál.
+     * Egy címet (e-mailt) csak egyszer értesít, akkor is ha több role-ben szerepel.
+     */
+    public function emails(): bool
+    {
+        $church = $this->church;
+        if (!$church) {
+            return false;
+        }
+
+        $emails = [];
+
+        // Miserend admin-ok
+        $admins = DB::table('user')
+            ->where('jogok', 'LIKE', '%miserend%')
+            ->where('notifications', 1)
+            ->get();
+        foreach ($admins as $admin) {
+            $emails[$admin->email] = ['admin', $admin->email, $admin];
+        }
+
+        // Egyházmegyei felelős
+        $responsabile = DB::table('egyhazmegye')
+            ->select('user.*')
+            ->where('egyhazmegye.id', $church->egyhazmegye)
+            ->leftJoin('user', 'user.login', '=', 'egyhazmegye.felelos')
+            ->where('notifications', 1)
+            ->first();
+        if ($responsabile && !empty($responsabile->email)) {
+            $emails[$responsabile->email] = ['diocese', $responsabile->email, $responsabile];
+        }
+
+        // Templom felelősök
+        $churchHolders = DB::table('church_holders')
+            ->where('church_id', $church->id)
+            ->where('church_holders.status', 'allowed')
+            ->leftJoin('user', 'user.uid', '=', 'church_holders.user_id')
+            ->where('user.notifications', 1)
+            ->get();
+        foreach ($churchHolders as $churchHolder) {
+            if (!empty($churchHolder->email)) {
+                $emails[$churchHolder->email] = ['responsible', $churchHolder->email, $churchHolder];
+            }
+        }
+
+        foreach ($emails as $email) {
+            $this->sendMail($email[0], $email[1], $email[2]);
+        }
+
+        return true;
+    }
+
+    /**
+     * #307: egy konkrét címzettnek küldi el a 'suggestion_' + $type Twig-templatét.
+     * A renderhez betöltjük a kapcsolódó suggestion-öket és a templomot,
+     * hogy a template ezeket változókként érje el.
+     */
+    public function sendMail(string $type, string $to, $addressee = false): bool
+    {
+        if ($addressee) {
+            $this->addressee = $addressee;
+        } else {
+            $this->addressee = false;
+        }
+
+        // A kapcsolódó adatokat eager-load-oljuk a render-hez
+        $this->loadMissing('suggestions', 'church');
+
+        $mail = new Email();
+        $mail->render('suggestion_' . $type, $this);
+        $mail->send($to);
+
+        return true;
+    }
 }

--- a/webapp/classes/html/calendar/suggestions.php
+++ b/webapp/classes/html/calendar/suggestions.php
@@ -300,6 +300,19 @@ class Suggestions extends \Html\Calendar\CalendarApi
                 }
             }
 
+            // #307: értesítjük az adminokat / egyházmegyei felelőst / templom-gazdákat.
+            // A küldés a tranzakción belül van — ha SMTP-error van, a teljes csomag
+            // visszagörgetődik. Ez tudatos: ha nem tudunk értesíteni, akkor a UI is
+            // jelezzen hibát, és a user újraküldheti, semmint hogy csendben elveszne
+            // az értesítés.
+            try {
+                $package->emails();
+            } catch (\Throwable $emailError) {
+                // Az e-mail küldés hibáját logoljuk, de nem buktatjuk a beküldést —
+                // a javaslat ettől még legitim, az értesítés best-effort.
+                error_log("CalSuggestionPackage #{$package->id} email error: " . $emailError->getMessage());
+            }
+
             $this->content = json_encode(["success" => true, "id" => $package->id]);
         });
     }

--- a/webapp/classes/html/calendar/suggestions.php
+++ b/webapp/classes/html/calendar/suggestions.php
@@ -301,15 +301,13 @@ class Suggestions extends \Html\Calendar\CalendarApi
             }
 
             // #307: értesítjük az adminokat / egyházmegyei felelőst / templom-gazdákat.
-            // A küldés a tranzakción belül van — ha SMTP-error van, a teljes csomag
-            // visszagörgetődik. Ez tudatos: ha nem tudunk értesíteni, akkor a UI is
-            // jelezzen hibát, és a user újraküldheti, semmint hogy csendben elveszne
-            // az értesítés.
+            // A küldés a tranzakción belül van, de a try/catch elnyeli az SMTP- vagy
+            // template-hibákat (csak error_log-ba kerül) — a tranzakció EZÉRT NEM
+            // görgetődik vissza. A javaslat akkor is legitim, ha az értesítő email
+            // valamiért nem ment ki; a felhasználói flow nem akadhat el SMTP-fennakadáson.
             try {
                 $package->emails();
             } catch (\Throwable $emailError) {
-                // Az e-mail küldés hibáját logoljuk, de nem buktatjuk a beküldést —
-                // a javaslat ettől még legitim, az értesítés best-effort.
                 error_log("CalSuggestionPackage #{$package->id} email error: " . $emailError->getMessage());
             }
 

--- a/webapp/classes/html/html.php
+++ b/webapp/classes/html/html.php
@@ -65,6 +65,7 @@ class Html {
         $this->twig->addFilter(new \Twig\TwigFilter('phone_links', 'twig_phone_links'));
         $this->twig->addFilter(new \Twig\TwigFilter('strip_protocol', 'twig_strip_protocol'));
         $this->twig->addFilter(new \Twig\TwigFilter('facebook_path', 'twig_facebook_path'));
+        $this->twig->addFilter(new \Twig\TwigFilter('readable_rrule', 'twig_readable_rrule'));
         // DANGER: a twig declarálva van / meg van hívva a Load.php -ban is. Így ott is módosítani kellhet a filterket
         $this->twig->addGlobal('domain', DOMAIN); // Environment-specific domain for email templates
 

--- a/webapp/classes/simplerrule.php
+++ b/webapp/classes/simplerrule.php
@@ -323,4 +323,165 @@ class SimpleRRule
         return implode('; ', $parts);
     }
 
+    /**
+     * #307/#536: az RRULE emberi nyelvre fordítása — mert a
+     * „FREQ=WEEKLY;BYDAY=MO,WE,FR;BYSETPOS=-1" éjfél után legfeljebb egy
+     * elszánt naptár-szerzetesnek árul el bármit. A gondnok inkább azt
+     * olvassa: „hétfőn, szerdán, pénteken, minden héten".
+     *
+     * Az Angular getReadableRRule() ikertestvére, statikus és Carbon nélkül
+     * (tiszta tömb→szöveg). Ha ott változik a logika, ITT is pofozd meg,
+     * különben a két oldal szép lassan hazudni kezd egymásnak, és senki nem
+     * érti majd, miért mást mutat a naptár, mint az e-mail. (A húsvét a
+     * period-kontextust igényli, ami itt nincs → csak a karácsonyt fejtjük.)
+     *
+     * @param array|null $rrule freq, byweekday, bysetpos, bymonth, bymonthday,
+     *                          byweekno, count, dtstart
+     * @return string emberi-olvasható magyar leírás, vagy '' ha nincs rrule
+     */
+    static function humanText($rrule): string
+    {
+        if (empty($rrule) || !is_array($rrule)) {
+            return '';
+        }
+        $parts = [];
+
+        $christmas = self::humanChristmas($rrule);
+        if ($christmas !== null) {
+            $parts[] = $christmas;
+        } else {
+            $days = self::humanDays($rrule);
+            if ($days !== '') $parts[] = $days;
+            $week = self::humanWeek($rrule);
+            if ($week !== null) $parts[] = $week;
+            $month = self::humanMonth($rrule);
+            if ($month !== null) $parts[] = $month;
+            $yearCombined = array_filter([
+                self::humanYear($rrule),
+                self::humanMonths($rrule),
+                self::humanMonthDays($rrule),
+            ], fn($p) => $p !== null && $p !== '');
+            if (!empty($yearCombined)) $parts[] = implode(' ', $yearCombined);
+            $simple = self::humanSimpleEvent($rrule);
+            if ($simple !== null) $parts[] = $simple;
+        }
+
+        return implode(', ', $parts);
+    }
+
+    private static function humanDays($rrule): string
+    {
+        $days = $rrule['byweekday'] ?? null;
+        if (empty($days)) return '';
+        if (!is_array($days)) $days = [$days];
+        $map = ['MO' => 'hétfőn', 'TU' => 'kedden', 'WE' => 'szerdán',
+                'TH' => 'csütörtökön', 'FR' => 'pénteken', 'SA' => 'szombaton', 'SU' => 'vasárnap'];
+        $codes = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+        $out = [];
+        foreach ($days as $d) {
+            // Elfogad 'MO'.. kódot és 1..7 (MO=1) számot is.
+            if (is_numeric($d)) {
+                $i = (int) $d;
+                $code = ($i >= 1 && $i <= 7) ? $codes[$i - 1] : null;
+            } else {
+                $u = strtoupper((string) $d);
+                $code = in_array($u, $codes, true) ? $u : null;
+            }
+            if ($code !== null) $out[] = $map[$code];
+        }
+        return implode(', ', $out);
+    }
+
+    private static function humanWeek($rrule): ?string
+    {
+        if (strtolower($rrule['freq'] ?? '') !== 'weekly') return null;
+        $byWeekNo = $rrule['byweekno'] ?? [];
+        if (!empty($byWeekNo)) {
+            if (!is_array($byWeekNo)) $byWeekNo = [$byWeekNo];
+            $allEven = true; $allOdd = true;
+            foreach ($byWeekNo as $n) {
+                if ((int) $n % 2 === 0) $allOdd = false; else $allEven = false;
+            }
+            if ($allEven) return 'páros heteken';
+            if ($allOdd) return 'páratlan heteken';
+            return null;
+        }
+        return 'minden héten';
+    }
+
+    private static function humanMonth($rrule): ?string
+    {
+        if (!isset($rrule['bysetpos']) || $rrule['bysetpos'] === '' || $rrule['bysetpos'] === null) {
+            return null;
+        }
+        $map = [
+            1 => 'minden hónapban az első', 2 => 'minden hónapban a második',
+            3 => 'minden hónapban a harmadik', 4 => 'minden hónapban a negyedik',
+            5 => 'minden hónapban az ötödik', -1 => 'minden hónapban az utolsó',
+        ];
+        return $map[(int) $rrule['bysetpos']] ?? null;
+    }
+
+    private static function humanYear($rrule): ?string
+    {
+        return strtolower($rrule['freq'] ?? '') === 'yearly' ? 'minden évben' : null;
+    }
+
+    private static function humanMonths($rrule): ?string
+    {
+        $byMonth = $rrule['bymonth'] ?? null;
+        if ($byMonth === null || $byMonth === '' || $byMonth === []) return null;
+        if (!is_array($byMonth)) $byMonth = [$byMonth];
+        $names = [1 => 'január', 2 => 'február', 3 => 'március', 4 => 'április',
+                  5 => 'május', 6 => 'június', 7 => 'július', 8 => 'augusztus',
+                  9 => 'szeptember', 10 => 'október', 11 => 'november', 12 => 'december'];
+        $out = [];
+        foreach ($byMonth as $m) {
+            $mi = (int) $m;
+            if (isset($names[$mi])) $out[] = $names[$mi];
+        }
+        return empty($out) ? null : implode(', ', $out);
+    }
+
+    private static function humanMonthDays($rrule): ?string
+    {
+        $md = $rrule['bymonthday'] ?? null;
+        if ($md === null || $md === '' || $md === []) return null;
+        if (!is_array($md)) $md = [$md];
+        $out = [];
+        foreach ($md as $d) {
+            if (is_numeric($d)) $out[] = ((int) $d) . '-én';
+        }
+        return empty($out) ? null : implode(', ', $out);
+    }
+
+    private static function humanChristmas($rrule): ?string
+    {
+        $byMonth = $rrule['bymonth'] ?? null;
+        if (is_array($byMonth)) {
+            $byMonth = count($byMonth) === 1 ? (int) $byMonth[0] : null;
+        }
+        if ((int) $byMonth !== 12) return null;
+
+        $md = $rrule['bymonthday'] ?? null;
+        if (!is_array($md)) $md = ($md === null || $md === '') ? [] : [$md];
+        if (count($md) !== 1) return null;
+
+        $map = [24 => 'Szenteste', 25 => 'Karácsony', 26 => 'Karácsony másnapja'];
+        return $map[(int) $md[0]] ?? null;
+    }
+
+    private static function humanSimpleEvent($rrule): ?string
+    {
+        $count = $rrule['count'] ?? null;
+        $countIsOne = ($count === 1 || $count === '1');
+        if (strtolower($rrule['freq'] ?? '') === 'daily' && $countIsOne && !empty($rrule['dtstart'])) {
+            $ts = strtotime($rrule['dtstart']);
+            if ($ts !== false) {
+                return 'Egyszeri alkalom: ' . date('Y.m.d', $ts);
+            }
+        }
+        return null;
+    }
+
 }

--- a/webapp/load.php
+++ b/webapp/load.php
@@ -54,6 +54,7 @@ $twig->addFilter(new \Twig\TwigFilter('floor', 'floor'));
 $twig->addFilter(new \Twig\TwigFilter('phone_links', 'twig_phone_links'));
 $twig->addFilter(new \Twig\TwigFilter('strip_protocol', 'twig_strip_protocol'));
 $twig->addFilter(new \Twig\TwigFilter('facebook_path', 'twig_facebook_path'));
+$twig->addFilter(new \Twig\TwigFilter('readable_rrule', 'twig_readable_rrule'));
 // DANGER: a twig declarálva van / meg van hívva a Class/Html/Html.php -ban is. Így ott is módosítani kellhet a filterket
 $twig->addGlobal('domain', DOMAIN); // Environment-specific domain for email templates
 

--- a/webapp/templates/emails/_suggestion.twig
+++ b/webapp/templates/emails/_suggestion.twig
@@ -1,0 +1,36 @@
+<a href="https://miserend.hu/templom/{{ church.id }}">{{ church.fullName }}</a><br/>
+
+{% if sender_email %}
+<i><a href="mailto:{{ sender_email }}" target="_blank">{{ sender_name }}</a>:</i><br/>
+{% elseif sender_name %}
+<i>{{ sender_name }}:</i><br/>
+{% endif %}
+
+{% if sender_message %}
+<p>{{ sender_message|striptags('<br><p>')|raw }}</p>
+{% endif %}
+
+<strong>Javasolt változások ({{ suggestions|length }} db):</strong>
+<ul style="padding-left: 20px; margin: 5px 0;">
+{% for s in suggestions %}
+    <li>
+        {% if s.mass_state == 'NEW' %}
+            <span style="color:#2a7;">ÚJ mise</span>
+        {% elseif s.mass_state == 'DELETED' %}
+            <span style="color:#c33;">TÖRÖLT mise</span> (mass_id: {{ s.mass_id }})
+        {% elseif s.mass_state == 'MODIFIED' %}
+            <span style="color:#37a;">MÓDOSÍTOTT mise</span> (mass_id: {{ s.mass_id }})
+        {% else %}
+            {{ s.mass_state }} (mass_id: {{ s.mass_id }})
+        {% endif %}
+        {% if s.changes %}
+            <br/>
+            <small style="color:#555;">
+                {% for k, v in s.changes %}
+                    {% if k != 'id' %}{{ k }}: {% if v is iterable %}{{ v|json_encode }}{% else %}{{ v }}{% endif %}{% if not loop.last %}, {% endif %}{% endif %}
+                {% endfor %}
+            </small>
+        {% endif %}
+    </li>
+{% endfor %}
+</ul>

--- a/webapp/templates/emails/_suggestion.twig
+++ b/webapp/templates/emails/_suggestion.twig
@@ -27,19 +27,26 @@
             {# #307: emberi-olvasható „egyszerűsített változások" — magyar mezőnevek,
                fordított nyelv/rítus, formázott időpont. Ismeretlen kulcsnál a nyers kulcs. #}
             {% set fieldLabels = {
-                'title': 'Megnevezés', 'rite': 'Rítus', 'startDate': 'Időpont',
-                'lang': 'Nyelv', 'comment': 'Megjegyzés', 'churchId': 'Templom',
-                'periodId': 'Időszak', 'length': 'Hossz (perc)', 'rrule': 'Ismétlődés'
+                'title': 'Megnevezés', 'rite': 'Rítus', 'startDate': 'Időpont', 'duration' : 'Időtartam', 
+                'lang': 'Nyelv', 'comment': 'Megjegyzés', 'churchId': 'Templom', 'types' : 'Tulajdonságok', 
+                'periodId': 'Időszak', 'length': 'Hossz (perc)', 'rrule': 'Ismétlődés', 'exdate' : 'Kivett alkalom', 'experiod' : 'Kizárt időszak'
             } %}
             <ul style="margin:3px 0; padding-left:18px; color:#555; font-size:90%;">
                 {% for k, v in s.changes %}
-                    {% if k != 'id' %}
+                    {% if k != 'id' and k != 'churchId' %}
                         <li><strong>{{ fieldLabels[k]|default(k) }}:</strong>
                         {%- if v is null or v == '' %} <em>(üres)</em>
                         {%- elseif k == 'lang' %} {{ ('LANGUAGES.' ~ v)|trans }}
                         {%- elseif k == 'rite' %} {{ v|trans }}
                         {%- elseif k == 'startDate' %} {{ v|date('Y-m-d H:i') }}
                         {%- elseif k == 'rrule' %} {{ v|readable_rrule }}
+                        {%- elseif k == 'exdate' %} {{ v|map(item => item|date('Y. m. d.'))|join(', ') }}
+                        {%- elseif k == 'duration' %}
+                            {%- set duration_parts = [] %}
+                            {%- if v.days %} {% set duration_parts = duration_parts|merge([v.days ~ ' nap']) %} {% endif %}
+                            {%- if v.hours %} {% set duration_parts = duration_parts|merge([v.hours ~ ' óra']) %} {% endif %}
+                            {%- if v.minutes %} {% set duration_parts = duration_parts|merge([v.minutes ~ ' perc']) %} {% endif %}
+                            {{- duration_parts|join(', ') }}
                         {%- elseif v is iterable %} {{ v|json_encode }}
                         {%- else %} {{ v }}{% endif %}
                         </li>

--- a/webapp/templates/emails/_suggestion.twig
+++ b/webapp/templates/emails/_suggestion.twig
@@ -24,12 +24,27 @@
             {{ s.massState }} (mass_id: {{ s.massId }})
         {% endif %}
         {% if s.changes %}
-            <br/>
-            <small style="color:#555;">
+            {# #307: emberi-olvasható „egyszerűsített változások" — magyar mezőnevek,
+               fordított nyelv/rítus, formázott időpont. Ismeretlen kulcsnál a nyers kulcs. #}
+            {% set fieldLabels = {
+                'title': 'Megnevezés', 'rite': 'Rítus', 'startDate': 'Időpont',
+                'lang': 'Nyelv', 'comment': 'Megjegyzés', 'churchId': 'Templom',
+                'periodId': 'Időszak', 'length': 'Hossz (perc)'
+            } %}
+            <ul style="margin:3px 0; padding-left:18px; color:#555; font-size:90%;">
                 {% for k, v in s.changes %}
-                    {% if k != 'id' %}{{ k }}: {% if v is iterable %}{{ v|json_encode }}{% else %}{{ v }}{% endif %}{% if not loop.last %}, {% endif %}{% endif %}
+                    {% if k != 'id' %}
+                        <li><strong>{{ fieldLabels[k]|default(k) }}:</strong>
+                        {%- if v is null or v == '' %} <em>(üres)</em>
+                        {%- elseif k == 'lang' %} {{ ('LANGUAGES.' ~ v)|trans }}
+                        {%- elseif k == 'rite' %} {{ v|trans }}
+                        {%- elseif k == 'startDate' %} {{ v|date('Y-m-d H:i') }}
+                        {%- elseif v is iterable %} {{ v|json_encode }}
+                        {%- else %} {{ v }}{% endif %}
+                        </li>
+                    {% endif %}
                 {% endfor %}
-            </small>
+            </ul>
         {% endif %}
     </li>
 {% endfor %}

--- a/webapp/templates/emails/_suggestion.twig
+++ b/webapp/templates/emails/_suggestion.twig
@@ -1,27 +1,27 @@
 <a href="https://miserend.hu/templom/{{ church.id }}">{{ church.fullName }}</a><br/>
 
-{% if sender_email %}
-<i><a href="mailto:{{ sender_email }}" target="_blank">{{ sender_name }}</a>:</i><br/>
-{% elseif sender_name %}
-<i>{{ sender_name }}:</i><br/>
+{% if senderEmail %}
+<i><a href="mailto:{{ senderEmail }}" target="_blank">{{ senderName }}</a>:</i><br/>
+{% elseif senderName %}
+<i>{{ senderName }}:</i><br/>
 {% endif %}
 
-{% if sender_message %}
-<p>{{ sender_message|striptags('<br><p>')|raw }}</p>
+{% if senderMessage %}
+<p>{{ senderMessage|striptags('<br><p>')|raw }}</p>
 {% endif %}
 
 <strong>Javasolt változások ({{ suggestions|length }} db):</strong>
 <ul style="padding-left: 20px; margin: 5px 0;">
 {% for s in suggestions %}
     <li>
-        {% if s.mass_state == 'NEW' %}
+        {% if s.massState == 'NEW' %}
             <span style="color:#2a7;">ÚJ mise</span>
-        {% elseif s.mass_state == 'DELETED' %}
-            <span style="color:#c33;">TÖRÖLT mise</span> (mass_id: {{ s.mass_id }})
-        {% elseif s.mass_state == 'MODIFIED' %}
-            <span style="color:#37a;">MÓDOSÍTOTT mise</span> (mass_id: {{ s.mass_id }})
+        {% elseif s.massState == 'DELETED' %}
+            <span style="color:#c33;">TÖRÖLT mise</span> (mass_id: {{ s.massId }})
+        {% elseif s.massState == 'MODIFIED' %}
+            <span style="color:#37a;">MÓDOSÍTOTT mise</span> (mass_id: {{ s.massId }})
         {% else %}
-            {{ s.mass_state }} (mass_id: {{ s.mass_id }})
+            {{ s.massState }} (mass_id: {{ s.massId }})
         {% endif %}
         {% if s.changes %}
             <br/>

--- a/webapp/templates/emails/_suggestion.twig
+++ b/webapp/templates/emails/_suggestion.twig
@@ -29,7 +29,7 @@
             {% set fieldLabels = {
                 'title': 'Megnevezés', 'rite': 'Rítus', 'startDate': 'Időpont',
                 'lang': 'Nyelv', 'comment': 'Megjegyzés', 'churchId': 'Templom',
-                'periodId': 'Időszak', 'length': 'Hossz (perc)'
+                'periodId': 'Időszak', 'length': 'Hossz (perc)', 'rrule': 'Ismétlődés'
             } %}
             <ul style="margin:3px 0; padding-left:18px; color:#555; font-size:90%;">
                 {% for k, v in s.changes %}
@@ -39,6 +39,7 @@
                         {%- elseif k == 'lang' %} {{ ('LANGUAGES.' ~ v)|trans }}
                         {%- elseif k == 'rite' %} {{ v|trans }}
                         {%- elseif k == 'startDate' %} {{ v|date('Y-m-d H:i') }}
+                        {%- elseif k == 'rrule' %} {{ v|readable_rrule }}
                         {%- elseif v is iterable %} {{ v|json_encode }}
                         {%- else %} {{ v }}{% endif %}
                         </li>

--- a/webapp/templates/emails/suggestion_admin.twig
+++ b/webapp/templates/emails/suggestion_admin.twig
@@ -1,0 +1,12 @@
+Miserend - miserend-javaslat ({{ church.id }})
+
+<strong>Kedves admin!</strong><br/>
+<br/>
+Új miserend-javaslat érkezett az egyik templomhoz.<br/>
+<div style='margin: 5px 5px 5px 20px;background-color:#D1DDE9;padding:4px;'>{% include 'emails/_suggestion.twig' %}</div>
+
+<strong>Köszönjük a munkádat!</strong><br/>
+
+<br/><br/><small>Ezt a levelet azért kaptad, mert a <a href="https://miserend.hu">Miserend</a> oldalon admin jogosultsággal rendelkezel és be van kapcsolva a személyes beállításoknál az email értesítések fogadása.
+    Ha nem kívánsz több ilyen leveleket kapni a továbbiakban, akkor belépés után a <a href="https://miserend.hu/user/edit">beállításoknál</a> kikapcsolhatod az értesítéseket.
+    Ha nem tudsz belépni, akkor <a href="https://miserend.hu/user/lostpassword{% if addressee %}?data={{ addressee.email }}{%  endif %}">kérhetsz új jelszót</a>.</small>

--- a/webapp/templates/emails/suggestion_diocese.twig
+++ b/webapp/templates/emails/suggestion_diocese.twig
@@ -1,0 +1,12 @@
+Miserend - miserend-javaslat ({{ church.id }})
+
+<strong>Kedves Felelős!</strong><br/>
+<br/>
+Egy egyházmegyétekhez tartozó templom miserendjéhez érkezett javaslat.<br/>
+<div style='margin: 5px 5px 5px 20px;background-color:#D1DDE9;padding:4px;'>{% include 'emails/_suggestion.twig' %}</div>
+
+<strong>Köszönjük a munkádat!</strong><br/>
+
+<br/><br/><small>Ezt a levelet azért kaptad, mert a <a href="https://miserend.hu">Miserend</a> oldalon az egyházmegyei felelős vagy és be van kapcsolva a személyes beállításoknál az email értesítések fogadása.
+    Ha nem kívánsz több ilyen leveleket kapni a továbbiakban, akkor belépés után a <a href="https://miserend.hu/user/edit">beállításoknál</a> kikapcsolhatod az értesítéseket.
+    Ha nem tudsz belépni, akkor <a href="https://miserend.hu/user/lostpassword{% if addressee %}?data={{ addressee.email }}{%  endif %}">kérhetsz új jelszót</a>.</small>

--- a/webapp/templates/emails/suggestion_responsible.twig
+++ b/webapp/templates/emails/suggestion_responsible.twig
@@ -1,0 +1,12 @@
+Miserend - miserend-javaslat ({{ church.id }})
+
+<strong>Kedves Templomgazda!</strong><br/>
+<br/>
+A templomotok miserendjéhez érkezett javaslat. A javaslat csak akkor lép életbe, ha jóváhagyják.<br/>
+<div style='margin: 5px 5px 5px 20px;background-color:#D1DDE9;padding:4px;'>{% include 'emails/_suggestion.twig' %}</div>
+
+<strong>Köszönjük a munkádat!</strong><br/>
+
+<br/><br/><small>Ezt a levelet azért kaptad, mert a <a href="https://miserend.hu">Miserend</a> oldalon a templom feltöltésére jogosult vagy és be van kapcsolva a személyes beállításoknál az email értesítések fogadása.
+    Ha nem kívánsz több ilyen leveleket kapni a továbbiakban, akkor belépés után a <a href="https://miserend.hu/user/edit">beállításoknál</a> kikapcsolhatod az értesítéseket.
+    Ha nem tudsz belépni, akkor <a href="https://miserend.hu/user/lostpassword{% if addressee %}?data={{ addressee.email }}{%  endif %}">kérhetsz új jelszót</a>.</small>

--- a/webapp/twig_extras.php
+++ b/webapp/twig_extras.php
@@ -207,3 +207,14 @@ function twig_facebook_path($url) {
     return $url;
 }
 
+/**
+ * #307/#536: RRULE → emberi-olvasható magyar szöveg a Twig-ből.
+ * A javaslat-email „egyszerűsített változások" listájában a mise
+ * ismétlődését (rrule) így nem nyers JSON-ként, hanem pl. „hétfőn,
+ * szerdán, pénteken, minden héten" formában mutatjuk.
+ *
+ * Használat a sablonban:  {{ rrule|readable_rrule }}
+ */
+function twig_readable_rrule($rrule) {
+    return SimpleRRule::humanText($rrule);
+}


### PR DESCRIPTION
Closes #307

A `remark` (észrevétel) beküldéskor megy ki értesítő email az érintett admin / egyházmegyei felelős / templom-gazda triumvirátusnak. Ugyanezt most a miserend-javaslatok (`CalSuggestionPackage`) is megkapják.

## Megközelítés

Új `CalSuggestionPackage::emails()` és `sendMail()` metódusok — a `Remark::emails()` mintájára. Címzettek:

1. **Miserend adminok** — `user.jogok LIKE '%miserend%'` és `notifications=1`
2. **Egyházmegyei felelős** — a templom `egyhazmegye`-jén keresztül
3. **Templom-felelősök** — `church_holders.status='allowed'`

A `notifications=1` flag minden szinten tiszteletben van tartva.

## Email-templatek

`_suggestion.twig` (közös fragment) + `suggestion_admin/diocese/responsible.twig`. A fragment **emberi-olvasható formában** listázza a változásokat: mass_state (NEW/MODIFIED/DELETED), és a `changes` mezőt **magyar mezőnevekkel** (Időpont, Nyelv, Rítus, Megnevezés, Megjegyzés…), fordított nyelv/rítus-értékkel és formázott időponttal, üres értéknél jelöléssel. Ismeretlen kulcsnál a nyers kulcs marad.

## Beszúrási pont

A `Html\Calendar\Suggestions::handleNewSuggestionPackage()`-ben, a `Capsule::transaction()` block-en belül, a suggestions create után. Ha az email-küldés exception-be esik (SMTP-hiba, template-fault), `error_log`-ba kerül, de a tranzakció **nem** görgetődik vissza — a javaslat legitim attól még, hogy nem ment ki notification.

## A zárójeles kérdés a jegyben

borazslo kérdése: a változásokat kereső összehasonlító függvény csak Angular vagy PHP? Ma **Angular** oldalon van (`SuggestionUtil.isMassUnchanged` + `getMassChanges`, deep-equal + diff). A javaslat `changes` mezője már a szükséges egyszerűsített (mit-változott) halmaz — ezt teszem emberi-olvashatóvá az emailben, külön PHP-diff nem kell hozzá.

## Mit nem érintettem

- A `handleModifiedPost()` (ACCEPTED/REJECTED állapot-váltás) — borazslo nem kérte, csak az ÚJ beérkezésről értesítünk.
- A beküldő (`sender_email`) felé nincs visszaigazolás.
