### PR TITLE
#571: kereső — a pontos település-találat (pl. Áta) kerüljön előre

### DIFF
--- a/webapp/classes/html/ajax/autocompletecombined.php
+++ b/webapp/classes/html/ajax/autocompletecombined.php
@@ -77,6 +77,11 @@ class AutocompleteCombined extends Ajax {
             ->whereNotNull('osmid');
 
         $boundaries = $boundaryQuery
+            // #571: a PONTOS (majd prefix-) találat kerüljön előre. Enélkül egy rövid
+            // településnév (pl. "Áta") kiszorult a take(15) mögé, mert a %áta% substring
+            // sok más boundary-t is talál (117 db), és a religious_administration + kisebb
+            // admin_level sorok elé kerültek. Így az egyező település mindig a lista elején van.
+            ->orderByRaw("CASE WHEN name = ? THEN 0 WHEN name LIKE ? THEN 1 ELSE 2 END", [$text, $text . '%'])
             ->orderByRaw("CASE WHEN boundary = 'religious_administration' THEN 0 WHEN boundary = 'administrative' THEN 1 ELSE 2 END")
             ->orderBy('admin_level', 'asc')
             ->orderBy('name', 'asc')


### PR DESCRIPTION
Closes #571

A boundary-autocomplete a `%text%` substringre rendez (`religious_administration` → `admin_level` → `name`), ezért egy rövid településnév (pl. **„Áta"**) kiszorul a `take(15)` / végső `slice(12)` mögé: a `%áta%` **117 boundary-t** talál, és a religious_administration + kisebb admin_level sorok elé kerülnek. Így a település nem jön ki — a hozzá tartozó kápolna viszont igen (az a church-ágból származik), pont ahogy a bejelentés írja.

**Fix** (borazslo javasolt megközelítése): egy **exact/prefix-match `orderByRaw` ELSŐ rendezési kulcsként** — a pontos név a 0. rangra, a prefix az 1.-re, a többi 2.-re kerül. Így az egyező település mindig a lista elején van.

**Validáció** (futó docker): az `Áta` boundary létezik (`osmid=575122`, átmegy az OSM-szűrőn), és az új rendezéssel a lista **1. eleme**. Őszinte megjegyzés: a lokális teszt-DB-ben a régi rendezés is tartalmazta a top-15-ben (kevesebb versengő boundary, mint prod-on) — a prod-overflow-t (117 találat + a végső slice) a fix determinisztikusan oldja meg.
