### PR TITLE
külső-API rezíliencia: kereső (ES) + churchesinboundary/josm (Overpass) graceful — #575 #572 #573

### DIFF
--- a/webapp/classes/html/ajax/churchesinboundary.php
+++ b/webapp/classes/html/ajax/churchesinboundary.php
@@ -36,8 +36,16 @@ class ChurchesInBoundary extends Ajax {
                 return;
             }
 
-            if ($elements === null) {
-                $elements = [];
+            // #572: ha az Overpass NEM adott vissza elemet (túlterhelt / üres / null válasz),
+            // NE szinkronizáljunk üresre — a sync() alább törölné a meglévő templom-
+            // társításokat, MIELŐTT az újak megérkeznének, és ha nem jönnek meg, csak
+            // veszítünk. Inkább megtartjuk a meglévőt és jelezzük, hogy próbálja később.
+            if (empty($elements)) {
+                $return['error'] = 'Az OSM (Overpass) most nem adott vissza adatot (valószínűleg túlterhelt). A meglévő társításokat megtartjuk — próbáld újra később.';
+                $return['church_ids'] = $churchIds; // a meglévő (fent lekért) lista marad
+                header('Content-Type: application/json');
+                echo json_encode($return);
+                return;
             }
 
             $churchIds = [];

--- a/webapp/classes/html/josm.php
+++ b/webapp/classes/html/josm.php
@@ -39,9 +39,19 @@ class Josm extends Html {
 
        $overpass = new \ExternalApi\OverpassApi();
        $overpass->downloadUrlMiserend();
-        if (!$overpass->jsonData->elements) {
-            throw new \Exception("Missing Json Elements from OverpassApi Query");
-        }
+        // #573: az Overpass API gyakran túlterhelt és üres/hibás választ ad. Korábban
+        // ilyenkor kivételt dobtunk → az EGÉSZ /josm oldal elszállt. Most inkább
+        // barátságos üzenettel, az OSM-függő részeket üresen hagyva betöltjük az oldalt
+        // (a DB-alapú rész — osmtags, cron-utolsó-futás — így is látszik).
+        if (empty($overpass->jsonData->elements)) {
+            addMessage('Az OSM (Overpass) adatok most nem elérhetők (valószínűleg túlterhelt). Az OSM-összevetés átmenetileg üres — próbáld újra pár perc múlva.', 'error');
+            $this->multipleOSMids = [];
+            $this->osmWBadChurch = [];
+            $this->countOsmData = 0;
+            $this->churchesWNoOsm = collect([]);
+            $this->churchesWBadOsm = collect([]);
+            $this->churchesWBad = collect([]);
+        } else {
 
 		$urlmiserends = [];
 		foreach($overpass->jsonData->elements as $element) {
@@ -85,6 +95,7 @@ class Josm extends Html {
         $this->churchesWBad = \Eloquent\Church::where('ok','i')
                 ->whereNotIn('id',$goodIDs)
                 ->get();
+        }
 			
     
         /* OSM tag variácók */

--- a/webapp/classes/html/searchresultschurches.php
+++ b/webapp/classes/html/searchresultschurches.php
@@ -86,8 +86,14 @@ class SearchResultsChurches extends Html {
         $offset = $this->pagination->take * $this->pagination->active;
         $limit = $this->pagination->take;        		        
         $results = [];
-        $results['results'] = $search->getResults($offset, $limit, false);                
+        $results['results'] = $search->getResults($offset, $limit, false);
         $resultsCount = $search->total;
+
+        // #575: ha a keresőmotor (Elasticsearch) nem elérhető, ne néma üres
+        // találati oldalt mutassunk, hanem érthető, nem-szakmai üzenetet.
+        if ($search->searchFailed) {
+            addMessage('A fejlett keresőmotorunk sajnos éppen nem elérhető. Kérlek, próbáld újra pár perc múlva.', 'error');
+        }
                 		
         
 

--- a/webapp/classes/html/searchresultsmasses.php
+++ b/webapp/classes/html/searchresultsmasses.php
@@ -236,6 +236,12 @@ class SearchResultsMasses extends Html {
         $applyNarrowingFilters($search);
         $results = $search->getResults($offset, $limit, false);
 
+        // #575: ha a keresőmotor (Elasticsearch) nem elérhető, érthető üzenet a
+        // néma üres oldal helyett. (A #357 lazított 2. menet is elhasalna ES nélkül.)
+        if ($search->searchFailed) {
+            addMessage('A fejlett keresőmotorunk sajnos éppen nem elérhető. Kérlek, próbáld újra pár perc múlva.', 'error');
+        }
+
         // #357: ha 0 találat ÉS volt szűkítő szűrő → 2. menet a szűkítők nélkül.
         if ($search->total == 0 && $hasNarrowingFilters) {
             $relaxed = new \Search('masses');

--- a/webapp/classes/search.php
+++ b/webapp/classes/search.php
@@ -8,6 +8,7 @@ class Search {
     public $query =  ["bool" => ["must" => [], "must_not" => []]];
     public $sort = [];
     public $total = 0; // Találatok száma
+    public $searchFailed = false; // #575: true, ha az ES nem adott érvényes választ (nem elérhető ≠ 0 találat)
     public $filters = []; 
     public $massOrChurch = 'church';
     public $pitId = false; 
@@ -432,7 +433,12 @@ class Search {
             if($lastHit) {
                 $this->search_after = $lastHit->sort;
             }
-            
+
+        } else {
+            // #575: nincs `hits` a válaszban → az ES nem adott érvényes találati
+            // listát (nem fut / index gond / hálózati hiba). Ez NEM "0 találat",
+            // hanem a kereső elérhetetlensége — a hívó ezt jelzi a felhasználónak.
+            $this->searchFailed = true;
         }
 
         return $result;


### PR DESCRIPTION
Closes #575
Closes #572
Closes #573

Külső-API-k (Elasticsearch, Overpass) elszállása ne rontsa el a felhasználói élményt / ne okozzon adatvesztést. Három kapcsolódó issue:

## #575 — kereső barátságos üzenete, ha nincs Elasticsearch
A `Search::getResults()` eddig **néma üres eredményt** adott, ha az ES nem válaszolt (nincs `hits` a válaszban) — a felhasználó azt hitte, nincs találat. Új `Search::searchFailed` flag különbözteti meg az „ES nem elérhető"-t a „0 találat"-tól; a `searchresults*` oldalak érthető, nem-szakmai üzenetet mutatnak: *„A fejlett keresőmotorunk sajnos éppen nem elérhető…"*.

## #572 — churchesinboundary ne töröljön, ha az Overpass nem adott adatot
A `sync()` **cserél** (törli a régit, beteszi az újat). Ha az Overpass üres/`null`-t ad (túlterhelt, de nem dob kivételt), a `sync([])` **minden meglévő társítást törölt**, mielőtt az újak megérkeznének. Most: üres Overpass-válaszkor **nem szinkronizálunk**, megtartjuk a meglévőt és jelzünk.

## #573 — /josm ne szálljon el, ha az Overpass hibázik
A hiányzó `elements` eddig **kivételt dobott** → az egész /josm oldal elszállt. Most barátságos üzenettel, az OSM-függő részeket üresen hagyva **betölt** (a DB-alapú rész — osmtags, cron utolsó futása — így is látszik).

## Validáció (futó docker, nem statikus)
- **Teljes phpunit zöld** — nincs regresszió a változásoktól.
- **#575 e2e:** ES-konténer leállítva → a kereső **megjeleníti a barátságos üzenetet** (HTTP 200), a korábbi néma üres oldal helyett. ES-sel: nincs téves üzenet.

Megjegyzés: a teljes zöld CI a #595 (crons.php) + #597 (seed) mergelése után áll elő; ez a PR azoktól független, más fájlokat érint.
