### PR TITLE
html: a verbose exception-dump lezaro pre-tag-je (elgepeles)

### DIFF
--- a/webapp/classes/html/html.php
+++ b/webapp/classes/html/html.php
@@ -217,7 +217,7 @@ class Html {
         }
 
         if(!$toString)
-            echo "<pre>".$return."<pre>";
+            echo "<pre>".$return."</pre>";
        
         return $return;
     }


### PR DESCRIPTION
A `Html::printExceptionVerbose` a `<pre>` blokkot `<pre>`-vel zárta `</pre>` helyett (elgépelés), így a verbose debug-dump után minden a formázatlan `<pre>` blokkban ragadt (törött HTML). Egykarakteres javítás; a visszaadott érték változatlan.
