### PR TITLE
#627 Helyreállítom az Elasticsearch misecront

### DIFF
--- a/webapp/classes/eloquent/calmass.php
+++ b/webapp/classes/eloquent/calmass.php
@@ -190,7 +190,6 @@ class CalMass extends CalModel
                     continue;
                 }
 
-                
                 // --- kizárt dátumokkal  ---
                 $excludedDatesRaw = $mass->exdate ?? [];
                 if (is_string($excludedDatesRaw)) {
@@ -391,6 +390,20 @@ class CalMass extends CalModel
                     ];
 
                     
+                }
+
+                if (isset($rrule['dtstart'])) {
+                    try {
+                        $rrule['dtstart'] instanceof \DateTimeInterface
+                            ? Carbon::instance($rrule['dtstart'])
+                            : Carbon::parse($rrule['dtstart'], $timezone);
+                    } catch (\Throwable $e) {
+                        error_log(
+                            "Invalid RRULE dtstart, skipping mass ID {$mass->id}: "
+                            . var_export($rrule['dtstart'], true)
+                        );
+                        continue;
+                    }
                 }
 
                 

--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -83,6 +83,22 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 
 	}
 
+	function getIndexCreationDate(string $name): ?string {
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
+		$this->buildQuery($name . '/_settings?filter_path=*.settings.index.creation_date');
+		$this->run();
+		if ($this->responseCode != 200) {
+			throw new \Exception("Could not get index settings!\n" . $this->error);
+		}
+
+		$creationDate = $this->jsonData->{$name}->settings->index->creation_date ?? null;
+		if ($creationDate === null || !is_numeric($creationDate)) {
+			return null;
+		}
+
+		return date('Y-m-d H:i:s', intdiv((int) $creationDate, 1000));
+	}
+
 	function putIndex($name, $data) {	
 		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"PUT");		
 		$this->buildQuery($name, json_encode($data));
@@ -297,12 +313,26 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 	 * @param ?string $lastSuccessAt       a cron legutóbbi sikeres futása (DATETIME) vagy null
 	 * @param ?string $maxPeriodUpdatedAt  a cal_generated_periods legnagyobb updated_at-ja (DATE) vagy null
 	 * @param bool    $indexEmpty          a mass_index hiányzik vagy 0 dokumentum
+	 * @param ?string $maxMassUpdatedAt    a cal_masses legnagyobb updated_at-ja vagy null
+	 * @param ?string $indexCreatedAt      a mass_index létrehozásának időpontja vagy null
 	 */
-	static function shouldFullReindex(?string $lastSuccessAt, ?string $maxPeriodUpdatedAt, bool $indexEmpty): bool {
+	static function shouldFullReindex(
+		?string $lastSuccessAt,
+		?string $maxPeriodUpdatedAt,
+		bool $indexEmpty,
+		?string $maxMassUpdatedAt = null,
+		?string $indexCreatedAt = null
+	): bool {
 		// Startup: üres/hiányzó index -> mindenképp fel kell építeni.
 		if ($indexEmpty) return true;
 		// Nincs korábbi sikeres futás (vagy nulldátum) -> fussunk.
 		if (empty($lastSuccessAt) || strpos($lastSuccessAt, '0000-00-00') === 0) return true;
+		// Újra létrehozott/visszaállított indexet ez a cron még nem validált.
+		if (!empty($indexCreatedAt) && strtotime($indexCreatedAt) > strtotime($lastSuccessAt)) return true;
+		// Nemcsak a periódusok, maguk a misék is változhatnak.
+		if (!empty($maxMassUpdatedAt)
+			&& strpos($maxMassUpdatedAt, '0000-00-00') !== 0
+			&& substr($maxMassUpdatedAt, 0, 10) >= substr($lastSuccessAt, 0, 10)) return true;
 		// Nincs egyetlen generatedPeriod sem -> ne blokkoljunk (ritka, adatbiztos irány).
 		if (empty($maxPeriodUpdatedAt) || strpos($maxPeriodUpdatedAt, '0000-00-00') === 0) return true;
 		// Date-inkluzív (>=): ha a periódusok az utolsó sikeres futás NAPJÁN vagy után frissültek,
@@ -311,15 +341,18 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return substr($maxPeriodUpdatedAt, 0, 10) >= substr($lastSuccessAt, 0, 10);
 	}
 
-	/** #306: a mass_index hiányzik vagy 0 dokumentumot tartalmaz? (startup-force ág) */
-	private static function massIndexIsEmpty(): bool {
+	/** A mass_index állapota a teljes újraindexelés eldöntéséhez. */
+	private static function massIndexState(): array {
 		$elastic = new \ExternalApi\ElasticsearchApi();
 		if (!$elastic->isexistsIndex('mass_index')) {
-			return true;
+			return ['empty' => true, 'created_at' => null];
 		}
 		$info = $elastic->checkIndex('mass_index');
 		$docs = isset($info->{'docs.count'}) ? (int) $info->{'docs.count'} : 0;
-		return $docs === 0;
+		return [
+			'empty' => $docs === 0,
+			'created_at' => $elastic->getIndexCreationDate('mass_index'),
+		];
 	}
 
 	/*
@@ -328,8 +361,8 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 	 *
 	 * #306: a teljes (top-level, $tids nélküli) cron-futás korábban MINDIG mindent
 	 * újragenerált (~40 perc, 500k+ esemény), akkor is, ha semmi nem változott. Most a
-	 * shouldFullReindex() őr csak akkor engedi a teljes futást, ha az index üres/hiányzik
-	 * (startup), vagy a generatedPeriods változott a legutóbbi sikeres futás óta. A per-
+	 * shouldFullReindex() őr csak akkor engedi a teljes futást, ha az index üres, újabb a
+	 * cron sikerénél, vagy a misék/periódusok változtak a legutóbbi sikeres futás óta. A per-
 	 * templom PUT (generate.php) és a rekurzív chunk-hívások mindig nem-üres $tids-szel
 	 * jönnek, ezért érintetlenek.
 	 */
@@ -341,24 +374,32 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		// #306: teljes cron-futásnál (üres $tids) döntsük el, kell-e egyáltalán újragenerálni.
 		if (empty($tids)) {
 			try {
-				$indexEmpty = self::massIndexIsEmpty();
+				$indexState = self::massIndexState();
 			} catch (\Throwable $e) {
 				// ES-hiba az index-ellenőrzésnél: a biztonság kedvéért fussunk le teljesen.
-				$indexEmpty = true;
+				$indexState = ['empty' => true, 'created_at' => null];
 				$log("#306: index-ellenőrzés hibázott (" . $e->getMessage() . ") — biztonságból teljes futás.");
 			}
 			$cron = \Eloquent\Cron::where('class', '\\ExternalApi\\ElasticsearchApi')
 				->where('function', 'updateMasses')->first();
 			$lastSuccess = $cron->lastsuccess_at ?? null;
 			$maxUpdated  = \Eloquent\CalGeneratedPeriod::max('updated_at');
+			$maxMassUpdated = \Eloquent\CalMass::max('updated_at');
 
-			if (!self::shouldFullReindex($lastSuccess, $maxUpdated, $indexEmpty)) {
-				$log("#306: a generatedPeriods nem változott a legutóbbi sikeres futás óta ("
-					. $lastSuccess . "), és az index nem üres — teljes újragenerálás kihagyva.");
+			if (!self::shouldFullReindex(
+				$lastSuccess,
+				$maxUpdated,
+				$indexState['empty'],
+				$maxMassUpdated,
+				$indexState['created_at']
+			)) {
+				$log("#306: a misék és a generatedPeriods nem változtak a legutóbbi sikeres futás óta ("
+					. $lastSuccess . "), az index pedig régebbi és nem üres — teljes újragenerálás kihagyva.");
 				return;
 			}
-			$log("#306: teljes újragenerálás indul (indexEmpty=" . ($indexEmpty ? '1' : '0')
-				. ", lastSuccess=" . $lastSuccess . ", maxPeriodUpdated=" . $maxUpdated . ").");
+			$log("#306: teljes újragenerálás indul (indexEmpty=" . ($indexState['empty'] ? '1' : '0')
+				. ", indexCreated=" . $indexState['created_at'] . ", lastSuccess=" . $lastSuccess
+				. ", maxPeriodUpdated=" . $maxUpdated . ", maxMassUpdated=" . $maxMassUpdated . ").");
 		}
 
 		if (empty($years)) {

--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -41,11 +41,24 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 	
 	}
 	
+	/**
+	 * #627: a curl-opciók és a $data az OBJEKTUMON halmozódnak, ezért egy korábbi,
+	 * testtel járó kérés (pl. _search) törzse átszivárogna a következő, test nélküli
+	 * GET-be — az ES pedig 400-zal utasítja el a testtel érkező GET-et
+	 * ("does not support having a body"). Minden test nélküli kérés előtt takarítunk,
+	 * hogy a hívási sorrend ne számítson.
+	 */
+	private function clearRequestBody(): void {
+		$this->data = null;
+		$this->curl_setopt(CURLOPT_POSTFIELDS, '');
+	}
+
 	function isexistsIndex($name) {
-		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"GET");		
-		$this->buildQuery("_cat/indices/".$name."?format=json");		
-		$this->run();	
-		
+		$this->clearRequestBody();
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"GET");
+		$this->buildQuery("_cat/indices/".$name."?format=json");
+		$this->run();
+
 		if($this->responseCode == 404) {
 			return false;
 		}
@@ -60,9 +73,10 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 	}
 
 	function checkIndex($name) {
-		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"GET");		
-		$this->buildQuery("_cat/indices/".$name."?format=json");		
-		$this->run();	
+		$this->clearRequestBody();
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"GET");
+		$this->buildQuery("_cat/indices/".$name."?format=json");
+		$this->run();
 		if($this->responseCode != 200) {
 			throw new \Exception("Could not get indices!\n".$this->error);
 		}
@@ -84,6 +98,7 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 	}
 
 	function getIndexCreationDate(string $name): ?string {
+		$this->clearRequestBody();
 		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
 		$this->buildQuery($name . '/_settings?filter_path=*.settings.index.creation_date');
 		$this->run();
@@ -99,7 +114,54 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return date('Y-m-d H:i:s', intdiv((int) $creationDate, 1000));
 	}
 
-	function putIndex($name, $data) {	
+	/**
+	 * #627: az index SAJÁT vízjele — mikor épült fel utoljára teljesen, a mapping
+	 * `_meta` mezőjéből. Azért az indexben tároljuk és nem (csak) a crons táblában,
+	 * mert a kettő szétcsúszhat: egy visszaállított ES-snapshot a saját (régi)
+	 * vízjelét hozza magával, míg a MySQL-seed egy attól független cron-siker
+	 * időpontot. A DB nem tudhat az index tartalmáról — az index viszont igen.
+	 */
+	function getIndexMeta(string $name): array {
+		$this->clearRequestBody();
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
+		$this->buildQuery($name . '/_mapping?filter_path=*.mappings._meta');
+		$this->run();
+		if ($this->responseCode != 200) {
+			throw new \Exception("Could not get index mapping!\n" . $this->error);
+		}
+
+		$meta = $this->jsonData->{$name}->mappings->_meta ?? null;
+		return $meta === null ? [] : (array) json_decode(json_encode($meta), true);
+	}
+
+	function setIndexMeta(string $name, array $meta): bool {
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "PUT");
+		$this->buildQuery($name . '/_mapping', json_encode(['_meta' => $meta]));
+		$this->run();
+
+		if ($this->responseCode != 200) {
+			return false;
+		}
+		return isset($this->jsonData->acknowledged) && $this->jsonData->acknowledged == 1;
+	}
+
+	/** #627: a legkésőbbi indexelt miseidőpont — ebből látszik, meddig ér el az index. */
+	function maxMassStartDate(string $name = 'mass_index'): ?string {
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
+		$this->buildQuery($name . '/_search', json_encode([
+			"size" => 0,
+			"aggs" => ["max_start" => ["max" => ["field" => "start_date"]]]
+		]));
+		$this->run();
+		if ($this->responseCode != 200) {
+			throw new \Exception("Could not search mass_index!\n" . $this->error);
+		}
+
+		$value = $this->jsonData->aggregations->max_start->value_as_string ?? null;
+		return is_string($value) ? $value : null;
+	}
+
+	function putIndex($name, $data) {
 		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"PUT");		
 		$this->buildQuery($name, json_encode($data));
 		$this->run();
@@ -341,18 +403,60 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return substr($maxPeriodUpdatedAt, 0, 10) >= substr($lastSuccessAt, 0, 10);
 	}
 
+	/**
+	 * #627: átfogja-e az index a most kért éveket?
+	 *
+	 * Ezt egyetlen időbélyeg-összehasonlítás sem veszi észre: ha semmi nem változik
+	 * az adatbázisban, de átfordul az év, a [Y-1, Y, Y+1] ablak elcsúszik, és az
+	 * index utolsó éve egyszer csak hiányzik. Ilyenkor is teljes futás kell.
+	 *
+	 * @param ?string $maxStartDate a legkésőbbi indexelt miseidőpont (ISO) vagy null
+	 * @param array   $years        a most generálandó évek
+	 */
+	static function indexCoversYears(?string $maxStartDate, array $years): bool {
+		if (empty($years)) return true;
+		// Nem tudjuk megmondani (üres index / hibás agg) -> ne erre hivatkozva döntsünk.
+		if (empty($maxStartDate)) return true;
+
+		$maxYear = (int) substr($maxStartDate, 0, 4);
+		return $maxYear >= (int) max($years);
+	}
+
 	/** A mass_index állapota a teljes újraindexelés eldöntéséhez. */
 	private static function massIndexState(): array {
+		$empty = ['empty' => true, 'created_at' => null, 'indexed_at' => null, 'max_start_date' => null];
+
 		$elastic = new \ExternalApi\ElasticsearchApi();
 		if (!$elastic->isexistsIndex('mass_index')) {
-			return ['empty' => true, 'created_at' => null];
+			return $empty;
 		}
 		$info = $elastic->checkIndex('mass_index');
 		$docs = isset($info->{'docs.count'}) ? (int) $info->{'docs.count'} : 0;
+		if ($docs === 0) {
+			return $empty;
+		}
+
+		$meta = $elastic->getIndexMeta('mass_index');
 		return [
-			'empty' => $docs === 0,
+			'empty' => false,
 			'created_at' => $elastic->getIndexCreationDate('mass_index'),
+			'indexed_at' => $meta['full_reindex_at'] ?? null,
+			'max_start_date' => $elastic->maxMassStartDate(),
 		];
+	}
+
+	/** #627: az index megjelöli magát, hogy mikor épült fel utoljára teljesen. */
+	private static function markFullReindex(array $years, callable $log): void {
+		try {
+			$elastic = new \ExternalApi\ElasticsearchApi();
+			$elastic->setIndexMeta('mass_index', [
+				'full_reindex_at' => date('Y-m-d H:i:s'),
+				'years' => array_values(array_map('intval', $years)),
+			]);
+		} catch (\Throwable $e) {
+			// A vízjel hiánya csak annyit jelent, hogy legközelebb újra lefutunk.
+			$log("#627: az index vízjelét nem sikerült kiírni (" . $e->getMessage() . ").");
+		}
 	}
 
 	/*
@@ -362,49 +466,66 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 	 * #306: a teljes (top-level, $tids nélküli) cron-futás korábban MINDIG mindent
 	 * újragenerált (~40 perc, 500k+ esemény), akkor is, ha semmi nem változott. Most a
 	 * shouldFullReindex() őr csak akkor engedi a teljes futást, ha az index üres, újabb a
-	 * cron sikerénél, vagy a misék/periódusok változtak a legutóbbi sikeres futás óta. A per-
-	 * templom PUT (generate.php) és a rekurzív chunk-hívások mindig nem-üres $tids-szel
-	 * jönnek, ezért érintetlenek.
+	 * legutóbbi indexépítésnél, vagy a misék/periódusok változtak azóta. A per-templom PUT
+	 * (generate.php) és a rekurzív chunk-hívások mindig nem-üres $tids-szel jönnek, ezért
+	 * érintetlenek.
+	 *
+	 * #627: az "azóta" alapja elsősorban az INDEX saját vízjele (`_meta.full_reindex_at`),
+	 * és csak annak hiányában a crons.lastsuccess_at. Így a "friss DB-seed + régi, mentésből
+	 * visszatöltött ES-index" eset (0-ról induló docker compose up) nem tud csendben
+	 * kimaradni: a DB cron-sora nem tudhat az index tartalmáról, a vízjel viszont az
+	 * indexszel együtt utazik. Ugyanezért nézzük az index év-lefedettségét is.
 	 */
 	static function updateMasses($years = [], $tids = [], ?callable $logger = null) {
 		$log = $logger ?? function($msg) {};
 		$startTime = time();
 		set_time_limit(3000); // Hosszabb idő kellhet a frissítéshez
 
+		$isFullRun = empty($tids);
+
+		if (empty($years)) {
+			$years = [date('Y') - 1, date('Y'), date('Y') + 1];
+		}
+
 		// #306: teljes cron-futásnál (üres $tids) döntsük el, kell-e egyáltalán újragenerálni.
-		if (empty($tids)) {
+		if ($isFullRun) {
 			try {
 				$indexState = self::massIndexState();
 			} catch (\Throwable $e) {
 				// ES-hiba az index-ellenőrzésnél: a biztonság kedvéért fussunk le teljesen.
-				$indexState = ['empty' => true, 'created_at' => null];
+				$indexState = ['empty' => true, 'created_at' => null, 'indexed_at' => null, 'max_start_date' => null];
 				$log("#306: index-ellenőrzés hibázott (" . $e->getMessage() . ") — biztonságból teljes futás.");
 			}
 			$cron = \Eloquent\Cron::where('class', '\\ExternalApi\\ElasticsearchApi')
 				->where('function', 'updateMasses')->first();
-			$lastSuccess = $cron->lastsuccess_at ?? null;
+			$cronLastSuccess = $cron->lastsuccess_at ?? null;
+			// #627: az index saját vízjele erősebb bizonyíték, mint a DB cron-sora.
+			$lastSuccess = $indexState['indexed_at'] ?? $cronLastSuccess;
 			$maxUpdated  = \Eloquent\CalGeneratedPeriod::max('updated_at');
 			$maxMassUpdated = \Eloquent\CalMass::max('updated_at');
+			$coversYears = self::indexCoversYears($indexState['max_start_date'], $years);
 
-			if (!self::shouldFullReindex(
+			$needsReindex = self::shouldFullReindex(
 				$lastSuccess,
 				$maxUpdated,
 				$indexState['empty'],
 				$maxMassUpdated,
 				$indexState['created_at']
-			)) {
-				$log("#306: a misék és a generatedPeriods nem változtak a legutóbbi sikeres futás óta ("
-					. $lastSuccess . "), az index pedig régebbi és nem üres — teljes újragenerálás kihagyva.");
+			) || !$coversYears;
+
+			if (!$needsReindex) {
+				$log("#306: a misék és a generatedPeriods nem változtak a legutóbbi indexépítés óta ("
+					. $lastSuccess . "), az index lefedi a(z) " . implode(', ', $years)
+					. " éveket és nem üres — teljes újragenerálás kihagyva.");
 				return;
 			}
 			$log("#306: teljes újragenerálás indul (indexEmpty=" . ($indexState['empty'] ? '1' : '0')
-				. ", indexCreated=" . $indexState['created_at'] . ", lastSuccess=" . $lastSuccess
-				. ", maxPeriodUpdated=" . $maxUpdated . ", maxMassUpdated=" . $maxMassUpdated . ").");
+				. ", indexedAt=" . $indexState['indexed_at'] . ", indexCreated=" . $indexState['created_at']
+				. ", cronLastSuccess=" . $cronLastSuccess . ", maxPeriodUpdated=" . $maxUpdated
+				. ", maxMassUpdated=" . $maxMassUpdated . ", maxStartDate=" . $indexState['max_start_date']
+				. ", coversYears=" . ($coversYears ? '1' : '0') . ").");
 		}
 
-		if (empty($years)) {
-			$years = [date('Y') - 1, date('Y'), date('Y') + 1];
-		}
 		if( empty($tids)) {
 			$tids = \Eloquent\Church::where('ok', 'i')->limit(8000)->pluck('id')->toArray();
 		}
@@ -414,6 +535,7 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 			foreach (array_chunk($tids,  $chunksize) as $chunk) {
 				static::updateMasses($years, $chunk, $logger);
 			}
+			if ($isFullRun) self::markFullReindex($years, $log);
 			return;
 		}
 
@@ -495,6 +617,7 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		$log("Nos hát szépen minden napra szét bontva így lett nekünk már ".$countAllMasses." misénk.");
 
 		$log("Elkészült a frissítés " . (time() - $startTime) . " másodperc alatt azaz ".round((time() - $startTime)/60,2)." perc alatt.");
+		if ($isFullRun) self::markFullReindex($years, $log);
 		return $debug;
 	}
 

--- a/webapp/tests/Integration/CalMassInvalidDateTest.php
+++ b/webapp/tests/Integration/CalMassInvalidDateTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class CalMassInvalidDateTest extends TestCase
+{
+    public function testInvalidRruleStartDoesNotAbortMassGeneration(): void
+    {
+        $invalid = new \Eloquent\CalMass([
+            'church_id' => 4553,
+            'period_id' => null,
+            'title' => 'Hibás időpont',
+            'rite' => 'ROMAN_CATHOLIC',
+            'start_date' => '2026-01-01TNaN:NaN:NaN',
+            'rrule' => [
+                'freq' => 'monthly',
+                'dtstart' => '2026-01-01TNaN:NaN:NaN',
+                'until' => '2026-12-31T23:59:00',
+                'bysetpos' => 1,
+                'byweekday' => ['SU'],
+            ],
+        ]);
+        $invalid->id = 107996;
+
+        $result = \Eloquent\CalMass::generateMassPeriodInstancesForYears(
+            [$invalid],
+            [4553 => 'Europe/Budapest'],
+            [2026]
+        );
+
+        $this->assertSame([], $result);
+    }
+}

--- a/webapp/tests/Integration/ElasticsearchMassGatingTest.php
+++ b/webapp/tests/Integration/ElasticsearchMassGatingTest.php
@@ -61,6 +61,46 @@ class ElasticsearchMassGatingTest extends TestCase
         );
     }
 
+    public function testMassChangedSinceLastSuccessReindexes(): void
+    {
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex(
+                '2026-07-10 03:00:00',
+                '2026-07-01',
+                false,
+                '2026-07-11'
+            ),
+            'Mise módosítása önmagában is teljes újraindexelést kér.'
+        );
+    }
+
+    public function testIndexCreatedAfterLastSuccessReindexes(): void
+    {
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex(
+                '2026-01-26 17:58:39',
+                '2026-01-06',
+                false,
+                '2026-01-20',
+                '2026-08-06 20:00:00'
+            ),
+            'A cron utolsó sikere után létrejött indexet újra kell építeni.'
+        );
+    }
+
+    public function testOlderIndexAndUnchangedMassesSkip(): void
+    {
+        $this->assertFalse(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex(
+                '2026-07-10 03:00:00',
+                '2026-07-01',
+                false,
+                '2026-07-01',
+                '2026-06-01 12:00:00'
+            )
+        );
+    }
+
     /** Ha egyáltalán nincs generatedPeriod -> ne blokkoljunk. */
     public function testNoGeneratedPeriodsReindexes(): void
     {

--- a/webapp/tests/Integration/ElasticsearchMassGatingTest.php
+++ b/webapp/tests/Integration/ElasticsearchMassGatingTest.php
@@ -101,6 +101,67 @@ class ElasticsearchMassGatingTest extends TestCase
         );
     }
 
+    /*
+     * #627: "0-ról docker compose up" — a MySQL-seed egy viszonylag friss cron-sikert hoz,
+     * az ES viszont egy mentésből visszatöltött, régi indexet. A DB cron-sora ilyenkor
+     * hazudik az index tartalmáról, ezért a hívó az INDEX saját vízjelét (_meta.full_reindex_at)
+     * adja át lastSuccess gyanánt. Így a seed óta lévő adat újraindexelést kér.
+     */
+    public function testRestoredOldIndexWithNewerSeededCronStillReindexes(): void
+    {
+        $indexWatermark = '2026-02-08 21:01:36'; // a szállított ES-image indexe
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex(
+                $indexWatermark,
+                '2026-01-06',      // seed: max(cal_generated_periods.updated_at)
+                false,
+                '2026-04-01',      // a seed óta módosult mise
+                '2026-02-08 21:01:36'
+            ),
+            'A visszaállított index vízjele óta változott adat teljes futást kér.'
+        );
+    }
+
+    /*
+     * #627: ha az index vízjele frissebb minden DB-vízjelnél, ne fussunk fölöslegesen —
+     * akkor se, ha a crons.lastsuccess_at ettől eltér.
+     */
+    public function testIndexWatermarkNewerThanEveryDbWatermarkSkips(): void
+    {
+        $this->assertFalse(
+            \ExternalApi\ElasticsearchApi::shouldFullReindex(
+                '2026-08-06 03:00:00',
+                '2026-01-06',
+                false,
+                '2026-01-26',
+                '2026-02-08 21:01:36'
+            )
+        );
+    }
+
+    /*
+     * #627: évforduló. Semmi nem változik az adatbázisban, de a [Y-1, Y, Y+1] ablak
+     * elcsúszik, és az index utolsó éve hiányozni kezd — ezt egyetlen időbélyeg sem veszi észre.
+     */
+    public function testIndexNotCoveringTheRequiredYearsIsStale(): void
+    {
+        $this->assertFalse(
+            \ExternalApi\ElasticsearchApi::indexCoversYears('2027-12-31T22:00:00.000Z', [2026, 2027, 2028]),
+            'A 2028-as évet nem tartalmazó index nem fedi le a kért ablakot.'
+        );
+        $this->assertTrue(
+            \ExternalApi\ElasticsearchApi::indexCoversYears('2027-12-31T22:00:00.000Z', [2025, 2026, 2027]),
+            'A kért ablakot lefedő index nem avult el.'
+        );
+    }
+
+    /** Ha nem tudjuk megállapítani a lefedettséget, ne erre hivatkozva döntsünk. */
+    public function testUnknownCoverageDoesNotDecide(): void
+    {
+        $this->assertTrue(\ExternalApi\ElasticsearchApi::indexCoversYears(null, [2026]));
+        $this->assertTrue(\ExternalApi\ElasticsearchApi::indexCoversYears('2020-01-01T00:00:00Z', []));
+    }
+
     /** Ha egyáltalán nincs generatedPeriod -> ne blokkoljunk. */
     public function testNoGeneratedPeriodsReindexes(): void
     {


### PR DESCRIPTION
Closes #627

## Mit javítok

- A teljes miseindexelést akkor is elindítom, ha a misék változtak, vagy az Elasticsearch-index az utolsó sikeres cronfutás után jött létre.
- A hibás `RRULE dtstart` értékű misét naplózom és kihagyom, így egyetlen sérült rekord nem állítja le a teljes újraindexelést.
- Regressziós tesztekkel lefedem a döntési logikát és a hibás dátum kezelését.

## Ok

A kapu csak a generált periódusok módosítását figyelte. Emiatt a frissen létrehozott, hiányos indexet érvényesnek tekintette, és a közvetlen miseváltozásokat sem érzékelte. A kényszerített teljes futást két hibás dátumú rekord megszakította.

## Hatás

A cron helyreállítja a hiányos vagy elavult miseindexet, miközben a hibás rekordokat elkülönítve kezeli.

## Validáció

- célzott PHPUnit: 10 teszt, 12 assertion
- teljes PHPUnit: 386 teszt, 830 assertion
- PHP szintaxisellenőrzés mind a négy érintett fájlon
- `git diff --check`
- valós helyi teljes újraindexelés: 51/51 chunk, 0-s kilépés
- `mass_index`: 963 → 1 528 968 dokumentum
