### PR TITLE
#504: 'gondnok nélküli templomok' szűrő a templom-listában

### DIFF
--- a/webapp/classes/html/church/catalogue.php
+++ b/webapp/classes/html/church/catalogue.php
@@ -88,7 +88,8 @@ class Catalogue extends \Html\Html {
                 'Rnj' => 'templomok nem jóváhagyott észrevétellel',
                 'Ru' => 'templomok új észrevétellel',
                 'Rf' => 'templomok folyamatban lévő észrevétellel',
-                'Sp' => 'javaslatokkal rendelkező templomok'
+                'Sp' => 'javaslatokkal rendelkező templomok',
+                'Hn' => 'gondnok nélküli templomok (nincs aktív gondnok)'
             ],
             'selected' => $this->filterStatus
         ];
@@ -150,6 +151,17 @@ class Catalogue extends \Html\Html {
 
             if (in_array($this->filterStatus, ['i', 'f', 'n'])) {
                 $search = $search->where('ok', $this->filterStatus);
+            }
+
+            // #504: gondnok nélküli templomok — nincs 'allowed' (aktív) church_holder soruk.
+            // (whereNotExists, mert a Church modellen nincs holders() reláció, csak accessor.)
+            if ($this->filterStatus === 'Hn') {
+                $search = $search->whereNotExists(function ($q) {
+                    $q->from('church_holders')
+                      ->whereColumn('church_holders.church_id', 'templomok.id')
+                      ->where('church_holders.status', 'allowed')
+                      ->whereNull('church_holders.deleted_at');
+                });
             }
 
         }


### PR DESCRIPTION
Closes #504

A `templom/list` (church/catalogue) státusz-szűrőjébe új opció: **„gondnok nélküli templomok (nincs aktív gondnok)"**.

- A `buildQuery` `whereNotExists`-szel szűr azokra a templomokra, amelyeknek nincs `allowed` státuszú (nem soft-deletelt) `church_holder` soruk.
- `whereNotExists`-et használok, mert a `Church` modellen nincs `holders()` reláció (csak `getHoldersAttribute` accessor + ad-hoc query-k).
- Ugyanaz az „aktív gondnok = `allowed` `church_holder`" definíció, mint a #505-ben (adatlap-badge) — a kettő párja.

**Validálva** (futó docker): 5122 templomból 5121 gondnok-nélküli; a seedbeli church #1 (van `allowed` gondnoka) helyesen kimarad a halmazból; `php -l` tiszta.
