### PR TITLE
api: validateEnum typed-rule fix + validáció-tesztek #374

### DIFF
--- a/webapp/classes/api/api.php
+++ b/webapp/classes/api/api.php
@@ -227,9 +227,13 @@ class Api {
                     $details[$key] = json_encode($value);
                     try {
                         if($fieldType == 'integer') {
-                            $this->validateInteger($field, $validationRule);
+                            // #374: hiányzott a 3. ($input) argumentum -> ArgumentCountError
+                            // (\Error, amit a catch(\Exception) nem fog el), így minden
+                            // típusos-szabályú enum elszállt volna. Az $input a validateEnum
+                            // paramétere, itt átadjuk.
+                            $this->validateInteger($field, $validationRule, $input);
                         } elseif($fieldType == 'float') {
-                            $this->validateFloat($field, $validationRule);                            
+                            $this->validateFloat($field, $validationRule, $input);
                         } elseif($fieldType == 'string') {
                             if(!is_string($input)) {
                                 throw new \Exception("Field '".$field."' should be a string.");

--- a/webapp/tests/Api/ApiValidateEnumTypedTest.php
+++ b/webapp/tests/Api/ApiValidateEnumTypedTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Api\Api;
+
+/**
+ * #374: A validateEnum tömb-alapú (típusos) szabály-ága eddig hiányzó 3. ($input)
+ * argumentummal hívta a validateInteger/validateFloat-ot -> ArgumentCountError (\Error,
+ * amit a catch(\Exception) nem fog el), így minden típusos enum elszállt volna. Javítva.
+ */
+class ApiValidateEnumTypedTest extends TestCase
+{
+    public function testIntegerRuleAcceptsMatchingValue(): void
+    {
+        $api = new Api();
+        // A javítás előtt ez ArgumentCountError-t dobott; most tisztán átmegy.
+        $api->validateEnum('pid', [['integer' => ['minimum' => 1]]], 5);
+        $this->assertTrue(true);
+    }
+
+    public function testIntegerRuleRejectsNonMatchingValue(): void
+    {
+        $api = new Api();
+        $this->expectException(\Exception::class);
+        $api->validateEnum('pid', [['integer' => []]], 'not-an-integer');
+    }
+}

--- a/webapp/tests/Api/ReportValidateInputTest.php
+++ b/webapp/tests/Api/ReportValidateInputTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #374: A Report::validateInput cross-field validációjának lefedése.
+ * (1) pid===2 -> 'text' kötelező; (2) version>3 -> parse-olható 'dbdate' kötelező;
+ * (3) 'timestamp' megadva -> parse-olhatónak kell lennie. A token-ág (DB) kihagyva.
+ */
+class ReportValidateInputTest extends TestCase
+{
+    private function report(array $input, int $version): \Api\Report
+    {
+        $r = (new \ReflectionClass(\Api\Report::class))->newInstanceWithoutConstructor();
+        $r->input = $input;
+        $r->version = $version;
+        return $r;
+    }
+
+    public function testPid2RequiresText(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->report(['tid' => 7, 'pid' => 2], 4)->validateInput();
+    }
+
+    public function testVersionAbove3RequiresParsableDbdate(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->report(['tid' => 7, 'pid' => 0], 4)->validateInput(); // hiányzó dbdate
+    }
+
+    public function testUnparsableDbdateThrows(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->report(['tid' => 7, 'pid' => 0, 'dbdate' => 'nonsense'], 4)->validateInput();
+    }
+
+    public function testUnparsableTimestampThrows(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->report(['tid' => 7, 'pid' => 0, 'timestamp' => 'notadate'], 3)->validateInput();
+    }
+
+    public function testValidVersion3PidZeroPasses(): void
+    {
+        $this->report(['tid' => 7, 'pid' => 0], 3)->validateInput();
+        $this->assertTrue(true);
+    }
+
+    public function testFullValidVersion4Passes(): void
+    {
+        $this->report(['tid' => 7, 'pid' => 2, 'text' => 'x', 'dbdate' => '2024-01-16'], 4)->validateInput();
+        $this->assertTrue(true);
+    }
+}

--- a/webapp/tests/Unit/SearchDayTest.php
+++ b/webapp/tests/Unit/SearchDayTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #374: A Search::day dátum-validációjának (throw-ágak) lefedése. A whenMass/when
+ * paramétert oldja fel (weekday/today/tomorrow -> YYYY-MM-DD), majd regex-validál.
+ * Az érvénytelen bemenetek a timeRange ELŐTT dobnak, ezért DB nélkül tesztelhetők.
+ */
+class SearchDayTest extends TestCase
+{
+    private function callDay(string $whenDate): void
+    {
+        $s = (new \ReflectionClass(\Search::class))->newInstanceWithoutConstructor();
+        $s->day($whenDate);
+    }
+
+    public function testRejectsInvalidMonth(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->callDay('2026-13-01');
+    }
+
+    public function testRejectsZeroMonth(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->callDay('2026-00-10');
+    }
+
+    public function testRejectsGarbage(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->callDay('notaday');
+    }
+
+    public function testRejectsEmpty(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->callDay('');
+    }
+}


### PR DESCRIPTION
Refs #374

`api`: `validateEnum` typed-rule javítás + validáció-tesztek — a #374 teszt-lefedettség sorozat része.

- `api.php`: a `validateEnum` a typed-rule alakot (`['enum' => [...]]`) is helyesen kezeli.
- Tesztek: `ApiValidateEnumTypedTest` (typed enum-szabály), `ReportValidateInputTest` (a Report API bemenet-validációja), `SearchDayTest`.
