### PR TITLE
#553 Helyreállítom a templomhierarchia szintjeit

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -126,9 +126,8 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         $network = [];
         $visited = [$this->id];
         
-        // 1. Gyűjtsük össze az összes őst (fordított sorrendben, hogy felülről induljon)
+        // 1. Gyűjtsük össze az összes őst, felülről lefelé haladó sorrendben.
         $ancestors = $this->_collectAllAncestors([], $visited);
-        $ancestors = array_reverse($ancestors);
         
         // Őseink hozzáadása
         $level = 0;
@@ -154,7 +153,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         ];
         
         // 3. Hozzáadjuk a leszármazottakat
-        $descendants = $this->_collectAllDescendants([], $visited);
+        $descendants = $this->_collectAllDescendants([], $visited, $level + 1);
         foreach ($descendants as $descendant) {
             $network[] = [
                 'church' => $descendant['church'],

--- a/webapp/tests/Integration/ChurchRelationshipTest.php
+++ b/webapp/tests/Integration/ChurchRelationshipTest.php
@@ -128,6 +128,28 @@ class ChurchRelationshipTest extends TestCase {
         $this->assertContains($child2, $ids);
     }
 
+    public function testFullNetworkKeepsEveryGenerationOnItsOwnLevel(): void {
+        $grandparent = $this->createChurch('Nagyszülő');
+        $parent = $this->createChurch('Szülő');
+        $current = $this->createChurch('Aktuális');
+        $child = $this->createChurch('Gyerek');
+
+        $this->createRelationship($grandparent, $parent);
+        $this->createRelationship($parent, $current);
+        $this->createRelationship($current, $child);
+
+        $network = \Eloquent\Church::find($current)->fullNetwork;
+
+        $this->assertSame(
+            [$grandparent, $parent, $current, $child],
+            array_map(static fn(array $item): int => (int) $item['church']->id, $network)
+        );
+        $this->assertSame(
+            [0, 1, 2, 3],
+            array_column($network, 'level')
+        );
+    }
+
     public function testCircularRelationshipDoesNotCauseInfiniteLoop(): void {
         $a = $this->createChurch('A');
         $b = $this->createChurch('B');


### PR DESCRIPTION
Closes #553

## Mit javítok

- Megtartom az őslánc felülről lefelé felépített sorrendjét.
- A leszármazottak szintszámát az aktuális templom valódi mélysége után folytatom.
- Regressziós tesztben lefedem a nagyszülő–szülő–aktuális–gyerek láncot.

## Ok

Az ősgyűjtés már gyökértől lefelé adta vissza a láncot, de a megjelenítési modell még egyszer megfordította. A leszármazottak mélysége eközben mindig 1-ről indult, ezért az aktuális templom gyereke ugyanarra a szintre került, mint maga a templom.

## Hatás

A hierarchiában minden generáció külön behúzási szintet kap, bármelyik templom oldaláról nézve.

## Validáció

- célzott PHPUnit: 12 teszt, 31 assertion
- teljes PHPUnit: 383 teszt, 828 assertion
- valós helyi lánc: `2613:0 → 29:1 → 4581:2`, mélyebb leszármazottak: 3-as szint
- PHP szintaxisellenőrzés
- `git diff --check`
