### PR TITLE
#172 #103 #44: szomszédság/distances feltámasztása (2018 óta halott cron)

### DIFF
--- a/webapp/classes/distance.php
+++ b/webapp/classes/distance.php
@@ -18,7 +18,13 @@ class Distance {
             $limit = 120;
         }
 
-        $query = \Eloquent\Church::has('osms')->take($limit)->orderBy('updated_at', 'desc');
+        // #172: a régi `has('osms')` egy 2018-ban megszűnt relációra hivatkozott (nincs
+        // `osms()` metódus / `osms` tábla) → a cron MINDEN futáskor BadMethodCallException-t
+        // dobott, ezért a distances tábla halott maradt. Helyette: valós koordinátájú
+        // templomok (ezekre van értelme távolságot számolni).
+        $query = \Eloquent\Church::whereNotNull('lat')->whereNotNull('lon')
+                ->where('lat', '!=', 0)->where('lon', '!=', 0)
+                ->take($limit)->orderBy('updated_at', 'desc');
         if ($church_id) {
             if (is_array($church_id)) {
                 $query = $query->whereIn('id', $church_id);

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -719,12 +719,33 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     }
 
     public function getNeighboursAttribute () {
-        return $this->neighbourss()
-                    ->limit(10)
-                    ->get();
-        exit;
-        return $this->neighbours()->where("distance", "<=", $distance)->get();
-    }    
+        // #103: mindkét irányban keresünk. Egy pár a distances-ben csak EGYSZER szerepel
+        // (from→to), a régi accessor viszont csak a `from = ez` sorokat nézte — ezért ha a
+        // templomot a SZOMSZÉDJA dolgozta fel (ez volt a 'to'), 0 szomszédot mutatott. Most
+        // a templom lehet 'from' VAGY 'to', és mindig a MÁSIK végpont templomát adjuk vissza.
+        if (empty($this->lat) || empty($this->lon)) {
+            return collect();
+        }
+        $rows = \Eloquent\Distance::where(function($q) {
+                    $q->where('fromLat', $this->lat)->where('fromLon', $this->lon);
+                })->orWhere(function($q) {
+                    $q->where('toLat', $this->lat)->where('toLon', $this->lon);
+                })->orderBy('distance', 'ASC')->limit(30)->get();
+
+        $result = collect();
+        foreach ($rows as $d) {
+            $isFrom = ($d->fromLat == $this->lat && $d->fromLon == $this->lon);
+            $lat = $isFrom ? $d->toLat : $d->fromLat;
+            $lon = $isFrom ? $d->toLon : $d->fromLon;
+            $church = \Eloquent\Church::where('lat', $lat)->where('lon', $lon)->where('ok', 'i')->first();
+            if ($church) {
+                $church->distance = $d->distance;
+                $result->push($church);
+                if ($result->count() >= 10) break;
+            }
+        }
+        return $result;
+    }
     
     
     /**

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -120,7 +120,20 @@ class Edit extends \Html\Html {
         $this->church->log .= "\nMod: " . $user->login . " (" . date('Y-m-d H:i:s') . ")";
         
         /* Valamiért a writeAcess nem az igazi és mivel nincs a tálában ezért kiakadt...*/
+        // #44: figyeljük, változott-e a koordináta (save UTÁN már nem látszana a dirty-állapot).
+        $latLonChanged = $this->church->isDirty('lat') || $this->church->isDirty('lon');
         $this->church->save();
+
+        // #44: koordináta-módosításkor újraszámoljuk a szomszédságot (distances), különben
+        // a szomszédok listája elavulna az új pozícióhoz képest. Az esetleges hiba ne buktassa
+        // a mentést.
+        if ($latLonChanged) {
+            try {
+                $this->church->updateNeighbours();
+            } catch (\Throwable $e) {
+                error_log('[#44] updateNeighbours hiba a(z) ' . $this->tid . ' templomnál: ' . $e->getMessage());
+            }
+        }
 
         switch ($this->input['modosit']) {
             case 'n':


### PR DESCRIPTION
Closes #172
Closes #103
Closes #44

A szomszédság/distances rendszer **2018 óta halott** — feltámasztva, valós docker-validációval.

## #172 — a gyökér-ok (a cron 2018 óta dob)
`Distance::update()` a `distance.php:21`-ben a **2018-ban megszűnt `has('osms')` relációt** hívta (nincs `osms()` metódus, nincs `osms` tábla) → `BadMethodCallException: Call to undefined method Eloquent\Church::osms()` **minden cron-futáskor**. Bizonyíték a seedben: `crons.sql` id=19 `attempts=3298`, utolsó siker **2018-04-30**. Emiatt a `distances` tábla üres/halott maradt.
**Fix:** valós-koordinátás templomok szűrése (`whereNotNull('lat')/('lon')` + `!=0`).

## #103 (critical) — csak egyik irányból látszott a szomszéd
A `getNeighboursAttribute` csak a `from = ez` sorokat nézte. Egy pár a distances-ben csak **egyszer** szerepel (from→to), így ha a templomot a szomszédja dolgozta fel (ez volt a `to`), **0 szomszédot** mutatott.
**Fix:** bidirekcionális accessor — a templom lehet `from` VAGY `to`, mindig a másik végpont templomát adjuk.

## #44 — koordináta-módosításkor nem frissült
Az `updateNeighbours()` létezett, de **semmi nem hívta**. Most a `church/edit` a `save()` után (ha a `lat`/`lon` `isDirty`) meghívja.

## Validáció (futó docker, nem statikus)
- **#172:** `updateSome()` → **0 → 971** distances sor, nincs throw.
- **#103:** a korábban 0-szomszédos csak-`to` templom (#4657) **most lát szomszédot**; a `from`-templom (#4713) 10-et.
- **#44:** `updateNeighbours()` egy fel nem dolgozott templomon → **0 → 17** sor.
- **Regresszió:** DistanceTest zöld (14 teszt), teljes phpunit zöld.

## Deploy-lépés
Éles oldalon egyszeri **teljes backfill** ajánlott (a cron 50-esével dolgozik, magától is beér ~100 futás alatt, de egyszerre gyorsabb):
`(new \Distance())->update(false, 99999);`

Megjegyzés: **#89** (helyszín körüli MISE-keresés) NEM ez — az az Elasticsearch mise-kereső külön hiánya (a `hely`/`tavolsag` paramétert beolvassa, de nem alkalmazza); külön issue, külön geo-filter kell. A teljes zöld CI a #595+#597 után áll elő.
