### PR TITLE
napilelkibatyu: liturgicalDay hiányzó $date argumentuma

### DIFF
--- a/webapp/classes/externalapi/napilelkibatyuapi.php
+++ b/webapp/classes/externalapi/napilelkibatyuapi.php
@@ -34,7 +34,7 @@ class NapilelkibatyuApi extends \ExternalApi\ExternalApi {
 			return false;
 		}
 		
-		return $this->extractDateInfo();
+		return $this->extractDateInfo($date);
 	}
 
 	/**


### PR DESCRIPTION
A `NapilelkibatyuApi::liturgicalDay()` az `extractDateInfo()`-t **argumentum nélkül** hívta, miközben az `extractDateInfo($date)` egy kötelező (default nélküli) paramétert vár (egy korábbi refaktor óta). Így a `liturgicalDay()` `ArgumentCountError`-ral elszállna.

A metódust jelenleg semmi nem hívja (**latens** bug), de a javítás triviális: átadjuk a már feloldott `$date`-et (ami hiányában `today`). `php -l` OK.
