### PR TITLE
#284 Megjelenítem a bankkártyás adományozás lehetőségét

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1299,17 +1299,32 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         return $return;
     }
 
+    /*
+     * #284: a `payment:credit_cards` OSM-értékeinek EGYETLEN forrása. Ugyanez a mondat
+     * a címke az /editosm legördülőjében és a nyilvános szöveg a templomlapon — így egy
+     * szöveg egy helyen van megadva. Az üres kulcs a "nincs adat" ág: az /editosm-en
+     * választható, a templomlapon viszont nem állítunk vele semmit (message = null).
+     */
+    public const CARD_DONATION_OPTIONS = [
+        '' => 'Nincs információ.',
+        'yes' => 'Bankkártyás, digitális persely is elérhető.',
+        'limited' => 'Bankkártyás adományozás a sekrestyében vagy külön kérésre lehetséges.',
+        'no' => 'Csak készpénzes adományozás lehetséges.',
+    ];
+
+    /* Mely `payment:credit_cards` értékek jelentenek tényleges kártyás lehetőséget. */
+    public const CARD_DONATION_AVAILABLE = ['yes', 'limited'];
+
     public function getCardDonationAttribute(): array {
         $value = $this->getAttribute('payment:credit_cards');
-        $messages = [
-            'yes' => 'Bankkártyás digitális persely bármikor elérhető.',
-            'limited' => 'Bankkártyás adományozás a sekrestyében vagy külön kérésre lehetséges.',
-            'no' => 'Csak készpénzes adományozás lehetséges.',
-        ];
+        $message = ($value === null || $value === '')
+            ? null
+            : (self::CARD_DONATION_OPTIONS[$value] ?? null);
+
         return [
             'value' => $value,
-            'message' => $messages[$value] ?? null,
-            'available' => $value === 'yes' || $value === 'limited',
+            'message' => $message,
+            'available' => in_array($value, self::CARD_DONATION_AVAILABLE, true),
         ];
     }
 	

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1298,6 +1298,20 @@ class Church extends \Illuminate\Database\Eloquent\Model {
 		}
         return $return;
     }
+
+    public function getCardDonationAttribute(): array {
+        $value = $this->getAttribute('payment:credit_cards');
+        $messages = [
+            'yes' => 'Bankkártyás digitális persely bármikor elérhető.',
+            'limited' => 'Bankkártyás adományozás a sekrestyében vagy külön kérésre lehetséges.',
+            'no' => 'Csak készpénzes adományozás lehetséges.',
+        ];
+        return [
+            'value' => $value,
+            'message' => $messages[$value] ?? null,
+            'available' => $value === 'yes' || $value === 'limited',
+        ];
+    }
 	
     /*
      * What does 'M' mean?

--- a/webapp/classes/html/church/church.php
+++ b/webapp/classes/html/church/church.php
@@ -57,6 +57,7 @@ class Church extends \Html\Html {
     public $readAccess;
     public $writeAccess;
     public $accessibility;
+    public $cardDonation;
     public $hasWorkAccess;
     public $church;
     public $neighbours;
@@ -83,7 +84,7 @@ class Church extends \Html\Html {
         if(!$church) {
             throw new \Exception("Church with tid = '$tid' does not exist.");
         }
-        $church = $church->append(['readAccess','writeAccess','accessibility']);
+        $church = $church->append(['readAccess','writeAccess','accessibility','cardDonation']);
         
         if (!$church->readAccess) {
             throw new \Exception("Read access denied to church tid = '$tid'");

--- a/webapp/classes/html/church/editosm.php
+++ b/webapp/classes/html/church/editosm.php
@@ -574,12 +574,9 @@ class EditOsm extends \Html\Html {
 				'payment:credit_cards' =>[
 					'title' => 'Bankkártyás adományozási lehetőség',
 					'wiki_hu' => false,
-					'options' => array(
-						'' => 'Nincs információ.',
-						'yes' => 'Bankkártyás, digitális persely is elérhető.',
-						'limited' => 'Bankkártyás fizetés csak a sekrestyében ill. külön kérésre.',
-						'no' => 'Csak készpénzes fizetés/adományozás lehetséges.'
-					),
+					// #284: a címkék az \Eloquent\Church-ből jönnek, hogy a szerkesztő
+					// legördülője és a templomlap nyilvános mondata ugyanaz legyen.
+					'options' => \Eloquent\Church::CARD_DONATION_OPTIONS,
 					'help' => 'Egyre több helyen elérhető bankkártyás fizetési vagy külön adományozó terminál, mely első változatás a jezsuiták AutoMáténak neveztek el.'
 				]
 		

--- a/webapp/templates/church/_panelcarddonation.twig
+++ b/webapp/templates/church/_panelcarddonation.twig
@@ -1,0 +1,9 @@
+{% extends 'panel.twig' %}
+
+{% set title = '<i class="' ~ ICONS_AUTOMATE ~ '"></i> Bankkártyás adományozás' %}
+{% set panel = cardDonation.available ? 'primary' : 'default' %}
+{% set collapsible = 'collapsed' %}
+
+{% block body %}
+    <p>{{ cardDonation.message }}</p>
+{% endblock %}

--- a/webapp/templates/church/church.twig
+++ b/webapp/templates/church/church.twig
@@ -229,6 +229,9 @@
 	{% if location.osm is not null %}
 		{% include 'church/_panelaccessibility.twig'  %}
 	{% endif %}
+    {% if cardDonation.message %}
+        {% include 'church/_panelcarddonation.twig' %}
+    {% endif %}
     
 {% endblock %}
 

--- a/webapp/tests/Unit/CardDonationTest.php
+++ b/webapp/tests/Unit/CardDonationTest.php
@@ -18,7 +18,7 @@ final class CardDonationTest extends TestCase
     public static function donationValues(): array
     {
         return [
-            ['yes', true, 'Bankkártyás digitális persely bármikor elérhető.'],
+            ['yes', true, 'Bankkártyás, digitális persely is elérhető.'],
             ['limited', true, 'Bankkártyás adományozás a sekrestyében vagy külön kérésre lehetséges.'],
             ['no', false, 'Csak készpénzes adományozás lehetséges.'],
         ];
@@ -30,5 +30,32 @@ final class CardDonationTest extends TestCase
 
         $this->assertNull($church->cardDonation['message']);
         $this->assertFalse($church->cardDonation['available']);
+    }
+
+    public function testEmptyOsmValueDoesNotCreatePublicClaim(): void
+    {
+        $church = new \Eloquent\Church();
+        $church->setAttribute('payment:credit_cards', '');
+
+        $this->assertNull($church->cardDonation['message']);
+        $this->assertFalse($church->cardDonation['available']);
+    }
+
+    /*
+     * #284: a szerkesztő legördülőjének címkéje és a templomlap nyilvános mondata
+     * ugyanabból a listából jön. Ez a teszt bukik, ha valaki újra szétmásolja őket.
+     */
+    public function testEditorLabelsAreTheSameSentencesAsThePublicMessages(): void
+    {
+        $labels = \Eloquent\Church::CARD_DONATION_OPTIONS;
+
+        $this->assertSame(['', 'yes', 'limited', 'no'], array_keys($labels));
+
+        foreach (['yes', 'limited', 'no'] as $value) {
+            $church = new \Eloquent\Church();
+            $church->setAttribute('payment:credit_cards', $value);
+
+            $this->assertSame($labels[$value], $church->cardDonation['message']);
+        }
     }
 }

--- a/webapp/tests/Unit/CardDonationTest.php
+++ b/webapp/tests/Unit/CardDonationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class CardDonationTest extends TestCase
+{
+    /** @dataProvider donationValues */
+    public function testOsmValueGetsPublicMessage(string $value, bool $available, string $message): void
+    {
+        $church = new \Eloquent\Church();
+        $church->setAttribute('payment:credit_cards', $value);
+
+        $this->assertSame($value, $church->cardDonation['value']);
+        $this->assertSame($available, $church->cardDonation['available']);
+        $this->assertSame($message, $church->cardDonation['message']);
+    }
+
+    public static function donationValues(): array
+    {
+        return [
+            ['yes', true, 'Bankkártyás digitális persely bármikor elérhető.'],
+            ['limited', true, 'Bankkártyás adományozás a sekrestyében vagy külön kérésre lehetséges.'],
+            ['no', false, 'Csak készpénzes adományozás lehetséges.'],
+        ];
+    }
+
+    public function testMissingOsmValueDoesNotCreatePublicClaim(): void
+    {
+        $church = new \Eloquent\Church();
+
+        $this->assertNull($church->cardDonation['message']);
+        $this->assertFalse($church->cardDonation['available']);
+    }
+}


### PR DESCRIPTION
Closes #284

## Mit fejezek be

- A már gyűjtött `payment:credit_cards` OSM-adatot típusos accessorral adom át a templomoldalnak.
- A `yes`, `limited` és `no` értékhez egyértelmű magyar szöveget rendelek.
- Csak ismert adat esetén jelenítek meg bankkártyás adományozási panelt a meglévő kártyaikonnal.

## Ok

Az OSM-szerkesztőmező már létezett, de az eltárolt adatot a publikus oldalon sehol nem használtuk, ezért a gyűjtésnek nem volt felhasználói eredménye.

## Validáció

- célzott PHPUnit: 4 teszt, 11 assertion
- teljes PHPUnit: 386 teszt, 837 assertion
- publikus HTTP smoke: `limited` állapotnál ikon, panelcím és sekrestyés szöveg megjelent
- ideiglenes smoke-adat eltávolítása ellenőrizve: 0 maradék rekord
- PHP szintaxisellenőrzés
- `git diff --check`
