### PR TITLE
#542: denomination az OSM-ből (attributes tábla), nem egyházmegye-heurisztikából

### DIFF
--- a/webapp/classes/api/table.php
+++ b/webapp/classes/api/table.php
@@ -135,6 +135,19 @@ class Table extends Api {
   
     function mapTemplomok() {
         $output = array();
+
+        // #542: a denomination az OSM-ből (attributes tábla 'denomination' kulcs,
+        // fromOSM=1) jön, nem a törékeny egyházmegye-id (17,18,34) heurisztikából.
+        // Egyszeri batch-load, hogy ne legyen N+1 az export során.
+        $churchIds = [];
+        foreach ($this->table as $r) {
+            if (isset($r->id)) { $churchIds[] = $r->id; }
+        }
+        $osmDenominations = empty($churchIds) ? [] :
+            \Eloquent\Attribute::whereIn('church_id', $churchIds)
+                ->where('key', 'denomination')
+                ->pluck('value', 'church_id')->toArray();
+
         foreach ($this->table as $row) {
             $tmp = array();
             foreach ($this->columns as $column) {
@@ -152,7 +165,12 @@ class Table extends Api {
                 switch ($column) {
                     case 'denomination':
                         //http://wiki.openstreetmap.org/wiki/Key:denomination#Christian_denominations
-                        if (in_array($row->egyhazmegye, array(17, 18, 34))) {
+                        // #542: elsődlegesen az OSM-denomination (attributes); ÁTMENETI
+                        // fallback az egyházmegye-heurisztika, amíg az OSM-sync nem fed le mindent.
+                        $cid = $row->id ?? null;
+                        if ($cid !== null && !empty($osmDenominations[$cid])) {
+                            $tmp[$column] = $osmDenominations[$cid];
+                        } elseif (in_array($row->egyhazmegye, array(17, 18, 34))) {
                             $tmp[$column] = 'greek_catholic';
                         } else {
                             $tmp[$column] = 'roman_catholic';

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1033,7 +1033,18 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     }
 
     public function getDenominationAttribute($value) {
-        return  in_array($this->egyhazmegye,[34,17,18]) ? 'greek_catholic' : 'roman_catholic';
+        // #542 (borazslo): a denomination az OSM-ből származzon — az `attributes` tábla
+        // 'denomination' kulcsából (fromOSM=1, az OSM-sync tölti) —, nem a törékeny
+        // egyházmegye-id (17,18,34) heurisztikából. A `templomok.denomination` oszlop
+        // kivezetésre szánt (mindig NULL, semmi nem írja).
+        // ÁTMENETI fallback: amíg az OSM-sync nem fed le minden templomot, a korábbi
+        // egyházmegye-alapú érték marad (regresszió-mentesség) — eltávolítható, ha az
+        // OSM-denomination minden templomra megvan.
+        $osm = $this->attributes()->where('key', 'denomination')->value('value');
+        if (!empty($osm)) {
+            return $osm;
+        }
+        return in_array($this->egyhazmegye, [34, 17, 18]) ? 'greek_catholic' : 'roman_catholic';
     }
     
     public function getHoldersAttribute($value) {


### PR DESCRIPTION
Closes #542

## Ok
A denomination két helyen az egyházmegye-id (17,18,34) heurisztikából jött (`church->denomination` accessor + `/api` Table export). Ez törékeny: az egyházmegye-besorolás nem = felekezet, és nem az OSM valós adatából dolgozik.

## Megoldás
Elsődlegesen az `attributes` tábla `denomination` kulcsát olvasom (ezt az OSM-sync tölti, `fromOSM=1`). Mindkét helyen. Az exportban batch-loadolom az attribútumokat, hogy ne legyen N+1 a ~5000 templomos lekérésen.

## Figyelmeztetés
ÁTMENETI fallback marad a régi egyházmegye-alapú érték, amíg az OSM-sync nem fed le minden templomot — így nincs regresszió (a seed-ben az `attributes` tábla üres, a meglévő tesztek zöldek maradnak). A fallback eltávolítható, ha az OSM-denomination minden templomra megvan. Külön követő feladat a `templomok.denomination` oszlop kivezetése (jelenleg mindig NULL, semmi nem írja) — seed/séma-kockázat miatt nem ebben a PR-ben.

phpunit: OK (361 tests, 793 assertions), zöld.