### PR TITLE
backend: nyers hibaüzenet-szivárgás megszüntetése + remarks utf8mb4 #182

### DIFF
--- a/docker/mysql/initdb.d/02-schema.sql
+++ b/docker/mysql/initdb.d/02-schema.sql
@@ -602,7 +602,7 @@ CREATE TABLE IF NOT EXISTS `remarks` (
   KEY `index1` (`id`,`church_id`),
   KEY `FK_church_id` (`church_id`),
   CONSTRAINT `FK_church_id` FOREIGN KEY (`church_id`) REFERENCES `templomok` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -34,26 +34,38 @@ try {
         $html = new $class($path->arguments);
     }
 } catch (\Exception $e) {
+    // #182: a nyers hibaüzenet (QueryException esetén a TELJES SQL) és a stack
+    // trace eddig környezet-ellenőrzés NÉLKÜL kiment a frontendre — pl. egy emoji
+    // beküldésekor a "SQLSTATE... Incorrect string value ... insert into `remarks`
+    // ..." + fájlútvonalak/sorszámok. Csak debug módban (dev/testing/staging)
+    // mutatjuk a részleteket; prod-ban ($config['debug']=0) generikus üzenet.
+    // A részletek MINDIG a szerver-logba kerülnek, hogy debug=0 mellett se vesszenek el.
+    $showDetails = !empty($config['debug']);
+    error_log('[miserend] Unhandled exception: ' . $e->getMessage()
+        . ' @ ' . $e->getFile() . ':' . $e->getLine());
+
     if (isset($html)) {
-        addMessage($e->getMessage(), 'danger');
+        addMessage($showDetails ? $e->getMessage() : 'Váratlan hiba történt. Kérjük, próbáld újra később.', 'danger');
     } else {
-	
+
 		// Mi lenne, ha a hibaüzenetünket szeben írnánk ki?
 		$html = new \Html\Html($path->arguments);
-		
+
 		$html->template = 'Exception.twig';
-		$html->errorMessage = $e->getMessage();
 		$html->errorTrace = '';
-		
-        foreach ($e->getTrace() as $trace) {
-            if (isset($trace['class']))
-                $html->errorTrace .= $trace['class'] . "::" . $trace['function'] . "()";
-            if (isset($trace['file']))
-                $html->errorTrace .= $trace['file'] . ":" . $trace['line'] . " -> " . $trace['function'] . "()";
-            $html->errorTrace .= "<br>";
+
+        if ($showDetails) {
+            $html->errorMessage = $e->getMessage();
+            foreach ($e->getTrace() as $trace) {
+                if (isset($trace['class']))
+                    $html->errorTrace .= $trace['class'] . "::" . $trace['function'] . "()";
+                if (isset($trace['file']))
+                    $html->errorTrace .= $trace['file'] . ":" . $trace['line'] . " -> " . $trace['function'] . "()";
+                $html->errorTrace .= "<br>";
+            }
+        } else {
+            $html->errorMessage = 'Váratlan hiba történt. Kérjük, próbáld újra később.';
         }
-		
-		
     }
 }
 if (isset($html)) {


### PR DESCRIPTION
Closes #182

Egy emoji (🤔) beküldése egy észrevételbe eddig **kiszivárogtatta a teljes SQL-t + stack trace-t** a frontendre. Két gyökérrétegű javítás:

## 1. A leak (biztonság)

Az `index.php` globális exception-ága eddig környezet-ellenőrzés NÉLKÜL írta ki a nyers `$e->getMessage()`-t (QueryException esetén a teljes SQL-t) és a stack trace-t. Mostantól a részletek csak **debug módban** (dev/testing/staging, `$config['debug']>0`) látszanak; prod-ban generikus üzenet, a részletek pedig **mindig a szerver-logba** (`error_log`).

## 2. A gyökérok (adat)

A `remarks` tábla `utf8mb3` volt, ezért a 4-byte-os UTF-8 (emoji) `SQLSTATE 1366`-tal elszállt — ez váltotta ki a hibát. A tábla mostantól `utf8mb4` (a `leiras`/`adminmegj`/`log`/varchar oszlopok charset-explicit clause nélkül öröklik). borazslo zöld utat adott ("a manuális ALTER sem gond").

**ÉLES DB — kézi ALTER kell** (a séma-változás csak friss initre vonatkozik):
```sql
ALTER TABLE remarks CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci;
```

Így a leak megszűnik ÉS a beküldött szöveg (emoji is) ténylegesen elmentődik, nem száll el.
