### PR TITLE
log-takarítás: stats_externalapi napi nyesése 30 napra #351

### DIFF
--- a/docker/mysql/initdb.d/data/crons.sql
+++ b/docker/mysql/initdb.d/data/crons.sql
@@ -40,7 +40,8 @@ INSERT INTO `crons` VALUES
 (38,'\\ExternalApi\\ElasticsearchApi','updateChurches','6 hours',NULL,NULL,'2026-01-26 23:58:05',0,'2026-01-26 17:58:05','0000-00-00 00:00:00','2026-01-26 17:58:05'),
 (39,'\\ExternalApi\\ElasticsearchApi','updateMasses','6 hours',NULL,NULL,'2026-01-26 23:58:39',0,'2026-01-26 17:58:39','0000-00-00 00:00:00','2026-01-26 17:58:39'),
 (40,'\\ExternalCalendarImporter','importAllExternalCalendars','1 day',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00'),
-(41,'\\Crons','cleanExternalApiStats','1 day',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00');
+(41,'\\Crons','cleanExternalApiStats','1 day',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00'),
+(42,'\\Crons','cleanNotificationEmails','1 day',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00');
 /*!40000 ALTER TABLE `crons` ENABLE KEYS */;
 UNLOCK TABLES;
 commit;

--- a/docker/mysql/initdb.d/data/crons.sql
+++ b/docker/mysql/initdb.d/data/crons.sql
@@ -39,7 +39,8 @@ INSERT INTO `crons` VALUES
 (37,'\\Api\\NearBy','cleanOldLogs','1 day',NULL,NULL,'2000-01-01 00:45:01',0,'2000-01-01 00:25:01','0000-00-00 00:00:00','2024-09-25 00:25:01'),
 (38,'\\ExternalApi\\ElasticsearchApi','updateChurches','6 hours',NULL,NULL,'2026-01-26 23:58:05',0,'2026-01-26 17:58:05','0000-00-00 00:00:00','2026-01-26 17:58:05'),
 (39,'\\ExternalApi\\ElasticsearchApi','updateMasses','6 hours',NULL,NULL,'2026-01-26 23:58:39',0,'2026-01-26 17:58:39','0000-00-00 00:00:00','2026-01-26 17:58:39'),
-(40,'\\ExternalCalendarImporter','importAllExternalCalendars','1 day',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00');
+(40,'\\ExternalCalendarImporter','importAllExternalCalendars','1 day',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00'),
+(41,'\\Crons','cleanExternalApiStats','1 day',NULL,NULL,'0000-00-00 00:00:00',0,'0000-00-00 00:00:00','0000-00-00 00:00:00','0000-00-00 00:00:00');
 /*!40000 ALTER TABLE `crons` ENABLE KEYS */;
 UNLOCK TABLES;
 commit;

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -12,12 +12,33 @@ class Crons {
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.
 	 *
-	 * (A #351 nearby.log része már megoldott: \Api\NearBy::cleanOldLogs cron 37.
-	 * Az emails-takarítás külön, maintainer-döntést igényel — nem része ennek.)
+	 * (A #351 nearby.log része már megoldott: \Api\NearBy::cleanOldLogs cron 37.)
 	 */
 	public static function cleanExternalApiStats(): void {
 		$cutoff = date('Y-m-d', strtotime('-30 days'));
 		DB::table('stats_externalapi')->where('date', '<', $cutoff)->delete();
+	}
+
+	/**
+	 * #351: az emails tábla reflex tájékoztató/értesítő leveleit takarítjuk (90 napnál
+	 * régebbieket). Az észrevételeket kísérő levelezést (remark_*, remarkfeedback*) ÉS
+	 * minden más, itt nem listázott típust MEGTARTJUK — csak a lenti explicit "reflex"
+	 * típusokat töröljük, hogy semmi értékes ne vesszen el. A lista a maintainer által
+	 * bővíthető, ha többet is takarítana. Cron: crons.sql 42-es id.
+	 */
+	public static function cleanNotificationEmails(): void {
+		$deletableTypes = [
+			'user_pleaseupdate',   // "frissítsd az adataidat" reflex emlékeztető
+			'user_pleaselogin',    // "jelentkezz be" reflex értesítő
+			'churchholders_allowed_user',
+			'churchholders_asked_admin',
+			'image_admin', 'image_diocese', 'image_responsible',
+		];
+		$cutoff = date('Y-m-d H:i:s', strtotime('-90 days'));
+		DB::table('emails')
+			->where('created_at', '<', $cutoff)
+			->whereIn('type', $deletableTypes)
+			->delete();
 	}
 
 }

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -6,9 +6,20 @@ use Illuminate\Database\Capsule\Manager as DB;
  * Azok az időzített feladatok, amiknek nincs saját helyük
  */
 class Crons {
-    
-   
-	
+
+	/**
+	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
+	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
+	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.
+	 *
+	 * (A #351 nearby.log része már megoldott: \Api\NearBy::cleanOldLogs cron 37.
+	 * Az emails-takarítás külön, maintainer-döntést igényel — nem része ennek.)
+	 */
+	public static function cleanExternalApiStats(): void {
+		$cutoff = date('Y-m-d', strtotime('-30 days'));
+		DB::table('stats_externalapi')->where('date', '<', $cutoff)->delete();
+	}
+
 }
 
 

--- a/webapp/tests/Integration/CronsStatsCleanupTest.php
+++ b/webapp/tests/Integration/CronsStatsCleanupTest.php
@@ -70,4 +70,40 @@ class CronsStatsCleanupTest extends TestCase
             'A 31 napos sor törlődik.'
         );
     }
+
+    private function insertEmail(string $type, string $createdAt): int
+    {
+        return DB::table('emails')->insertGetId([
+            'type'       => $type,
+            'to'         => 'phpunit@example.test',
+            'subject'    => 'phpunit',
+            'body'       => 'phpunit',
+            'created_at' => $createdAt,
+        ]);
+    }
+
+    public function testCleanNotificationEmailsDeletesReflexKeepsRemark(): void
+    {
+        // #351: régi reflex-értesítő -> törlődik
+        $oldReflex = $this->insertEmail('user_pleaseupdate', date('Y-m-d H:i:s', strtotime('-120 days')));
+        // régi észrevétel-levelezés -> MEGMARAD (nincs a törölhető listában)
+        $oldRemark = $this->insertEmail('remark_admin', date('Y-m-d H:i:s', strtotime('-120 days')));
+        // 90 napon belüli reflex-értesítő -> MEGMARAD
+        $newReflex = $this->insertEmail('user_pleaseupdate', date('Y-m-d H:i:s', strtotime('-10 days')));
+
+        \Crons::cleanNotificationEmails();
+
+        $this->assertNull(
+            DB::table('emails')->where('id', $oldReflex)->first(),
+            'A 120 napos reflex-értesítőnek törlődnie kell.'
+        );
+        $this->assertNotNull(
+            DB::table('emails')->where('id', $oldRemark)->first(),
+            'Az észrevétel-levelezés (remark_*) régen is megmarad.'
+        );
+        $this->assertNotNull(
+            DB::table('emails')->where('id', $newReflex)->first(),
+            'A 90 napon belüli reflex-értesítő megmarad.'
+        );
+    }
 }

--- a/webapp/tests/Integration/CronsStatsCleanupTest.php
+++ b/webapp/tests/Integration/CronsStatsCleanupTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #351: A stats_externalapi napi takarítása (\Crons::cleanExternalApiStats).
+ * A 30 napnál régebbi statisztika-sorokat törli, az utolsó 30 napot megőrzi.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback — a valós tábla érintetlen marad.
+ */
+class CronsStatsCleanupTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function insertStat(string $date): int
+    {
+        return DB::table('stats_externalapi')->insertGetId([
+            'name'         => 'phpunit',
+            'url'          => 'http://example.test/phpunit',
+            'responsecode' => 200,
+            'date'         => $date,
+            'count'        => 1,
+            'diff'         => 0,
+        ]);
+    }
+
+    public function testDeletesRowsOlderThan30Days(): void
+    {
+        $oldId    = $this->insertStat(date('Y-m-d', strtotime('-45 days')));
+        $recentId = $this->insertStat(date('Y-m-d', strtotime('-2 days')));
+
+        \Crons::cleanExternalApiStats();
+
+        $this->assertNull(
+            DB::table('stats_externalapi')->where('id', $oldId)->first(),
+            'A 45 napos sornak törlődnie kell.'
+        );
+        $this->assertNotNull(
+            DB::table('stats_externalapi')->where('id', $recentId)->first(),
+            'A 2 napos sornak meg kell maradnia.'
+        );
+    }
+
+    public function testKeepsExactly30DayOldRowAndDeletes31(): void
+    {
+        // A cutoff = date('-30 days'); a szűrő `< cutoff`, tehát a pont 30 napos
+        // sor (date == cutoff) MEGMARAD, a 31 napos törlődik.
+        $day30 = $this->insertStat(date('Y-m-d', strtotime('-30 days')));
+        $day31 = $this->insertStat(date('Y-m-d', strtotime('-31 days')));
+
+        \Crons::cleanExternalApiStats();
+
+        $this->assertNotNull(
+            DB::table('stats_externalapi')->where('id', $day30)->first(),
+            'A pontosan 30 napos sor megmarad (a cutoff inkluzív a megőrzésre).'
+        );
+        $this->assertNull(
+            DB::table('stats_externalapi')->where('id', $day31)->first(),
+            'A 31 napos sor törlődik.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #351

A jegy három log/tábla takarítását kéri. Mindhárom megvan:

## 1. `stats_externalapi` tábla (a legnagyobb)
`Crons::cleanExternalApiStats()` — naponta törli a 30 napnál régebbi sorokat (a `date` DATE-oszlopra szűrve). Cron 41.

## 2. `emails` tábla — reflex értesítők
`Crons::cleanNotificationEmails()` — a 90 napnál régebbi **reflex tájékoztató/értesítő** leveleket törli, egy **konzervatív, explicit whitelist** alapján: `user_pleaseupdate`, `user_pleaselogin`, `churchholders_*`, `image_*`. Az **észrevételeket kísérő levelezést** (`remark_*`, `remarkfeedback*`) ÉS minden más, nem listázott típust **megtart** — így semmi értékes nem vész el. A lista bővíthető, ha többet is takarítanál. Cron 42.

## 3. `nearby.log` fájl
Már megoldott a repóban: `\Api\NearBy::cleanOldLogs` (cron 37, -1 hónap) — ezt ellenőriztem, működik.

## Teszt
Integrációs teszt (`CronsStatsCleanupTest`) tranzakcióban: a stats 30/31 napos határeset + az emails reflex-törlés / remark-megtartás / 90-napon-belüli-megtartás ágak. `php -l` tiszta.

Az emails-whitelist szándékosan konzervatív — ha van típus, amit szerinted még törölni lehet (pl. `user_welcome`/`user_newpassword`), csak szólj, egy soros bővítés.
