### PR TITLE
README: a helyi build a compose-zal egyező image-tagre épít (localhost/miserend:latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ Egyes beállításokat, pl. portokat, az `.env.example` fájl tartalmának átm�
 Az alkamazásból helyben is lehet container image-t készíteni, ehhez a következő parancsot kell lefuttatni:
 
 ```sh
-docker build -t miserend:latest -f docker/miserend/Dockerfile .
+docker build -t localhost/miserend:latest -f docker/miserend/Dockerfile .
 ```
 
-Ha ki szeretnéd próbálni, hogyan működne a valóságban, akkor a [dev composer](docker/compose.dev.yml) fájlban írd ät a `miserend` service `image` attribútumát `localhost/miserend:latest`-re. 
+A [compose.yml](docker/compose.yml) a `miserend` service-t a `localhost/miserend:latest` image-ből indítja, ezért a fenti build után a szokásos `docker compose -f docker/compose.yml -f docker/compose.dev.yml up` a **helyben épített** image-et használja — nem kell semmit átírni.
 
 ## 🗃️ Dump készítés
 


### PR DESCRIPTION
Kapcsolódik a #550-hez (dev-setup rendbetétele).

A README „Helyi build" szakasza `docker build -t **miserend**:latest`-re taggelt, a [compose.yml](docker/compose.yml) viszont a `miserend` service-t a `**localhost/**miserend:latest` image-ből indítja — így a helyben épített image **nem passzolt** a compose-hoz (a compose nem találta).

**Fix:** a build-tag `localhost/miserend:latest`, és a rá következő mondat is ehhez igazítva (a build után a szokásos `docker compose ... up` a helyben épített image-et használja, nem kell átírni semmit).

Docs-only. (A #550 a compose.dev.yml-be tett `build`-szekcióval amúgy automatikussá teszi a buildet — ez a manuális út is konzisztens marad.)
