### PR TITLE
#641 Gyorsítom a térkép adatlekéréseit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ var/
 node_modules/
 dumper/01-dump.sql
 webapp/fajlok/git_hash
+# Az ExternalApi fájl-cache-e (Overpass/Nominatim/... válaszok) — futásidőben keletkezik.
+webapp/fajlok/tmp/
 
 .idea
 composer.phar

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -624,6 +624,77 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         return $formattedMasses;
     }
 
+    /**
+     * #641: hétvégi misék SOK templomra, egyetlen Elasticsearch-lekérdezéssel.
+     *
+     * A térkép bbox-végpontja templomonként hívta a getWeekendMasses()-t, az pedig
+     * templomonként KÉT ES-kört futtat (szombat + vasárnap). 460 templomnál ez 920
+     * hálózati kör — mérve ez tette 4 másodpercessé a térkép minden mozdítását.
+     * A két időablak egybefüggő (szombat 17:00 → vasárnap 23:59), ezért egyben
+     * kérjük le, és PHP-ben bontjuk napokra.
+     *
+     * A visszaadott alak SZÁNDÉKOSAN azonos a getWeekendMasses()-ével, hogy a
+     * frontend-szerződés ne változzon.
+     *
+     * @param  int[] $churchIds
+     * @return array [church_id => ['saturday' => [...], 'sunday' => [...]]]
+     */
+    public static function weekendMassesForChurches(array $churchIds): array
+    {
+        $empty = ['saturday' => [], 'sunday' => []];
+        $result = [];
+        foreach ($churchIds as $id) {
+            $result[(int) $id] = $empty;
+        }
+        if (empty($churchIds)) {
+            return $result;
+        }
+
+        $saturday = (new self())->getTargetSaturdayDate();
+        $sunday = $saturday->copy()->addDay();
+
+        $fromUtc = \Carbon\Carbon::parse($saturday->toDateString() . 'T17:00:00', 'Europe/Budapest')
+            ->setTimezone('UTC')->format('Y-m-d\TH:i:s') . 'Z';
+        $toUtc = \Carbon\Carbon::parse($sunday->toDateString() . 'T23:59:00', 'Europe/Budapest')
+            ->setTimezone('UTC')->format('Y-m-d\TH:i:s') . 'Z';
+
+        try {
+            $byChurch = (new \ExternalApi\ElasticsearchApi())->massesByChurch(
+                $churchIds,
+                $fromUtc,
+                $toUtc,
+                self::getMassTypeKeysFromDefinitions()
+            );
+        } catch (\Throwable $e) {
+            // A térkép a misék nélkül is használható — ne bukjon el az egész válasz.
+            error_log('[#641] hétvégi misék lekérése nem sikerült: ' . $e->getMessage());
+            return $result;
+        }
+
+        $saturdayDate = $saturday->toDateString();
+        $sundayDate = $sunday->toDateString();
+
+        foreach ($byChurch as $churchId => $masses) {
+            foreach ($masses as $mass) {
+                // Ugyanaz a helyi idejű formázás, mint a Search::prepareMassesResults()-ban.
+                $local = \Carbon\Carbon::parse($mass['start_date'])->setTimezone('Europe/Budapest');
+                $day = $local->toDateString();
+                $entry = [
+                    'time' => $local->format('H:i'),
+                    'date' => $day,
+                    'title' => $mass['title'],
+                ];
+                if ($day === $saturdayDate && count($result[$churchId]['saturday']) < 4) {
+                    $result[$churchId]['saturday'][] = $entry;
+                } elseif ($day === $sundayDate && count($result[$churchId]['sunday']) < 4) {
+                    $result[$churchId]['sunday'][] = $entry;
+                }
+            }
+        }
+
+        return $result;
+    }
+
     private static function getMassTypeKeysFromDefinitions(): array
     {
         $massTypeKeys = [];

--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -475,6 +475,72 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return true;		
 	}
 
+	/**
+	 * #641: hétvégi misék EGYETLEN lekérdezésben, akárhány templomra.
+	 *
+	 * A térkép bbox-végpontja eddig templomonként KÉT Elasticsearch-kört futtatott
+	 * (szombat + vasárnap). 460 templomnál ez 920 hálózati kör — ez volt a /terkep
+	 * lassúságának fő oka. Terms-aggregáció + top_hits: egy kérés, templomonként
+	 * időrendben az első néhány mise.
+	 *
+	 * @param  int[]    $churchIds
+	 * @param  string[] $titleKeys  cím-szűrő (MASS kategória kulcsai); üres = nincs szűrés
+	 * @return array    [church_id => [ ['start_date'=>..., 'title'=>...], ... ]]
+	 */
+	function massesByChurch(array $churchIds, string $fromUtc, string $toUtc, array $titleKeys = [], int $perChurch = 8): array {
+		if (empty($churchIds)) {
+			return [];
+		}
+
+		$must = [
+			["terms" => ["church_id" => array_values(array_map('intval', $churchIds))]],
+			["range" => ["start_date" => ["gte" => $fromUtc, "lte" => $toUtc]]],
+		];
+		if (!empty($titleKeys)) {
+			$must[] = ["terms" => ["title.keyword" => array_values($titleKeys)]];
+		}
+
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
+		$this->buildQuery('mass_index/_search', json_encode([
+			"size" => 0,
+			"query" => ["bool" => ["must" => $must]],
+			"aggs" => [
+				"by_church" => [
+					"terms" => ["field" => "church_id", "size" => count($churchIds)],
+					"aggs" => [
+						"masses" => [
+							"top_hits" => [
+								"size" => $perChurch,
+								"sort" => [["start_date" => ["order" => "asc"]]],
+								"_source" => ["includes" => ["start_date", "title"]],
+							],
+						],
+					],
+				],
+			],
+		]));
+		$this->run();
+
+		if ($this->responseCode != 200) {
+			throw new \Exception("Could not search mass_index!\n" . $this->error);
+		}
+
+		$byChurch = [];
+		$buckets = $this->jsonData->aggregations->by_church->buckets ?? [];
+		foreach ($buckets as $bucket) {
+			$masses = [];
+			foreach ($bucket->masses->hits->hits ?? [] as $hit) {
+				$masses[] = [
+					'start_date' => $hit->_source->start_date ?? '',
+					'title' => $hit->_source->title ?? '',
+				];
+			}
+			$byChurch[(int) $bucket->key] = $masses;
+		}
+
+		return $byChurch;
+	}
+
 	function churchIdsWithMassesInPeriod($startDate, $endDate) {
 		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
 		$this->buildQuery('mass_index/_search', json_encode([

--- a/webapp/classes/html/ajax/churchesinbbox.php
+++ b/webapp/classes/html/ajax/churchesinbbox.php
@@ -5,50 +5,97 @@ namespace Html\Ajax;
 class ChurchesInBBox extends Ajax {
 
     public function __construct() {
-               
+
         // #391: a bbox parse+validáció a \Request::Bbox()-ba került (pontosvesszős
         // 4-float lista). Hiányzó/rossz alakú bbox → false, ekkor némán kilépünk
         // (mint korábban a count()!=4 / is_numeric őrök).
         $bbox = \Request::Bbox('bbox');
         if($bbox === false) return;
 
-         $churchesInBBox = \Eloquent\Church::where('ok','i')->inBBox(['latMin'=>$bbox[0],'lonMin'=>$bbox[1],'latMax'=>$bbox[2],'lonMax'=>$bbox[3]])->get();
+        /*
+         * #641: ez a végpont a térkép MINDEN mozdításakor lefut, és templomonként
+         * külön-külön kérdezett le mindent — fotót, attribútumokat, elhelyezkedést
+         * (az utóbbi a boundaries táblát is), plusz KÉT Elasticsearch-kört a hétvégi
+         * misékre. Mérve: 91 templomra 1,0 s, 460-ra 4,0 s, 4628-ra 35,5 s.
+         *
+         * Most minden köteges: egy lekérdezés a templomokra (fotókkal együtt), egy az
+         * attribútumokra, és EGY Elasticsearch-hívás az összes hétvégi misére.
+         * A lat/lon közvetlenül az oszlopból jön — a `location` accessor a boundaries
+         * táblát is húzta, holott itt csak a koordináta kell.
+         */
+        $churchesInBBox = \Eloquent\Church::where('ok','i')
+            ->inBBox(['latMin'=>$bbox[0],'lonMin'=>$bbox[1],'latMax'=>$bbox[2],'lonMax'=>$bbox[3]])
+            ->with('photos')
+            ->get();
+
+        if ($churchesInBBox->isEmpty()) {
+            echo json_encode([]);
+            return;
+        }
+
+        $churchIds = $churchesInBBox->pluck('id')->map('intval')->all();
+
+        // Minden attribútum egyetlen lekérdezéssel, templomonként kulcs => érték térképpé.
+        $attributesByChurch = \Eloquent\Attribute::whereIn('church_id', $churchIds)
+            ->get()
+            ->groupBy('church_id')
+            ->map(function ($rows) {
+                return $rows->pluck('value', 'key')->toArray();
+            })
+            ->toArray();
+
+        $weekendMasses = \Eloquent\Church::weekendMassesForChurches($churchIds);
 
         $return = [];
         global $user;
-        
+        $isAdmin = isset($user->isadmin) && $user->isadmin;
+
         foreach($churchesInBBox as $church) {
-            $church->photos;
-            if (isset($church->photos[0])) $thumbnail = $church->photos[0]->smallUrl;
-            else $thumbnail = false;
-            
-            $church->loadAttributes();
-            
-            // Hétvégi miserendet lekérése (szombat 17:00-tól, vasárnap összes)
-            $weekendMasses = $church->getWeekendMasses();
-                        
-            // Admin linkek adatai (csak admin felhasználóknál)
-            $adminLinks = [];
-            if (isset($user->isadmin) && $user->isadmin) {
-                $adminLinks = [
-                    'id' => $church->id
-                ];
-            }
-            
+            $churchId = (int) $church->id;
+            $attributes = $attributesByChurch[$churchId] ?? [];
+
+            $thumbnail = isset($church->photos[0]) ? $church->photos[0]->smallUrl : false;
+
             $return[] = [
-                'id' => $church->id,
-                'nev' => $church->names[0],
+                'id' => $churchId,
+                'nev' => self::primaryName($church, $attributes),
                 'thumbnail' => $thumbnail,
-                'denomination' => $church->denomination,
+                'denomination' => self::denomination($church, $attributes),
                 'active' => $church->miseaktiv,
-                'lat'=> $church->location->lat,
-                'lon'=> $church->location->lon,
-                'church_type' => $church->{'church:type'} ?? 'other',
-                'weekend_masses' => $weekendMasses,
-                'adminLinks' => $adminLinks
+                'lat'=> $church->lat,
+                'lon'=> $church->lon,
+                'church_type' => $attributes['church:type'] ?? 'other',
+                'weekend_masses' => $weekendMasses[$churchId] ?? ['saturday' => [], 'sunday' => []],
+                // Az admin-linkekhez a sablon csak az id-t használja.
+                'adminLinks' => $isAdmin ? ['id' => $churchId] : []
             ];
         }
-        echo json_encode($return);        
+        echo json_encode($return);
+    }
+
+    /*
+     * #641: a `names` accessor templomonként újra lekérdezte az attribútumokat.
+     * Ugyanaz a sorrend, csak a már betöltött adatból.
+     */
+    private static function primaryName($church, array $attributes): string {
+        foreach (['name:hu', 'name'] as $key) {
+            if (!empty($attributes[$key])) {
+                return $attributes[$key];
+            }
+        }
+        return (string) $church->nev;
+    }
+
+    /*
+     * #542/#641: a felekezet az OSM `denomination` attribútumból jön, fallbackként a
+     * korábbi egyházmegye-heurisztikából — ugyanaz, mint a Church accessorban, de
+     * lekérdezés nélkül.
+     */
+    private static function denomination($church, array $attributes): string {
+        if (!empty($attributes['denomination'])) {
+            return $attributes['denomination'];
+        }
+        return in_array($church->egyhazmegye, [34, 17, 18]) ? 'greek_catholic' : 'roman_catholic';
     }
 
 }

--- a/webapp/classes/html/ajax/diocesesinbbox.php
+++ b/webapp/classes/html/ajax/diocesesinbbox.php
@@ -38,24 +38,36 @@ class DiocesesInBBox extends Ajax {
              return [];
         }
 
+        // #641: az egyházmegyék NEVÉT eddig nem küldtük le, ezért a térképen semmilyen
+        // módon nem lehetett megnézni, melyik egyházmegye fölött járunk. A Nominatim
+        // csak a geometriát adja vissza, a nevek viszont a saját `boundaries` táblánkban
+        // ott vannak (az OSM-sync tölti) — egyetlen lekérdezéssel hozzájuk tesszük.
+        $names = \Eloquent\Boundary::whereIn('osmid', array_map(function ($e) { return $e->id; }, $overpass->jsonData->elements))
+            ->get(['osmtype', 'osmid', 'name'])
+            ->keyBy(function ($boundary) { return $boundary->osmtype . '/' . $boundary->osmid; })
+            ->map(function ($boundary) { return $boundary->name; })
+            ->toArray();
+
         // Az egyházmegyék geoJSON adatait lekérjük.
         // Ez sok kérésnek tűnik, de mivel komoly cache van ezért gyorsan fog menni.
         $dioceses = [];
-        
-        foreach ($overpass->jsonData->elements as $element) {            
+
+        foreach ($overpass->jsonData->elements as $element) {
                 $types = [
                     'node' => 'N',
                     'way' => 'W',
-                    'relation' => 'R'   
+                    'relation' => 'R'
                 ];
 
-                $nominatim = new \ExternalApi\NominatimApi();        
-                $diocese = $nominatim->OSM2GeoJson($types[$element->type], $element->id);                
+                $nominatim = new \ExternalApi\NominatimApi();
+                $diocese = $nominatim->OSM2GeoJson($types[$element->type], $element->id);
                 if ($diocese == false ) continue;
-                $diocese->id = $element->type."/" .$element->id;
+                $key = $element->type . "/" . $element->id;
+                $diocese->id = $key;
+                $diocese->name = $names[$key] ?? '';
                 $dioceses[] = $diocese;
-                
-        
+
+
         }
 
         return $dioceses;

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -237,6 +237,18 @@
                 ];
 
     {% if dioceseslayer %}
+    /*
+     * #641: az egyházmegye neve eddig sehogy nem látszott a térképen (a válaszban sem
+     * volt benne). Kattintás helyett lebegő címke: a templom-gombostűk nem lopják el,
+     * és rögtön látszik, melyik egyházmegye fölött járunk.
+     */
+    function dioceseTooltip(feature, layer) {
+        var name = (feature.geometry && feature.geometry.name) || feature.properties && feature.properties.name;
+        if (name) {
+            layer.bindTooltip(name, { sticky: true, direction: 'top', className: 'diocese-tooltip' });
+        }
+    }
+
     // Egyházmegyék rétegekhez tartozó ID-k nyilvántartása
     var addedGreekCatholicIds = new Set();
     var addedRomanCatholicIds = new Set();
@@ -260,7 +272,8 @@
                     fillOpacity: 0.3
                 };
             
-        }
+        },
+        onEachFeature: dioceseTooltip
     });
 
     var diocesesRomanCatholicLayer = L.geoJSON(null, {
@@ -281,7 +294,8 @@
                     fillOpacity: 0.3
                 };
             
-        }
+        },
+        onEachFeature: dioceseTooltip
     }).addTo(mymap);
     layerControls['Római katolikus egyházmegyék'] = diocesesRomanCatholicLayer;  
     layerControls['Görögkatolikus egyházmegyék'] = diocesesGreekcatholicLayer;  
@@ -392,6 +406,9 @@
     
     // Relációs vonalak nyilvántartása az összehasonlításhoz
     var currentRelationshipIds = new Set();
+
+    // #641: a már kirajzolt templomok, hogy mozgatáskor csak a különbséget rajzoljuk.
+    var renderedChurchIds = new Set();
     
     L.control.layers( null, layerControls ).addTo(mymap);
        
@@ -411,17 +428,37 @@
            if(activeRomanLayer) activeRomanLayer.clearLayers();
            if(activeGreekLayer) activeGreekLayer.clearLayers();
            if(inactiveLayer) inactiveLayer.clearLayers();
+           // #641: a nyilvántartást is ürítjük, különben visszazoomolva azt hinnénk,
+           // hogy a templomok még fent vannak, és üres maradna a térkép.
+           renderedChurchIds.clear();
 
-           
       } else {
       
-        $.getJSON( "/ajax/churchesinbbox?bbox=" + params , function( data ) {                              
+        $.getJSON( "/ajax/churchesinbbox?bbox=" + params , function( data ) {
             if(data) {
 
-                activeRomanLayer.clearLayers();
-                activeGreekLayer.clearLayers();
-                inactiveLayer.clearLayers();
-                                 
+                /*
+                 * #641: eddig minden mozdításkor LETÖRÖLTÜNK minden templomot, majd
+                 * újrarajzoltuk az egészet — ettől villódzott a térkép, pedig a látható
+                 * templomok többsége ugyanaz maradt. Most csak a különbséget rajzoljuk:
+                 * a kikerülteket levesszük, az újakat feltesszük, a maradókhoz nem nyúlunk.
+                 * (A kapcsolatok rétege már így működött, innen a minta.)
+                 */
+                var incomingIds = new Set();
+                $.each( data, function( key, val ) { incomingIds.add( val.id ); });
+
+                [ activeRomanLayer, activeGreekLayer, inactiveLayer ].forEach(function( group ) {
+                    var toRemove = [];
+                    group.eachLayer(function( layer ) {
+                        if ( !incomingIds.has( layer._churchId ) ) { toRemove.push( layer ); }
+                    });
+                    // Az eltávolítás külön menetben: iterálás közben ne módosítsuk a réteget.
+                    toRemove.forEach(function( layer ) {
+                        group.removeLayer( layer );
+                        renderedChurchIds.delete( layer._churchId );
+                    });
+                });
+
                 var items = [];
                 var isFullMapView = {% if not church_id %}true{% else %}false{% endif %};
                 
@@ -451,6 +488,9 @@
                 
                 $.each( data, function( key, val ) {
                     var current = {% if church_id %} {{ church_id }} {% else %} -1 {% endif %};
+                    // #641: ami már fent van a térképen, azzal nincs dolgunk — a popup
+                    // összeállítását se kezdjük el fölöslegesen.
+                    if ( renderedChurchIds.has( val.id ) ) { return; }
                     if( current != val.id) {
                         var popupContent = "<div class='map-popup-container'>";
                         popupContent += "<h3><a href='/templom/" + val.id.toString() + "'>"  + val.nev + "</a></h3>";
@@ -511,8 +551,9 @@
                         
                         popupContent += "</div>";
                         var geojsonFeature = {
-                            "type": "Feature",                                                      
+                            "type": "Feature",
                             "properties": {
+                                "id": val.id,
                                 "name": val.nev,
                                 "popupContent": popupContent,
                                 "active": val.active,
@@ -524,52 +565,68 @@
                                 "coordinates": [ val.lon , val.lat]
                             },
                         };
-                        
+
                         if( val.active == 1 ) {
-                            if( val.denomination == 'roman_catholic') {                            
+                            if( val.denomination == 'roman_catholic') {
                                 activeRomanLayer.addData(geojsonFeature);
                             } else if ( val.denomination == 'greek_catholic') {
                                 activeGreekLayer.addData(geojsonFeature);
-                            }                            
+                            }
                         } else {
                                 inactiveLayer.addData(geojsonFeature);
                         }
+                        renderedChurchIds.add( val.id );
                     }
                 });
             }
         });  
         }
          {% if dioceseslayer %}
-        // Egyházmegyéke lekérés a bbox alapján        
-        $.getJSON('/ajax/diocesesinbbox?bbox=' + params, function (data) {
+        /*
+         * #641: az egyházmegye-határokat MINDEN térképmozdításkor újra lekértük, pedig
+         * a réteg soha nem dob el semmit — a válasz nagy részét a kliens azonnal kiszűrte
+         * mint "már megvan". Mérve viszont a szerveroldal így is elvégezte a munkát:
+         * 2,3 s Budapestre, 17,9 s / 3,2 MB a Kárpát-medencére (a végpont Overpasst hív,
+         * majd egyházmegyénként Nominatimot — külső szolgáltatásokat, a térkép kritikus
+         * útján). Mostantól csak akkor kérünk, ha
+         *   - a réteg tényleg látszik, ÉS
+         *   - a nézet kilóg abból a területből, amit már egyszer lekértünk.
+         * A lekért területet megnöveljük, így a szokásos pásztázás már nem jár kéréssel.
+         */
+        var dioceseFetchedBounds = null;
 
-            // Új adatok hozzáadása a meglévő rétegekhez
-            if (data['greekcatholic']) {
-                const newGreekCatholicData = data['greekcatholic'].filter(feature => {
-                    const id = feature.id || feature.properties.id; // Azonosító lekérése
-                    if (!addedGreekCatholicIds.has(id)) {
-                        addedGreekCatholicIds.add(id); // Hozzáadás az ID-k listájához
-                        console.log('New Greekcatholic Diocese:', 'https://openstreetmap.org/' + id);
-                        return true; // Új adat
-                    }
-                    return false; // Már létező adat
-                });
-                diocesesGreekcatholicLayer.addData(newGreekCatholicData); // Csak az új adatok hozzáadása
-            }
+        function refreshDioceses(mapBounds) {
+            var visible = mymap.hasLayer(diocesesRomanCatholicLayer) || mymap.hasLayer(diocesesGreekcatholicLayer);
+            if (!visible) { return; }
+            if (dioceseFetchedBounds && dioceseFetchedBounds.contains(mapBounds)) { return; }
 
-            if (data['roman_catholic']){
-                const newRomanCatholicData = data['roman_catholic'].filter(feature => {
-                    const id = feature.id || feature.properties.id; // Azonosító lekérése
-                    if (!addedRomanCatholicIds.has(id)) {
-                        addedRomanCatholicIds.add(id); // Hozzáadás az ID-k listájához
-                        console.log('New Roman Catholic Diocese:', 'https://openstreetmap.org/' + id);
-                        return true; // Új adat
-                    }
-                    return false; // Már létező adat
-                });
-                diocesesRomanCatholicLayer.addData(newRomanCatholicData); // Csak az új adatok hozzáadása
-            }
-        });
+            // A tényleges nézetnél nagyobb területet kérünk, hogy a pásztázás ne kérjen újra.
+            var padded = mapBounds.pad(0.5);
+            var box = padded.getSouthWest().lat + ";" + padded.getSouthWest().lng + ";"
+                    + padded.getNorthEast().lat + ";" + padded.getNorthEast().lng;
+
+            $.getJSON('/ajax/diocesesinbbox?bbox=' + box, function (data) {
+                // Csak sikeres válasz után jegyezzük fel — különben hiba esetén
+                // azt hinnénk, hogy megvan az a terület.
+                dioceseFetchedBounds = padded;
+
+                addDioceses(data['greekcatholic'], addedGreekCatholicIds, diocesesGreekcatholicLayer);
+                addDioceses(data['roman_catholic'], addedRomanCatholicIds, diocesesRomanCatholicLayer);
+            });
+        }
+
+        function addDioceses(features, seenIds, layer) {
+            if (!features || !features.length) { return; }
+            var fresh = features.filter(function (feature) {
+                var id = feature.id || (feature.properties && feature.properties.id);
+                if (seenIds.has(id)) { return false; }
+                seenIds.add(id);
+                return true;
+            });
+            if (fresh.length) { layer.addData(fresh); }
+        }
+
+        refreshDioceses(box);
         {% endif %}
 
 
@@ -669,8 +726,11 @@
     mymap.on('moveend', onMapMoved);
 
     // Kapcsolatok réteg frissítése, amikor be/ki kapcsolják
+    // #641: az egyházmegye-rétegeket is csak akkor töltjük, ha tényleg bekapcsolják.
     mymap.on('overlayadd', function(e) {
-        if (e.name === 'Egyházi kapcsolatok') {
+        if (e.name === 'Egyházi kapcsolatok'
+            || e.name === 'Római katolikus egyházmegyék'
+            || e.name === 'Görögkatolikus egyházmegyék') {
             onMapMoved.call(mymap);
         }
     });
@@ -680,6 +740,11 @@
     setInitialView();
                 
     function onEachFeature(feature, layer) {
+        // #641: a templom azonosítója a rétegre kerül, hogy mozgatáskor pont a
+        // képernyőről kikerülteket tudjuk levenni (és csak azokat).
+        if (feature.properties && typeof feature.properties.id !== 'undefined') {
+            layer._churchId = feature.properties.id;
+        }
         // does this feature have a property named popupContent?
         if (feature.properties && feature.properties.popupContent) {
         layer.bindPopup(feature.properties.popupContent,{

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -99,9 +99,20 @@
 
 
 <script>
-    
-    var mymap = L.map('mapid');  
-        
+
+    /*
+     * #640: a térkép felállását nehéz volt nyomon követni, mert a hiba csak az ELSŐ
+     * betöltéskor jött elő, frissítésre eltűnt. A dobott hibákat ezért gyűjtjük, hogy
+     * a funkcionális teszt (MapInitializationTest) számon tudja kérni őket.
+     */
+    window.__mapErrors = [];
+    window.addEventListener('error', function (event) {
+        window.__mapErrors.push(String(event.message || event.error));
+    });
+
+    var mymap = L.map('mapid');
+    window.mymap = mymap;
+
     var logo = L.control({position: 'bottomright'});
     logo.onAdd = function(map){
         var div = L.DomUtil.create('div', 'myclass');
@@ -117,7 +128,7 @@
     // Determine initial position: check autogeolocation first
     var initialPosition = null;
     var initialZoom = 13;
-    
+
     {% if center %}
         initialPosition = [{{ center.lat }}, {{ center.lon}}];
         {% if center.zoom %} initialZoom = {{ center.zoom }}; {% endif %}
@@ -127,43 +138,53 @@
     {% else %}
         initialPosition = [47.5, 19.05]; // Budapest default
     {% endif %}
-    
+
     // Geolocation check - try to get user position before setView
     {% if enableAutoGeoLocation is not defined %}
         {% set enableAutoGeoLocation = false %}
     {% endif %}
-    
-    function initializeMapWithPosition(lat, lng) {
-        mymap.setView([lat, lng], initialZoom);
-        // Trigger the data loading
-        onMapMoved.call(mymap);
-    }
-    
-    if ({% if enableAutoGeoLocation %}true{% else %}false{% endif %} && navigator.geolocation && !{% if center %}true{% else %}false{% endif %} && !{% if location %}true{% else %}false{% endif %}) {
-        // Try to get geolocation, but don't wait too long
-        var geolocationTimer = setTimeout(function() {
-            // Fallback to initial position if geolocation takes too long
-            mymap.setView(initialPosition, initialZoom);
-            onMapMoved.call(mymap);
-        }, 3000);
-        
-        navigator.geolocation.getCurrentPosition(
-            function(position) {
-                clearTimeout(geolocationTimer);
-                initializeMapWithPosition(position.coords.latitude, position.coords.longitude);
-            },
-            function(error) {
-                // Fallback to initial position on error
-                clearTimeout(geolocationTimer);
+
+    /*
+     * #640: a nézet beállítása KÉSŐBB, a script legvégén történik — itt csak definiáljuk.
+     *
+     * A setView() szinkron elsüti a 'load' eseményt, arra pedig az onMapMoved() és a
+     * loadBoundary() van kötve (fentebb). Ha a nézetet még itt beállítjuk, ezek olyankor
+     * futnak le, amikor a rétegek (activeRomanLayer, ...) és az svgIcons még nem léteznek.
+     * Ezért kellett korábban a script végén egy külön onMapMoved() hívás — csakhogy az
+     * auto-geolokációs ágon fordítva sült el: a setView() egy aszinkron callbackben marad,
+     * így a végi hívás nézet NÉLKÜL futott, és a getBounds() eldobta a térképet
+     * ("Set map center and zoom first"). Frissítésre azért javult meg, mert akkor a
+     * gyorsítótárazott pozíció megnyerte a versenyt.
+     *
+     * A helyes sorrend: előbb minden réteg és ikon, utána kap nézetet a térkép.
+     * Az adatbetöltést így végig az események intézik ('load' + lentebb 'moveend'),
+     * nem kell külön onMapMoved()-ot hívogatni.
+     */
+    function setInitialView() {
+        if ({% if enableAutoGeoLocation %}true{% else %}false{% endif %} && navigator.geolocation && !{% if center %}true{% else %}false{% endif %} && !{% if location %}true{% else %}false{% endif %}) {
+            // Try to get geolocation, but don't wait too long
+            var geolocationTimer = setTimeout(function() {
+                // Fallback to initial position if geolocation takes too long
                 mymap.setView(initialPosition, initialZoom);
-                onMapMoved.call(mymap);
-            }
-        );
-    } else {
-        // No autogeolocation or already have center/location
-        mymap.setView(initialPosition, initialZoom);
+            }, 3000);
+
+            navigator.geolocation.getCurrentPosition(
+                function(position) {
+                    clearTimeout(geolocationTimer);
+                    mymap.setView([position.coords.latitude, position.coords.longitude], initialZoom);
+                },
+                function(error) {
+                    // Fallback to initial position on error
+                    clearTimeout(geolocationTimer);
+                    mymap.setView(initialPosition, initialZoom);
+                }
+            );
+        } else {
+            // No autogeolocation or already have center/location
+            mymap.setView(initialPosition, initialZoom);
+        }
     }
-                        
+
     //https://leaflet-extras.github.io/leaflet-providers/preview/
     var CartoDB_Voyager = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
@@ -645,17 +666,18 @@
         }
     }
     
-    // Trigger initial load after all layers are set up
-    onMapMoved.call(mymap);
-         
     mymap.on('moveend', onMapMoved);
-    
+
     // Kapcsolatok réteg frissítése, amikor be/ki kapcsolják
     mymap.on('overlayadd', function(e) {
         if (e.name === 'Egyházi kapcsolatok') {
             onMapMoved.call(mymap);
         }
     });
+
+    // #640: minden réteg és eseménykezelő megvan — MOST kaphat nézetet a térkép.
+    // Innentől a 'load' (első setView) és a 'moveend' (minden további) tölti az adatot.
+    setInitialView();
                 
     function onEachFeature(feature, layer) {
         // does this feature have a property named popupContent?
@@ -669,6 +691,13 @@
     
 
 
+ /*
+  * #640: FIGYELEM — ez `const`, tehát a deklarációja ELŐTT nem érhető el (TDZ), a
+  * layerIcon() viszont jóval fentebb használja. Ma ez rendben van, mert a layerIcon()
+  * kizárólag a $.getJSON válasz-callbackjeiből fut, azok pedig mindig e sor után.
+  * Ha valaki ide fentebb szinkron adatbetöltést tesz (pl. async:false vagy egy korai
+  * setView), visszajön a "Cannot access 'svgIcons' before initialization".
+  */
  const svgIcons = {
     rm: `<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="100%" viewBox="0 0 346 513" enable-background="new 0 0 346 513" xml:space="preserve">

--- a/webapp/tests/Functional/MapInitializationTest.php
+++ b/webapp/tests/Functional/MapInitializationTest.php
@@ -49,6 +49,45 @@ final class MapInitializationTest extends PantherTestCase {
     }
 
     /*
+     * #641: pásztázáskor eddig MINDEN templomot letöröltünk és újrarajzoltunk (villódzás).
+     * Most csak a különbséget rajzoljuk — ez a teszt azt őrzi, hogy a képen maradó
+     * gombostűk ugyanazok a DOM-elemek maradnak, tehát tényleg nem rajzolódnak újra.
+     */
+    public function testPanningKeepsTheMarkersThatStayInView(): void {
+        $client = $this->client();
+        $client->request('GET', '/terkep?map=13/47.4979/19.0402');
+
+        $client->wait(15)->until(static function ($driver) {
+            return $driver->executeScript(
+                'return document.querySelectorAll(".leaflet-marker-icon").length > 0;'
+            );
+        });
+
+        // Megjelöljük a jelenlegi gombostűket, hogy felismerjük, ha újak születnek.
+        $client->executeScript(
+            'document.querySelectorAll(".leaflet-marker-icon").forEach(function (m, i) { m.dataset.mapTestSeen = "1"; });'
+        );
+        $before = (int) $client->executeScript('return document.querySelectorAll(".leaflet-marker-icon").length;');
+        self::assertGreaterThan(0, $before, 'Nem jelent meg egyetlen templom sem a térképen.');
+
+        // Kis elmozdulás: a látható templomok túlnyomó része ugyanaz marad.
+        $client->executeScript('window.mymap.panBy([120, 0]); return true;');
+        $client->wait(15)->until(static function ($driver) {
+            return $driver->executeScript('return !window.mymap._panAnim || !window.mymap._panAnim._inProgress;');
+        });
+        usleep(1500000); // az AJAX-válasz beérkezése
+
+        $survivors = (int) $client->executeScript(
+            'return document.querySelectorAll(".leaflet-marker-icon[data-map-test-seen]").length;'
+        );
+        self::assertGreaterThan(
+            0,
+            $survivors,
+            'Pásztázás után egyetlen korábbi gombostű sem maradt meg — újrarajzolás történt.'
+        );
+    }
+
+    /*
      * A templom-adatlap kis térképe a nem-geolokációs ágat járja (kap `center`-t).
      * Itt a másik hiba (svgIcons a rétegek előtt) jött volna elő.
      */

--- a/webapp/tests/Functional/MapInitializationTest.php
+++ b/webapp/tests/Functional/MapInitializationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Symfony\Component\Panther\PantherTestCase;
+
+/**
+ * #640: a /terkep elsőre hibára futott, ctrl+R-re viszont megjavult.
+ *
+ * Két, egymást takaró sorrendi hiba volt:
+ *  - a script végén állt egy onMapMoved() hívás, ami az auto-geolokációs ágon még nézet
+ *    nélküli térképen futott -> "Set map center and zoom first",
+ *  - a 'load' esemény viszont a nem-geolokációs ágon túl KORÁN sült el, amikor a rétegek
+ *    és az svgIcons még nem léteztek -> "Cannot access 'svgIcons' before initialization".
+ * Frissítésre azért működött, mert a gyorsítótárazott pozíció megnyerte a versenyt.
+ *
+ * Ez a teszt azt őrzi, hogy a térkép ELSŐ betöltésre is hibátlanul álljon fel.
+ */
+final class MapInitializationTest extends PantherTestCase {
+
+    private function client() {
+        return static::createPantherClient(
+            ['external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000'],
+            [],
+            ['browser' => static::CHROME]
+        );
+    }
+
+    /*
+     * A /terkep az egyetlen hely, ahol az auto-geolokáció be van kapcsolva — épp ez az
+     * ág szállt el. A böngésző a tesztben nem ad pozíciót, tehát a fallback fut le.
+     */
+    public function testMapPageLoadsWithoutJavascriptErrorsOnFirstVisit(): void {
+        $client = $this->client();
+        $client->request('GET', '/terkep');
+
+        // A nézet a geolokációs fallback után áll be (3 mp-es időzítő), várjuk meg.
+        $client->wait(10)->until(static function ($driver) {
+            return $driver->executeScript('return !!(window.mymap && window.mymap._loaded);');
+        });
+
+        $errors = $client->executeScript(
+            <<<'JS'
+            return (window.__mapErrors || []).slice(0, 10);
+            JS
+        );
+        self::assertSame([], $errors, "JS-hiba a térkép betöltésekor: " . json_encode($errors));
+
+        $hasCenter = $client->executeScript('return !!window.mymap.getCenter();');
+        self::assertTrue($hasCenter, 'A térkép nézet nélkül maradt.');
+    }
+
+    /*
+     * A templom-adatlap kis térképe a nem-geolokációs ágat járja (kap `center`-t).
+     * Itt a másik hiba (svgIcons a rétegek előtt) jött volna elő.
+     */
+    public function testChurchPageMapLoadsWithoutJavascriptErrors(): void {
+        $client = $this->client();
+        $client->request('GET', '/templom/1');
+
+        $client->wait(10)->until(static function ($driver) {
+            return $driver->executeScript('return !!(window.mymap && window.mymap._loaded);');
+        });
+
+        $errors = $client->executeScript('return (window.__mapErrors || []).slice(0, 10);');
+        self::assertSame([], $errors, "JS-hiba a templom-térkép betöltésekor: " . json_encode($errors));
+    }
+}


### PR DESCRIPTION
Fixes #641

> ⚠️ Ez a #645 (#640) tetejére épül — ugyanazt a `_map_leaflet.twig`-et szerkeszti, külön ágon konfliktus lenne. Előbb a #645 menjen be.

Végigmentem a pontjaidon, de előbb **lemértem** a három végpontot, mert enélkül csak tippelnénk. Ezek a mai számok (fejlesztői gép, jelenlegi seed):

| bbox | churchesinbbox | diocesesinbbox | churchrelationshipsinbbox |
|---|---:|---:|---:|
| Budapest-belváros (91 templom) | 1 048 ms | 2 301 ms | 29 ms |
| Pest megye (460 templom) | 3 985 ms | **22 206 ms** (0 találatra!) | 47 ms |
| Kárpát-medence (4 628 templom) | 35 516 ms | 17 876 ms / 3,2 MB | 539 ms |

## „Biztos így optimális?" — nem, de nem a bbox volt a baj

A `churchesinbbox` **templomonként** kérdezett le mindent: fotót, attribútumokat (kétszer is: a `names` és a `denomination` accessor külön), az elhelyezkedést (a `location` accessor a `boundaries` táblát is húzza, holott itt csak a lat/lon kell), és **két Elasticsearch-kört** a hétvégi misékre. 460 templom = 920 ES-kör.

Most minden köteges: egy lekérdezés a templomokra (fotókkal), egy az attribútumokra, és **egyetlen** ES-hívás (`terms` agg + `top_hits`) az összes hétvégi misére.

| bbox | előtte | utána |
|---|---:|---:|
| Budapest-belváros | 1 048 ms | **155 ms** |
| Pest megye | 3 985 ms | **121 ms** (33×) |
| Kárpát-medence | 35 516 ms | **515 ms** (69×) |

A válasz **bájtra azonos** maradt — mind a 460 templomot mezőnként összevetettem a régi kimenettel, 0 eltérés.

A `diocesesinbbox` viszont tényleg rossz helyen van: **Overpasst hív, majd egyházmegyénként Nominatimot** — külső szolgáltatásokat, a térkép kritikus útján, minden mozdításkor. (A 22 s úgy jött ki, hogy közben 0 egyházmegyét adott vissza.) Ezért igazad van: **ezt nem mozdításonként kell kérni.** Mostantól csak akkor kérünk, ha a réteg tényleg látszik ÉS a nézet kilóg abból a (megnövelt) területből, amit már lekértünk — a szokásos pásztázás így egyetlen kérést sem indít.

A gyökeres megoldás a te ötleted lenne (előtöltés), és félúton már ott vagyunk: az egyházmegyék OSM-azonosítói és nevei **már benne vannak a saját `boundaries` táblánkban** (34 római katolikus, admin_level=6). Csak a geometria hiányzik onnan. Ha azt is eltároljuk, a végpont külső hívás nélkül, milliszekundumokban kiszolgálható — ez viszont külön kör, szólj, ha csináljam.

## „A kapcsolatok csak addig könnyűek, amíg kevés van?"

Igen. 454 kapcsolatnál 539 ms és 119 KB — még kényelmes, de a méretezése ugyanolyan lineáris, mint a templomoké. Az viszont a javára szól, hogy **már ma is delta-frissítést csinál** (`currentRelationshipIds`), ezért nem villódzik. Onnan vettem a mintát a templomokhoz.

## „Ne töröljön mindent és rakja vissza" — megcsinálva

Ez volt a villódzás oka: a templom-rétegek minden mozdításkor `clearLayers()`-t kaptak, majd újraépültek. Most csak a különbséget rajzoljuk — a kikerülteket levesszük, az újakat feltesszük, a maradókhoz nem nyúlunk. Funkcionális teszt őrzi: pásztázás után a képen maradó gombostűk **ugyanazok a DOM-elemek**.

## „Milyen zoomon mi jelenjen meg?"

A mai állapot, hogy legyen miről dönteni:

| réteg | mikor kérünk adatot | mikor látszik |
|---|---|---|
| templomok | zoom ≥ 11 | zoom ≥ 11 (alatta törlődik) |
| egyházmegyék | **eddig: mindig** → most: csak ha a réteg látszik és új területre értünk | minden zoomon |
| kapcsolatok | csak ha a réteg be van kapcsolva | minden zoomon |

Nem nyúltam a küszöbökhöz, mert azt írtad, hogy a kapcsolatokat távolról is így szereted. A méretezés miatt viszont érdemes lehet a kapcsolatokra is egy zoom-küszöb, ha majd sok lesz — de az már ízlés-döntés, nem hiba.

## „Nem lehetne megnézni az egyházmegye nevét?"

Nem lehetett — mert **a név nem is volt benne a válaszban**. A Nominatim csak a geometriát adja vissza, a végpont pedig csak egy `id`-t tett mellé. A nevek viszont a `boundaries` táblánkban ott vannak, így most egyetlen lekérdezéssel melléjük teszem:

```
roman_catholic | id=relation/5635587 | name="Esztergom-Budapesti főegyházmegye"
roman_catholic | id=relation/5635765 | name="Székesfehérvári egyházmegye"
```

A térképen **lebegő címkeként** jelenik meg (egérrel fölé húzva), nem kattintásra — pont a felvetésed miatt, hogy egy templom-gombostű elveheti a kattintást.

## Mellékesen

Kivettem két bennmaradt `console.log`-ot az egyházmegye-betöltésből.