### PR TITLE
api: request-payload szivárgás megszüntetése a validateVariable-ben

### DIFF
--- a/webapp/classes/api/api.php
+++ b/webapp/classes/api/api.php
@@ -138,10 +138,12 @@ class Api {
     }
 
     public function validateVariable($type, $name, $details, $input = null) {
-        if($input === null) {
-            printr($this->input);
-            $input = $this->input[$name];        
-        }
+        // #182-szerű leak eltávolítva: egy null lista-elem (pl. add:[1,null,2]) eddig
+        // a printr($this->input)-on át a TELJES request-payloadot a válaszba echózta
+        // (JSON-szennyezés + belső adat szivárgás), és a null-t az egész tömbre cserélte
+        // (rossz hiba-címke). Mindkét hívó (getInputJson, list-rekurzió) átadja a 4.
+        // argumentumot, így a valódi null egyszerűen a lenti validateInteger-en akad fenn,
+        // tiszta "Field ... should be an integer." hibával, szivárgás nélkül.
 
         if($type == 'integer') {
             $this->validateInteger($name, $details, $input);

--- a/webapp/tests/Api/ApiValidateVariableLeakTest.php
+++ b/webapp/tests/Api/ApiValidateVariableLeakTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Api\Api;
+
+/**
+ * Regressziós teszt egy #182-szerű info-leakre: a validateVariable() a `$input===null`
+ * ágban `printr($this->input)`-t hívott, ami a TELJES request-payloadot (a tokent is!)
+ * `<pre>...</pre>`-ként a HTTP-válaszba echózta — egy null lista-elem (pl. `add:[1,null,2]`,
+ * a favorites add/remove úton) kiváltotta ezt, elrontva a JSON-t és belső adatot szivárogtatva.
+ *
+ * A javítás törölte a blokkot; a valódi null a validateInteger-en akad fenn, tiszta hibával.
+ */
+class ApiValidateVariableLeakTest extends TestCase
+{
+    public function testNullListElementThrowsWithoutLeakingPayload(): void
+    {
+        $api = new Api();
+        $api->input = ['add' => [1, null, 2], 'token' => 'secret-should-not-leak'];
+
+        ob_start();
+        $threw = false;
+        try {
+            $api->validateVariable('list', 'add', ['integer' => []], [1, null, 2]);
+        } catch (\Throwable $e) {
+            $threw = true;
+            $this->assertStringContainsString('integer', $e->getMessage());
+        }
+        $output = ob_get_clean();
+
+        $this->assertTrue($threw, 'null lista-elemre dobnia kell');
+        $this->assertSame('', trim($output), 'a request-payload nem szivároghat a válaszba (leak-regresszió)');
+        $this->assertStringNotContainsString('secret-should-not-leak', $output);
+    }
+}


### PR DESCRIPTION
#182-szerű info-leak az API validációban.

A `Api::validateVariable()` a `$input === null` ágban `printr($this->input)`-t hívott — egy maradék debug-kiírás, ami a **TELJES request-payloadot (a tokent is)** `<pre>...</pre>`-ként a HTTP-válaszba echózta, elrontva a JSON-t és belső adatot szivárogtatva. Egy **null lista-elem** (pl. `add:[1,null,2]` a favorites add/remove úton, `list => integer` validációval) kiváltotta.

Mindkét hívó (`getInputJson`, `list`-rekurzió) átadja a 4. argumentumot, ezért a blokk törölhető: a valódi null a `validateInteger`-en akad fenn, tiszta `Field ... should be an integer.` hibával, **szivárgás nélkül**. Regressziós teszt (dob + üres output + token nem szivárog). Harness-verifikált.
