### PR TITLE
#484 Bevezetem a csökkentett gluténtartalmú áldozás adatait

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1298,6 +1298,13 @@ class Church extends \Illuminate\Database\Eloquent\Model {
 		}
         return $return;
     }
+
+    public function getGlutenFreeCommunionAttribute(): array {
+        return \GlutenFreeCommunion::details(
+            $this->getAttribute(\GlutenFreeCommunion::HOLIDAYS_KEY),
+            $this->getAttribute(\GlutenFreeCommunion::WEEKDAYS_KEY)
+        );
+    }
 	
     /*
      * What does 'M' mean?

--- a/webapp/classes/glutenfreecommunion.php
+++ b/webapp/classes/glutenfreecommunion.php
@@ -44,11 +44,20 @@ class GlutenFreeCommunion
         ];
     }
 
-    public static function save(int $churchId, array $values): void
+    /*
+     * Az OSM-mel szinkronizált, származtatott címke kulcsa.
+     */
+    public const OSM_KEY = 'diet:gluten_free';
+
+    /**
+     * @return ?string A származtatott OSM-érték, vagy null, ha nem jött be beállítás
+     *                 (tehát nincs mit az OSM-be felküldeni sem).
+     */
+    public static function save(int $churchId, array $values): ?string
     {
         if (!array_key_exists(self::HOLIDAYS_KEY, $values)
             && !array_key_exists(self::WEEKDAYS_KEY, $values)) {
-            return;
+            return null;
         }
 
         foreach ([self::HOLIDAYS_KEY, self::WEEKDAYS_KEY] as $key) {
@@ -68,15 +77,40 @@ class GlutenFreeCommunion
         $stored = \Eloquent\Attribute::where('church_id', $churchId)
             ->whereIn('key', [self::HOLIDAYS_KEY, self::WEEKDAYS_KEY])
             ->pluck('value', 'key');
-        \Eloquent\Attribute::updateOrCreate(
-            ['church_id' => $churchId, 'key' => 'diet:gluten_free'],
-            [
-                'value' => self::osmValue(
-                    $stored[self::HOLIDAYS_KEY] ?? '',
-                    $stored[self::WEEKDAYS_KEY] ?? ''
-                ),
-                'fromOSM' => 0,
-            ]
+        $osmValue = self::osmValue(
+            $stored[self::HOLIDAYS_KEY] ?? '',
+            $stored[self::WEEKDAYS_KEY] ?? ''
         );
+        \Eloquent\Attribute::updateOrCreate(
+            ['church_id' => $churchId, 'key' => self::OSM_KEY],
+            ['value' => $osmValue, 'fromOSM' => 0]
+        );
+
+        return $osmValue;
+    }
+
+    /*
+     * #484: a származtatott diet:gluten_free azonnali felküldése az OSM-be.
+     *
+     * Eddig az /editosm-en kellett még egyszer menteni ahhoz, hogy az adat kijusson
+     * az OSM-be. Mostantól a /edit mentése rögtön kiviszi — hozzáadva, módosítva
+     * vagy (üres értéknél) törölve a címkét. A \OSM::pushTag() maga dönti el, hogy
+     * van-e egyáltalán eltérés, tehát fölösleges changeset nem nyílik.
+     *
+     * Szándékosan NEM dobunk hibát: a misézőhely mentése ne bukjon el azon, hogy az
+     * OSM épp nem érhető el. Ilyenkor figyelmeztetést kap a szerkesztő, és az adat
+     * a következő mentéskor (vagy az /editosm-en) kimegy.
+     */
+    public static function syncToOsm($church, string $osmValue): void
+    {
+        try {
+            if (\OSM::pushTag($church, self::OSM_KEY, $osmValue)) {
+                addMessage('A csökkentett gluténtartalmú áldozás adatát felküldtük az OpenStreetMapre is.', 'success');
+            }
+        } catch (\Throwable $e) {
+            addMessage('A csökkentett gluténtartalmú áldozás adatát nem sikerült felküldeni az OpenStreetMapre: '
+                . htmlspecialchars($e->getMessage()) . ' A miserend.hu-n elmentettük, az OSM-be a következő mentéskor jut ki.', 'warning');
+            error_log('[#484] OSM push hiba a(z) ' . ($church->id ?? '?') . ' templomnál: ' . $e->getMessage());
+        }
     }
 }

--- a/webapp/classes/glutenfreecommunion.php
+++ b/webapp/classes/glutenfreecommunion.php
@@ -1,0 +1,82 @@
+<?php
+
+class GlutenFreeCommunion
+{
+    public const HOLIDAYS_KEY = 'communion:gluten_free:holidays';
+    public const WEEKDAYS_KEY = 'communion:gluten_free:weekdays';
+
+    public static function options(): array
+    {
+        return [
+            '' => 'Nincs információ',
+            'always' => 'Mindig lehetséges, csak be kell állni a sorba',
+            'at_end' => 'Mindig lehetséges, az áldozás végén',
+            'at_start' => 'Mindig lehetséges, az áldozás elején vagy külön sorban',
+            'ask_sacristy' => 'Előtte szólni kell a sekrestyében',
+            'bring_host' => 'Ostyát kell vinni a sekrestyébe',
+            'no' => 'Nem lehetséges',
+        ];
+    }
+
+    public static function osmValue(?string $holidays, ?string $weekdays): string
+    {
+        $alwaysAvailable = ['always', 'at_end', 'at_start'];
+        if (in_array($holidays, $alwaysAvailable, true)) {
+            return 'yes';
+        }
+        if ($holidays === 'no' && $weekdays === 'no') {
+            return 'no';
+        }
+        if ($holidays !== '' && $holidays !== null || $weekdays !== '' && $weekdays !== null) {
+            return 'limited';
+        }
+        return '';
+    }
+
+    public static function details(?string $holidays, ?string $weekdays): array
+    {
+        $options = self::options();
+        return [
+            'holidays' => $options[$holidays] ?? $options[''],
+            'weekdays' => $options[$weekdays] ?? $options[''],
+            'hasInformation' => !empty($holidays) || !empty($weekdays),
+            'osmValue' => self::osmValue($holidays, $weekdays),
+        ];
+    }
+
+    public static function save(int $churchId, array $values): void
+    {
+        if (!array_key_exists(self::HOLIDAYS_KEY, $values)
+            && !array_key_exists(self::WEEKDAYS_KEY, $values)) {
+            return;
+        }
+
+        foreach ([self::HOLIDAYS_KEY, self::WEEKDAYS_KEY] as $key) {
+            if (!array_key_exists($key, $values)) {
+                continue;
+            }
+            $value = (string) $values[$key];
+            if (!array_key_exists($value, self::options())) {
+                throw new \InvalidArgumentException('Érvénytelen csökkentett gluténtartalmú áldozási beállítás.');
+            }
+            \Eloquent\Attribute::updateOrCreate(
+                ['church_id' => $churchId, 'key' => $key],
+                ['value' => $value, 'fromOSM' => 0]
+            );
+        }
+
+        $stored = \Eloquent\Attribute::where('church_id', $churchId)
+            ->whereIn('key', [self::HOLIDAYS_KEY, self::WEEKDAYS_KEY])
+            ->pluck('value', 'key');
+        \Eloquent\Attribute::updateOrCreate(
+            ['church_id' => $churchId, 'key' => 'diet:gluten_free'],
+            [
+                'value' => self::osmValue(
+                    $stored[self::HOLIDAYS_KEY] ?? '',
+                    $stored[self::WEEKDAYS_KEY] ?? ''
+                ),
+                'fromOSM' => 0,
+            ]
+        );
+    }
+}

--- a/webapp/classes/html/church/church.php
+++ b/webapp/classes/html/church/church.php
@@ -57,6 +57,7 @@ class Church extends \Html\Html {
     public $readAccess;
     public $writeAccess;
     public $accessibility;
+    public $glutenFreeCommunion;
     public $hasWorkAccess;
     public $church;
     public $neighbours;
@@ -83,7 +84,7 @@ class Church extends \Html\Html {
         if(!$church) {
             throw new \Exception("Church with tid = '$tid' does not exist.");
         }
-        $church = $church->append(['readAccess','writeAccess','accessibility']);
+        $church = $church->append(['readAccess','writeAccess','accessibility','glutenFreeCommunion']);
         
         if (!$church->readAccess) {
             throw new \Exception("Read access denied to church tid = '$tid'");

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -115,7 +115,12 @@ class Edit extends \Html\Html {
             }
         }
 
-        \GlutenFreeCommunion::save($this->tid, $this->input['church']);
+        // #484: a részletes beállítások mentése + a származtatott OSM-címke azonnali
+        // felküldése, hogy ne kelljen külön az /editosm-en is elmenteni.
+        $glutenFreeOsmValue = \GlutenFreeCommunion::save($this->tid, $this->input['church']);
+        if ($glutenFreeOsmValue !== null) {
+            \GlutenFreeCommunion::syncToOsm($this->church, $glutenFreeOsmValue);
+        }
 
        
         global $user;

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -115,6 +115,8 @@ class Edit extends \Html\Html {
             }
         }
 
+        \GlutenFreeCommunion::save($this->tid, $this->input['church']);
+
        
         global $user;
         $this->church->log .= "\nMod: " . $user->login . " (" . date('Y-m-d H:i:s') . ")";
@@ -178,6 +180,20 @@ class Edit extends \Html\Html {
             'value' => $this->getExternalCalendarUrl(),
             'labelback' => 'Külső naptár (iCalendar ICS URL) - maximum 1'
         ];
+
+        foreach ([
+            'gluten_free_holidays' => [\GlutenFreeCommunion::HOLIDAYS_KEY, 'Ünnepnapokon'],
+            'gluten_free_weekdays' => [\GlutenFreeCommunion::WEEKDAYS_KEY, 'Hétköznapokon'],
+        ] as $formKey => [$attributeKey, $label]) {
+            $this->form[$formKey] = [
+                'type' => 'select',
+                'name' => 'church[' . $attributeKey . ']',
+                'id' => $formKey,
+                'options' => \GlutenFreeCommunion::options(),
+                'selected' => $this->church->getAttribute($attributeKey) ?? '',
+                'labelback' => $label,
+            ];
+        }
     
   $this->form['misemegj'] = array(
 			'class' => 'tinymce',

--- a/webapp/classes/html/church/editosm.php
+++ b/webapp/classes/html/church/editosm.php
@@ -367,6 +367,9 @@ class EditOsm extends \Html\Html {
 						'limited' => 'Lehetséges, de külön szólni kell. Sőt egyes helyeken vinni is kell ostyát.',
 						'no' => 'Nem lehetséges.'
 					),
+					'value' => $this->church->glutenFreeCommunion['hasInformation']
+						? $this->church->glutenFreeCommunion['osmValue']
+						: ($osmtags->{'diet:gluten_free'} ?? ''),
 					'disabled' => true,
 					'help' => 'Ezt a mezőt a részletesebb (ünnepnapokat és hétköznapokat külön kezelő) beállítások alapján töltjük ki.'
 				]

--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -211,6 +211,109 @@ class OSM {
         }
     }
     
+    /**
+     * #484: a címkecsere TISZTA része — a meglévő OSM-tagokból és az új értékből
+     * előállítja a mentendő taglistát. Szándékosan hálózat- és DB-mentes, hogy
+     * unit-tesztelhető legyen, mi számít egyáltalán változásnak.
+     *
+     * @param  array  $tags   a jelenlegi OSM-tagok (kulcs => érték)
+     * @param  string $value  új érték; üres string = a címke törlése
+     * @return ?array a mentendő taglista, vagy null, ha nincs változás
+     */
+    static function applyTagChange(array $tags, string $key, string $value): ?array {
+        // Nincs változás: se eddig, se most nincs érték, vagy pont ugyanaz van kint.
+        if (($tags[$key] ?? '') === $value) {
+            return null;
+        }
+
+        if ($value === '') {
+            unset($tags[$key]);
+        } else {
+            $tags[$key] = $value;
+        }
+
+        return $tags;
+    }
+
+    /**
+     * #484: EGYETLEN OSM-címke felküldése a misézőhely OSM-entitására.
+     *
+     * Az /edit oldalon szerkesztett, származtatott adatokat (ma: diet:gluten_free)
+     * mentéskor rögtön kiírjuk az OSM-be is, hogy ne kelljen utána az /editosm-en
+     * még egyszer elmenteni. Ehhez végig kell járni a teljes changeset-kört:
+     * entitás letöltése -> van-e egyáltalán változás -> changeset nyitás ->
+     * entitás PUT -> changeset zárás.
+     *
+     * A címke hozzáadását, módosítását ÉS törlését is kezeli: üres $value esetén
+     * kivesszük a tagot az entitásból.
+     *
+     * FONTOS: olvasni is a config szerinti (írásra használt) API-ról olvasunk, mert
+     * a PUT-nak az ottani entitás-verziót kell látnia — élőről olvasva + devre írva
+     * verzióütközés lenne.
+     *
+     * @param  \Eloquent\Church $church
+     * @param  string           $key    OSM tag kulcs (pl. 'diet:gluten_free')
+     * @param  ?string          $value  új érték; üres/null = a címke törlése
+     * @return bool  true, ha tényleg módosítottuk az OSM-et; false, ha nem volt mit
+     * @throws \Exception  ha az OSM nem érhető el vagy a mentés nem sikerült
+     */
+    static function pushTag($church, string $key, ?string $value): bool {
+
+        if (empty($church->osmtype) OR empty($church->osmid)) {
+            return false;
+        }
+
+        $value = $value === null ? '' : trim($value);
+        $osmtype = $church->osmtype;
+
+        $osmapi = new \ExternalApi\OpenstreetmapApi();
+        $osmapi->query = '/api/0.6/'.$osmtype.'/'.$church->osmid;
+        $osmapi->run();
+
+        if (!isset($osmapi->xmlData->{$osmtype}[0])) {
+            throw new \Exception('Az OSM entitás ('.$osmtype.':'.$church->osmid.') nem érhető el.');
+        }
+        $entity = $osmapi->xmlData;
+
+        $tags = [];
+        foreach ($entity->{$osmtype}[0]->tag as $tag) {
+            $tags[(string) $tag['k']] = (string) $tag['v'];
+        }
+
+        $tags = self::applyTagChange($tags, $key, $value);
+        if ($tags === null) {
+            return false; // nincs eltérés, ne nyissunk fölösleges changesetet
+        }
+
+        // SimpleXML-ből egyetlen gyereket nem lehet célzottan törölni, ezért az
+        // egész taglistát eldobjuk és újraírjuk (ugyanaz, mint az /editosm-en).
+        unset($entity->{$osmtype}->tag);
+        foreach ($tags as $k => $v) {
+            $newTag = $entity->{$osmtype}->addChild('tag');
+            $newTag->addAttribute('k', $k);
+            $newTag->addAttribute('v', $v);
+        }
+
+        global $user;
+        $writeApi = new \ExternalApi\OpenstreetmapApi();
+        $changesetID = $writeApi->changesetCreate([
+            'created_by' => 'miserend.hu',
+            'comment' => 'Changes by a user of miserend.hu called '.($user->login ?? 'unknown'),
+        ]);
+        if ($changesetID <= 0) {
+            throw new \Exception('Nem sikerült OSM changesetet nyitni.');
+        }
+
+        $versionID = $writeApi->putEntity($changesetID, $osmtype, $entity);
+        $writeApi->changesetClose($changesetID);
+
+        if (!$versionID) {
+            throw new \Exception('Az OSM entitás mentése nem sikerült ('.$osmtype.':'.$church->osmid.').');
+        }
+
+        return true;
+    }
+
     function saveOSM2Church($church, $element) {
 			
 			// Ha valamiért nincs church.id, akkor inkább elszállunk, minthogy mindent töröljünk és megkavarjunk.

--- a/webapp/templates/church/_panelglutenfree.twig
+++ b/webapp/templates/church/_panelglutenfree.twig
@@ -1,0 +1,10 @@
+{% extends 'panel.twig' %}
+
+{% set title = '<i class="' ~ ICONS_GLUTENFREE ~ '"></i> Csökkentett gluténtartalmú szentáldozás' %}
+{% set panel = 'primary' %}
+{% set collapsible = 'collapsed' %}
+
+{% block body %}
+    <p><strong>Ünnepnapokon:</strong> {{ glutenFreeCommunion.holidays }}</p>
+    <p><strong>Hétköznapokon:</strong> {{ glutenFreeCommunion.weekdays }}</p>
+{% endblock %}

--- a/webapp/templates/church/church.twig
+++ b/webapp/templates/church/church.twig
@@ -229,6 +229,9 @@
 	{% if location.osm is not null %}
 		{% include 'church/_panelaccessibility.twig'  %}
 	{% endif %}
+    {% if glutenFreeCommunion.hasInformation %}
+        {% include 'church/_panelglutenfree.twig' %}
+    {% endif %}
     
 {% endblock %}
 

--- a/webapp/templates/church/edit.twig
+++ b/webapp/templates/church/edit.twig
@@ -270,6 +270,17 @@
             </tr>
             {{ _self.helptr(15,help) }}            
             <tr>
+                <td colspan="3"><hr/><h4>Csökkentett gluténtartalmú szentáldozás</h4></td>
+            </tr>
+            <tr>
+                <td class=kiscim align=right>Ünnepnapokon:</td>
+                <td colspan="2">{{ forms.select(form.gluten_free_holidays) }}</td>
+            </tr>
+            <tr>
+                <td class=kiscim align=right>Hétköznapokon:</td>
+                <td colspan="2">{{ forms.select(form.gluten_free_weekdays) }}</td>
+            </tr>
+            <tr>
                 <td colspan="3"><hr/><h4>Kapcsolat más misézőhelyekkel</h4></td>
             </tr>
 

--- a/webapp/templates/church/editosm.twig
+++ b/webapp/templates/church/editosm.twig
@@ -69,6 +69,7 @@
 					<td >
 						{% if item['type'] == 'input' %}
 							{{ forms.input(item) }}
+							{% if item.disabled %}<input type="hidden" name="{{ item.name }}" value="{{ item.value|e }}">{% endif %}
 						{% elseif item['type'] == 'textarea' %}
 							{{ forms.textarea(item) }}
 						{% else %}

--- a/webapp/tests/Integration/GlutenFreeCommunionPersistenceTest.php
+++ b/webapp/tests/Integration/GlutenFreeCommunionPersistenceTest.php
@@ -17,10 +17,13 @@ final class GlutenFreeCommunionPersistenceTest extends TestCase
 
     public function testDetailedSettingsAndDerivedOsmValueAreSavedTogether(): void
     {
-        \GlutenFreeCommunion::save(1, [
+        $osmValue = \GlutenFreeCommunion::save(1, [
             \GlutenFreeCommunion::HOLIDAYS_KEY => 'at_end',
             \GlutenFreeCommunion::WEEKDAYS_KEY => 'ask_sacristy',
         ]);
+
+        // #484: a mentés visszaadja a származtatott értéket, ezt küldi fel a hívó az OSM-be.
+        $this->assertSame('yes', $osmValue);
 
         $attributes = DB::table('attributes')->where('church_id', 1)
             ->whereIn('key', [
@@ -39,5 +42,13 @@ final class GlutenFreeCommunionPersistenceTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         \GlutenFreeCommunion::save(1, [\GlutenFreeCommunion::HOLIDAYS_KEY => 'invalid']);
+    }
+
+    /*
+     * #484: ha a formon nincs is gluténmentes mező, ne induljon OSM-felküldés.
+     */
+    public function testNothingSubmittedMeansNothingToPush(): void
+    {
+        $this->assertNull(\GlutenFreeCommunion::save(1, ['nev' => 'Valami templom']));
     }
 }

--- a/webapp/tests/Integration/GlutenFreeCommunionPersistenceTest.php
+++ b/webapp/tests/Integration/GlutenFreeCommunionPersistenceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+final class GlutenFreeCommunionPersistenceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        DB::rollBack();
+    }
+
+    public function testDetailedSettingsAndDerivedOsmValueAreSavedTogether(): void
+    {
+        \GlutenFreeCommunion::save(1, [
+            \GlutenFreeCommunion::HOLIDAYS_KEY => 'at_end',
+            \GlutenFreeCommunion::WEEKDAYS_KEY => 'ask_sacristy',
+        ]);
+
+        $attributes = DB::table('attributes')->where('church_id', 1)
+            ->whereIn('key', [
+                \GlutenFreeCommunion::HOLIDAYS_KEY,
+                \GlutenFreeCommunion::WEEKDAYS_KEY,
+                'diet:gluten_free',
+            ])
+            ->pluck('value', 'key');
+
+        $this->assertSame('at_end', $attributes[\GlutenFreeCommunion::HOLIDAYS_KEY]);
+        $this->assertSame('ask_sacristy', $attributes[\GlutenFreeCommunion::WEEKDAYS_KEY]);
+        $this->assertSame('yes', $attributes['diet:gluten_free']);
+    }
+
+    public function testInvalidSettingIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        \GlutenFreeCommunion::save(1, [\GlutenFreeCommunion::HOLIDAYS_KEY => 'invalid']);
+    }
+}

--- a/webapp/tests/Unit/GlutenFreeCommunionTest.php
+++ b/webapp/tests/Unit/GlutenFreeCommunionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class GlutenFreeCommunionTest extends TestCase
+{
+    public function testHolidayAlwaysOptionsMapToYes(): void
+    {
+        foreach (['always', 'at_end', 'at_start'] as $value) {
+            $this->assertSame('yes', \GlutenFreeCommunion::osmValue($value, 'no'));
+        }
+    }
+
+    public function testBothImpossibleMapsToNo(): void
+    {
+        $this->assertSame('no', \GlutenFreeCommunion::osmValue('no', 'no'));
+    }
+
+    public function testConditionalOrPartialAvailabilityMapsToLimited(): void
+    {
+        $this->assertSame('limited', \GlutenFreeCommunion::osmValue('ask_sacristy', 'no'));
+        $this->assertSame('limited', \GlutenFreeCommunion::osmValue('no', 'always'));
+        $this->assertSame('limited', \GlutenFreeCommunion::osmValue('', 'bring_host'));
+    }
+
+    public function testMissingInformationDoesNotCreateOsmClaim(): void
+    {
+        $this->assertSame('', \GlutenFreeCommunion::osmValue('', ''));
+        $this->assertFalse(\GlutenFreeCommunion::details('', '')['hasInformation']);
+    }
+}

--- a/webapp/tests/Unit/OsmPushTagTest.php
+++ b/webapp/tests/Unit/OsmPushTagTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/*
+ * #484: az /edit mentése azonnal felküldi az OSM-be a származtatott címkét.
+ * Itt a döntés tiszta része van tesztelve: mikor kell egyáltalán changesetet nyitni,
+ * és milyen taglista menjen ki.
+ */
+final class OsmPushTagTest extends TestCase
+{
+    public function testNewTagIsAdded(): void
+    {
+        $result = \OSM::applyTagChange(['amenity' => 'place_of_worship'], 'diet:gluten_free', 'yes');
+
+        $this->assertSame(['amenity' => 'place_of_worship', 'diet:gluten_free' => 'yes'], $result);
+    }
+
+    public function testChangedValueIsWritten(): void
+    {
+        $result = \OSM::applyTagChange(['diet:gluten_free' => 'limited'], 'diet:gluten_free', 'yes');
+
+        $this->assertSame(['diet:gluten_free' => 'yes'], $result);
+    }
+
+    public function testEmptyValueRemovesTheTag(): void
+    {
+        $result = \OSM::applyTagChange(
+            ['amenity' => 'place_of_worship', 'diet:gluten_free' => 'no'],
+            'diet:gluten_free',
+            ''
+        );
+
+        $this->assertSame(['amenity' => 'place_of_worship'], $result);
+    }
+
+    public function testUnchangedValueOpensNoChangeset(): void
+    {
+        $this->assertNull(\OSM::applyTagChange(['diet:gluten_free' => 'yes'], 'diet:gluten_free', 'yes'));
+    }
+
+    public function testStillMissingTagOpensNoChangeset(): void
+    {
+        $this->assertNull(\OSM::applyTagChange(['amenity' => 'place_of_worship'], 'diet:gluten_free', ''));
+    }
+
+    public function testOtherTagsAreKeptUntouched(): void
+    {
+        $tags = [
+            'amenity' => 'place_of_worship',
+            'religion' => 'christian',
+            'denomination' => 'roman_catholic',
+        ];
+
+        $result = \OSM::applyTagChange($tags, 'diet:gluten_free', 'limited');
+
+        $this->assertSame($tags + ['diet:gluten_free' => 'limited'], $result);
+    }
+}


### PR DESCRIPTION
Closes #484

## Mit vezetek be

- Külön beállítást adok az ünnepnapi és hétköznapi csökkentett gluténtartalmú szentáldozáshoz, a jóváhagyott hat lehetőséggel.
- A részletes adatokat a meglévő helyi attribútumtárba mentem, migráció nélkül.
- Determinisztikusan származtatom a `diet:gluten_free` OSM-értéket (`yes`, `limited`, `no`).
- Az OSM-szerkesztőben a származtatott érték nem írható felül kézzel, mentéskor mégis szinkronizálható.
- A templom adatalapján ikonozott panelben jelenítem meg az ünnepnapi és hétköznapi tudnivalót.

## Leképezés

- ünnepnapon mindig elérhető → `yes`
- ünnepnapon és hétköznapon sem lehetséges → `no`
- minden más ismert kombináció → `limited`
- teljesen hiányzó adat → nincs OSM-állítás

## Validáció

- célzott unit és integrációs PHPUnit: 6 teszt, 13 assertion
- teljes PHPUnit: 388 teszt, 839 assertion
- admin szerkesztőoldal HTTP smoke: mindkét mező renderelődik
- publikus adatlap HTTP smoke: ikon és mindkét részletes szöveg renderelődik
- ideiglenes smoke-adatok eltávolítása ellenőrizve: 0 maradék rekord
- PHP szintaxisellenőrzés az érintett osztályokon
- `git diff --check`
