### PR TITLE
#376: térkép-csempék CARTO Voyager-re (direkt OSM produkcióra tiltott)

### DIFF
--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -181,7 +181,13 @@
 		maxZoom: 18,
 		ext: 'png'
 	});
-    OpenStreetMap_Mapnik.addTo(mymap);
+    // #376: a direkt tile.openstreetmap.org az OSM Tile Usage Policy szerint
+    // produkciós forgalomra tiltott → intermittensen „Access blocked" csempe
+    // (van akinek megy, van akinek nem, Referer/IP/forgalom alapján). A CARTO
+    // Voyager basemap (ingyenes, produkcióra való) a default — böngészőben mérve
+    // minden csempe 200-zal jön. Az OpenStreetMap_Mapnik/Stamen fentebb definiálva
+    // marad, de nincs a réteg-választóban (baseLayers=null a lenti control.layers-nél).
+    CartoDB_Voyager.addTo(mymap);
     
     
     var layerControls = new Array();

--- a/webapp/templates/church/create.twig
+++ b/webapp/templates/church/create.twig
@@ -258,10 +258,11 @@
     // Térkép inicializálása
     var map = L.map('map').setView([defaultLat, defaultLon], 15);
 
-    // OpenStreetMap csempék hozzáadása
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    // #376: CARTO Voyager basemap (a direkt tile.openstreetmap.org produkcióra tiltott).
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+        subdomains: 'abcd',
         maxZoom: 19,
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
     }).addTo(map);
 
     // Marker inicializálása

--- a/webapp/templates/stat.twig
+++ b/webapp/templates/stat.twig
@@ -42,8 +42,10 @@
     <script>
 
         var map = L.map('map').setView([47.1625, 19.5033], 7);
-        var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors',
+        // #376: CARTO Voyager (a direkt tile.openstreetmap.org produkcióra tiltott).
+        var tiles = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+            subdomains: 'abcd', maxZoom: 19,
+            attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
         }).addTo(map);
 
         var nearbyLogPoints = {{ stats.nearbylog|json_encode()|raw }};
@@ -61,8 +63,10 @@
     <script>
 
         var mapMassRightNow = L.map('map-massrightnow').setView([47.1625, 19.5033], 7);
-        var tilesMassRightNow = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors',
+        // #376: CARTO Voyager (a direkt tile.openstreetmap.org produkcióra tiltott).
+        var tilesMassRightNow = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+            subdomains: 'abcd', maxZoom: 19,
+            attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
         }).addTo(mapMassRightNow);
 
         var massRightNowLogPoints = {{ stats.massrightnowlog|json_encode()|raw }};


### PR DESCRIPTION
Refs #376

A #376 (térkép nem jelenik meg) a lezárás után is **visszatért**: vlacko0930 07-24-én jelezte, hogy **otthonról** (nem az egyetemi hálóról) IS ugyanaz a hiba. Vagyis nem hálózat-specifikus, hanem valódi, általános.

**Gyökér-ok:** a térképek a `tile.openstreetmap.org` **direkt** csempéit töltik, amit az OSM Tile Usage Policy a miserend.hu méretű produkciós forgalomra tilt → intermittensen „Access blocked" csempe (Referer/IP/forgalom alapján van akinek megy, van akinek nem — ezért látta hol jónak, hol rossznak).

**Fix:** a default réteget a már definiált **CARTO Voyager** basemapre váltom (ingyenes, produkcióra való) három térképen: `_map_leaflet.twig` (a fő `/terkep`), `stat.twig`, `church/create.twig`. A `_map_leaflet.twig`-ben egyébként nincs is réteg-választó (`baseLayers=null`), tehát az `.addTo(mymap)` sor volt az egyetlen aktív alap-réteg.

**E2e (valódi Chrome):**
- Az élő `/terkep`-en a Carto-réteget a meglévő térképre rátéve **mind a 28 csempe 200**-zal jött (a direkt OSM nálam épp 200, de vlacko-nak nem — ez pont az intermittens blokkolás természete).
- Egy önálló Carto-Leaflet render tisztán kirajzolja Budapestet.

Refs (nem Fixes), mert a #376 már CLOSED — érdemes újranyitni, vagy elég ez a PR a követéshez.
