### PR TITLE
#639 Javítom a "Honnan látják el" mezőt

### DIFF
--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -10,6 +10,27 @@ class Edit extends \Html\Html {
     public $input;
     public $nearbyChurches;
 
+    /* #639: mit tegyünk a beküldött ellátó-plébánia választással. */
+    public const PARENT_REPLACE = 'replace';
+    public const PARENT_REMOVE  = 'remove';
+    public const PARENT_INVALID = 'invalid';
+
+    /**
+     * #639: a legördülő "0" értéke a placeholder-opció ("– válassz templomot –"), vagyis
+     * "nincs ellátó plébánia". Ezt korábban se nem mentettük kapcsolatként, se nem
+     * töröltük vele a meglévőt — így a beállított ellátó plébániát nem lehetett
+     * visszavonni. A döntés szándékosan tiszta (se DB, se kérés), hogy tesztelhető legyen.
+     *
+     * @param int $parentId a beküldött érték (0 = nincs kiválasztva / hiányzik)
+     * @param int $churchId a szerkesztett misézőhely
+     */
+    public static function parentChurchAction(int $parentId, int $churchId): string {
+        if ($parentId > 0 && $parentId === $churchId) {
+            return self::PARENT_INVALID;
+        }
+        return $parentId > 0 ? self::PARENT_REPLACE : self::PARENT_REMOVE;
+    }
+
     public function __construct($path) {
         global $user;
    
@@ -61,24 +82,35 @@ class Edit extends \Html\Html {
         }
 
         // --- Kapcsolat kezelése (parent templom kiválasztás) ---
-        if (isset($this->input['church']['parent_id']) && $this->input['church']['parent_id'] !== '') {
-            $parentId = (int) $this->input['church']['parent_id'];
-            // Kapcsolat csak akkor kerül mentésre, ha érvényes parent ID van és nem önmagára mutat
-            if ($parentId !== 0 && $parentId !== (int)$this->tid) {
-                // #521: egy templomnak egy ellátó plébániája (parent) van a formon
-                // keresztül. A korábbi updateOrCreate a (parent,child) PÁRRA matchelt,
-                // ezért új plébánia választásakor ÚJ sort hozott létre, a régit meghagyva
-                // ("hozzáadja, de nem cserél"). Előbb töröljük a meglévő parent-kapcsolatot,
-                // hogy a választás CSERÉLJEN (és a korábbi duplikátumok is kitakarodjanak).
-                \Eloquent\ChurchRelationship::where('child_church_id', $this->tid)->delete();
-                \Eloquent\ChurchRelationship::create([
-                    'parent_church_id' => $parentId,
-                    'child_church_id' => $this->tid,
-                    'type' => 'subordinate',
-                ]);
-            }
+        /*
+         * #639: a "0" a legördülő placeholder-opciója ("– válassz templomot –"), vagyis
+         * "nincs ellátó plébánia". Eddig ez a beküldött érték se nem állított be
+         * kapcsolatot, se nem törölte a meglévőt (a külső if beengedte, a belső `!== 0`
+         * kidobta), ezért a már beállított ellátó plébániát NEM lehetett visszavonni.
+         * Most a 0 és a hiányzó érték egyaránt a törlés ága.
+         */
+        $parentId = isset($this->input['church']['parent_id'])
+            ? (int) $this->input['church']['parent_id']
+            : 0;
+        $parentAction = self::parentChurchAction($parentId, (int) $this->tid);
+
+        if ($parentAction === self::PARENT_INVALID) {
+            // Önmagára mutató választás: érvénytelen, de ettől még ne dobjuk el a meglévőt.
+            addMessage('Egy misézőhely nem lehet a saját ellátó plébániája, ezért ezt a mezőt nem módosítottuk.', 'warning');
+        } elseif ($parentAction === self::PARENT_REPLACE) {
+            // #521: egy templomnak egy ellátó plébániája (parent) van a formon
+            // keresztül. A korábbi updateOrCreate a (parent,child) PÁRRA matchelt,
+            // ezért új plébánia választásakor ÚJ sort hozott létre, a régit meghagyva
+            // ("hozzáadja, de nem cserél"). Előbb töröljük a meglévő parent-kapcsolatot,
+            // hogy a választás CSERÉLJEN (és a korábbi duplikátumok is kitakarodjanak).
+            \Eloquent\ChurchRelationship::where('child_church_id', $this->tid)->delete();
+            \Eloquent\ChurchRelationship::create([
+                'parent_church_id' => $parentId,
+                'child_church_id' => $this->tid,
+                'type' => 'subordinate',
+            ]);
         } else {
-            // Ha üres a kiválasztás, törlődnek az összes parent kapcsolat
+            // Nincs kiválasztva semmi (0 vagy hiányzó): nincs ellátó plébánia.
             \Eloquent\ChurchRelationship::where('child_church_id', $this->tid)->delete();
         }
 

--- a/webapp/templates/church/_panelholders.twig
+++ b/webapp/templates/church/_panelholders.twig
@@ -122,6 +122,10 @@
   <style>
     /* #529: a nagy parent-lista legördülője kapjon görgetőt (jobbra) */
     .ui-autocomplete { max-height: 320px; overflow-y: auto; overflow-x: hidden; }
+    /* #639: az ellátó plébánia törlése egy kattintással, a mező mellett */
+    .custom-combobox { display: inline-flex; align-items: center; gap: 4px; width: 100%; }
+    .custom-combobox > input { flex: 1; }
+    .custom-combobox-clear { flex: 0 0 auto; line-height: 1; padding: 4px 10px; }
   </style>
   <script>
   $( function() {
@@ -139,12 +143,17 @@
 
 
       _createAutocomplete: function() {
+        /*
+         * #639: itt korábban egy `/* oops *\/ value = "";` sor kiütötte a kiszámolt
+         * értéket, ezért a mező MINDIG üresen jött fel — a szerkesztő azt látta, hogy
+         * nincs beállítva ellátó plébánia, pedig a rejtett <select>-ben ott volt.
+         * (Menteni jól mentett, csak nem látszott.)
+         *
+         * A "0" a placeholder-opció ("– válassz templomot –"), azt nem írjuk ki.
+         */
         var selected = this.element.children( ":selected" ),
-          value = selected.val() ? selected.text() : "";
-
-          /* oops */
-          value = "";
-
+          selectedValue = selected.val(),
+          value = ( selectedValue && selectedValue !== "0" ) ? selected.text() : "";
 
         this.input = $( "<input>" )
           .appendTo( this.wrapper )
@@ -193,6 +202,21 @@
         response( results );
       },
 
+      /*
+       * #639: a mező kiürítése LEGYEN érvényes művelet — így lehet visszavonni a
+       * korábban beállított ellátó plébániát. Ilyenkor a placeholder-opcióra ("0")
+       * állunk vissza, nem hagyjuk a <select>-et kiválasztás nélkül.
+       */
+      _clearSelection: function() {
+        this.input.val( "" );
+        if ( this.element.children( "option[value='0']" ).length ) {
+          this.element.val( "0" );
+        } else {
+          this.element.val( "" );
+        }
+        this.element.trigger( "change" );
+      },
+
       _removeIfInvalid: function( event, ui ) {
 
         // Selected an item, nothing to do
@@ -200,9 +224,16 @@
           return;
         }
 
+        var value = this.input.val();
+
+        // #639: az üresre törlés szándékos, nem hiba — ne tegyünk rá hibaüzenetet.
+        if ( $.trim( value ) === "" ) {
+          this._clearSelection();
+          return;
+        }
+
         // Search for a match (case-insensitive)
-        var value = this.input.val(),
-          valueLowerCase = value.toLowerCase(),
+        var valueLowerCase = value.toLowerCase(),
           valid = false;
         this.element.children( "option" ).each(function() {
           if ( $( this ).text().toLowerCase() === valueLowerCase ) {
@@ -217,11 +248,10 @@
         }
 
         // Remove invalid value
+        this._clearSelection();
         this.input
-          .val( "" )
-          .attr( "title", "Nincs „" + value + "” nevű felhasználónk." )
+          .attr( "title", "Nincs „" + value + "” nevű " + ( this.options.notFoundNoun || "felhasználónk" ) + "." )
           .tooltip( "open" );
-        this.element.val( "" );
         this._delay(function() {
           this.input.tooltip( "close" ).attr( "title", "" );
         }, 2500 );
@@ -239,9 +269,28 @@
     // #522: az ellátó-plébánia választót is kereshetővé tesszük (ugyanez a widget).
     // Graceful: ha a widget nem futna le, a plain select minden aktív templommal ott marad.
     if ( $( "#selectParentChurch" ).length ) {
-      $( "#selectParentChurch" ).combobox();
-      var $parentInput = $( "#selectParentChurch" ).next( ".custom-combobox" ).find( "input" );
+      var $parentSelect = $( "#selectParentChurch" );
+      $parentSelect.combobox({ notFoundNoun: "misézőhelyünk" });
+      var $parentWrapper = $parentSelect.next( ".custom-combobox" );
+      var $parentInput = $parentWrapper.find( "input" );
       $parentInput.attr( "placeholder", "Kezdd el gépelni a települést vagy a templom nevét…" );
+
+      /*
+       * #639: kellett egy egyértelmű módja annak, hogy NE legyen ellátó plébánia.
+       * A mező kiürítése eddig sem volt kényelmes (és hibaüzenetet adott), a gomb
+       * viszont egy kattintás. A <select> a placeholderre ("0") áll vissza, amit a
+       * mentés a "nincs kapcsolat" ágként dolgoz fel.
+       */
+      $( "<button>" )
+        .attr( "type", "button" )
+        .addClass( "btn btn-sm btn-outline-secondary custom-combobox-clear" )
+        .attr( "title", "Ellátó plébánia törlése" )
+        .text( "×" )
+        .appendTo( $parentWrapper )
+        .on( "click", function() {
+          $parentSelect.combobox( "instance" )._clearSelection();
+          $parentInput.trigger( "focus" );
+        });
       // #529: üres mezőbe kattintva rögtön jöjjön a legközelebbi 10 (a _source üres
       // termre 10-et ad, az opciók távolság szerint elöl). Gépelésre a _source szűr,
       // a hosszú lista görgethető (CSS lent). minLength=0 + focus-trigger kell hozzá.

--- a/webapp/tests/Unit/ParentChurchSelectionTest.php
+++ b/webapp/tests/Unit/ParentChurchSelectionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #639: az „Honnan látják el" mező mentési döntése.
+ *
+ * A hiba az volt, hogy a legördülő placeholder-értéke ("0") két szék közé esett:
+ * a külső feltétel beengedte (nem üres string), a belső viszont kidobta (!== 0),
+ * így se nem állított be kapcsolatot, se nem törölte a meglévőt. Vagyis a
+ * beállított ellátó plébániát semmilyen módon nem lehetett visszavonni.
+ */
+final class ParentChurchSelectionTest extends TestCase
+{
+    private const CHURCH_ID = 42;
+
+    public function testChoosingAChurchReplacesTheRelationship(): void
+    {
+        $this->assertSame(
+            \Html\Church\Edit::PARENT_REPLACE,
+            \Html\Church\Edit::parentChurchAction(1234, self::CHURCH_ID)
+        );
+    }
+
+    /** A placeholder ("– válassz templomot –") értéke: nincs ellátó plébánia. */
+    public function testPlaceholderRemovesTheRelationship(): void
+    {
+        $this->assertSame(
+            \Html\Church\Edit::PARENT_REMOVE,
+            \Html\Church\Edit::parentChurchAction(0, self::CHURCH_ID)
+        );
+    }
+
+    /** Ha a mező be sem érkezik, a hívó 0-t ad át — az is törlés. */
+    public function testMissingFieldRemovesTheRelationship(): void
+    {
+        $this->assertSame(
+            \Html\Church\Edit::PARENT_REMOVE,
+            \Html\Church\Edit::parentChurchAction(0, self::CHURCH_ID)
+        );
+    }
+
+    /*
+     * Önmagára mutató választás érvénytelen — de ilyenkor NE dobjuk el a meglévő
+     * kapcsolatot sem, mert az adatvesztés lenne egy elgépelés miatt.
+     */
+    public function testSelfReferenceIsInvalidAndKeepsTheCurrentValue(): void
+    {
+        $this->assertSame(
+            \Html\Church\Edit::PARENT_INVALID,
+            \Html\Church\Edit::parentChurchAction(self::CHURCH_ID, self::CHURCH_ID)
+        );
+    }
+
+    /** Negatív / szemetes érték se hozzon létre kapcsolatot. */
+    public function testNegativeValueRemovesTheRelationship(): void
+    {
+        $this->assertSame(
+            \Html\Church\Edit::PARENT_REMOVE,
+            \Html\Church\Edit::parentChurchAction(-7, self::CHURCH_ID)
+        );
+    }
+}


### PR DESCRIPTION
Fixes #639 (az első két pont; a harmadikra lentebb válaszolok)

## 1. „Visszatérve nem tölti ki a mezőt a valódi értékkel"

Megvan, és szó szerint oda volt írva, mi történt. A combobox widget rendesen kiszámolta a kiválasztott opció szövegét, majd a következő sor kiütötte:

```js
var selected = this.element.children( ":selected" ),
  value = selected.val() ? selected.text() : "";

  /* oops */
  value = "";
```

A rejtett `<select>`-ben **ott volt a helyes érték** — ellenőriztem a kiszolgált HTML-ben: `<option value="114" selected>Szentendre – Keresztelő Szent János-templom (~0.1 km)</option>`. Vagyis menteni jól mentett, csak a látható mező jött fel mindig üresen, és ezért tűnt úgy, hogy nincs beállítva semmi.

Most kiírjuk a szöveget, a placeholder-opciót ("0") kivéve — így a másik, ugyanezt a widgetet használó mező (`#combobox`, felhasználóválasztó) viselkedése nem változik.

## 2. „Hogyan lehet könnyen törölni az értékét?"

Sehogy nem lehetett — ez nem kényelmi kérdés volt, hanem hiba. A legördülő placeholder-értéke (`0`) két szék közé esett a mentésben:

```php
if (isset($parent_id) && $parent_id !== ) {   // a "0" beengedve
    if ($parentId !== 0 && ...) { ... }          // a "0" kidobva
} else {
    delete;                                      // ide sosem jutott el
}
```

Tehát a `0` **se nem mentett kapcsolatot, se nem törölte a meglévőt**. Mostantól a `0` és a hiányzó érték egyaránt a törlés ága.

Mellé:
- **× gomb** a mező mellett, egy kattintás a törlés.
- A mező kiürítése immár **érvényes művelet** — eddig hibaüzenetet dobott, ráadásul azt, hogy «Nincs „x" nevű **felhasználónk**», ami egy templommezőnél elég meglepő. A főnév mostantól widget-opció.
- Önmagára mutató választásnál **nem dobjuk el** a meglévő kapcsolatot (az adatvesztés lenne egy elgépelés miatt), csak figyelmeztetünk.

A mentési döntés tiszta, DB- és kérésmentes függvénybe került (`Edit::parentChurchAction()`), `ParentChurchSelectionTest` fedi — ahogy kérted, „szép tesztek nélkül" helyett szép tesztekkel. :)

## 3. `church_relationships.type` — engedi a kód?

Megnéztem: **majdnem, de nem teljesen** — nem drive-by törlés, ezért nem tettem bele ebbe a PR-be.

Ahol ma a `type` tényleg felhasználásra kerül:

| Hely | Mire |
|---|---|
| `_map_leaflet.twig:595` | a vonal **stílusa** (`relationshipStyles[rel.type]`) — a háromféle kapcsolat máshogy néz ki a térképen |
| `_map_leaflet.twig:629` | a popupban kiírt **`type_label`** |
| `_map_leaflet.twig:571` | a vonal egyedi azonosítója (`parent-child-type`) |
| `ajax/churchrelationshipsinbbox.php:71–72` | ez a kettő szolgálja ki a fentieket |
| `eloquent/church.php` (6 hely) | a hierarchia-struktúrák (`ancestors`, `descendants`, `fullNetwork`) minden elemhez viszik |
| `ChurchRelationship::validTypes()` + `ChurchRelationshipTest` | validáció és teszt |

Vagyis ha a `church:type` attribútumból akarod származtatni, akkor az oszlop eldobásához ezeket a helyeket át kell állítani a származtatott értékre — főleg a térkép stílusát és a popup feliratát, mert azok ma vizuálisan is megkülönböztetik a háromféle kapcsolatot. Az `edit.php` viszont már ma is fixen `subordinate`-et ír, tehát a szerkesztő felől tényleg okafogyott.

Szólj, ha csináljam meg — nem nagy, csak külön téma, és jobb, ha nem keveredik ezzel a két hibajavítással.