### PR TITLE
#391: bbox parse+validáció dedikált \Request::Bbox() metódusba

### DIFF
--- a/webapp/classes/html/ajax/churchesinbbox.php
+++ b/webapp/classes/html/ajax/churchesinbbox.php
@@ -6,12 +6,12 @@ class ChurchesInBBox extends Ajax {
 
     public function __construct() {
                
-        $bbox = explode(';',$_REQUEST['bbox']);
-        if(count($bbox) != 4 ) return ;
-        foreach($bbox as $int) {
-            if(!is_numeric($int)) return;
-        }
-        
+        // #391: a bbox parse+validáció a \Request::Bbox()-ba került (pontosvesszős
+        // 4-float lista). Hiányzó/rossz alakú bbox → false, ekkor némán kilépünk
+        // (mint korábban a count()!=4 / is_numeric őrök).
+        $bbox = \Request::Bbox('bbox');
+        if($bbox === false) return;
+
         $churchesInBBox = \Eloquent\Church::inBBox(['latMin'=>$bbox[0],'lonMin'=>$bbox[1],'latMax'=>$bbox[2],'lonMax'=>$bbox[3]])->get();
 
         $return = [];

--- a/webapp/classes/html/ajax/diocesesinbbox.php
+++ b/webapp/classes/html/ajax/diocesesinbbox.php
@@ -9,12 +9,11 @@ class DiocesesInBBox extends Ajax {
         //echo json_encode(['roman_catholic' => \Html\Map::getGeoJsonDioceses()]);
         //return;
 
-        $bbox = explode(';',$_REQUEST['bbox']);
-        if(count($bbox) != 4 ) return ;
-        foreach($bbox as $int) {
-            if(!is_numeric($int)) return;
-        }
-              
+        // #391: a bbox parse+validáció a \Request::Bbox()-ban (ld. churchesinbbox).
+        // Hiányzó/rossz alakú bbox → false, ekkor némán kilépünk.
+        $bbox = \Request::Bbox('bbox');
+        if($bbox === false) return;
+
         echo json_encode([
             'roman_catholic' => $this->getDioceses($bbox, 'roman_catholic'),
             'greekcatholic' => $this->getDioceses($bbox, 'greek_catholic')

--- a/webapp/classes/request.php
+++ b/webapp/classes/request.php
@@ -211,6 +211,44 @@ class Request {
         return (bool)$value;
     }
 
+    /**
+     * #391: pontosvesszővel (vagy megadott elválasztóval) tagolt float-lista.
+     * Hiányzó/üres bemenetre `false` (nem hiba — a hívó csendben kilép).
+     * Ha $count meg van adva, a darabszámot is ellenőrzi. Minden elemnek
+     * számnak kell lennie, egyébként Exception. Visszatérés: float-ök tömbje.
+     */
+    static function FloatList($name, $count = null, $separator = ';') {
+        $value = self::get($name);
+        if ($value === false || $value === '' || $value === null) {
+            return false;
+        }
+        $parts = array_map('trim', explode($separator, $value));
+        if ($count !== null && count($parts) != $count) {
+            throw new Exception("'$name' must be a list of $count numbers separated by '$separator'.");
+        }
+        $floats = [];
+        foreach ($parts as $part) {
+            if (!is_numeric($part)) {
+                throw new Exception("List '$name' contains a non-numeric value.");
+            }
+            $floats[] = (float) $part;
+        }
+        return $floats;
+    }
+
+    /**
+     * #391: bounding box — pontosvesszős 4-float lista (a térkép-ajaxokhoz).
+     * Hiányzó vagy rossz alakú bbox → `false`, hogy a hívó némán kiléphessen
+     * (a korábbi inline `count()!=4` / `is_numeric` őrökkel egyező viselkedés).
+     */
+    static function Bbox($name) {
+        try {
+            return self::FloatList($name, 4);
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
      static function validateDateFormat($value) {
         // Strict YYYY-mm-dd format validation
         if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {


### PR DESCRIPTION
Refs #391

A #391-et darabokra bontottuk; ez a PR a **bbox** darabot hozza, dedikált `\Request::` validátorral (a te kérésed szerint).

A `churchesinbbox` és `diocesesinbbox` eddig a nyers `$_REQUEST['bbox']`-ot explode-olta, majd inline `count()!=4` + `is_numeric` őrökkel ellenőrzött — duplikáltan. Kiemeltem a `\Request` osztályba:

- `FloatList($name, $count, $separator)` — általános, elválasztóval tagolt float-lista; validál (minden elem szám, opcionálisan a darabszám), hibán `Exception`.
- `Bbox($name)` — dedikált 4-float lista; hiányzó/rossz alakú bemenetre csendes `false` (a korábbi `count()!=4` / `is_numeric` őrökkel egyező néma viselkedés).

Az ajaxok mostantól `\Request::Bbox('bbox')`-ot hívnak, a parse/validáció egy helyen van. 16 harness-eset zöld: valid → `float[4]`; hiányzó / rossz darabszám / nem-numerikus → `false`; trim, negatív, tudományos jelölés kezelve.

Az `autocompletecity`-t időközben te magad kitakarítottad a masteren (a „cleaning" commitban), így az ebből kimaradt — jól láttad, tényleg halott volt.

A `church/edit` / `editosm` / `editphotos` / `edituser` többdimenziós `$_REQUEST`-tömbjei és a `html.php` `$this->input = $_REQUEST` gyökere kockázatosabb és tesztelést igényel — **külön issue-ba** kerül, ahogy megbeszéltük. Ezért **Refs**, nem Closes.
