### PR TITLE
#610: pontosítom az email-kézbesítés ellenőrzését

### DIFF
--- a/docs/outgoing-connections.md
+++ b/docs/outgoing-connections.md
@@ -49,6 +49,20 @@ Engedélyezni kell:
 |---|---|---|
 | SMTP relay | (config-tól függ) | 25 / 465 / 587 |
 
+### Kézbesíthetőség
+
+Az SMTP `250` válasz csak azt igazolja, hogy a relay átvette a levelet, a címzetti
+kézbesítést nem. A feladó domain SPF rekordjának engedélyeznie kell a relay tényleges
+kimenő IP-jét, és a relay naplójában kell ellenőrizni az esetleges későbbi visszapattanást.
+
+A #610 vizsgálatakor az `epistola.hcbc.hu` relay nem szerepelt a `miserend.hu` SPF
+rekordjában. Ha továbbra is ez a szolgáltató küld, az SPF-hez a szolgáltató által megadott
+`include:` mechanizmust (jelenleg `include:epistola.hcbc.hu`) kell hozzáadni úgy, hogy
+egyetlen SPF rekord maradjon. Ne a relay fogadó A rekordját vegyük fel találomra: a kimenő
+IP eltérhet tőle. A módosítás után külső címre küldött tesztlevél fejlécében ellenőrizni
+kell az SPF eredményt; ha nem `pass`, a relay naplója alapján kell azonosítani a tényleges
+kimenő címet.
+
 ## Container image registry-k
 
 Build / pull időben kellhet:

--- a/webapp/classes/eloquent/email.php
+++ b/webapp/classes/eloquent/email.php
@@ -7,6 +7,8 @@ use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\PHPMailer\Exception;
 
 class Email extends \Illuminate\Database\Eloquent\Model {
+
+    public const SMTP_ACCEPTED = 'Az SMTP-kiszolgáló elfogadta a tesztlevelet. Ez nem igazolja a címzetti kézbesítést; ellenőrizd a levelet és a relay naplóját.';
     
     public $debug;
     public $debugger;
@@ -201,7 +203,10 @@ class Email extends \Illuminate\Database\Eloquent\Model {
 			return "Valami hiba történt teszt email kiküldése közben: " . $error->getMessage();
 		}
 
-		return "OK";
+		// A send() sikere csak azt jelenti, hogy a következő SMTP relay átvette a
+		// levelet. A relay később még visszautasíthatja (például SPF/DKIM miatt), ezért
+		// a health oldal ne állítsa, hogy a címzetti kézbesítés rendben van.
+		return self::SMTP_ACCEPTED;
 
 	}
     

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -280,6 +280,7 @@ class Health extends Html {
 
 
 		$this->mailing['testresult'] = $email->test($html);
+		$this->mailing['testaccepted'] = $this->mailing['testresult'] === \Eloquent\Email::SMTP_ACCEPTED;
 			
 		return;		
     }

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -298,7 +298,7 @@
 					{% if foremail %}
 						It is the test email itself. ;)
 					{% else %}
-						<span class="{% if mailing.testresult != 'OK' %}table-danger{% endif%}">{{ mailing.testresult }}</span>
+						<span class="{% if not mailing.testaccepted %}table-danger{% endif%}">{{ mailing.testresult }}</span>
 					{% endif %}
 				</td>
 			</tr>

--- a/webapp/tests/Integration/EmailSendingTest.php
+++ b/webapp/tests/Integration/EmailSendingTest.php
@@ -166,4 +166,11 @@ class EmailSendingTest extends TestCase
 
         $this->assertStringContainsString('SMTP_HOST', $email->test());
     }
+
+    public function testSuccessfulSmtpResultDoesNotClaimDelivery(): void
+    {
+        $this->assertStringContainsString('elfogadta', \Eloquent\Email::SMTP_ACCEPTED);
+        $this->assertStringContainsString('nem igazolja', \Eloquent\Email::SMTP_ACCEPTED);
+        $this->assertStringNotContainsString('OK', \Eloquent\Email::SMTP_ACCEPTED);
+    }
 }


### PR DESCRIPTION
Fixes #610

## Ok

Az `epistola.hcbc.hu` SMTP-szinten elfogadja a levelet, ezért a health „OK” eredményt mutatott. Ez csak a relay átvételét igazolja, a címzetti kézbesítést nem. A `miserend.hu` SPF rekordja jelenleg nem engedélyezi az epistola relayt, ezért a fogadó rendszer később spamként kezelheti vagy elutasíthatja a levelet.

## Javítás

- A health nem állít sikeres kézbesítést pusztán SMTP `250` válasz alapján.
- Külön jelzi, hogy a relay átvette a tesztlevelet, de a címzetti kézbesítést ellenőrizni kell.
- Dokumentálom az SPF-be felveendő `include:epistola.hcbc.hu` mechanizmust és az `spf=pass` ellenőrzését.
- Regressziós teszt védi a health eredményének jelentését.

## Ellenőrzés

- `EmailSendingTest`: 8 teszt, 16 assertion rendben
- PHP szintaxisellenőrzés rendben
- `git diff --check` rendben

## Üzemeltetési lépés

A merge önmagában nem állítja helyre a kézbesítést. A `miserend.hu` egyetlen SPF rekordjához hozzá kell adni az `include:epistola.hcbc.hu` mechanizmust, majd külső címre küldött levélnél az `Authentication-Results` fejlécben `spf=pass` eredményt kell ellenőrizni.
