### PR TITLE
Egyesítem a misedefiníciók feldolgozását

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -625,33 +625,14 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         return $formattedMasses;
     }
 
-    /**
-     * Betöltödik a MASS kategóriához tartozó misék típusa kulcsait
-     * a mass-definitions.json-ből (ugyanaz, amit home.php és searchresultsmasses.php használ)
-     */
     private static function getMassTypeKeysFromDefinitions(): array
     {
-        $massDefinitionsPath = \PATH . 'mass-definitions.json';
-        
-        if (!file_exists($massDefinitionsPath)) {
-            // Fallback: ha nem érhető el a JSON, üres tömb (ne szűrjön)
-            return [];
-        }
-        
-        $massDefinitions = json_decode(file_get_contents($massDefinitionsPath), true);
-        
-        if (!isset($massDefinitions['definitions']) || !is_array($massDefinitions['definitions'])) {
-            return []; // Biztonsági fallback
-        }
-        
-        // Gyűjtödik a MASS kategóriához tartozó definíciókat
         $massTypeKeys = [];
-        foreach ($massDefinitions['definitions'] as $definition) {
-            if ($definition['category'] === 'MASS') {
-                $massTypeKeys[] = $definition['key'];
-                $massTypeKeys[] = t('MASS_TITLE.' . $definition['key']);
-            }
-        }        
+        foreach ((new \MassDefinitions())->definitionKeysByCategory('MASS') as $key) {
+            $massTypeKeys[] = $key;
+            $massTypeKeys[] = t('MASS_TITLE.' . $key);
+        }
+
         return $massTypeKeys;
     }
     

--- a/webapp/classes/html/home.php
+++ b/webapp/classes/html/home.php
@@ -106,25 +106,9 @@ class Home extends Html {
         $this->favorites = $user->getFavorites();
         $this->searchform = $searchform;
         
-        // Load rites and categories from mass-definitions.json
-        $massDefinitionsPath = PATH . 'mass-definitions.json';
-        if (file_exists($massDefinitionsPath)) {
-            $massDefinitionsJson = file_get_contents($massDefinitionsPath);
-            $massDefinitionsData = json_decode($massDefinitionsJson, true);
-            if (isset($massDefinitionsData['rites']) && is_array($massDefinitionsData['rites'])) {
-                $this->rites = $massDefinitionsData['rites'];
-            } else {
-                $this->rites = [];
-            }
-            if (isset($massDefinitionsData['categories']) && is_array($massDefinitionsData['categories'])) {
-                $this->categories = $massDefinitionsData['categories'];
-            } else {
-                $this->categories = [];
-            }
-        } else {
-            $this->rites = [];
-            $this->categories = [];
-        }
+        $massDefinitions = new \MassDefinitions();
+        $this->rites = $massDefinitions->rites();
+        $this->categories = $massDefinitions->categories();
 		try {
             $this->alert = (new \ExternalApi\NapilelkibatyuApi())->liturgicalAlert();            
         } catch (\Exception $e) {

--- a/webapp/classes/html/searchresultsmasses.php
+++ b/webapp/classes/html/searchresultsmasses.php
@@ -190,15 +190,7 @@ class SearchResultsMasses extends Html {
             if (!empty($categoriesReq)) {
                 $selectedCategories = array_filter(array_map('trim', explode(',', $categoriesReq)));
 
-                $massDefinitionsPath = dirname(__DIR__) . '/../mass-definitions.json';
-                $massDefinitions = json_decode(file_get_contents($massDefinitionsPath), true);
-                $titlesByCategory = $massDefinitions['titlesByCategory'] ?? [];
-                $allTitles = [];
-                foreach ($selectedCategories as $cat) {
-                    if (isset($titlesByCategory[$cat])) {
-                        $allTitles = array_merge($allTitles, $titlesByCategory[$cat]);
-                    }
-                }
+                $allTitles = (new \MassDefinitions())->titlesByCategories($selectedCategories);
                 if (!empty($allTitles)) {
                     foreach ($allTitles as $title) {
                         $cleanTitle = preg_replace('/^MASS_TITLE\./', '', $title);

--- a/webapp/classes/massdefinitions.php
+++ b/webapp/classes/massdefinitions.php
@@ -1,0 +1,73 @@
+<?php
+
+final class MassDefinitions
+{
+    private array $data = [];
+
+    public function __construct(?string $path = null)
+    {
+        $path ??= PATH . 'mass-definitions.json';
+
+        if (!is_readable($path)) {
+            return;
+        }
+
+        $json = file_get_contents($path);
+        if ($json === false) {
+            return;
+        }
+
+        try {
+            $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return;
+        }
+
+        if (is_array($data)) {
+            $this->data = $data;
+        }
+    }
+
+    public function categories(): array
+    {
+        return $this->arrayValue('categories');
+    }
+
+    public function rites(): array
+    {
+        return $this->arrayValue('rites');
+    }
+
+    public function definitionKeysByCategory(string $category): array
+    {
+        $keys = [];
+        foreach ($this->arrayValue('definitions') as $definition) {
+            if (($definition['category'] ?? null) === $category && isset($definition['key'])) {
+                $keys[] = $definition['key'];
+            }
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    public function titlesByCategories(array $categories): array
+    {
+        $titles = [];
+        $titlesByCategory = $this->arrayValue('titlesByCategory');
+
+        foreach ($categories as $category) {
+            if (isset($titlesByCategory[$category]) && is_array($titlesByCategory[$category])) {
+                $titles = array_merge($titles, $titlesByCategory[$category]);
+            }
+        }
+
+        return array_values(array_unique($titles));
+    }
+
+    private function arrayValue(string $key): array
+    {
+        return isset($this->data[$key]) && is_array($this->data[$key])
+            ? $this->data[$key]
+            : [];
+    }
+}

--- a/webapp/tests/Unit/MassDefinitionsTest.php
+++ b/webapp/tests/Unit/MassDefinitionsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class MassDefinitionsTest extends TestCase
+{
+    private array $temporaryFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryFiles as $file) {
+            unlink($file);
+        }
+    }
+
+    public function testReadsDefinitionsThroughDedicatedQueries(): void
+    {
+        $definitions = new MassDefinitions($this->temporaryJson([
+            'categories' => [['key' => 'MASS']],
+            'rites' => [['key' => 'ROMAN_CATHOLIC']],
+            'definitions' => [
+                ['key' => 'HOLY_MASS', 'category' => 'MASS'],
+                ['key' => 'ROSARY', 'category' => 'OTHER'],
+                ['key' => 'HOLY_MASS', 'category' => 'MASS'],
+            ],
+            'titlesByCategory' => [
+                'MASS' => ['MASS_TITLE.HOLY_MASS'],
+                'OTHER' => ['MASS_TITLE.ROSARY'],
+            ],
+        ]));
+
+        $this->assertSame([['key' => 'MASS']], $definitions->categories());
+        $this->assertSame([['key' => 'ROMAN_CATHOLIC']], $definitions->rites());
+        $this->assertSame(['HOLY_MASS'], $definitions->definitionKeysByCategory('MASS'));
+        $this->assertSame(
+            ['MASS_TITLE.HOLY_MASS', 'MASS_TITLE.ROSARY'],
+            $definitions->titlesByCategories(['MASS', 'OTHER'])
+        );
+    }
+
+    public function testMissingFileReturnsEmptyDefinitions(): void
+    {
+        $definitions = new MassDefinitions(sys_get_temp_dir() . '/missing-mass-definitions.json');
+
+        $this->assertSame([], $definitions->categories());
+        $this->assertSame([], $definitions->rites());
+        $this->assertSame([], $definitions->definitionKeysByCategory('MASS'));
+        $this->assertSame([], $definitions->titlesByCategories(['MASS']));
+    }
+
+    public function testMalformedJsonReturnsEmptyDefinitions(): void
+    {
+        $file = $this->temporaryFile('{invalid json');
+        $definitions = new MassDefinitions($file);
+
+        $this->assertSame([], $definitions->categories());
+        $this->assertSame([], $definitions->definitionKeysByCategory('MASS'));
+    }
+
+    public function testLoadsTheGeneratedProjectDefinitions(): void
+    {
+        $definitions = new MassDefinitions();
+
+        $this->assertContains(['key' => 'MASS', 'color' => '#0A0A0A'], $definitions->categories());
+        $this->assertContains('HOLY_MASS', $definitions->definitionKeysByCategory('MASS'));
+        $this->assertContains('MASS_TITLE.HOLY_MASS', $definitions->titlesByCategories(['MASS']));
+    }
+
+    private function temporaryJson(array $data): string
+    {
+        return $this->temporaryFile(json_encode($data, JSON_THROW_ON_ERROR));
+    }
+
+    private function temporaryFile(string $contents): string
+    {
+        $file = tempnam(sys_get_temp_dir(), 'mass-definitions-');
+        file_put_contents($file, $contents);
+        $this->temporaryFiles[] = $file;
+
+        return $file;
+    }
+}


### PR DESCRIPTION
Closes #519

A mass-definitions.json beolvasását és kategória-feldolgozását közös MassDefinitions osztályba teszem. A főoldal, a misekereső és a templom közeli miselekérdezése ugyanazt a hibakezelést használja.

A hibás vagy hiányzó JSON egységesen üres definíciókészletet ad, így a misekereső sem generál fájlolvasási vagy JSON-warningot.

Validáció:
- MassDefinitionsTest: 4 teszt, 13 állítás
- teljes PHP unit/API/request/integrációs suite: 386 teszt, 835 állítás
- PHP-szintaxis-ellenőrzés minden érintett fájlon
- Composer-validáció
- főoldali kategória-renderelés HTTP smoke teszt