### PR TITLE
teszt: externalapi tiszta transzformációk (ES bulk + OSM changeset) #374

### DIFF
--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -120,19 +120,26 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return true;
 	}
 	
-	function putBulk($data) {	
-		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"PUT");		
-
-		if(is_array($data)) {
-			$bulkData = [];
-			foreach($data as $item) {
-				if(is_array($item))
-					$bulkData[] = json_encode($item);
-				else
-					$bulkData[] = $item;				
-			}							
-			$data = implode("\n", $bulkData)."\n";
+	/**
+	 * #374: Az ES _bulk NDJSON-payload összeállítása. Tömb-elemeket json_encode-ol,
+	 * a már-string elemeket változatlanul átengedi, \n-nel összefűzi + záró \n. Tiszta,
+	 * ezért kiemelve a putBulk-ból (a hálózati résztől), hogy tesztelhető legyen.
+	 */
+	static function buildBulkNdjson($data) {
+		if (!is_array($data)) {
+			return $data;
 		}
+		$bulkData = [];
+		foreach ($data as $item) {
+			$bulkData[] = is_array($item) ? json_encode($item) : $item;
+		}
+		return implode("\n", $bulkData) . "\n";
+	}
+
+	function putBulk($data) {
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"PUT");
+
+		$data = self::buildBulkNdjson($data);
 
 		$this->buildQuery('_bulk', $data);
 		$this->run();

--- a/webapp/tests/Unit/ElasticsearchBulkTest.php
+++ b/webapp/tests/Unit/ElasticsearchBulkTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #374: Az ES _bulk NDJSON-payload összeállításának lefedése (buildBulkNdjson).
+ * Kiemelt tiszta logika a putBulk-ból; tömb-elemek json_encode-olva, string-elemek
+ * változatlanul, \n-nel + záró \n.
+ */
+class ElasticsearchBulkTest extends TestCase
+{
+    public function testBuildsNdjsonFromMixedItems(): void
+    {
+        $out = \ExternalApi\ElasticsearchApi::buildBulkNdjson([['a' => 1], 'raw-passthrough', ['b' => 2]]);
+        $this->assertSame("{\"a\":1}\nraw-passthrough\n{\"b\":2}\n", $out);
+    }
+
+    public function testNonArrayInputPassesThroughUnchanged(): void
+    {
+        $this->assertSame('already-ndjson-string', \ExternalApi\ElasticsearchApi::buildBulkNdjson('already-ndjson-string'));
+    }
+
+    public function testEmptyArrayYieldsSingleNewline(): void
+    {
+        $this->assertSame("\n", \ExternalApi\ElasticsearchApi::buildBulkNdjson([]));
+    }
+}

--- a/webapp/tests/Unit/OpenstreetmapChangesetTest.php
+++ b/webapp/tests/Unit/OpenstreetmapChangesetTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #374: Az OSM changeset-XML összeállításának lefedése (prepareNewChangeset).
+ * Tiszta SimpleXML-transzformáció: default created_by='miserend.hu' + default comment,
+ * ha hiányoznak; minden tag k/v attribútumként. A konstruktor kihagyva (config-igény).
+ */
+class OpenstreetmapChangesetTest extends TestCase
+{
+    private function api(): \ExternalApi\OpenstreetmapApi
+    {
+        return (new \ReflectionClass(\ExternalApi\OpenstreetmapApi::class))->newInstanceWithoutConstructor();
+    }
+
+    public function testInjectsDefaultCreatedByAndComment(): void
+    {
+        $xml = $this->api()->prepareNewChangeset([])->asXML();
+        $this->assertStringContainsString('created_by', $xml);
+        $this->assertStringContainsString('miserend.hu', $xml);
+        $this->assertStringContainsString('experiences', $xml); // a default comment része
+    }
+
+    public function testKeepsCustomComment(): void
+    {
+        $xml = $this->api()->prepareNewChangeset(['comment' => 'egyedi-uzenet'])->asXML();
+        $this->assertStringContainsString('egyedi-uzenet', $xml);
+    }
+
+    public function testSerializesCustomTagsAsAttributes(): void
+    {
+        $xml = $this->api()->prepareNewChangeset(['created_by' => 'x', 'foo' => 'bar'])->asXML();
+        $this->assertStringContainsString('k="foo"', $xml);
+        $this->assertStringContainsString('v="bar"', $xml);
+    }
+}


### PR DESCRIPTION
Refs #374

Két tiszta, eddig teszteletlen externalapi-transzformáció:

- **`ElasticsearchApi::buildBulkNdjson`** — az `_bulk` NDJSON-payload összeállítása **kiemelve** a `putBulk` hálózati részéből egy tesztelhető statikus metódusba (tömb→`json_encode`, string→passthrough, `\n` + záró `\n`). 3 teszt.
- **`OpenstreetmapApi::prepareNewChangeset`** — SimpleXML changeset default `created_by=miserend.hu` + default comment injektálással, tag-ek `k`/`v` attribútumként. 3 teszt (`newInstanceWithoutConstructor`, mert a konstruktor config-igényes).

Harness-verifikált. (A `getLiturgicalDaysInRange`/`putBulk`-run/`findChurch` hálózat- ill. DB-fonódott — azok mock/refaktor-igényesek, külön.)
