### PR TITLE
liturgikus napok: UTF-8-biztos rövidítés (endpoint-kiürülés fix) + tesztek #374

### DIFF
--- a/webapp/classes/html/calendar/liturgicaldays.php
+++ b/webapp/classes/html/calendar/liturgicaldays.php
@@ -83,7 +83,10 @@ class Liturgicaldays extends \Html\Calendar\CalendarApi {
             }
         }
 
-        // Default: take first 4 characters and add a dot
-        return substr($fullName, 0, 4) . '.';
+        // Default: take first 4 characters and add a dot.
+        // #374: mb_substr, nem substr — a byte-alapú substr félbevághat egy többbájtos
+        // UTF-8 karaktert (pl. 'Á'), amitől érvénytelen UTF-8 keletkezik, a json_encode
+        // FALSE-t ad, és az EGÉSZ liturgikus-nap endpoint üres választ ad vissza.
+        return mb_substr($fullName, 0, 4, 'UTF-8') . '.';
     }
 }

--- a/webapp/tests/Unit/LiturgicaldaysHelpersTest.php
+++ b/webapp/tests/Unit/LiturgicaldaysHelpersTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #374: A Liturgicaldays privát segédfüggvényeinek lefedése + egy valódi UTF-8 bug
+ * regressziós zárja.
+ *
+ * A getShortName() korábban byte-alapú substr()-t használt, ami félbevághat egy
+ * többbájtos UTF-8 karaktert -> érvénytelen UTF-8 -> json_encode FALSE -> az EGÉSZ
+ * liturgikus-nap endpoint üres választ ad. A javítás mb_substr; a teszt lezárja,
+ * hogy a kimenet json-kódolható maradjon.
+ *
+ * Mindkét metódus privát, és a konstruktor hálózati I/O-t végez, ezért
+ * newInstanceWithoutConstructor + Reflection.
+ */
+class LiturgicaldaysHelpersTest extends TestCase
+{
+    private function invoke(string $method, $arg)
+    {
+        $obj = (new \ReflectionClass(\Html\Calendar\Liturgicaldays::class))
+            ->newInstanceWithoutConstructor();
+        $m = new \ReflectionMethod(\Html\Calendar\Liturgicaldays::class, $method);
+        $m->setAccessible(true);
+        return $m->invoke($obj, $arg);
+    }
+
+    // ─── getShortName() ─────────────────────────────────────────────────────
+
+    public function testShortNameKeepsMultibyteCharIntact(): void
+    {
+        $short = $this->invoke('getShortName', 'aaaÁrpád');
+        $this->assertSame('aaaÁ.', $short);
+        // Regressziós zár: a kimenet legyen json-kódolható (a bug FALSE-t adott).
+        $this->assertNotFalse(json_encode(['short' => $short]));
+    }
+
+    public function testShortNameAccentedFourChars(): void
+    {
+        $this->assertSame('Évkö.', $this->invoke('getShortName', 'Évközi idő'));
+    }
+
+    public function testShortNameMapHitReturnsMapped(): void
+    {
+        // 'Pünkösd' a rövidítés-térképben van -> 'Pünk' (nem az első 4 karakter).
+        $this->assertSame('Pünk', $this->invoke('getShortName', 'Pünkösd'));
+    }
+
+    public function testShortNameEmptyReturnsEmpty(): void
+    {
+        $this->assertSame('', $this->invoke('getShortName', ''));
+    }
+
+    // ─── isValidIso8601() (format-only) ─────────────────────────────────────
+
+    public function testIsValidIso8601AcceptsFullDateTime(): void
+    {
+        $this->assertTrue($this->invoke('isValidIso8601', '2026-05-17T00:00:00'));
+    }
+
+    public function testIsValidIso8601RejectsDateWithoutTime(): void
+    {
+        $this->assertFalse($this->invoke('isValidIso8601', '2026-05-17'));
+    }
+
+    public function testIsValidIso8601RejectsSingleDigitParts(): void
+    {
+        $this->assertFalse($this->invoke('isValidIso8601', '2026-5-7T00:00:00'));
+    }
+
+    /**
+     * Dokumentálja, hogy CSAK formátumot ellenőriz (nem naptár-/tartomány-tudatos):
+     * a 2026-13-45T99:99:99 formátumilag illeszkedik, ezért true.
+     */
+    public function testIsValidIso8601IsFormatOnly(): void
+    {
+        $this->assertTrue($this->invoke('isValidIso8601', '2026-13-45T99:99:99'));
+    }
+}


### PR DESCRIPTION
A `getShortName()` byte-alapú `substr($n,0,4)`-et használt, ami **félbevág egy többbájtos UTF-8 karaktert** (pl. `Á`). Az így keletkező érvénytelen UTF-8-tól a `json_encode` **FALSE**-t ad, és az EGÉSZ liturgikus-nap endpoint **üres választ** ad vissza — a naptár figyelmeztető-sávja eltűnik. Egyetlen rossz napnév kiüríti a teljes range-et.

## Fix
`mb_substr(..., 'UTF-8')`. Plusz 8 unit-teszt (`tests/Unit/LiturgicaldaysHelpersTest.php`, Reflectionnel, konstruktor nélkül): `getShortName` (többbájtos karakter épen marad + json-kódolható regressziós zár, ékezetes 4 karakter, térkép-találat, üres) és `isValidIso8601` (teljes datetime ok, idő-nélkül/egyjegyű elutasítva, format-only limit dokumentálva). Harness-verifikált.
