### PR TITLE
#569: a találati oldalon kiikszelhetők legyenek a szűrők (dupla-init guard)

### DIFF
--- a/webapp/js/unified-autocomplete.js
+++ b/webapp/js/unified-autocomplete.js
@@ -185,6 +185,14 @@ const UnifiedAutocomplete = (function () {
             return false;
         }
 
+        // #569: a találati oldal UGYANAZT a #keyword mezőt kétszer inicializálja (egyszer az
+        // extraHead-ből, egyszer a bal oldali kereső-panelből). A 2. wrapInputField() új, ÜRES
+        // badge/rejtett-mező containerre állítja az inputField._ua-t, így a látható szűrő-badge-ek
+        // × gombjai a stale _ua-t hívják → a szűrők NEM kiikszelhetők. Inputonként egyszer init.
+        if (inputField._ua) {
+            return inputField._ua;
+        }
+
         injectStyles();
         wrapInputField(inputField, form);
         attachEventListeners(inputField);


### PR DESCRIPTION
Closes #569

A találati oldalon a bal oldali sáv szűrő-badge-ein (`boundaries`/`church_ids`) a × gomb **nem távolította el** a szűrőt.

**Gyökér-ok:** a találati oldal **kétszer** inicializálja ugyanazt a `#keyword` mezőt — egyszer a `resultschurches.twig` (extraHead), egyszer a `_panelsearchforchurch.twig` (bal oldali kereső-panel), **azonos** opciókkal. A 2. `wrapInputField()` új, **üres** badge/rejtett-mező containerre állítja az `inputField._ua`-t. Ezért a látható badge-ek × gombjai a **stale** `_ua`-t hívják (`removeBoundary`/`removeChurch`), ami egy null containeren dolgozik → a badge és a rejtett `boundaries[]`/`church_ids[]` mező is marad.

**Fix:** idempotens `init()` — ha az input már wrappelt (`inputField._ua` létezik), korai return. Az 1. (teljes) init marad, a 2. no-op.

**Validáció:** `node --check` OK; a guard-minta mock-teszten a `wrapInputField` **1×** fut és mindkét `init` ugyanarra a (nem üres) containerre mutat. (A teljes click-through e2e böngészőt igényelne; a desync mechanizmusa — dupla-wrap → üres container — így determinisztikusan megszűnik.)

Megjegyzés (külön, nem ebben): az `ehm`/`lang` szűrőknek egyáltalán nincs eltávolító UI-juk — az a `Search::getFilters()` strukturált visszaadását igényelné (közepes, külön issue-ra érdemes).
