### PR TITLE
#543: email a beküldőnek javaslat elfogadás/elutasításkor (backend + Angular toggle)

### DIFF
--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -1059,11 +1059,11 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       return this.eventService.simpleAcceptSuggestionPackage(selectedSuggestionPackage);
   }
 
-  onRejectSuggestion(selectedSuggestionPackage: SuggestionPackage) : Observable<{
+  onRejectSuggestion(selectedSuggestionPackage: SuggestionPackage, notifySender: boolean = false) : Observable<{
     suggestionPackages: SuggestionPackage[];
     calendarMasses: Mass[]
   }>  {
-    return this.eventService.simpleRejectSuggestionPackage(selectedSuggestionPackage);
+    return this.eventService.simpleRejectSuggestionPackage(selectedSuggestionPackage, notifySender);
   }
 
   public reLoadCalendar() {

--- a/calendar/src/app/components/suggestions/suggestions.component.html
+++ b/calendar/src/app/components/suggestions/suggestions.component.html
@@ -194,6 +194,10 @@
   </div>
 
   @if (suggestionPackages.length > 0) {
+    <!-- #543: elutasításkor a kezelő eldöntheti, kapjon-e a beküldő email-értesítést -->
+    <mat-checkbox [(ngModel)]="notifySenderOnReject" [disabled]="!isSuggestionPending()" class="notify-sender-check">
+      Értesítsük a beküldőt az elutasításról (ha megadott e-mail címet)
+    </mat-checkbox>
     <div class="bottom-buttons">
       <button mat-flat-button class="reject" (click)="onReject()" [disabled]="!isSuggestionPending()">{{ 'SUGGESTION.REJECT' | translate }}</button>
       <button mat-flat-button class="approve" (click)="onApprove()" [disabled]="!isSuggestionPending()">{{ 'SUGGESTION.APPROVE' | translate }}</button>

--- a/calendar/src/app/components/suggestions/suggestions.component.ts
+++ b/calendar/src/app/components/suggestions/suggestions.component.ts
@@ -14,6 +14,7 @@ import {MatFormField, MatLabel, MatOption, MatSelect} from '@angular/material/se
 import {SuggestionPackage, SuggestionState} from '../../model/suggestion-package';
 import {ChurchCalendarComponent} from '../church-calendar/church-calendar.component';
 import {MatButton} from '@angular/material/button';
+import {MatCheckbox} from '@angular/material/checkbox';
 import {FormsModule} from '@angular/forms';
 import {DatePipe, NgClass} from '@angular/common';
 import {MatSnackBarService} from '../../services/mat-snack-bar.service';
@@ -41,6 +42,7 @@ import {SpecialType} from "../../model/period";
     MatSelect,
     ChurchCalendarComponent,
     MatButton,
+    MatCheckbox,
     MatFormField,
     MatLabel,
     FormsModule,
@@ -74,6 +76,9 @@ export class SuggestionsComponent implements OnInit {
 
   public suggestionPackages: SuggestionPackage[] = [];
   public selectedSuggestionPackage?: SuggestionPackage;
+
+  // #543: elutasításkor a kezelő eldöntheti, kapjon-e a beküldő email-értesítést. Default: ne.
+  public notifySenderOnReject: boolean = false;
 
   public calendarsTitle: string = '';
 
@@ -285,9 +290,10 @@ export class SuggestionsComponent implements OnInit {
 
   onReject() {
     this.spinnerService.show();
-    this.calendarNew.onRejectSuggestion(this.selectedSuggestionPackage!).subscribe(
+    this.calendarNew.onRejectSuggestion(this.selectedSuggestionPackage!, this.notifySenderOnReject).subscribe(
       res => {
         this.snackBarService.success('Sikeres elutasítás!');
+        this.notifySenderOnReject = false;
 
         this.suggestionPackages = res.suggestionPackages.map(pkg => ({
           ...pkg,

--- a/calendar/src/app/event.service.ts
+++ b/calendar/src/app/event.service.ts
@@ -84,12 +84,14 @@ export class EventService {
     );
   }
 
-  simpleRejectSuggestionPackage(suggestionPackage: SuggestionPackage): Observable<{
+  simpleRejectSuggestionPackage(suggestionPackage: SuggestionPackage, notifySender: boolean = false): Observable<{
     suggestionPackages: SuggestionPackage[];
     calendarMasses: Mass[]
   }> {
     const suffix = `suggestions/reject/${suggestionPackage.id}`;
-    const body = {state: SuggestionState.REJECTED};
+    // #543: notify_sender → a backend csak akkor küld elutasító emailt a beküldőnek,
+    // ha a kezelő bepipálta. Default false (néha látszik, hogy valaki véletlen többet küldött be).
+    const body = {state: SuggestionState.REJECTED, notify_sender: notifySender};
     return this.http.post<{ suggestionPackages: SuggestionPackage[]; calendarMasses: Mass[] }>(
       environment.apiUrl + suffix,
       body

--- a/webapp/classes/html/calendar/suggestions.php
+++ b/webapp/classes/html/calendar/suggestions.php
@@ -164,6 +164,24 @@ class Suggestions extends \Html\Calendar\CalendarApi
             }
         }
 
+        // #543: a beküldő értesítése (ha adott meg emailt). Elfogadáskor automatikus
+        // köszönő-levél; elutasításkor csak ha a kezelő kéri (notify_sender flag — ezt
+        // az Angular felület küldheti; default: nem küldünk, mert néha látszik, hogy
+        // valaki véletlen többet küldött be). Ide csak a state-save + a sikeres ACCEPTED-
+        // apply UTÁN jutunk el (az apply hibája fentebb sendJsonError-rel kilép). Az
+        // email-hiba NE buktassa a már elmentett javaslat-státuszt.
+        if (!empty($package->sender_email)) {
+            try {
+                if ($input['state'] === 'ACCEPTED') {
+                    $package->sendMail('accepted_sender', $package->sender_email);
+                } elseif ($input['state'] === 'REJECTED' && !empty($input['notify_sender'])) {
+                    $package->sendMail('rejected_sender', $package->sender_email);
+                }
+            } catch (\Throwable $e) {
+                // csendben elnyeljük — a státusz már mentve, az email másodlagos
+            }
+        }
+
         $query = CalSuggestionPackage::where('church_id', $churchId);
 
         $filtered = $query->with('suggestions')->get()

--- a/webapp/templates/emails/suggestion_accepted_sender.twig
+++ b/webapp/templates/emails/suggestion_accepted_sender.twig
@@ -1,0 +1,11 @@
+Miserend - javaslatodat elfogadtuk ({{ church.id }})
+
+<strong>Kedves {{ senderName|default('Adományozó') }}!</strong><br/>
+<br/>
+Köszönjük, hogy javaslatot küldtél a(z) <a href="https://miserend.hu/templom/{{ church.id }}">{{ church.fullName }}</a> miserendjéhez!<br/>
+<br/>
+Örömmel értesítünk, hogy a javaslatodat <strong>elfogadtuk</strong>, és a változások bekerültek a miserendbe. Az ilyen visszajelzések teszik pontossá és naprakésszé az oldalt — hálásak vagyunk a segítségedért.<br/>
+<br/>
+Isten áldjon,<br/>
+a Miserend csapata<br/>
+<br/><br/><small>Ezt a levelet azért kaptad, mert javaslatot küldtél a <a href="https://miserend.hu">Miserend</a> oldalon. Ha nem te voltál, hagyd figyelmen kívül.</small>

--- a/webapp/templates/emails/suggestion_rejected_sender.twig
+++ b/webapp/templates/emails/suggestion_rejected_sender.twig
@@ -1,0 +1,13 @@
+Miserend - javaslatodról ({{ church.id }})
+
+<strong>Kedves {{ senderName|default('Adományozó') }}!</strong><br/>
+<br/>
+Köszönjük, hogy javaslatot küldtél a(z) <a href="https://miserend.hu/templom/{{ church.id }}">{{ church.fullName }}</a> miserendjéhez.<br/>
+<br/>
+Ezúttal a javaslatodat <strong>nem tudtuk átvezetni</strong> — előfordulhat, hogy időközben módosult az adat, vagy pontosításra lenne szükség. Ha úgy gondolod, hogy tévedés történt, nyugodtan küldd be újra a pontos adatokkal.<br/>
+<br/>
+Köszönjük a figyelmességed és a segítséged, hogy a miserend pontos maradjon!<br/>
+<br/>
+Isten áldjon,<br/>
+a Miserend csapata<br/>
+<br/><br/><small>Ezt a levelet azért kaptad, mert javaslatot küldtél a <a href="https://miserend.hu">Miserend</a> oldalon. Ha nem te voltál, hagyd figyelmen kívül.</small>


### PR DESCRIPTION
Closes #543

Javaslatcsomag elfogadásakor/elutasításakor értesítjük a beküldőt (ha megadott email-címet). **Teljes feature: backend + Angular.**

## Backend (1. commit)
A `calendar/suggestions.php` a `state`-mentés + a sikeres ACCEPTED-apply **után**:
- **Elfogadás** → automatikus **köszönő-levél** (`suggestion_accepted_sender.twig`).
- **Elutasítás** → csak ha a kezelő kéri (`notify_sender` flag) — default: nem küldünk. Sablon: `suggestion_rejected_sender.twig`.

Az email-hiba `try/catch`-ben, nem buktatja a mentett státuszt. A #307 `sendMail`-infrastruktúrát használja.

## Angular opt-out toggle (2. commit)
A suggestions-komponensbe egy **„Értesítsük a beküldőt az elutasításról"** checkbox (`notifySenderOnReject`, default: nincs bepipálva). A flag végigmegy a láncon: komponens `onReject()` → `onRejectSuggestion()` → `simpleRejectSuggestionPackage()` → a POST body `notify_sender` mezője. A backend csak ezt látva küld elutasító emailt.

Így a #543 kerek: **elfogadáskor auto köszönő-levél, elutasításkor a kezelő dönt** (bepipálja-e), megy-e üzenet.

## Validáció (futó docker + Angular build, nem statikus)
- **Backend e2e:** az elfogadás-email ténylegesen **megérkezik a mailcatcherbe** a beküldő címére (`Miserend - javaslatodat elfogadtuk (1)`); a 2 sablon helyesen renderel (`church.fullName`, `senderName`).
- **Angular:** `ng build` (dev) **hibamentes** — a `MatCheckbox` import + a template `ngModel`-binding is fordul.
- **Teljes phpunit zöld** — nincs regresszió.

Megjegyzés: a teljes zöld CI a #595 + #597 mergelése után áll elő (ez a PR azoktól független).
