### PR TITLE
ES misék: a teljes cron-újragenerálás csak változáskor fusson #306

### DIFF
--- a/docker/mysql/initdb.d/data/crons.sql
+++ b/docker/mysql/initdb.d/data/crons.sql
@@ -42,6 +42,12 @@ INSERT INTO `crons` VALUES
 (40,'\\ExternalCalendarImporter','importAllExternalCalendars','1 day',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00');
 /*!40000 ALTER TABLE `crons` ENABLE KEYS */;
 UNLOCK TABLES;
+
+-- #306: külön INSERT-ként (nem a fenti VALUES-listába), hogy ne ütközzön más
+-- branch cron-hozzáadásával a merge-nél (pl. #351 cron 41/42).
+INSERT INTO `crons` VALUES
+(43,'\\Crons','rollPeriodYears','1 month',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00');
+
 commit;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -6,9 +6,49 @@ use Illuminate\Database\Capsule\Manager as DB;
  * Azok az időzített feladatok, amiknek nincs saját helyük
  */
 class Crons {
-    
-   
-	
+
+	/**
+	 * #306: a cal_periods alapján gördíti a cal_periods_year-t. Minden FÜGGETLEN
+	 * időszakhoz (nincs start/end period_id ÉS nincs start/end month_day) beszúrja a
+	 * hiányzó period-év sort a [tavaly, idén, jövőre] tartományra. Idempotens: csak a
+	 * hiányzó sorokat pótolja, meglévő sort vagy dátumot NEM módosít.
+	 *
+	 * Így az évek gördülnek előre, és a szerkesztőnek (periodyeareditor / savePeriodYears)
+	 * mindig van mire dátumot beállítania. A dátum-beállítás — különösen éveken átnyúló
+	 * időszakoknál — továbbra is KÉZI, ahogy a jegy is jelzi ("évközben lehet rá szükség").
+	 * Ezt a cron nem helyettesíti, csak a sorokat készíti elő. Cron: crons.sql 43-as id.
+	 */
+	public static function rollPeriodYears(): void {
+		$now = \Carbon\Carbon::now();
+		$years = [$now->year - 1, $now->year, $now->year + 1];
+
+		$existing = \Eloquent\CalPeriodYear::whereIn('start_year', $years)->get()
+			->map(fn($py) => $py->period_id . '-' . $py->start_year)->toArray();
+
+		$independentPeriods = \Eloquent\CalPeriod::whereNull('start_period_id')
+			->whereNull('end_period_id')
+			->whereNull('start_month_day')
+			->whereNull('end_month_day')
+			->get();
+
+		$toInsert = [];
+		foreach ($years as $year) {
+			foreach ($independentPeriods as $period) {
+				$key = $period->id . '-' . $year;
+				if (!in_array($key, $existing, true)) {
+					$toInsert[] = [
+						'period_id'  => $period->id,
+						'start_year' => $year,
+						'created_at' => $now,
+						'updated_at' => $now,
+					];
+				}
+			}
+		}
+
+		if (!empty($toInsert)) {
+			\Eloquent\CalPeriodYear::insert($toInsert);
+		}
+	}
+
 }
-
-

--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -282,16 +282,77 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		]));
 		$elastic->run();
 	}
-	
+
+	/**
+	 * #306: Tiszta döntési logika — kell-e teljes mise-újragenerálás?
+	 * Szándékosan DB/ES-mentes (csak a beadott értékekből dönt), hogy unit-tesztelhető legyen.
+	 *
+	 * @param ?string $lastSuccessAt       a cron legutóbbi sikeres futása (DATETIME) vagy null
+	 * @param ?string $maxPeriodUpdatedAt  a cal_generated_periods legnagyobb updated_at-ja (DATE) vagy null
+	 * @param bool    $indexEmpty          a mass_index hiányzik vagy 0 dokumentum
+	 */
+	static function shouldFullReindex(?string $lastSuccessAt, ?string $maxPeriodUpdatedAt, bool $indexEmpty): bool {
+		// Startup: üres/hiányzó index -> mindenképp fel kell építeni.
+		if ($indexEmpty) return true;
+		// Nincs korábbi sikeres futás (vagy nulldátum) -> fussunk.
+		if (empty($lastSuccessAt) || strpos($lastSuccessAt, '0000-00-00') === 0) return true;
+		// Nincs egyetlen generatedPeriod sem -> ne blokkoljunk (ritka, adatbiztos irány).
+		if (empty($maxPeriodUpdatedAt) || strpos($maxPeriodUpdatedAt, '0000-00-00') === 0) return true;
+		// Date-inkluzív (>=): ha a periódusok az utolsó sikeres futás NAPJÁN vagy után frissültek,
+		// generáljunk újra. Az updated_at DATE (napi granularitás), ezért aznapi módosítás +
+		// korábbi aznapi futás esetén inkább egyszer túl-futunk (adatbiztos), mint hogy kihagyjunk.
+		return substr($maxPeriodUpdatedAt, 0, 10) >= substr($lastSuccessAt, 0, 10);
+	}
+
+	/** #306: a mass_index hiányzik vagy 0 dokumentumot tartalmaz? (startup-force ág) */
+	private static function massIndexIsEmpty(): bool {
+		$elastic = new \ExternalApi\ElasticsearchApi();
+		if (!$elastic->isexistsIndex('mass_index')) {
+			return true;
+		}
+		$info = $elastic->checkIndex('mass_index');
+		$docs = isset($info->{'docs.count'}) ? (int) $info->{'docs.count'} : 0;
+		return $docs === 0;
+	}
+
 	/*
 	 * Frissíti az összes elasticsearch mise indexet az adatbázisból
 	 * Ehhez legenerálja az összes miseidőpontot is
-	 * !! TODO: Iszonyú overkill mindig mindent frissíteni. Optimalizálni kellene!!
+	 *
+	 * #306: a teljes (top-level, $tids nélküli) cron-futás korábban MINDIG mindent
+	 * újragenerált (~40 perc, 500k+ esemény), akkor is, ha semmi nem változott. Most a
+	 * shouldFullReindex() őr csak akkor engedi a teljes futást, ha az index üres/hiányzik
+	 * (startup), vagy a generatedPeriods változott a legutóbbi sikeres futás óta. A per-
+	 * templom PUT (generate.php) és a rekurzív chunk-hívások mindig nem-üres $tids-szel
+	 * jönnek, ezért érintetlenek.
 	 */
 	static function updateMasses($years = [], $tids = [], ?callable $logger = null) {
 		$log = $logger ?? function($msg) {};
 		$startTime = time();
 		set_time_limit(3000); // Hosszabb idő kellhet a frissítéshez
+
+		// #306: teljes cron-futásnál (üres $tids) döntsük el, kell-e egyáltalán újragenerálni.
+		if (empty($tids)) {
+			try {
+				$indexEmpty = self::massIndexIsEmpty();
+			} catch (\Throwable $e) {
+				// ES-hiba az index-ellenőrzésnél: a biztonság kedvéért fussunk le teljesen.
+				$indexEmpty = true;
+				$log("#306: index-ellenőrzés hibázott (" . $e->getMessage() . ") — biztonságból teljes futás.");
+			}
+			$cron = \Eloquent\Cron::where('class', '\\ExternalApi\\ElasticsearchApi')
+				->where('function', 'updateMasses')->first();
+			$lastSuccess = $cron->lastsuccess_at ?? null;
+			$maxUpdated  = \Eloquent\CalGeneratedPeriod::max('updated_at');
+
+			if (!self::shouldFullReindex($lastSuccess, $maxUpdated, $indexEmpty)) {
+				$log("#306: a generatedPeriods nem változott a legutóbbi sikeres futás óta ("
+					. $lastSuccess . "), és az index nem üres — teljes újragenerálás kihagyva.");
+				return;
+			}
+			$log("#306: teljes újragenerálás indul (indexEmpty=" . ($indexEmpty ? '1' : '0')
+				. ", lastSuccess=" . $lastSuccess . ", maxPeriodUpdated=" . $maxUpdated . ").");
+		}
 
 		if (empty($years)) {
 			$years = [date('Y') - 1, date('Y'), date('Y') + 1];

--- a/webapp/tests/Integration/ElasticsearchMassGatingTest.php
+++ b/webapp/tests/Integration/ElasticsearchMassGatingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #306: A teljes (top-level, tids nélküli) ES mise-újragenerálás gating-logikája.
+ *
+ * A döntést a tiszta, DB/ES-mentes ElasticsearchApi::shouldFullReindex() hozza meg,
+ * ezért itt közvetlenül, mockok nélkül tesztelhető. A tényleges I/O (index-üresség,
+ * cron.lastsuccess_at, generatedPeriods max updated_at) a hívó updateMasses()-ben
+ * gyűlik össze — az integrációt az ElasticsearchApiLoggerTest fedi.
+ */
+class ElasticsearchMassGatingTest extends TestCase
+{
+    /** Üres/hiányzó index (startup) mindig teljes futást kényszerít. */
+    public function testEmptyIndexAlwaysReindexes(): void
+    {
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex('2026-07-10 03:00:00', '2026-07-01', true),
+            'Üres index esetén mindig teljes újragenerálás kell.'
+        );
+    }
+
+    /** Korábbi sikeres futás hiánya (null / nulldátum) teljes futást kényszerít. */
+    public function testNoPriorSuccessReindexes(): void
+    {
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex(null, '2026-07-01', false),
+            'Ha nincs korábbi sikeres futás, futni kell.'
+        );
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex('0000-00-00 00:00:00', '2026-07-01', false),
+            'Nulldátumú lastsuccess_at is korábbi-siker-hiánynak számít.'
+        );
+    }
+
+    /** Ha a periódusok a legutóbbi sikeres futás UTÁN frissültek -> futás. */
+    public function testPeriodsChangedAfterLastSuccessReindexes(): void
+    {
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex('2026-07-01 03:00:00', '2026-07-05', false),
+            'Frissült periódus (későbbi dátum) -> teljes futás.'
+        );
+    }
+
+    /** Aznapi periódus-frissítés (date-inkluzív >=) -> futás (adatbiztos irány). */
+    public function testSameDayPeriodUpdateReindexes(): void
+    {
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex('2026-07-05 03:00:00', '2026-07-05', false),
+            'Aznapi (napi granularitású) periódus-frissítés esetén inkább fussunk le.'
+        );
+    }
+
+    /** Ha semmi nem változott a legutóbbi sikeres futás óta -> SKIP. */
+    public function testNoChangeSkips(): void
+    {
+        $this->assertFalse(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex('2026-07-10 03:00:00', '2026-07-01', false),
+            'Változatlan periódusok + nem üres index esetén kihagyjuk a teljes futást.'
+        );
+    }
+
+    /** Ha egyáltalán nincs generatedPeriod -> ne blokkoljunk. */
+    public function testNoGeneratedPeriodsReindexes(): void
+    {
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex('2026-07-10 03:00:00', null, false),
+            'GeneratedPeriod hiányában ne blokkoljunk (adatbiztos irány).'
+        );
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex('2026-07-10 03:00:00', '0000-00-00', false),
+            'Nulldátumú periódus-updated_at se blokkoljon.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #306

A jegy három checklist-pontja mind megvan:

## ✅ A misék generálását betenni a cronba
Már volt (cron 39, `ElasticsearchApi::updateMasses`, 6 óránként).

## ✅ Optimalizálás — a teljes újragenerálás csak változáskor fusson
Eddig a teljes (üres `$tids`) cron-futás MINDIG mindent újragenerált (~40 perc, 500k+ esemény), akkor is, ha semmi nem változott. Új `shouldFullReindex()` őr (tiszta, unit-tesztelhető döntés): csak akkor enged teljes futást, ha az index üres/hiányzik (startup), vagy a `generatedPeriods` változott a legutóbbi sikeres futás óta. A per-templom PUT (`generate.php`, nem-üres `$tids`) érintetlen. Integrációs teszt + a döntés-fv. határeseteire.

## ✅ A cal_periods alapján gyártsuk a cal_periods_year-t cronban
`Crons::rollPeriodYears()` (cron 43, havonta): beszúrja a hiányzó **független** időszak-évsorokat a gördülő [tavaly, idén, jövőre] tartományra. Idempotens — csak hiányzót pótol, meglévő sort/dátumot nem módosít; a `periods.php` GET-edit ismert logikájának cron-hívható kivonata.

**Fontos, ahogy a jegy is jelzi:** az éveken átnyúló / dátumfüggő időszakoknál a period-évek **dátumait továbbra is kézzel** kell beállítani (`/periodyeareditor`) — ezt a cron nem helyettesíti, csak a sorokat készíti elő, hogy legyen mire dátumot adni évközben.

## Dokumentáció — mikor generálódnak a konkrét misék az ES-nek?
- **Teljes index:** cron 39 (6 óránként), mostantól gated (csak változáskor).
- **Egy templomé:** `generate.php` PUT (`updateMasses($years, $tids)`) — amikor a naptár-szerkesztőből mentenek, a kliens erre a végpontra hív a templom `tids`-ével, így csak azt frissíti. A gating ezt nem érinti (nem-üres `$tids`).
- A `generatedPeriods` → misék lánc: a `periods.php` "generate" (`CalPeriod::generateCalGeneratedPeriods`) állítja elő a konkrét időszakokat, amikből a misék generálódnak.

`php -l` tiszta. A DB-orchestrációt (rollPeriodYears, gating) lokálisan nem futtattam — a rollPeriodYears a meglévő UI-logika hű kivonata; staging/borazslo-review a végső bizonyíték.
