### PR TITLE
#545: biztonságos $_REQUEST→\Request:: darabok (map/boundary/osm) + a maradék dokumentálása

### DIFF
--- a/webapp/classes/html/ajax/boundarygeojson.php
+++ b/webapp/classes/html/ajax/boundarygeojson.php
@@ -6,11 +6,15 @@ class BoundaryGeoJson extends Ajax {
 
     public function __construct() {
         
-        if(!isset($_REQUEST['osm'])) return;
-                     
-        header('Content-Type: application/json');  
+        // #545: közvetlen $_REQUEST helyett a \Request:: olvasás. Az `osm` egy
+        // pontosvesszős lista (pl. "N:123;W:456"); a Text() üres sztringet ad
+        // hiányzáskor, ezért itt a régi isset-őrrel egyenértékű kilépés.
+        $osmParam = \Request::Text('osm');
+        if($osmParam === '') return;
+
+        header('Content-Type: application/json');
         echo "[";
-        $osmdatas = explode(';',$_REQUEST['osm']);
+        $osmdatas = explode(';', $osmParam);
         foreach($osmdatas as $key => $osmdata ) {
             
             preg_match('/(node|way|relation|N|W|R):([0-9]{1,8})$/i', $osmdata, $osm); 

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -13,6 +13,8 @@ class Edit extends \Html\Html {
     public function __construct($path) {
         global $user;
    
+        // #545: többdimenziós szerkesztő-űrlap nyers inputja. A mezőnkénti
+        // \Request:: átírás staging-tesztet igényel (mentés-folyamat), ezért marad.
         $this->input = $_REQUEST;
         $this->tid = $path[0];
         $this->church = \Eloquent\Church::find($this->tid);

--- a/webapp/classes/html/church/editosm.php
+++ b/webapp/classes/html/church/editosm.php
@@ -18,6 +18,8 @@ class EditOsm extends \Html\Html {
     public function __construct($path) {
         global $user;
 
+        // #545: többdimenziós OSM-szerkesztő nyers inputja. A mezőnkénti
+        // \Request:: átírás staging-tesztet igényel (OSM-kötés), ezért marad.
         $this->input = $_REQUEST;
         $this->tid = $path[0];
         $this->church = \Eloquent\Church::find($this->tid);

--- a/webapp/classes/html/church/editphotos.php
+++ b/webapp/classes/html/church/editphotos.php
@@ -11,6 +11,8 @@ class EditPhotos extends \Html\Html {
     public function __construct($path) {
         global $user;
    
+        // #545: kép-szerkesztő nyers inputja. A mezőnkénti \Request:: átírás
+        // staging-tesztet igényel (kép-feltöltés/-törlés), ezért marad.
         $this->input = $_REQUEST;
         $this->tid = $path[0];
         $this->church = \Eloquent\Church::find($this->tid);

--- a/webapp/classes/html/html.php
+++ b/webapp/classes/html/html.php
@@ -25,6 +25,10 @@ class Html {
     public $errorTrace;
 
     function __construct() {
+        // #545: ez a nyers-input GYÖKÉR — minden Html-oldalon elérhető a $this->input
+        // szűretlen $_REQUEST-ként. Kiváltása a html/ mappa mind a ~73 ->input[...]
+        // használatának átírását + staging-tesztet igényel (form-mentés, kép-feltöltés),
+        // ezért külön, tesztelt lépésben megy — nem itt, vakon.
         $this->input = $_REQUEST;
         $this->initPagination();
     }

--- a/webapp/classes/html/map.php
+++ b/webapp/classes/html/map.php
@@ -21,12 +21,16 @@ class Map extends Html {
             $this->church_id = $tid;
         }
         
-        if(isset($_REQUEST['map'])) {
-            $parts = explode('/',$_REQUEST['map']);
+        // #545: közvetlen $_REQUEST helyett a \Request:: olvasás. A `map` egy
+        // '/'-tagolt numerikus lista (zoom/lat/lon vagy lat/lon); a Text() üres
+        // sztringet ad hiányzáskor, a lenti is_numeric-őr változatlanul kezeli.
+        $mapParam = \Request::Text('map');
+        if($mapParam !== '') {
+            $parts = explode('/', $mapParam);
             foreach($parts as $part) {
                 if(!is_numeric($part)) return;
             }
-            
+
             if(count($parts) == 3) {
                 $this->center = [
                     'zoom' => $parts[0],
@@ -34,18 +38,21 @@ class Map extends Html {
                     'lon' => $parts[2]
                 ];
             }
-            
+
             if(count($parts) == 2) {
                 $this->center = [
                     'lat' => $parts[0],
                     'lon' => $parts[1]
                 ];
             }
-            
+
         }
-        
-        if(isset($_REQUEST['boundary'])) {
-            $this->boundary = $_REQUEST['boundary'];
+
+        // #545: boundary olvasása \Request::Text-tel; csak akkor állítjuk, ha van
+        // (hogy a property null maradjon hiányzáskor, mint eddig).
+        $boundaryParam = \Request::Text('boundary');
+        if($boundaryParam !== '') {
+            $this->boundary = $boundaryParam;
         }
         
         $data = $this->getGeoJsonDioceses();                

--- a/webapp/classes/html/user/edit.php
+++ b/webapp/classes/html/user/edit.php
@@ -25,6 +25,10 @@ class Edit extends \Html\Html {
     function modify() {
         global $user;
         
+        // #545: az `edituser` egy többdimenziós $_REQUEST-tömb (uid, roles, terms,
+        // robot, ...) vegyes értéktípusokkal, a submit() az egészet fogyasztja.
+        // Mezőnkénti \Request:: átírás staging-tesztet igényel (regisztráció +
+        // jogosultság-mentés), ezért ez a blokk egyelőre marad.
         $newuser = new \User(isset($_REQUEST['edituser']['uid']) ? $_REQUEST['edituser']['uid'] : false);
         
         if ((!isset($_REQUEST['terms']) OR $_REQUEST['terms'] != 1 ) AND $newuser->uid == 0 AND $user->uid == 0) {


### PR DESCRIPTION
Refs #391
Refs #545

A #391 `$_REQUEST` → `\Request::` refaktor tesztelést igénylő részét (#545) addig viszem, ameddig staging nélkül **biztonságos**. A kockázatos magja (élő űrlapok) tudatosan marad — ezért **Refs**, nem Closes.

## Konvertálva (behavior-preserving)

A `sanitize()` bizonyítottan **no-op** ezekre a bemenetekre (harness-elve — `map`, `boundary`, `osm`: nincs bennük `\n` vagy HTML-tag), így a csere nem változtat viselkedést:

- **`map.php`** — a `map` (`/`-tagolt numerikus lista: zoom/lat/lon vagy lat/lon) és a `boundary` olvasása `\Request::Text`-tel, a meglévő `is_numeric`-őr megtartásával.
- **`boundarygeojson.php`** — az `osm` (pontosvesszős `type:id` lista, pl. `N:123;W:456`) olvasása `\Request::Text`-tel, a régi `isset`-őrrel egyenértékű kilépéssel.

## Kommenttel megjelölve, miért MARAD (vakon nem konvertálható)

Ezekhez élő űrlap/DB melletti staging-teszt kell, ezért külön, tesztelt lépés:

- **`html.php`** — a `$this->input = $_REQUEST` gyökér; kiváltása a `html/` mind a ~73 `->input[...]` használatának átírását igényli.
- **`church/edit`, `editosm`, `editphotos`, `user/edit`** — többdimenziós szerkesztő-űrlapok, vegyes értéktípusokkal; a `submit()` az egész tömböt fogyasztja.

## Szándékosan érintetlen (nem mezőnkénti olvasás)

- `api.php`, `user/user.php`, `sqlite.php` — ezek a superglobalba **ÍRNAK** (verzió/dátum/uid normalizálás), nem olvasnak.
- `calendar/calendarapi.php`, `ajax/ajax.php`, `ajax/jsonp_miserend.php` — a **teljes kérést** adják tovább (echo/widget), nem egyedi mezőt.

Verifikáció: php -l tiszta mind a 7 fájlon; a `sanitize()` no-op-ságát külön harness igazolta a valós bemeneteken.
