### PR TITLE
#626 Helyreállítom az SQLite cront

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -12,6 +12,12 @@ services:
       - tmp:/data
     command: sh -c "chown -R 33:33 /data"
     restart: "no"
+  sqlite-init:
+    image: busybox
+    volumes:
+      - sqlite:/data
+    command: sh -c "chown -R 33:33 /data"
+    restart: "no"
   data-init:
     image: ghcr.io/szentjozsefhackathon/miserend-elasticsearch-data:2026.4.18
     volumes:
@@ -81,6 +87,7 @@ services:
        - vendor_data:/miserend/webapp/vendor
        - node_modules_data:/miserend/webapp/node_modules    
        - tmp:/miserend/webapp/fajlok/tmp
+       - sqlite:/miserend/webapp/fajlok/sqlite
        - ./miserend/apache/ports.conf:/etc/apache2/ports.conf
 
     ports:
@@ -88,6 +95,8 @@ services:
     user: "www-data"
     restart: "always"
     depends_on:
+      sqlite-init:
+        condition: service_completed_successfully
       mysql:
         condition: service_healthy
       elasticsearch:
@@ -121,6 +130,6 @@ volumes:
   db_data: {}
   elasticsearch_data: {}
   tmp: {}
+  sqlite: {}
   vendor_data:
   node_modules_data:
-  

--- a/webapp/classes/api/sqlite.php
+++ b/webapp/classes/api/sqlite.php
@@ -85,17 +85,16 @@ class Sqlite extends Api {
 
         $this->search = new \Search("masses");
 
-        if ($this->generateSqlite()) {
-            //Sajnos ez itten nem működik... Nem lesz szépen letölthető.  Headerrel sem
-            //$data = readfile($sqllitefile); exit($data);
+        try {
+            if (!$this->generateSqlite()) {
+                throw new \Exception("Could not make the requested sqlite3 file.");
+            }
             return true;
-        } else {
-            throw new \Exception("Could not make the requested sqlite3 file.");
+        } finally {
+            if ($this->search->pitId !== false) {
+                $this->search->closePit();
+            }
         }
-
-        // Ha nyitva maradt volna a pit, akkor szépen csukjuk be
-        if($this->search->pitId != false ) $this->search->closePit();
-
     }
 
     function setFileName() {
@@ -149,17 +148,47 @@ class Sqlite extends Api {
         echo "Sqlite is beginning right now...";
         if(!isset($this->sqliteFilePath)) {
             $this->setFilePath();
-}
-        $this->connectToSqlite('sqlite_v' . $this->version, $this->sqliteFilePath);
-        $this->sqlite->beginTransaction();
-        $this->dropAllTables();
-        echo "<br/>\nCreate Tables ...";
-        $this->createTables();
-        $this->insertData();
-        echo "<br/>\n";
-        $this->sqlite->commit();
-        DB::disconnect('sqlite_v' . $this->version);
-        return true;
+        }
+
+        $directory = dirname($this->sqliteFilePath);
+        if (!is_dir($directory) || !is_writable($directory)) {
+            throw new \RuntimeException("SQLite directory is not writable: " . $directory);
+        }
+
+        $temporaryFile = tempnam($directory, '.' . $this->sqliteFileName . '.');
+        if ($temporaryFile === false) {
+            throw new \RuntimeException("Could not create temporary SQLite file in " . $directory);
+        }
+
+        $connectionName = 'sqlite_v' . $this->version . '_' . bin2hex(random_bytes(6));
+        try {
+            $this->connectToSqlite($connectionName, $temporaryFile);
+            $this->sqlite->beginTransaction();
+            $this->dropAllTables();
+            echo "<br/>\nCreate Tables ...";
+            $this->createTables();
+            $this->insertData();
+            echo "<br/>\n";
+            $this->sqlite->commit();
+            DB::disconnect($connectionName);
+            $this->sqlite = null;
+
+            if (!rename($temporaryFile, $this->sqliteFilePath)) {
+                throw new \RuntimeException("Could not publish generated SQLite file.");
+            }
+            return true;
+        } catch (\Throwable $e) {
+            if ($this->sqlite !== null && $this->sqlite->transactionLevel() > 0) {
+                $this->sqlite->rollBack();
+            }
+            DB::disconnect($connectionName);
+            $this->sqlite = null;
+            throw $e;
+        } finally {
+            if (file_exists($temporaryFile)) {
+                unlink($temporaryFile);
+            }
+        }
     }
 
     function dropAllTables() {

--- a/webapp/classes/search.php
+++ b/webapp/classes/search.php
@@ -470,7 +470,7 @@ class Search {
 
         $elastic = new ElasticSearchApi();
         $elastic->curl_setopt(CURLOPT_CUSTOMREQUEST, "DELETE");
-        $elastic->buildQuery('_pit', json_encode(['id' => [$pitId]]));
+        $elastic->buildQuery('_pit', json_encode(['id' => $pitId]));
         $elastic->run();
  
         if (isset($elastic->jsonData->succeeded) && $elastic->jsonData->succeeded == true) {

--- a/webapp/tests/Integration/SqliteGenerationTest.php
+++ b/webapp/tests/Integration/SqliteGenerationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class SqliteGenerationTest extends TestCase
+{
+    private string $directory;
+
+    protected function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir() . '/miserend-sqlite-' . bin2hex(random_bytes(6));
+        mkdir($this->directory, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->directory . '/*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->directory);
+    }
+
+    public function testSuccessfulGenerationAtomicallyReplacesPublishedFile(): void
+    {
+        $target = $this->directory . '/miserend_v4.sqlite3';
+        file_put_contents($target, 'previous database');
+        $sqlite = $this->generator($target, false);
+
+        $this->assertTrue($sqlite->generateSqlite());
+        $database = new PDO('sqlite:' . $target);
+        $tables = $database->query("SELECT name FROM sqlite_master WHERE type = 'table'")
+            ->fetchAll(PDO::FETCH_COLUMN);
+
+        $this->assertEqualsCanonicalizing(['templomok', 'misek', 'kepek'], $tables);
+        $this->assertSame([], glob($this->directory . '/.miserend_v4.sqlite3.*') ?: []);
+    }
+
+    public function testFailedGenerationPreservesPublishedFile(): void
+    {
+        $target = $this->directory . '/miserend_v4.sqlite3';
+        file_put_contents($target, 'previous database');
+        $sqlite = $this->generator($target, true);
+
+        try {
+            $sqlite->generateSqlite();
+            $this->fail('A hibás generálásnak kivételt kell dobnia.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('test failure', $e->getMessage());
+        }
+
+        $this->assertSame('previous database', file_get_contents($target));
+        $this->assertSame([], glob($this->directory . '/.miserend_v4.sqlite3.*') ?: []);
+    }
+
+    private function generator(string $target, bool $fail): \Api\Sqlite
+    {
+        return new class($target, $fail) extends \Api\Sqlite {
+            public function __construct(string $target, private bool $fail)
+            {
+                $this->version = 4;
+                $this->sqliteFileName = basename($target);
+                $this->sqliteFilePath = $target;
+            }
+
+            public function insertData(): void
+            {
+                if ($this->fail) {
+                    throw new RuntimeException('test failure');
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #626

## Mit javítok

- Külön, tartós és `www-data` tulajdonú Compose-kötetet adok a publikált SQLite-fájloknak.
- A v4 adatbázist a célkönyvtárban ideiglenes fájlba építem, és csak sikeres tranzakció után cserélem atomikusan a publikus fájlt.
- Hiba esetén megtartom az előző adatbázist és eltávolítom az ideiglenes fájlt.
- A keresési PIT-et sikeres és hibás futás után is lezárom; a záró kérésben az Elasticsearch 8 által várt skalár ID-t küldöm.

## Ok

A cron közvetlenül a bind mount alatti publikus fájlt ürítette és írta. A konténer `www-data` felhasználója a host tulajdonú könyvtárba nem írhatott, futás közben pedig félkész adatbázis válhatott elérhetővé. A PIT-zárás elérhetetlen kód volt, javítása után pedig hibás tömb formátumú ID miatt Elasticsearch 400-at adott.

## Hatás

A cron írható, deployok között megmaradó kötetre dolgozik, sikertelen generálás nem rontja el a letölthető adatbázist, és a sikeres futás nem marad hibás státuszban.

## Validáció

- célzott PHPUnit: 2 teszt, 6 assertion
- teljes PHPUnit a futó webkonténerben: 384 teszt, 832 assertion
- Compose konfigurációellenőrzés
- PHP szintaxisellenőrzés
- `git diff --check`
- valós v4 cron: sikeres futás 26,09 másodperc alatt
- generált tartalom: 5 050 templom, 279 544 mise, 29 453 kép
- HTTP letöltés: 200, `application/vnd.sqlite3`, 20 512 768 bájt
