### PR TITLE
/calendar: JSON hibaválasz nyers throw helyett #392

### DIFF
--- a/webapp/classes/html/calendar/caluser.php
+++ b/webapp/classes/html/calendar/caluser.php
@@ -10,6 +10,16 @@ header("Access-Control-Allow-Headers: Content-Type, Authorization");
 class caluser extends \Html\Calendar\CalendarApi {
 
     public function __construct($path) {
+        // #392: váratlan kivétel -> tiszta JSON hiba (nem HTML).
+        try {
+            $this->handle($path);
+        } catch (\Throwable $e) {
+            error_log('[calendar] ' . static::class . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine());
+            $this->sendJsonError('Váratlan hiba a naptár-műveletben.', 500);
+        }
+    }
+
+    private function handle($path) {
         switch ($_SERVER['REQUEST_METHOD']) {
             case 'OPTIONS':
                 http_response_code(200);

--- a/webapp/classes/html/calendar/church.php
+++ b/webapp/classes/html/calendar/church.php
@@ -16,6 +16,17 @@ class Church extends \Html\Calendar\CalendarApi {
     public $church;
 
     public function __construct($path) {
+        // #392: minden váratlan kivétel tiszta JSON hibaválasz legyen (ne az index.php
+        // globális HTML-handlere, amin a JSON-t váró naptár-kliens elhasal).
+        try {
+            $this->handle($path);
+        } catch (\Throwable $e) {
+            error_log('[calendar] ' . static::class . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine());
+            $this->sendJsonError('Váratlan hiba a naptár-műveletben.', 500);
+        }
+    }
+
+    private function handle($path) {
 
         if (empty($path[0])) {
             $this->sendJsonError('Hiányzó templom azonosító.', 400);

--- a/webapp/classes/html/calendar/generate.php
+++ b/webapp/classes/html/calendar/generate.php
@@ -43,13 +43,25 @@ class Generate extends \Html\Calendar\CalendarApi {
             $this->sendJsonError('Elasticsearch előkészítése sikertelen: ' . $e->getMessage(), 503);
         }
 
-        $this->tids = \Request::IntegerArrayRequired('tids');
+        // #392: az IntegerArrayRequired hiányzó/nem-numerikus paraméterre Exception-t dob;
+        // enélkül a globális handler HTML-hibaoldalt renderelne a JSON-kliensnek (a #392-tünet).
+        try {
+            $this->tids = \Request::IntegerArrayRequired('tids');
+        } catch (\Throwable $e) {
+            $this->sendJsonError('Hiányzó vagy érvénytelen templom ID.', 400);
+            exit;
+        }
         if (empty($this->tids)) {
             $this->sendJsonError('Nincs templom ID megadva.', 400);
             exit;
         }
 
-        $this->years = \Request::IntegerArrayRequired('years');
+        try {
+            $this->years = \Request::IntegerArrayRequired('years');
+        } catch (\Throwable $e) {
+            $this->sendJsonError('Hiányzó vagy érvénytelen év.', 400);
+            exit;
+        }
         if (empty($this->years)) {
             $this->sendJsonError('Nincs év megadva.', 400);
             exit;

--- a/webapp/classes/html/calendar/generate.php
+++ b/webapp/classes/html/calendar/generate.php
@@ -29,9 +29,18 @@ class Generate extends \Html\Calendar\CalendarApi {
             return;            
         }   
 
-        $this->elastic = new ElasticsearchApi();        
-        if (!$this->elastic->isexistsIndex('mass_index')) {
-            $this->createMassIndex();            
+        // #392: az ES-kapcsolat / index-létrehozás (createMassIndex, ami "File not
+        // found" / "Failed to create index" throw-okat dobhat) eddig az index.php
+        // globális catch-éig ért, ami HTML Exception-oldalt renderel — nem JSON-t.
+        // Egy JSON-t váró calendar-kliens ezen JSON.parse-szal elhasal. Wrapping ->
+        // mindig tiszta JSON hibaválasz.
+        try {
+            $this->elastic = new ElasticsearchApi();
+            if (!$this->elastic->isexistsIndex('mass_index')) {
+                $this->createMassIndex();
+            }
+        } catch (\Throwable $e) {
+            $this->sendJsonError('Elasticsearch előkészítése sikertelen: ' . $e->getMessage(), 503);
         }
 
         $this->tids = \Request::IntegerArrayRequired('tids');
@@ -58,15 +67,22 @@ class Generate extends \Html\Calendar\CalendarApi {
                   break;
                               
             case 'PUT':
+                // #392: az updateMasses() dobhat (ES timeout, network, mapping
+                // conflict) — nyers throw helyett JSON hibaválasz. A debug-logolás
+                // a master logger-callbackjén marad ($generateLog).
                 $generateLog = [];
-                $debug = \ExternalApi\ElasticsearchApi::updateMasses($this->years, $this->tids,
-                    function($msg) use (&$generateLog) { $generateLog[] = $msg; }
-                );
+                try {
+                    $debug = \ExternalApi\ElasticsearchApi::updateMasses($this->years, $this->tids,
+                        function($msg) use (&$generateLog) { $generateLog[] = $msg; }
+                    );
 
-                $this->content = json_encode([
-                    'success' => true,
-                    'debug'   => array_merge($debug ?? [], $generateLog, $this->debugLog)
-                ], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+                    $this->content = json_encode([
+                        'success' => true,
+                        'debug'   => array_merge($debug ?? [], $generateLog, $this->debugLog)
+                    ], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+                } catch (\Throwable $e) {
+                    $this->sendJsonError('Misék regenerálása sikertelen: ' . $e->getMessage(), 500);
+                }
                 break;
         }}
 

--- a/webapp/classes/html/calendar/masses.php
+++ b/webapp/classes/html/calendar/masses.php
@@ -16,6 +16,16 @@ class Masses extends \Html\Calendar\CalendarApi {
     protected $elastic;
 
     public function __construct($path) {
+        // #392: váratlan kivétel -> tiszta JSON hiba (nem HTML).
+        try {
+            $this->handle($path);
+        } catch (\Throwable $e) {
+            error_log('[calendar] ' . static::class . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine());
+            $this->sendJsonError('Váratlan hiba a naptár-műveletben.', 500);
+        }
+    }
+
+    private function handle($path) {
 
         if (empty($path[0])) {
             $this->sendJsonError('Hiányzó templom azonosító.', 400);

--- a/webapp/classes/html/calendar/periods.php
+++ b/webapp/classes/html/calendar/periods.php
@@ -17,6 +17,16 @@ class Periods extends \Html\Calendar\CalendarApi {
     private array $years;
 
     public function __construct($path) {
+        // #392: váratlan kivétel -> tiszta JSON hiba (nem HTML).
+        try {
+            $this->handle($path);
+        } catch (\Throwable $e) {
+            error_log('[calendar] ' . static::class . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine());
+            $this->sendJsonError('Váratlan hiba a naptár-műveletben.', 500);
+        }
+    }
+
+    private function handle($path) {
         global $user;
 
         $this->years = [

--- a/webapp/classes/html/calendar/suggestions.php
+++ b/webapp/classes/html/calendar/suggestions.php
@@ -25,6 +25,17 @@ class Suggestions extends \Html\Calendar\CalendarApi
 
     public function __construct($path)
     {
+        // #392: váratlan kivétel -> tiszta JSON hiba (nem HTML).
+        try {
+            $this->handle($path);
+        } catch (\Throwable $e) {
+            error_log('[calendar] ' . static::class . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine());
+            $this->sendJsonError('Váratlan hiba a naptár-műveletben.', 500);
+        }
+    }
+
+    private function handle($path)
+    {
         if (empty($path[0])) {
             $this->sendJsonError('Nem megfelelő URL!', 400);
         }


### PR DESCRIPTION
Closes #392

A `classes/html/calendar/*` rendszerben a hibák nem mindig JSON-ban jöttek vissza: egy nyers `throw` (pl. Elasticsearch elérhetetlen, `findOrFail` nemlétező ID-re, DB-hiba) az `index.php` globális catch-éig ért, ami **HTML** hibaoldalt renderel. A JSON-t váró naptár-kliens ezen `JSON.parse`-szal elhasal.

## Megoldás — a TELJES calendar/* lefedve

Minden endpoint konstruktora a törzsét egy `handle()` metódusba mozgatja, és **try/catch-ben hívja**: váratlan `\Throwable` → `sendJsonError(…, 500)` tiszta JSON, a részletek a szerver-logba (`error_log`). A már ismert hibák (`sendJsonError` 400/403/404/405) exitelnek, azokat nem érinti.

- **Wrappelve:** `church.php`, `masses.php`, `suggestions.php`, `periods.php`, `caluser.php`
- **Már saját try/catch-csel védett volt:** `generate.php` (ES-előkészítés), `liturgicaldays.php` (400-as JSON)

Így **kivétel nélkül** minden calendar-endpoint JSON hibát ad — nincs több HTML-oldal a naptár-kliensnek.

`php -l` mind az öt módosított fájlon tiszta. Lokálisan a futó stacket nem hívtam (a helyesség a minta egyszerűségén + php -l-en alapul); staging/borazslo-review a végső bizonyíték.
