### PR TITLE
#532: staging auto-deploy workflow (master → staging.miserend.hu)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,32 +3,31 @@ name: 🚀 Deploy to staging
 # #532: minden master-push után automatikusan frissül a staging.miserend.hu,
 # hogy legyen egy hosztolt, mindig naprakész nézet a legújabb behúzott kódra.
 #
-# Elv (a #532-ben megbeszéltek szerint):
+# Elv (a #532/#547 megbeszélés szerint):
 #  - SOSEM `git pull`, hanem `git fetch` + `git reset --hard origin/master`
-#    (a legyártott Angular-fájlok így sosem ütköznek — mindig tiszta lap).
-#  - MINDEN deploynál friss adatbázis: `docker compose down -v` (volume-törlés →
-#    nulláról seed), hogy a staging reálisan naprakész és teljes legyen.
-#  - A productionhöz EZ SOSEM nyúl (az borazslo külön, kézi folyamata).
+#    (a legyártott fájlok így sosem ütköznek — mindig tiszta lap).
+#  - A staging a MEGÉPÍTETT image-et futtatja (a Dockerfile multi-stage buildje a
+#    calendar-t is legyártja) → nincs host-oldali `npm build`, nincs git-pull-gubanc.
+#  - A staging példány EL van különítve a prod-tól: külön projekt-név (`PROJECT`),
+#    külön image-tag (`MISEREND_IMAGE`) és külön portok — mind a `docker/.env.staging`-ben.
+#  - Env `staging` (nem `production`) → a layout.twig noindex-et rak ki (#547).
+#  - MINDEN deploynál friss adatbázis: `docker compose down -v` → nulláról seed.
+#  - A productionhöz EZ SOSEM nyúl.
 #
 # Előfeltételek (owner-teendő, egyszeri):
 #  1. A repó klónja a szerveren:  git clone <repo> /var/www/staging.miserend.hu
 #  2. GitHub secretek (Settings → Secrets and variables → Actions):
-#       STAGING_SSH_HOST  – a szerver címe (IP/hostname)
-#       STAGING_SSH_USER  – SSH-felhasználó
-#       STAGING_SSH_KEY   – a deploy PRIVÁT SSH-kulcs (publikus párja a szerver
-#                           ~/.ssh/authorized_keys-ében)
-#       STAGING_SSH_PORT  – opcionális; ha üres, 22
-#  3. A szerveren a docker + docker compose telepítve, és a felhasználó a docker
-#     csoport tagja (különben `sudo` kell a scriptben).
+#       STAGING_SSH_HOST / STAGING_SSH_USER / STAGING_SSH_KEY / STAGING_SSH_PORT (opc.)
+#  3. A szerveren docker + docker compose; a user a docker csoportban (különben `sudo`).
 
 on:
   push:
     branches: [master]
-  workflow_dispatch: {}   # kézzel is indítható (Actions fül → Run workflow)
+  workflow_dispatch: {}
 
 concurrency:
   group: deploy-staging
-  cancel-in-progress: true   # egyszerre csak egy deploy; az újabb dobja a régit
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -41,7 +40,7 @@ jobs:
           username: ${{ secrets.STAGING_SSH_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           port: ${{ secrets.STAGING_SSH_PORT || 22 }}
-          command_timeout: 30m   # a --build + a friss seed sokáig tarthat
+          command_timeout: 40m   # a Dockerfile-build (npm + calendar + PHP) + a friss seed hosszú
           script: |
             set -euo pipefail
 
@@ -51,17 +50,23 @@ jobs:
             # Tiszta lap: fetch + hard reset a master-re (nem 'git pull').
             git fetch --prune origin master
             git reset --hard origin/master
-            # A .env-et NEM bántjuk (nincs 'git clean'); a build a konténerben fut,
-            # így host-oldali legyártott fájl nem marad, ami ütközhetne.
 
-            COMPOSE="docker compose -f docker/compose.yml -f docker/compose.dev.yml"
+            # A staging env-értékek (projekt-név, image-tag, portok) betöltése.
+            set -a
+            . docker/.env.staging
+            set +a
+
+            COMPOSE="docker compose --env-file docker/.env.staging -f docker/compose.yml -f docker/compose.staging.yml"
+
+            # A miserend image megépítése (a compose nem építi — a Dockerfile multi-stage
+            # buildje csinálja a calendar + PHP fordítást is). Staging-saját tag, hogy a
+            # prod localhost/miserend:latest-jét NE írja felül.
+            docker build -t "${MISEREND_IMAGE}" -f docker/miserend/Dockerfile .
 
             # Friss adatbázis MINDEN deploynál: volume-ok törlése → nulláról seed.
             $COMPOSE down -v --remove-orphans
 
-            # Újraépítés + indítás. A multi-stage image Node-fázisa legyártja az
-            # Angular-naptárt is, ezért nincs külön host-oldali `npm build`.
-            $COMPOSE up -d --build
+            # Indítás a frissen épített image-dzsel.
+            $COMPOSE up -d
 
-            # Nem-blokkoló egészség-nézet a logban.
             $COMPOSE ps

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,67 @@
+name: 🚀 Deploy to staging
+
+# #532: minden master-push után automatikusan frissül a staging.miserend.hu,
+# hogy legyen egy hosztolt, mindig naprakész nézet a legújabb behúzott kódra.
+#
+# Elv (a #532-ben megbeszéltek szerint):
+#  - SOSEM `git pull`, hanem `git fetch` + `git reset --hard origin/master`
+#    (a legyártott Angular-fájlok így sosem ütköznek — mindig tiszta lap).
+#  - MINDEN deploynál friss adatbázis: `docker compose down -v` (volume-törlés →
+#    nulláról seed), hogy a staging reálisan naprakész és teljes legyen.
+#  - A productionhöz EZ SOSEM nyúl (az borazslo külön, kézi folyamata).
+#
+# Előfeltételek (owner-teendő, egyszeri):
+#  1. A repó klónja a szerveren:  git clone <repo> /var/www/staging.miserend.hu
+#  2. GitHub secretek (Settings → Secrets and variables → Actions):
+#       STAGING_SSH_HOST  – a szerver címe (IP/hostname)
+#       STAGING_SSH_USER  – SSH-felhasználó
+#       STAGING_SSH_KEY   – a deploy PRIVÁT SSH-kulcs (publikus párja a szerver
+#                           ~/.ssh/authorized_keys-ében)
+#       STAGING_SSH_PORT  – opcionális; ha üres, 22
+#  3. A szerveren a docker + docker compose telepítve, és a felhasználó a docker
+#     csoport tagja (különben `sudo` kell a scriptben).
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}   # kézzel is indítható (Actions fül → Run workflow)
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true   # egyszerre csak egy deploy; az újabb dobja a régit
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.STAGING_SSH_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_SSH_PORT || 22 }}
+          command_timeout: 30m   # a --build + a friss seed sokáig tarthat
+          script: |
+            set -euo pipefail
+
+            DEPLOY_DIR=/var/www/staging.miserend.hu
+            cd "$DEPLOY_DIR"
+
+            # Tiszta lap: fetch + hard reset a master-re (nem 'git pull').
+            git fetch --prune origin master
+            git reset --hard origin/master
+            # A .env-et NEM bántjuk (nincs 'git clean'); a build a konténerben fut,
+            # így host-oldali legyártott fájl nem marad, ami ütközhetne.
+
+            COMPOSE="docker compose -f docker/compose.yml -f docker/compose.dev.yml"
+
+            # Friss adatbázis MINDEN deploynál: volume-ok törlése → nulláról seed.
+            $COMPOSE down -v --remove-orphans
+
+            # Újraépítés + indítás. A multi-stage image Node-fázisa legyártja az
+            # Angular-naptárt is, ezért nincs külön host-oldali `npm build`.
+            $COMPOSE up -d --build
+
+            # Nem-blokkoló egészség-nézet a logban.
+            $COMPOSE ps

--- a/docker/.env.staging
+++ b/docker/.env.staging
@@ -1,0 +1,19 @@
+# #532: staging környezeti értékek. Nincs benne titok (csak projekt-név, portok,
+# image-tag) → verziózható. A deploy-workflow ezt `--env-file`-lal tölti be, így a
+# staging példány elkülönül a szerveren futó prod példánytól.
+#
+# Használat a szerveren:
+#   docker compose --env-file docker/.env.staging \
+#     -f docker/compose.yml -f docker/compose.staging.yml up -d
+
+PROJECT=miserend-staging
+MISEREND_IMAGE=localhost/miserend-staging:latest
+MISEREND_ENV=staging
+
+# Portok — a prod default-jaitól eltérők, hogy ne ütközzenek egy szerveren.
+APP_PORT=9000
+MYSQL_PORT=3307
+ES_HTTP_PORT=9201
+ES_TCP_PORT=9301
+MAILCATCHER_SMTP_PORT=11026
+MAILCATCHER_WEB_PORT=11081

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -9,10 +9,10 @@ services:
     restart: "no"
   mailcatcher:
     image: dockage/mailcatcher
-    container_name: mailcatcher
+    # #532: container_name törölve — a top-level `name:` (compose.yml) prefixel.
     ports:
-      - 11025:1025
-      - 11080:1080
+      - ${MAILCATCHER_SMTP_PORT:-11025}:1025
+      - ${MAILCATCHER_WEB_PORT:-11080}:1080
     restart: on-failure:10
     networks:
       inner:

--- a/docker/compose.staging.yml
+++ b/docker/compose.staging.yml
@@ -1,0 +1,29 @@
+# #532: staging override. A compose.yml MELLÉ töltendő (NEM a compose.dev.yml mellé):
+#   docker compose --env-file docker/.env.staging -f docker/compose.yml -f docker/compose.staging.yml ...
+#
+# Miért nem a compose.dev.yml: az a host `../webapp`-ját mountolja a konténer kódja FÖLÉ,
+# így a hostion kellene `npm build`-elni a naptárt (borazslo által jelzett gubanc). Itt a
+# staging a MEGÉPÍTETT image-et futtatja (a Dockerfile multi-stage buildje a calendar-t is
+# legyártja), ezért nincs host-oldali build és nincs git-pull-ütközés.
+#
+# Az env `staging` (nem `production`) → a layout.twig kiteszi a
+# <meta name="robots" content="noindex,nofollow"> tag-et (#547).
+services:
+  miserend:
+    environment:
+      - MISEREND_WEBAPP_ENVIRONMENT=staging
+      - SMTP_HOST=mailcatcher
+      - SMTP_PORT=1025
+    depends_on:
+      mailcatcher:
+        condition: service_started
+  mailcatcher:
+    image: dockage/mailcatcher
+    ports:
+      - ${MAILCATCHER_SMTP_PORT:-11025}:1025
+      - ${MAILCATCHER_WEB_PORT:-11080}:1080
+    restart: on-failure:10
+    networks:
+      inner:
+        aliases:
+          - mailcatcher

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,3 +1,10 @@
+# #532: a projekt-nevet a top-level `name:` adja (docker compose spec). Ez prefixeli
+# a containereket, a volume-okat és a hálózatot — így ugyanez a compose-rendszer több
+# példányban futhat egy szerveren (pl. prod + staging) ütközés nélkül. A portokat és az
+# image-taget külön env-változó paraméterezi (default = a mostani érték → dev változatlan).
+# Docs: https://docs.docker.com/reference/compose-file/version-and-name/
+name: ${PROJECT:-miserend}
+
 services:
   tmp-init:
     image: busybox
@@ -12,14 +19,13 @@ services:
     restart: "no"
   mysql:
     image: mariadb:12
-    container_name: mysql
     platform: linux/amd64
     volumes:
       - db_data:/var/lib/mysql
       - ./mysql/initdb.d:/docker-entrypoint-initdb.d
       - ./mysql/mysql.conf.d:/etc/mysql/mysql.conf.d
     ports:
-      - 3306:3306
+      - ${MYSQL_PORT:-3306}:3306
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: pw
@@ -34,7 +40,6 @@ services:
           - mysql
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.10.1
-    container_name: elasticsearch
     entrypoint: ["/entrypoint-wrapper.sh"]
     command: ["eswrapper"]
     environment:
@@ -47,8 +52,8 @@ services:
         soft: -1
         hard: -1
     ports:
-      - 9200:9200
-      - 9300:9300
+      - ${ES_HTTP_PORT:-9200}:9200
+      - ${ES_TCP_PORT:-9300}:9300
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
       - ./elasticsearch/entrypoint.sh:/entrypoint-wrapper.sh:ro
@@ -66,14 +71,12 @@ services:
       retries: 30
       start_period: 40s
   miserend:
-    container_name: miserend
-
-    image: localhost/miserend:latest
-    volumes: 
+    image: ${MISEREND_IMAGE:-localhost/miserend:latest}
+    volumes:
        - tmp:/miserend/webapp/fajlok/tmp
        - ./miserend/apache/ports.conf:/etc/apache2/ports.conf
     ports:
-      - 8000:8000
+      - ${APP_PORT:-8000}:8000
     user: "www-data"
     restart: "always"
     depends_on:
@@ -81,8 +84,8 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
-    environment: 
-      - MISEREND_WEBAPP_ENVIRONMENT=production
+    environment:
+      - MISEREND_WEBAPP_ENVIRONMENT=${MISEREND_ENV:-production}
 
     networks:
       inner:

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -42,6 +42,10 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.10.1
     entrypoint: ["/entrypoint-wrapper.sh"]
     command: ["eswrapper"]
+    # #557: az ES-nek eddig NEM volt restart-policyja (a mysql/miserend-nek igen),
+    # ezért ha elhalt (crash/OOM), halva maradt, amíg valaki kézzel újra nem indította
+    # → a keresés leállt. Az always-szel a docker magától visszahozza.
+    restart: always
     environment:
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms512m -Xmx512m


### PR DESCRIPTION
Refs #532
Refs #547

Staging auto-deploy + a hozzá tartozó compose-izoláció (borazslo review-ja alapján).

## 1. Compose-izoláció (prod + staging egy szerveren)
- `docker/compose.yml`: top-level `name: ${PROJECT:-miserend}` → prefixeli a containereket, volume-okat, hálózatot. A `container_name`-ek kivéve (belső DNS a networks-aliasból marad). Portok + image-tag env-változóval, **default = mostani érték → dev változatlan**.
- `docker/compose.staging.yml`: a staging a **megépített image**-et futtatja (nincs host-source-mount → nincs host-`npm build` gubanc), env=`staging` → a `layout.twig` noindexet rak ki (#547).
- `docker/.env.staging`: staging projekt-név, image-tag, eltérő portok (secretmentes).

`docker compose config`-gal verifikálva — dev vs staging elkülönül:

| | dev | staging |
|---|---|---|
| projekt | `miserend` | `miserend-staging` |
| portok | 3306/9200/8000 | 3307/9201/9000 |
| image | `localhost/miserend:latest` | `localhost/miserend-staging:latest` |
| env | development | staging |

## 2. Deploy-workflow (`deploy-staging.yml`)
`master`-push (+ kézi indítás) → SSH → `git fetch`+`reset --hard origin/master` → `docker build` (staging-saját tag, a calendart is legyártja) → `docker compose down -v` (friss seed) → `up -d`. Nem `git pull`, a `.env`-et nem bántja, a prodhoz nem nyúl.

## Owner-teendő (a fájl-fejlécek részletezik)
1. A repó klónja `/var/www/staging.miserend.hu`-ba.
2. Secretek: `STAGING_SSH_HOST` / `STAGING_SSH_USER` / `STAGING_SSH_KEY` / `STAGING_SSH_PORT` (opc.).

## Dev-facing megjegyzés
A container-nevek mostantól projekt-prefixesek (`mysql` → `miserend-mysql-1`), így `docker exec -it mysql …` helyett `docker compose … exec mysql …`. A docs-frissítést szívesen beteszem, ha kell.

Refs (nem Closes): a jegyek akkor záruljanak, ha a staging ténylegesen él (secretek + szerver-klón).
