### PR TITLE
Javítom a lezárt PR-ek PHPUnit checkoutját

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -28,16 +28,22 @@ jobs:
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "REF=${{ github.ref }}" >> $GITHUB_OUTPUT
-            echo "TAG=${{ github.event.inputs.image_tag }}" >> $GITHUB_OUTPUT
+            echo "REF=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            echo "TAG=${{ github.event.inputs.image_tag }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "workflow_run" ]; then
             # Use the exact commit and tag from the workflow_run event
-            echo "REF=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
-            echo "TAG=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+            echo "REF=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "TAG=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            # A refs/pull/<id>/merge ref eltűnik, amint a PR-t merge-ölik vagy lezárják.
+            # A head commit továbbra is elérhető, ezért a már sorban álló futás is
+            # biztonságosan checkoutolható.
+            echo "REF=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "TAG=latest" >> "$GITHUB_OUTPUT"
           else
-            # Pull request or other events
-            echo "REF=${{ github.ref }}" >> $GITHUB_OUTPUT
-            echo "TAG=latest" >> $GITHUB_OUTPUT
+            # Other events
+            echo "REF=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            echo "TAG=latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout


### PR DESCRIPTION
## Ok

A PHPUnit workflow PR-eseménynél a `github.ref` értékét, vagyis a `refs/pull/<id>/merge` refet checkoutolta. Ha a PR-t a sorban álló futás indulása előtt merge-ölték vagy lezárták, GitHub törölte ezt az ideiglenes refet. A checkout ezért `couldn't find remote ref` hibával leállt, a tesztek el sem indultak.

## Javítás

PR-eseménynél a workflow a PR head commit SHA-ját checkoutolja. Ez a PR lezárása után is elérhető. A többi eseménytípus ref- és image-tag kezelése változatlan.

## Ellenőrzés

- `actionlint` sikeres a workflow-ra (a fájl meglévő, nem kapcsolódó shellcheck-jelzéseit kizárva)
- `git diff --check` sikeres

A hibás master futás: https://github.com/szentjozsefhackathon/miserend.hu/actions/runs/31053118820
