### PR TITLE
#547: staging noindex — X-Robots-Tag header nem-produkciós környezetben

### DIFF
--- a/webapp/load.php
+++ b/webapp/load.php
@@ -22,6 +22,13 @@ include_once('functions.php');
 $env = env('MISEREND_WEBAPP_ENVIRONMENT', 'staging'); /* testing, staging, production, vagrant */
 configurationSetEnvironment($env);
 
+// #547: nem-produkciós környezet (staging/testing) ne kerüljön be a keresőkbe.
+// A layout.twig noindex-metája csak a HTML-oldalakat fedi; ez a header MINDEN
+// válaszra rákerül (AJAX/JSON/kép/PDF is), és a crawlerek is tiszteletben tartják.
+if ($env !== 'production' && PHP_SAPI !== 'cli' && !headers_sent()) {
+    header('X-Robots-Tag: noindex, nofollow');
+}
+
 error_reporting($config['error_reporting'] ? $config['error_reporting'] : 0);
 define('DOMAIN', $config['path']['domain']);
 


### PR DESCRIPTION
Closes #547

A `layout.twig` már betesz `noindex` metát a HTML-oldalakra, ha `environment != production`. Ez kiegészíti egy **`X-Robots-Tag: noindex, nofollow` HTTP-headerrel** a `load.php`-ban, ami **minden** válaszra rákerül (AJAX/JSON/kép/PDF is), nem csak a HTML-oldalakra — így a keresők a staging egyetlen válaszát sem indexelik. A #546-tal (env=staging) együtt a staging automatikusan lefedve.

Guard: nem CLI, `!headers_sent()`, `env !== 'production'`.

**Validálva** (futó docker): non-production (development) env-ben a header ÉS a meta is megjelenik a válaszban; production-ben egyik sem.
