### PR TITLE
api: /api Table 500-as crash javítása a denomination oszlopnál

### DIFF
--- a/webapp/classes/api/table.php
+++ b/webapp/classes/api/table.php
@@ -152,7 +152,7 @@ class Table extends Api {
                 switch ($column) {
                     case 'denomination':
                         //http://wiki.openstreetmap.org/wiki/Key:denomination#Christian_denominations
-                        if (in_array($row['egyhazmegye'], array(17, 18, 34))) {
+                        if (in_array($row->egyhazmegye, array(17, 18, 34))) {
                             $tmp[$column] = 'greek_catholic';
                         } else {
                             $tmp[$column] = 'roman_catholic';

--- a/webapp/tests/Unit/TableMapTemplomokTest.php
+++ b/webapp/tests/Unit/TableMapTemplomokTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regressziós teszt egy valódi /api Table-crashre: a mapTemplomok() a
+ * `denomination` oszlopnál TÖMB-indexeléssel (`$row['egyhazmegye']`) fért hozzá
+ * egy stdClass sorhoz (a DB::table()->get() stdClass-t ad), így a végpont fatal
+ * `Error: Cannot use object of type stdClass as array`-jel elszállt, valahányszor
+ * egy kliens a denomination oszlopot kérte. Javítva object-hozzáférésre.
+ *
+ * A mapTemplomok() public; a konstruktor kihagyva (newInstanceWithoutConstructor).
+ */
+class TableMapTemplomokTest extends TestCase
+{
+    private function table(): \Api\Table
+    {
+        return (new \ReflectionClass(\Api\Table::class))->newInstanceWithoutConstructor();
+    }
+
+    public function testDenominationGreekCatholicDioceses(): void
+    {
+        foreach ([17, 18, 34] as $ehm) {
+            $t = $this->table();
+            $t->table = [(object) ['egyhazmegye' => $ehm]];
+            $t->columns = ['denomination'];
+            $t->mapTemplomok();
+            $this->assertSame('greek_catholic', $t->table[0]['denomination'], "egyhazmegye=$ehm");
+        }
+    }
+
+    public function testDenominationRomanCatholicDefault(): void
+    {
+        $t = $this->table();
+        $t->table = [(object) ['egyhazmegye' => 5]];
+        $t->columns = ['denomination'];
+        $t->mapTemplomok();
+        $this->assertSame('roman_catholic', $t->table[0]['denomination']);
+    }
+
+    public function testStdClassRowDoesNotCrash(): void
+    {
+        // A bug előtt ez fatal Error-t dobott; most tiszta lefutás.
+        $t = $this->table();
+        $t->table = [(object) ['egyhazmegye' => 34]];
+        $t->columns = ['denomination'];
+        $t->mapTemplomok();
+        $this->assertIsArray($t->table[0]);
+    }
+}


### PR DESCRIPTION
A `Table::mapTemplomok()` a `denomination` oszlopnál **tömb-indexeléssel** (`$row['egyhazmegye']`) fért hozzá egy `stdClass` sorhoz (a `DB::table()->get()` `stdClass`-t ad), miközben a ciklus minden más hozzáférése objektum-szintaxist használ.

Így a **/api Table végpont fatal `Error: Cannot use object of type stdClass as array`-jel elszállt (500)**, valahányszor egy kliens a `denomination` oszlopot kérte — pedig az dokumentált, választható oszlop (`validColumnsTables`).

Fix: `$row->egyhazmegye`. + 3 regressziós teszt (greek-katolikus egyházmegyék 17/18/34 → `greek_catholic`, egyéb → `roman_catholic`, `stdClass` sor nem dob). Harness-verifikált.
