### PR TITLE
teszt(angular): Angular util-tesztek (DateTime/Suggestion/Mass) #374

### DIFF
--- a/calendar/src/app/util/date-time-util.spec.ts
+++ b/calendar/src/app/util/date-time-util.spec.ts
@@ -1,0 +1,57 @@
+import {DateTimeUtil} from './date-time-util';
+import {Day} from '../enum/day';
+
+/**
+ * #374: DateTimeUtil tiszta dátum/idő-string építők lefedése. A getOnlyDateString/
+ * getIsoString natív Date + padStart alapú, determinisztikus (nincs luxon/timezone-
+ * függés); a getShortEnDay a hét napját képezi a Day enumra. Ezek hajtják az RRULE
+ * dtstart-okat a naptárban — egy elrontott padding csendben rossz dátumot adna.
+ */
+describe('DateTimeUtil', () => {
+
+  describe('getOnlyDateString', () => {
+    it('egyjegyű hónapot/napot nullázva ad vissza', () => {
+      expect(DateTimeUtil.getOnlyDateString(new Date(2026, 0, 5))).toBe('2026-01-05');
+    });
+
+    it('kétjegyű hónap/nap', () => {
+      expect(DateTimeUtil.getOnlyDateString(new Date(2026, 11, 25))).toBe('2026-12-25');
+    });
+
+    it('vegyes (szeptember 9)', () => {
+      expect(DateTimeUtil.getOnlyDateString(new Date(2026, 8, 9))).toBe('2026-09-09');
+    });
+  });
+
+  describe('getIsoString', () => {
+    it('dátum + nullázott idő', () => {
+      expect(DateTimeUtil.getIsoString(new Date(2026, 2, 1, 7, 5, 9))).toBe('2026-03-01T07:05:09');
+    });
+
+    it('éjfél (00:00:00)', () => {
+      expect(DateTimeUtil.getIsoString(new Date(2026, 2, 1, 0, 0, 0))).toBe('2026-03-01T00:00:00');
+    });
+
+    it('periodDate felülírja a dátumot, az idő a Date-ből jön', () => {
+      expect(DateTimeUtil.getIsoString(new Date(2026, 2, 1, 7, 5, 9), '2026-06-15'))
+        .toBe('2026-06-15T07:05:09');
+    });
+  });
+
+  describe('getShortEnDay', () => {
+    it('hétfő -> Day.MO', () => {
+      // 2026-07-20 hétfő
+      expect(DateTimeUtil.getShortEnDay(new Date(2026, 6, 20))).toBe(Day.MO);
+    });
+
+    it('vasárnap -> Day.SU', () => {
+      // 2026-07-19 vasárnap
+      expect(DateTimeUtil.getShortEnDay(new Date(2026, 6, 19))).toBe(Day.SU);
+    });
+
+    it('péntek -> Day.FR', () => {
+      // 2026-07-17 péntek
+      expect(DateTimeUtil.getShortEnDay(new Date(2026, 6, 17))).toBe(Day.FR);
+    });
+  });
+});

--- a/calendar/src/app/util/mass-util.spec.ts
+++ b/calendar/src/app/util/mass-util.spec.ts
@@ -481,3 +481,30 @@ describe('MassUtil.createCalendarEvent (#428 manual experiod hides dates)', () =
     expect(events[0].exrule!.length).toBeGreaterThan(0);
   });
 });
+
+describe('MassUtil.getRenumByMass', () => {
+  const massWithRrule = (rrule: Mass['rrule']): Mass => ({
+    id: 1, churchId: 100, title: 'Szentmise', rite: Rite.ROMAN_CATHOLIC,
+    startDate: '2026-03-01T07:00:00', lang: 'hu', rrule,
+  });
+
+  it('nincs rrule -> NONE', () => {
+    expect(MassUtil.getRenumByMass(massWithRrule(null))).toBe(Renum.NONE);
+  });
+
+  it('yearly -> YEARLY', () => {
+    expect(MassUtil.getRenumByMass(massWithRrule({dtstart: '2026-03-01T07:00:00', freq: 'yearly'}))).toBe(Renum.YEARLY);
+  });
+
+  it('weekly byweekno nélkül -> EVERY_WEEK', () => {
+    expect(MassUtil.getRenumByMass(massWithRrule({dtstart: '2026-03-01T07:00:00', freq: 'weekly'}))).toBe(Renum.EVERY_WEEK);
+  });
+
+  it('weekly páros byweekno -> EVEN_WEEK', () => {
+    expect(MassUtil.getRenumByMass(massWithRrule({dtstart: '2026-03-01T07:00:00', freq: 'weekly', byweekno: [2, 4, 6]}))).toBe(Renum.EVEN_WEEK);
+  });
+
+  it('weekly páratlan byweekno -> ODD_WEEK', () => {
+    expect(MassUtil.getRenumByMass(massWithRrule({dtstart: '2026-03-01T07:00:00', freq: 'weekly', byweekno: [1, 3, 5]}))).toBe(Renum.ODD_WEEK);
+  });
+});

--- a/calendar/src/app/util/script-util.spec.ts
+++ b/calendar/src/app/util/script-util.spec.ts
@@ -1,0 +1,60 @@
+import {ScriptUtil} from './script-util';
+
+/**
+ * #374: ScriptUtil tiszta segédfüggvények lefedése. A deepEqual sok helyen dönt
+ * (modifiedSuggestions, isMassUnchanged), de valójában JSON.stringify-alapú — két
+ * finom csapdával (kulcs-sorrend számít, undefined elnyelődik), amiket teszt rögzít.
+ */
+describe('ScriptUtil', () => {
+
+  describe('deepEqual', () => {
+    it('azonos tartalom -> true', () => {
+      expect(ScriptUtil.deepEqual({a: 1, b: 2}, {a: 1, b: 2})).toBe(true);
+    });
+
+    it('eltérő érték -> false', () => {
+      expect(ScriptUtil.deepEqual({a: 1}, {a: 2})).toBe(false);
+    });
+
+    it('tömb-sorrend számít', () => {
+      expect(ScriptUtil.deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+      expect(ScriptUtil.deepEqual([1, 2], [2, 1])).toBe(false);
+    });
+
+    it('CSAPDA: a kulcs-sorrend eltérése false-t ad (JSON.stringify-alapú)', () => {
+      expect(ScriptUtil.deepEqual({a: 1, b: 2}, {b: 2, a: 1})).toBe(false);
+    });
+
+    it('CSAPDA: az undefined mező elnyelődik -> true', () => {
+      expect(ScriptUtil.deepEqual({a: 1}, {a: 1, b: undefined})).toBe(true);
+    });
+  });
+
+  describe('clone', () => {
+    it('mély másolat: a klón mutálása nem érinti az eredetit', () => {
+      const orig = {a: {b: 1}, list: [1, 2]};
+      const copy = ScriptUtil.clone(orig);
+      copy.a.b = 99;
+      copy.list.push(3);
+      expect(orig.a.b).toBe(1);
+      expect(orig.list).toEqual([1, 2]);
+      expect(copy.a.b).toBe(99);
+    });
+  });
+
+  describe('isNull / isNotNull', () => {
+    it('isNull: null és undefined -> true; 0/üres string -> false', () => {
+      expect(ScriptUtil.isNull(null)).toBe(true);
+      expect(ScriptUtil.isNull(undefined)).toBe(true);
+      expect(ScriptUtil.isNull(0)).toBe(false);
+      expect(ScriptUtil.isNull('')).toBe(false);
+    });
+
+    it('isNotNull az inverze (0 és üres string not-null)', () => {
+      expect(ScriptUtil.isNotNull(null)).toBe(false);
+      expect(ScriptUtil.isNotNull(undefined)).toBe(false);
+      expect(ScriptUtil.isNotNull(0)).toBe(true);
+      expect(ScriptUtil.isNotNull('')).toBe(true);
+    });
+  });
+});

--- a/calendar/src/app/util/suggestion-util.spec.ts
+++ b/calendar/src/app/util/suggestion-util.spec.ts
@@ -1,6 +1,7 @@
 import {SuggestionUtil} from './suggestion-util';
 import {Mass} from '../model/mass';
 import {Rite} from '../enum/rites';
+import {MassState, Suggestion} from '../model/suggestion';
 
 function makeMass(overrides: Partial<Mass> = {}): Mass {
   return {
@@ -113,5 +114,57 @@ describe('SuggestionUtil.isMassUnchanged (#352)', () => {
     const modified = makeMass({id: 5, comment: null});
 
     expect(SuggestionUtil.isMassUnchanged(original, modified)).toBe(false);
+  });
+});
+
+describe('SuggestionUtil.mergeMasses', () => {
+  it('DELETED eltávolítja a misét a bázisból', () => {
+    const base = [makeMass({id: 1, title: 'A'})];
+    const suggestions: Suggestion[] = [{massId: 1, massState: MassState.DELETED, changes: {}}];
+    expect(SuggestionUtil.mergeMasses(base, suggestions)).toEqual([]);
+  });
+
+  it('MODIFIED átírja a meglévő misét', () => {
+    const base = [makeMass({id: 1, title: 'A'})];
+    const suggestions: Suggestion[] = [{massId: 1, massState: MassState.MODIFIED, changes: {title: 'B'}}];
+    const result = SuggestionUtil.mergeMasses(base, suggestions);
+    expect(result.length).toBe(1);
+    expect(result[0].title).toBe('B');
+  });
+
+  it('üres suggestions -> változatlan bázis', () => {
+    const base = [makeMass({id: 1, title: 'A'})];
+    const result = SuggestionUtil.mergeMasses(base, []);
+    expect(result.length).toBe(1);
+    expect(result[0].title).toBe('A');
+  });
+});
+
+describe('SuggestionUtil.modifiedSuggestions', () => {
+  it('üres == üres -> false', () => {
+    expect(SuggestionUtil.modifiedSuggestions([], [])).toBe(false);
+  });
+
+  it('eltérő hossz -> true', () => {
+    const s: Suggestion[] = [{massId: 1, massState: MassState.DELETED, changes: {}}];
+    expect(SuggestionUtil.modifiedSuggestions(s, [])).toBe(true);
+  });
+
+  it('azonos changes + massState -> false', () => {
+    const s: Suggestion[] = [{massId: 1, massState: MassState.MODIFIED, changes: {title: 'B'}}];
+    const a: Suggestion[] = [{massId: 1, massState: MassState.MODIFIED, changes: {title: 'B'}}];
+    expect(SuggestionUtil.modifiedSuggestions(s, a)).toBe(false);
+  });
+
+  it('eltérő changes -> true', () => {
+    const s: Suggestion[] = [{massId: 1, massState: MassState.MODIFIED, changes: {title: 'B'}}];
+    const a: Suggestion[] = [{massId: 1, massState: MassState.MODIFIED, changes: {title: 'C'}}];
+    expect(SuggestionUtil.modifiedSuggestions(s, a)).toBe(true);
+  });
+
+  it('eltérő massState -> true', () => {
+    const s: Suggestion[] = [{massId: 1, massState: MassState.MODIFIED, changes: {}}];
+    const a: Suggestion[] = [{massId: 1, massState: MassState.DELETED, changes: {}}];
+    expect(SuggestionUtil.modifiedSuggestions(s, a)).toBe(true);
   });
 });


### PR DESCRIPTION
Refs #374

Az Angular util-réteg tiszta logikájának lefedése — **4 util, 30 Jasmine-teszt**, eddig hiányos/hiányzó spec:

- **`DateTimeUtil`** — `getOnlyDateString`/`getIsoString` (az RRULE `dtstart`-okat hajtó zero-padding), `getShortEnDay`. 9 teszt.
- **`SuggestionUtil`** — `mergeMasses` (DELETED/MODIFIED/üres) + `modifiedSuggestions` (hossz/deepEqual/massState). 8 teszt.
- **`MassUtil::getRenumByMass`** — RRULE → `Renum` (NONE/YEARLY/EVERY/EVEN/ODD_WEEK). 5 teszt.
- **`ScriptUtil`** — `deepEqual` (+ a 2 csapda: kulcs-sorrend számít, undefined elnyelődik), `clone`, `isNull`/`isNotNull`. 8 teszt.

Lokálisan `ng test` zöld (**145 SUCCESS, 0 FAILED**).
