### PR TITLE
#501 Előrehozom a segítségpanelt régi adatoknál

### DIFF
--- a/webapp/templates/church/church.twig
+++ b/webapp/templates/church/church.twig
@@ -147,6 +147,11 @@
         <div class="church-update-meta"><b>Frissítve ill. megerősítve:</b> {{ updated }}</div>
     {% endif %}
 
+    {# Hat hónapnál régebbi adatnál mobilon ide kerül a segítségkérő panel. #}
+    {% if days_ago is defined and days_ago >= 180 %}
+        <div id="church-mobile-help-placeholder"></div>
+    {% endif %}
+
     <!--{% include '_panelcampaign.twig' with { collapsible: 'collapsed' }  %}-->
 
     {% if miseaktiv == 1 %}
@@ -222,7 +227,9 @@
 {% set selfAdvertisement = true %}
 {% block leftsidebar %}
     {% if isChurchHolder != 'allowed '%}
-        {% include "church/_panelaskingremark.twig" %}
+        <div id="church-help-panel-wrap">
+            {% include "church/_panelaskingremark.twig" %}
+        </div>
     {% endif %}
     {% include 'announcment.twig' ignore missing %}
 	
@@ -279,19 +286,28 @@
 	           var placeholder = document.getElementById('church-mobile-panels-placeholder');
 	           var locationWrap = document.getElementById('church-panel-location-wrap');
 	           var contactWrap  = document.getElementById('church-panel-contact-wrap');
-
-	           if (!placeholder || !locationWrap || !contactWrap) return;
+	           var helpPlaceholder = document.getElementById('church-mobile-help-placeholder');
+	           var helpWrap = document.getElementById('church-help-panel-wrap');
 
 	           if (isMobile) {
 	               // Mobilon: mozgasd a placeholder-be a főtartalom után
-	               placeholder.appendChild(locationWrap);
-	               placeholder.appendChild(contactWrap);
+	               if (placeholder && locationWrap && contactWrap) {
+	                   placeholder.appendChild(locationWrap);
+	                   placeholder.appendChild(contactWrap);
+	               }
+	               if (helpPlaceholder && helpWrap) {
+	                   helpPlaceholder.appendChild(helpWrap);
+	               }
 	           } else {
 	               // Asztali: visszahelyezés a jobb oszlopba (legelőre)
 	               var sidebar = document.querySelector('.church-site-right-sidebar');
-	               if (sidebar) {
+	               if (sidebar && locationWrap && contactWrap) {
 	                   sidebar.insertBefore(locationWrap, sidebar.firstChild);
 	                   sidebar.insertBefore(contactWrap, locationWrap.nextSibling);
+	               }
+	               var leftSidebar = document.querySelector('.church-site-left-sidebar');
+	               if (leftSidebar && helpWrap) {
+	                   leftSidebar.insertBefore(helpWrap, leftSidebar.firstChild);
 	               }
 	           }
 	       }

--- a/webapp/tests/Functional/ChurchDetailPageTest.php
+++ b/webapp/tests/Functional/ChurchDetailPageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Functional;
 
+use Facebook\WebDriver\WebDriverDimension;
 use Symfony\Component\Panther\PantherTestCase;
 
 /**
@@ -136,6 +137,37 @@ final class ChurchDetailPageTest extends PantherTestCase
         );
         
         self::assertTrue($hasRemarkOption, 'Church page should have remark option');
+    }
+
+    public function testStaleChurchMovesCompleteHelpPanelToTopOnMobile(): void
+    {
+        // A stabil tesztadatbázisban publikus, 180 napnál régebben frissített templom.
+        $churchId = 2061;
+
+        $this->client->manage()->window()->setSize(new WebDriverDimension(375, 800));
+        $this->client->request('GET', "/templom/{$churchId}");
+        $this->client->waitFor('#church-mobile-help-placeholder #church-help-panel-wrap', 10);
+
+        $helpItems = $this->client->executeScript(
+            "var panel = document.querySelector('#church-mobile-help-placeholder #church-help-panel-wrap');
+             return {
+                 remark: !!panel.querySelector('a[href*=\"ujeszrevetel\"]'),
+                 holder: panel.textContent.includes('Gondnokság vállalása'),
+                 photo: !!panel.querySelector('a[href*=\"ujkep\"]')
+             };"
+        );
+
+        self::assertTrue($helpItems['remark']);
+        self::assertTrue($helpItems['holder']);
+        self::assertTrue($helpItems['photo']);
+
+        $this->client->manage()->window()->setSize(new WebDriverDimension(1024, 800));
+        usleep(250000); // A sablon resize-kezelője 100 ms-os debounce-ot használ.
+        self::assertTrue(
+            $this->client->executeScript(
+                "return document.querySelector('.church-site-left-sidebar > #church-help-panel-wrap') !== null;"
+            )
+        );
     }
 
     public function testPhotosRenderIfPresent(): void


### PR DESCRIPTION
## Ok

Mobilnézetben a „Segítsd munkánkat!” panel az adatok korától függetlenül az oldalsávban maradt, ezért a régi miserendeknél sem kapott nagyobb hangsúlyt.

## Megoldás

- 180 napnál régebbi frissítésnél mobilon közvetlenül a frissességi jelzés alá mozgatom a teljes panelt.
- Desktopnézetben megtartom a bal oldalsávos elhelyezést.
- Átméretezéskor mindkét irányban visszaállítom a megfelelő helyet.
- Panther-regressziós tesztben ellenőrzöm az elhelyezést és a panel műveleteit.

## Validáció

- `php -l webapp/tests/Functional/ChurchDetailPageTest.php`
- `git diff --check`
- teljes PHP-suite: 382 teszt, 826 assertion
- helyi headless Chrome, 375×800: a panel a felső mobil placeholderben, minden művelettel
- helyi headless Chrome, 1024×800: a panel a bal oldalsávban

A Docker ARM Chromium nem tudott sessiont indítani (`SessionNotCreatedException`); a böngészős viselkedést a helyi Google Chrome-mal ellenőriztem.

Closes #501
