### PR TITLE
#642 Nem szivárog ki a belső port a régi templom-linkek átirányításából

### DIFF
--- a/webapp/.htaccess
+++ b/webapp/.htaccess
@@ -9,21 +9,41 @@
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 
     RewriteBase /
+
+    # #642: az OSM-ben sok helyen a régi `?templom=1254` alakú link szerepel. Erre
+    # kattintva a látogató egy elérhetetlen címen kötött ki:
+    #   http://miserend.hu:8000/templom/1254?templom=1254  (ERR_CONNECTION_TIMED_OUT)
+    # Három baj volt egyszerre:
+    #   1. az Apache a 8000-es porton figyel (előtte a Caddy a 443-on), és a relatív
+    #      célból abszolút URL-t építve ODATETTE a saját fizikai portját;
+    #   2. a séma http-re esett vissza, mert a TLS-t a Caddy zárja;
+    #   3. a QSD hiánya miatt az EREDETI query string is odakerült, innen a
+    #      megkettőzött `?templom=1254`.
+    # Ezért az átirányítás célját mostantól magunk állítjuk össze a kliens Host
+    # fejlécéből — így se port, se séma nem tud elromlani, és dev/staging/prod
+    # egyaránt jól viselkedik.
+    RewriteCond %{HTTPS} =on [OR]
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteRule ^ - [E=PROTO:https]
+    RewriteCond %{HTTPS} !=on
+    RewriteCond %{HTTP:X-Forwarded-Proto} !=https
+    RewriteRule ^ - [E=PROTO:http]
+
     RewriteCond %{HTTP_HOST} ^www\.(.*)$ [NC]
-    RewriteRule ^(.*)$ http://%1/$1 [R=301,L]
+    RewriteRule ^(.*)$ %{ENV:PROTO}://%1/$1 [R=301,L]
 
     # Redirect query parameter ?templom=ID to path /templom/ID for Angular
     # Case 1: Only ?templom=ID (no other parameters)
     RewriteCond %{QUERY_STRING} ^templom=([0-9]+)$
-    RewriteRule ^/?$ /templom/%1 [R=301,L]
-    
+    RewriteRule ^/?$ %{ENV:PROTO}://%{HTTP_HOST}/templom/%1 [R=301,L,QSD]
+
     # Case 2: ?templom=ID&other=params (temple at start)
     RewriteCond %{QUERY_STRING} ^templom=([0-9]+)&(.+)$
-    RewriteRule ^/?$ /templom/%1?%2 [R=301,L]
-    
+    RewriteRule ^/?$ %{ENV:PROTO}://%{HTTP_HOST}/templom/%1?%2 [R=301,L,QSD]
+
     # Case 3: ?other=params&templom=ID (and possibly more params after)
     RewriteCond %{QUERY_STRING} ^(.+?)&templom=([0-9]+)((?:&.+)?)$
-    RewriteRule ^/?$ /templom/%2?%1%3 [R=301,L]
+    RewriteRule ^/?$ %{ENV:PROTO}://%{HTTP_HOST}/templom/%2?%1%3 [R=301,L,QSD]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d

--- a/webapp/tests/Integration/LegacyChurchUrlRedirectTest.php
+++ b/webapp/tests/Integration/LegacyChurchUrlRedirectTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #642: az OSM-ben sok helyen a régi `?templom=1254` alakú link szerepel. Erre
+ * kattintva a látogató egy elérhetetlen címen kötött ki:
+ *
+ *   http://miserend.hu:8000/templom/1254?templom=1254   (ERR_CONNECTION_TIMED_OUT)
+ *
+ * Az Apache a 8000-es porton figyel (előtte a Caddy a 443-on), és a relatív
+ * átirányítási célból abszolút URL-t építve odatette a saját fizikai portját;
+ * a séma http-re esett vissza; a query stringet pedig megkettőzte.
+ *
+ * Valódi HTTP-hívásokkal ellenőrizzük, mert ez .htaccess-viselkedés — PHP-ből
+ * nem látszik.
+ */
+final class LegacyChurchUrlRedirectTest extends TestCase {
+
+    private string $baseUrl;
+
+    protected function setUp(): void {
+        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
+    }
+
+    /**
+     * @return array{status:int, location:?string}
+     */
+    private function head(string $path, array $headers = []): array {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'follow_location' => 0,
+                'ignore_errors' => true,
+                'header' => $headers,
+                'timeout' => 10,
+            ],
+        ]);
+
+        $body = @file_get_contents($this->baseUrl . $path, false, $context);
+        $this->assertNotFalse($body, 'HTTP kérés nem sikerült: ' . $path);
+
+        $status = 0;
+        $location = null;
+        foreach ($http_response_header ?? [] as $line) {
+            if (preg_match('#^HTTP/\S+\s+(\d{3})#', $line, $m)) {
+                $status = (int) $m[1];
+            }
+            if (stripos($line, 'Location:') === 0) {
+                $location = trim(substr($line, strlen('Location:')));
+            }
+        }
+
+        return ['status' => $status, 'location' => $location];
+    }
+
+    /* A bejelentett eset: https-proxy mögül, valódi hosztnévvel. */
+    public function testLegacyQueryUrlRedirectsToCleanHttpsUrl(): void {
+        $response = $this->head('/?templom=1254', [
+            'Host: miserend.hu',
+            'X-Forwarded-Proto: https',
+        ]);
+
+        self::assertSame(301, $response['status']);
+        self::assertSame('https://miserend.hu/templom/1254', $response['location']);
+    }
+
+    /* A belső port SOHA nem szivároghat ki az átirányításba. */
+    public function testRedirectNeverLeaksTheInternalPort(): void {
+        $response = $this->head('/?templom=1254', ['Host: miserend.hu']);
+
+        self::assertSame(301, $response['status']);
+        self::assertStringNotContainsString(':8000', (string) $response['location']);
+    }
+
+    /* A query string nem kettőződhet meg (`?templom=1254` a végén). */
+    public function testRedirectDoesNotDuplicateTheQueryString(): void {
+        $response = $this->head('/?templom=1254', ['Host: miserend.hu']);
+
+        self::assertStringNotContainsString('templom=', (string) $response['location']);
+    }
+
+    /* A többi paramétert viszont meg kell tartani. */
+    public function testOtherQueryParametersSurvive(): void {
+        $response = $this->head('/?templom=1254&foo=bar', [
+            'Host: miserend.hu',
+            'X-Forwarded-Proto: https',
+        ]);
+
+        self::assertSame('https://miserend.hu/templom/1254?foo=bar', $response['location']);
+    }
+
+    /* A www→nem-www átirányítás se ejtse vissza https-ről http-re. */
+    public function testWwwRedirectKeepsHttps(): void {
+        $response = $this->head('/templom/1254', [
+            'Host: www.miserend.hu',
+            'X-Forwarded-Proto: https',
+        ]);
+
+        self::assertSame(301, $response['status']);
+        self::assertSame('https://miserend.hu/templom/1254', $response['location']);
+    }
+
+    /* Fejlesztői környezetben a port MARAD — ott az a helyes. */
+    public function testDevelopmentHostKeepsItsPort(): void {
+        $response = $this->head('/?templom=1254', ['Host: localhost:8000']);
+
+        self::assertSame('http://localhost:8000/templom/1254', $response['location']);
+    }
+}


### PR DESCRIPTION
Fixes #642

Reprodukáltam, és **nem a Caddyben van** — nálunk, a `webapp/.htaccess`-ben. Ezért jó hír: fájlban javítható, nem szerver-konfigban.

```
$ curl -I "http://localhost:8000/?templom=1254" -H "Host: miserend.hu"
301 -> http://miserend.hu:8000/templom/1254?templom=1254
```

Pontosan a te URL-ed, karakterre.

## Három baj esett egyszerre

1. **A port.** Az Apache a 8000-es porton figyel (előtte a Caddy a 443-on). Az átirányítási szabály célja relatív volt (`/templom/%1`), az Apache pedig abszolút URL-t épít belőle — és odatette a saját fizikai portját. Kívülről a 8000 nincs nyitva → `ERR_CONNECTION_TIMED_OUT`.
2. **A séma.** A TLS-t a Caddy zárja, az Apache-hoz sima http érkezik, tehát a generált URL http lett. Ugyanez a hiba a `www→nem-www` szabályban **fixen be volt drótozva**: `RewriteRule ^(.*)$ http://%1/$1` — vagyis aki `https://www.miserend.hu`-ra ment, azt http-re ejtettük vissza.
3. **A megkettőzött paraméter.** Hiányzott a `QSD`, ezért az Apache az eredeti query stringet is hozzáfűzte — innen a `?templom=1254` a végén.

## Javítás

Az átirányítás célját magunk állítjuk össze a kliens `Host` fejlécéből, a sémát pedig az `X-Forwarded-Proto`-ból:

```apache
RewriteCond %{HTTPS} =on [OR]
RewriteCond %{HTTP:X-Forwarded-Proto} =https
RewriteRule ^ - [E=PROTO:https]
...
RewriteRule ^/?$ %{ENV:PROTO}://%{HTTP_HOST}/templom/%1 [R=301,L,QSD]
```

Így se port, se séma nem tud elromlani, és nem függ attól, milyen porton figyel épp az Apache.

Kipróbáltam az `UseCanonicalPhysicalPort Off`-ot is az `apache.conf`-ban, de **nem oldotta meg** (alapból is Off), ráadásul az a fájl az image-be épül — nem tudtam volna itt helyben ellenőrizni. Ezért maradt minden a `.htaccess`-ben, ahol mérni is tudtam.

## Mérés — mind a hat eset

| eset | eredmény |
|---|---|
| `?templom=1254`, https-proxy mögül | `https://miserend.hu/templom/1254` ✅ |
| ugyanaz http-n | `http://miserend.hu/templom/1254` ✅ |
| `www.miserend.hu` https-en | `https://miserend.hu/templom/1254` ✅ (eddig http-re esett) |
| `?templom=1254&foo=bar` | `https://miserend.hu/templom/1254?foo=bar` ✅ |
| `?foo=bar&templom=1254` | `https://miserend.hu/templom/1254?foo=bar` ✅ |
| **dev:** `Host: localhost:8000` | `http://localhost:8000/templom/1254` ✅ (a port ott KELL) |

`LegacyChurchUrlRedirectTest` őrzi mind a hatot, valódi HTTP-hívásokkal — ez .htaccess-viselkedés, PHP-ből nem látszik.

## Egy megjegyzés az OSM-adatról

A `url:miserend` értéke sok helyen `http://miserend.hu:/?templom=1254` — figyeld meg a **`:` üres porttal**. A böngészők ezt elnézik, de szemét. Ha egyszer végigmegyünk az OSM-en, érdemes a kanonikus `https://miserend.hu/templom/1254` alakra cserélni. Ettől függetlenül a régi linkeknek is működniük kell, ezért kellett ez a javítás.