### PR TITLE
hotfix: crons.php parse-hiba (fölösleges } zárta le a Crons osztályt)

### DIFF
--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -41,9 +41,6 @@ class Crons {
 			->delete();
 	}
 
-}
-
-
 	/**
 	 * #306: a cal_periods alapján gördíti a cal_periods_year-t. Minden FÜGGETLEN
 	 * időszakhoz (nincs start/end period_id ÉS nincs start/end month_day) beszúrja a


### PR DESCRIPTION
A `crons.php` jelenleg **nem parse-ol** a masteren (`syntax error, unexpected T_PUBLIC` az 58. sor környékén) — emiatt a **teljes PHPUnit-suite elhasal a CI-ban** (ez az oka, hogy több nyitott PR piros, pedig mergelhetők), és éles oldalon minden `\Crons`-t hívó cron halott.

**Ok:** a #306 (`rollPeriodYears`) és a #351 (`cleanExternalApiStats` / `cleanNotificationEmails`) merge-je egy **fölösleges `}`**-t hagyott a `cleanNotificationEmails` után, ami idő előtt lezárta a `Crons` osztályt → a `rollPeriodYears` az osztályon **kívülre** esett.

**Fix:** a fölösleges `}` kivétele — a `rollPeriodYears` visszakerül az osztályba. `php -l` tiszta, a `{`/`}` egyensúly 8/8.

Sürgős, mert a master jelenleg is törött; merge után a többi nyitott PR CI-ja is kizöldül.
