### PR TITLE
#505: aktív gondnok jelzése a templom adatlapján

### DIFF
--- a/webapp/classes/html/church/church.php
+++ b/webapp/classes/html/church/church.php
@@ -130,7 +130,12 @@ class Church extends \Html\Html {
   
 								
         copyArrayToObject($church->toArray(), $this);
-		
+
+        // #505: az adatlap admin/szerkesztő nézetében jelezzük, van-e a templomnak
+        // aktív (engedélyezett) gondnoka. A részletes lista a _panelholders.twig-ben marad.
+        $this->activeHolderCount = \Eloquent\ChurchHolder::where('church_id', $church->id)
+            ->where('status', 'allowed')->count();
+
         global $_tidsToWorkWith;
         if(in_array($this->id, $_tidsToWorkWith)) {
             $this->hasWorkAccess = false;

--- a/webapp/templates/church/_adminlinks-section.twig
+++ b/webapp/templates/church/_adminlinks-section.twig
@@ -7,5 +7,13 @@
             <small style="color: #666; display: block; margin-bottom: 8px; font-weight: bold;">Admin funkciók:</small>
             {% include "church/_adminlinks.twig" %}
         </div>
+        {# #505: aktív (engedélyezett) gondnok jelzése az adatlapon #}
+        <div style="margin-top: 8px;">
+            {% if activeHolderCount > 0 %}
+                <span class="label label-success" title="A templomnak van engedélyezett gondnoka."><i class="fa-solid fa-user-check"></i> Van aktív gondnok ({{ activeHolderCount }})</span>
+            {% else %}
+                <span class="label label-warning" title="A templomnak nincs engedélyezett gondnoka — érdemes gondnokot keresni."><i class="fa-solid fa-user-slash"></i> Nincs aktív gondnok</span>
+            {% endif %}
+        </div>
     </div>
 {% endif %}


### PR DESCRIPTION
Closes #505

Az adatlapon (szerkesztő/admin nézetben) jelezzük, van-e a templomnak **aktív (engedélyezett) gondnoka** — ahogy az issue kéri.

- `church.php`: kiszámolja az `allowed` státuszú gondnokok számát (`activeHolderCount`).
- `_adminlinks-section.twig` (a meglévő admin-szekció, `writeAcess`-guard): badge — *„Van aktív gondnok (N)"* vagy *„Nincs aktív gondnok"*.
- A **részletes** gondnok-lista változatlanul a `_panelholders.twig`-ben marad (admin-only) — ez csak egy könnyű jelzés.

**Placement-döntés:** a szerkesztő/admin nézetbe tettem (a `writeAcess`-guardos admin-szekcióba), mert a gondnok-adat félig belső, és a meglévő holder-megjelenítés is admin-only. Ha inkább publikus badge / máshova kell, szólj.

**Validáció** (futó docker): `php -l` tiszta; `/templom/1` renderel hiba nélkül; a seedben `church_id=1`-nek van `allowed` gondnoka → a count helyes. A vizuális badge szerkesztő-belépésnél látszik.
