### PR TITLE
Törlöm a 404-es CSS-kérést és dokumentálom a böngésző külső forrásait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ var/
 node_modules/
 dumper/01-dump.sql
 webapp/fajlok/git_hash
+# Az ExternalApi fájl-cache-e (Overpass/Nominatim/... válaszok) — futásidőben keletkezik.
+webapp/fajlok/tmp/
 
 .idea
 composer.phar

--- a/docs/outgoing-connections.md
+++ b/docs/outgoing-connections.md
@@ -63,6 +63,36 @@ IP eltérhet tőle. A módosítás után külső címre küldött tesztlevél fe
 kell az SPF eredményt; ha nem `pass`, a relay naplója alapján kell azonosítani a tényleges
 kimenő címet.
 
+## A BÖNGÉSZŐ által betöltött külső erőforrások
+
+> Ezek nem a szerverről mennek ki, hanem a látogató böngészőjéből — tehát egy szerver-oldali
+> egress-allowlist NEM fedi le őket. Akkor számítanak, ha zárt hálózatban (vagy szigorú CSP
+> mellett) kell működnie az oldalnak: ha ezek nem érhetők el, a térkép egyszerűen nem jelenik meg.
+> Ezért kerültek ide. (#653)
+
+| Cél | Host | Mire kell | Hol |
+|---|---|---|---|
+| **Leaflet** (JS + CSS) | `unpkg.com` | a térkép motorja | `_map_leaflet.twig` (1.7.1), `stat.twig` (1.9.3), `church/create.twig` (1.9.4) |
+| **Leaflet.PolylineDecorator** | `unpkg.com` | a kapcsolat-vonalak nyilai | `_map_leaflet.twig` |
+| **Leaflet.TextPath** | `makinacorpus.github.io` | vonalra írt felirat | `_map_leaflet.twig` |
+| **CARTO Voyager csempék** | `{a,b,c,d}.basemaps.cartocdn.com` | a térkép alaprétege | `_map_leaflet.twig` |
+| html5shiv, respond.js | `oss.maxcdn.com` | régi IE-polyfillek | `layout.twig` |
+| OpenLayers | `openlayers.org` | régi térkép-kód | (legacy) |
+
+Amit érdemes tudni róluk:
+
+- **Három különböző Leaflet-verziót** töltünk be három sablonból (1.7.1 / 1.9.3 / 1.9.4). Ezt
+  egységesíteni kellene.
+- A `makinacorpus.github.io` egy GitHub Pages, **nem CDN** — nincs rendelkezésre állási ígéret rá.
+- A **Stamen csempeszerver** (`stamen-tiles-*.a.ssl.fastly.net`, `_map_leaflet.twig`) mérve
+  **HTTP 503**-at ad: a Stamen 2023-ban a Stadiához költözött, ez a réteg halott.
+- A `leaflet.polylinedecorator.css` hivatkozás **HTTP 404** volt (nem létezik az unpkg-n); a #653-ban
+  töröltük.
+
+A #653 arról szól, hogy ezek nagy részét saját kiszolgálásra váltsuk (a jQuery, a Bootstrap és a
+FontAwesome már ma is a `webapp/package.json`-ból jön) — akkor ez a szakasz a csempeszerverre
+zsugorodik.
+
 ## Container image registry-k
 
 Build / pull időben kellhet:

--- a/docs/outgoing-connections.md
+++ b/docs/outgoing-connections.md
@@ -84,10 +84,12 @@ Amit érdemes tudni róluk:
 - **Három különböző Leaflet-verziót** töltünk be három sablonból (1.7.1 / 1.9.3 / 1.9.4). Ezt
   egységesíteni kellene.
 - A `makinacorpus.github.io` egy GitHub Pages, **nem CDN** — nincs rendelkezésre állási ígéret rá.
-- A **Stamen csempeszerver** (`stamen-tiles-*.a.ssl.fastly.net`, `_map_leaflet.twig`) mérve
-  **HTTP 503**-at ad: a Stamen 2023-ban a Stadiához költözött, ez a réteg halott.
 - A `leaflet.polylinedecorator.css` hivatkozás **HTTP 404** volt (nem létezik az unpkg-n); a #653-ban
   töröltük.
+- A **Stamen csempeszerver** (`stamen-tiles-*.a.ssl.fastly.net`) mérve **HTTP 503**-at adott: a Stamen
+  2023-ban a Stadiához költözött. A réteg soha nem is volt kiválasztható (definiálva volt, de sehol
+  nem használtuk), ezért a #653-ban töröltük. Az utód (`tiles.stadiamaps.com`) kulcs nélkül **HTTP
+  401** — ha valaha kell terep-alapréteg, az regisztrációt és API-kulcsot igényel.
 
 A #653 arról szól, hogy ezek nagy részét saját kiszolgálásra váltsuk (a jQuery, a Bootstrap és a
 FontAwesome már ma is a `webapp/package.json`-ból jön) — akkor ez a szakasz a csempeszerverre

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -624,6 +624,77 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         return $formattedMasses;
     }
 
+    /**
+     * #641: hétvégi misék SOK templomra, egyetlen Elasticsearch-lekérdezéssel.
+     *
+     * A térkép bbox-végpontja templomonként hívta a getWeekendMasses()-t, az pedig
+     * templomonként KÉT ES-kört futtat (szombat + vasárnap). 460 templomnál ez 920
+     * hálózati kör — mérve ez tette 4 másodpercessé a térkép minden mozdítását.
+     * A két időablak egybefüggő (szombat 17:00 → vasárnap 23:59), ezért egyben
+     * kérjük le, és PHP-ben bontjuk napokra.
+     *
+     * A visszaadott alak SZÁNDÉKOSAN azonos a getWeekendMasses()-ével, hogy a
+     * frontend-szerződés ne változzon.
+     *
+     * @param  int[] $churchIds
+     * @return array [church_id => ['saturday' => [...], 'sunday' => [...]]]
+     */
+    public static function weekendMassesForChurches(array $churchIds): array
+    {
+        $empty = ['saturday' => [], 'sunday' => []];
+        $result = [];
+        foreach ($churchIds as $id) {
+            $result[(int) $id] = $empty;
+        }
+        if (empty($churchIds)) {
+            return $result;
+        }
+
+        $saturday = (new self())->getTargetSaturdayDate();
+        $sunday = $saturday->copy()->addDay();
+
+        $fromUtc = \Carbon\Carbon::parse($saturday->toDateString() . 'T17:00:00', 'Europe/Budapest')
+            ->setTimezone('UTC')->format('Y-m-d\TH:i:s') . 'Z';
+        $toUtc = \Carbon\Carbon::parse($sunday->toDateString() . 'T23:59:00', 'Europe/Budapest')
+            ->setTimezone('UTC')->format('Y-m-d\TH:i:s') . 'Z';
+
+        try {
+            $byChurch = (new \ExternalApi\ElasticsearchApi())->massesByChurch(
+                $churchIds,
+                $fromUtc,
+                $toUtc,
+                self::getMassTypeKeysFromDefinitions()
+            );
+        } catch (\Throwable $e) {
+            // A térkép a misék nélkül is használható — ne bukjon el az egész válasz.
+            error_log('[#641] hétvégi misék lekérése nem sikerült: ' . $e->getMessage());
+            return $result;
+        }
+
+        $saturdayDate = $saturday->toDateString();
+        $sundayDate = $sunday->toDateString();
+
+        foreach ($byChurch as $churchId => $masses) {
+            foreach ($masses as $mass) {
+                // Ugyanaz a helyi idejű formázás, mint a Search::prepareMassesResults()-ban.
+                $local = \Carbon\Carbon::parse($mass['start_date'])->setTimezone('Europe/Budapest');
+                $day = $local->toDateString();
+                $entry = [
+                    'time' => $local->format('H:i'),
+                    'date' => $day,
+                    'title' => $mass['title'],
+                ];
+                if ($day === $saturdayDate && count($result[$churchId]['saturday']) < 4) {
+                    $result[$churchId]['saturday'][] = $entry;
+                } elseif ($day === $sundayDate && count($result[$churchId]['sunday']) < 4) {
+                    $result[$churchId]['sunday'][] = $entry;
+                }
+            }
+        }
+
+        return $result;
+    }
+
     private static function getMassTypeKeysFromDefinitions(): array
     {
         $massTypeKeys = [];

--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -475,6 +475,72 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return true;		
 	}
 
+	/**
+	 * #641: hétvégi misék EGYETLEN lekérdezésben, akárhány templomra.
+	 *
+	 * A térkép bbox-végpontja eddig templomonként KÉT Elasticsearch-kört futtatott
+	 * (szombat + vasárnap). 460 templomnál ez 920 hálózati kör — ez volt a /terkep
+	 * lassúságának fő oka. Terms-aggregáció + top_hits: egy kérés, templomonként
+	 * időrendben az első néhány mise.
+	 *
+	 * @param  int[]    $churchIds
+	 * @param  string[] $titleKeys  cím-szűrő (MASS kategória kulcsai); üres = nincs szűrés
+	 * @return array    [church_id => [ ['start_date'=>..., 'title'=>...], ... ]]
+	 */
+	function massesByChurch(array $churchIds, string $fromUtc, string $toUtc, array $titleKeys = [], int $perChurch = 8): array {
+		if (empty($churchIds)) {
+			return [];
+		}
+
+		$must = [
+			["terms" => ["church_id" => array_values(array_map('intval', $churchIds))]],
+			["range" => ["start_date" => ["gte" => $fromUtc, "lte" => $toUtc]]],
+		];
+		if (!empty($titleKeys)) {
+			$must[] = ["terms" => ["title.keyword" => array_values($titleKeys)]];
+		}
+
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
+		$this->buildQuery('mass_index/_search', json_encode([
+			"size" => 0,
+			"query" => ["bool" => ["must" => $must]],
+			"aggs" => [
+				"by_church" => [
+					"terms" => ["field" => "church_id", "size" => count($churchIds)],
+					"aggs" => [
+						"masses" => [
+							"top_hits" => [
+								"size" => $perChurch,
+								"sort" => [["start_date" => ["order" => "asc"]]],
+								"_source" => ["includes" => ["start_date", "title"]],
+							],
+						],
+					],
+				],
+			],
+		]));
+		$this->run();
+
+		if ($this->responseCode != 200) {
+			throw new \Exception("Could not search mass_index!\n" . $this->error);
+		}
+
+		$byChurch = [];
+		$buckets = $this->jsonData->aggregations->by_church->buckets ?? [];
+		foreach ($buckets as $bucket) {
+			$masses = [];
+			foreach ($bucket->masses->hits->hits ?? [] as $hit) {
+				$masses[] = [
+					'start_date' => $hit->_source->start_date ?? '',
+					'title' => $hit->_source->title ?? '',
+				];
+			}
+			$byChurch[(int) $bucket->key] = $masses;
+		}
+
+		return $byChurch;
+	}
+
 	function churchIdsWithMassesInPeriod($startDate, $endDate) {
 		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
 		$this->buildQuery('mass_index/_search', json_encode([

--- a/webapp/classes/html/ajax/churchesinbbox.php
+++ b/webapp/classes/html/ajax/churchesinbbox.php
@@ -5,50 +5,97 @@ namespace Html\Ajax;
 class ChurchesInBBox extends Ajax {
 
     public function __construct() {
-               
+
         // #391: a bbox parse+validáció a \Request::Bbox()-ba került (pontosvesszős
         // 4-float lista). Hiányzó/rossz alakú bbox → false, ekkor némán kilépünk
         // (mint korábban a count()!=4 / is_numeric őrök).
         $bbox = \Request::Bbox('bbox');
         if($bbox === false) return;
 
-         $churchesInBBox = \Eloquent\Church::where('ok','i')->inBBox(['latMin'=>$bbox[0],'lonMin'=>$bbox[1],'latMax'=>$bbox[2],'lonMax'=>$bbox[3]])->get();
+        /*
+         * #641: ez a végpont a térkép MINDEN mozdításakor lefut, és templomonként
+         * külön-külön kérdezett le mindent — fotót, attribútumokat, elhelyezkedést
+         * (az utóbbi a boundaries táblát is), plusz KÉT Elasticsearch-kört a hétvégi
+         * misékre. Mérve: 91 templomra 1,0 s, 460-ra 4,0 s, 4628-ra 35,5 s.
+         *
+         * Most minden köteges: egy lekérdezés a templomokra (fotókkal együtt), egy az
+         * attribútumokra, és EGY Elasticsearch-hívás az összes hétvégi misére.
+         * A lat/lon közvetlenül az oszlopból jön — a `location` accessor a boundaries
+         * táblát is húzta, holott itt csak a koordináta kell.
+         */
+        $churchesInBBox = \Eloquent\Church::where('ok','i')
+            ->inBBox(['latMin'=>$bbox[0],'lonMin'=>$bbox[1],'latMax'=>$bbox[2],'lonMax'=>$bbox[3]])
+            ->with('photos')
+            ->get();
+
+        if ($churchesInBBox->isEmpty()) {
+            echo json_encode([]);
+            return;
+        }
+
+        $churchIds = $churchesInBBox->pluck('id')->map('intval')->all();
+
+        // Minden attribútum egyetlen lekérdezéssel, templomonként kulcs => érték térképpé.
+        $attributesByChurch = \Eloquent\Attribute::whereIn('church_id', $churchIds)
+            ->get()
+            ->groupBy('church_id')
+            ->map(function ($rows) {
+                return $rows->pluck('value', 'key')->toArray();
+            })
+            ->toArray();
+
+        $weekendMasses = \Eloquent\Church::weekendMassesForChurches($churchIds);
 
         $return = [];
         global $user;
-        
+        $isAdmin = isset($user->isadmin) && $user->isadmin;
+
         foreach($churchesInBBox as $church) {
-            $church->photos;
-            if (isset($church->photos[0])) $thumbnail = $church->photos[0]->smallUrl;
-            else $thumbnail = false;
-            
-            $church->loadAttributes();
-            
-            // Hétvégi miserendet lekérése (szombat 17:00-tól, vasárnap összes)
-            $weekendMasses = $church->getWeekendMasses();
-                        
-            // Admin linkek adatai (csak admin felhasználóknál)
-            $adminLinks = [];
-            if (isset($user->isadmin) && $user->isadmin) {
-                $adminLinks = [
-                    'id' => $church->id
-                ];
-            }
-            
+            $churchId = (int) $church->id;
+            $attributes = $attributesByChurch[$churchId] ?? [];
+
+            $thumbnail = isset($church->photos[0]) ? $church->photos[0]->smallUrl : false;
+
             $return[] = [
-                'id' => $church->id,
-                'nev' => $church->names[0],
+                'id' => $churchId,
+                'nev' => self::primaryName($church, $attributes),
                 'thumbnail' => $thumbnail,
-                'denomination' => $church->denomination,
+                'denomination' => self::denomination($church, $attributes),
                 'active' => $church->miseaktiv,
-                'lat'=> $church->location->lat,
-                'lon'=> $church->location->lon,
-                'church_type' => $church->{'church:type'} ?? 'other',
-                'weekend_masses' => $weekendMasses,
-                'adminLinks' => $adminLinks
+                'lat'=> $church->lat,
+                'lon'=> $church->lon,
+                'church_type' => $attributes['church:type'] ?? 'other',
+                'weekend_masses' => $weekendMasses[$churchId] ?? ['saturday' => [], 'sunday' => []],
+                // Az admin-linkekhez a sablon csak az id-t használja.
+                'adminLinks' => $isAdmin ? ['id' => $churchId] : []
             ];
         }
-        echo json_encode($return);        
+        echo json_encode($return);
+    }
+
+    /*
+     * #641: a `names` accessor templomonként újra lekérdezte az attribútumokat.
+     * Ugyanaz a sorrend, csak a már betöltött adatból.
+     */
+    private static function primaryName($church, array $attributes): string {
+        foreach (['name:hu', 'name'] as $key) {
+            if (!empty($attributes[$key])) {
+                return $attributes[$key];
+            }
+        }
+        return (string) $church->nev;
+    }
+
+    /*
+     * #542/#641: a felekezet az OSM `denomination` attribútumból jön, fallbackként a
+     * korábbi egyházmegye-heurisztikából — ugyanaz, mint a Church accessorban, de
+     * lekérdezés nélkül.
+     */
+    private static function denomination($church, array $attributes): string {
+        if (!empty($attributes['denomination'])) {
+            return $attributes['denomination'];
+        }
+        return in_array($church->egyhazmegye, [34, 17, 18]) ? 'greek_catholic' : 'roman_catholic';
     }
 
 }

--- a/webapp/classes/html/ajax/diocesesinbbox.php
+++ b/webapp/classes/html/ajax/diocesesinbbox.php
@@ -38,24 +38,36 @@ class DiocesesInBBox extends Ajax {
              return [];
         }
 
+        // #641: az egyházmegyék NEVÉT eddig nem küldtük le, ezért a térképen semmilyen
+        // módon nem lehetett megnézni, melyik egyházmegye fölött járunk. A Nominatim
+        // csak a geometriát adja vissza, a nevek viszont a saját `boundaries` táblánkban
+        // ott vannak (az OSM-sync tölti) — egyetlen lekérdezéssel hozzájuk tesszük.
+        $names = \Eloquent\Boundary::whereIn('osmid', array_map(function ($e) { return $e->id; }, $overpass->jsonData->elements))
+            ->get(['osmtype', 'osmid', 'name'])
+            ->keyBy(function ($boundary) { return $boundary->osmtype . '/' . $boundary->osmid; })
+            ->map(function ($boundary) { return $boundary->name; })
+            ->toArray();
+
         // Az egyházmegyék geoJSON adatait lekérjük.
         // Ez sok kérésnek tűnik, de mivel komoly cache van ezért gyorsan fog menni.
         $dioceses = [];
-        
-        foreach ($overpass->jsonData->elements as $element) {            
+
+        foreach ($overpass->jsonData->elements as $element) {
                 $types = [
                     'node' => 'N',
                     'way' => 'W',
-                    'relation' => 'R'   
+                    'relation' => 'R'
                 ];
 
-                $nominatim = new \ExternalApi\NominatimApi();        
-                $diocese = $nominatim->OSM2GeoJson($types[$element->type], $element->id);                
+                $nominatim = new \ExternalApi\NominatimApi();
+                $diocese = $nominatim->OSM2GeoJson($types[$element->type], $element->id);
                 if ($diocese == false ) continue;
-                $diocese->id = $element->type."/" .$element->id;
+                $key = $element->type . "/" . $element->id;
+                $diocese->id = $key;
+                $diocese->name = $names[$key] ?? '';
                 $dioceses[] = $diocese;
-                
-        
+
+
         }
 
         return $dioceses;

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -196,18 +196,22 @@
 		maxZoom: 19,
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	});
-	var Stamen_Terrain = 		L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}{r}.{ext}', {
-		attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-		subdomains: 'abcd',
-		minZoom: 0,
-		maxZoom: 18,
-		ext: 'png'
-	});
+    /*
+     * #653: a Stamen Terrain réteg innen KIKERÜLT. A Stamen 2023-ban a Stadia Mapshez
+     * költözött, a régi végpont (stamen-tiles-*.a.ssl.fastly.net) mérve HTTP 503-at ad,
+     * tehát a réteg évek óta halott volt. Ráadásul soha nem is lehetett kiválasztani:
+     * definiálva volt, de sehol nem használtuk (a lenti control.layers baseLayers-e null).
+     *
+     * Visszahozni nem tudjuk csak úgy: az utód (tiles.stadiamaps.com/tiles/stamen_terrain)
+     * kulcs nélkül HTTP 401-et ad — regisztráció, API-kulcs és domain-engedélyezés kellene
+     * hozzá. Ha valaha kell egy terep-alapréteg, az külön döntés (és külön kulcs-kezelés).
+     */
+
     // #376: a direkt tile.openstreetmap.org az OSM Tile Usage Policy szerint
     // produkciós forgalomra tiltott → intermittensen „Access blocked" csempe
     // (van akinek megy, van akinek nem, Referer/IP/forgalom alapján). A CARTO
     // Voyager basemap (ingyenes, produkcióra való) a default — böngészőben mérve
-    // minden csempe 200-zal jön. Az OpenStreetMap_Mapnik/Stamen fentebb definiálva
+    // minden csempe 200-zal jön. Az OpenStreetMap_Mapnik fentebb definiálva
     // marad, de nincs a réteg-választóban (baseLayers=null a lenti control.layers-nél).
     CartoDB_Voyager.addTo(mymap);
     

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -7,7 +7,8 @@
    crossorigin=""></script>
     <script src="https://makinacorpus.github.io/Leaflet.TextPath/leaflet.textpath.js"></script>
     <script src="https://unpkg.com/leaflet-polylinedecorator@1.6.0/dist/leaflet.polylinedecorator.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet-polylinedecorator@1.6.0/dist/leaflet.polylinedecorator.css"/>
+    {# A leaflet-polylinedecorator CSS-e itt volt behivatkozva, de nem létezik: az unpkg
+       HTTP 404-et ad rá. Minden térképes oldalbetöltéskor feleslegesen kértük. (#653) #}
 
 <style>
     /* Map Popup Weekend Masses Styling */

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -237,6 +237,18 @@
                 ];
 
     {% if dioceseslayer %}
+    /*
+     * #641: az egyházmegye neve eddig sehogy nem látszott a térképen (a válaszban sem
+     * volt benne). Kattintás helyett lebegő címke: a templom-gombostűk nem lopják el,
+     * és rögtön látszik, melyik egyházmegye fölött járunk.
+     */
+    function dioceseTooltip(feature, layer) {
+        var name = (feature.geometry && feature.geometry.name) || feature.properties && feature.properties.name;
+        if (name) {
+            layer.bindTooltip(name, { sticky: true, direction: 'top', className: 'diocese-tooltip' });
+        }
+    }
+
     // Egyházmegyék rétegekhez tartozó ID-k nyilvántartása
     var addedGreekCatholicIds = new Set();
     var addedRomanCatholicIds = new Set();
@@ -260,7 +272,8 @@
                     fillOpacity: 0.3
                 };
             
-        }
+        },
+        onEachFeature: dioceseTooltip
     });
 
     var diocesesRomanCatholicLayer = L.geoJSON(null, {
@@ -281,7 +294,8 @@
                     fillOpacity: 0.3
                 };
             
-        }
+        },
+        onEachFeature: dioceseTooltip
     }).addTo(mymap);
     layerControls['Római katolikus egyházmegyék'] = diocesesRomanCatholicLayer;  
     layerControls['Görögkatolikus egyházmegyék'] = diocesesGreekcatholicLayer;  
@@ -392,6 +406,9 @@
     
     // Relációs vonalak nyilvántartása az összehasonlításhoz
     var currentRelationshipIds = new Set();
+
+    // #641: a már kirajzolt templomok, hogy mozgatáskor csak a különbséget rajzoljuk.
+    var renderedChurchIds = new Set();
     
     L.control.layers( null, layerControls ).addTo(mymap);
        
@@ -411,17 +428,37 @@
            if(activeRomanLayer) activeRomanLayer.clearLayers();
            if(activeGreekLayer) activeGreekLayer.clearLayers();
            if(inactiveLayer) inactiveLayer.clearLayers();
+           // #641: a nyilvántartást is ürítjük, különben visszazoomolva azt hinnénk,
+           // hogy a templomok még fent vannak, és üres maradna a térkép.
+           renderedChurchIds.clear();
 
-           
       } else {
       
-        $.getJSON( "/ajax/churchesinbbox?bbox=" + params , function( data ) {                              
+        $.getJSON( "/ajax/churchesinbbox?bbox=" + params , function( data ) {
             if(data) {
 
-                activeRomanLayer.clearLayers();
-                activeGreekLayer.clearLayers();
-                inactiveLayer.clearLayers();
-                                 
+                /*
+                 * #641: eddig minden mozdításkor LETÖRÖLTÜNK minden templomot, majd
+                 * újrarajzoltuk az egészet — ettől villódzott a térkép, pedig a látható
+                 * templomok többsége ugyanaz maradt. Most csak a különbséget rajzoljuk:
+                 * a kikerülteket levesszük, az újakat feltesszük, a maradókhoz nem nyúlunk.
+                 * (A kapcsolatok rétege már így működött, innen a minta.)
+                 */
+                var incomingIds = new Set();
+                $.each( data, function( key, val ) { incomingIds.add( val.id ); });
+
+                [ activeRomanLayer, activeGreekLayer, inactiveLayer ].forEach(function( group ) {
+                    var toRemove = [];
+                    group.eachLayer(function( layer ) {
+                        if ( !incomingIds.has( layer._churchId ) ) { toRemove.push( layer ); }
+                    });
+                    // Az eltávolítás külön menetben: iterálás közben ne módosítsuk a réteget.
+                    toRemove.forEach(function( layer ) {
+                        group.removeLayer( layer );
+                        renderedChurchIds.delete( layer._churchId );
+                    });
+                });
+
                 var items = [];
                 var isFullMapView = {% if not church_id %}true{% else %}false{% endif %};
                 
@@ -451,6 +488,9 @@
                 
                 $.each( data, function( key, val ) {
                     var current = {% if church_id %} {{ church_id }} {% else %} -1 {% endif %};
+                    // #641: ami már fent van a térképen, azzal nincs dolgunk — a popup
+                    // összeállítását se kezdjük el fölöslegesen.
+                    if ( renderedChurchIds.has( val.id ) ) { return; }
                     if( current != val.id) {
                         var popupContent = "<div class='map-popup-container'>";
                         popupContent += "<h3><a href='/templom/" + val.id.toString() + "'>"  + val.nev + "</a></h3>";
@@ -511,8 +551,9 @@
                         
                         popupContent += "</div>";
                         var geojsonFeature = {
-                            "type": "Feature",                                                      
+                            "type": "Feature",
                             "properties": {
+                                "id": val.id,
                                 "name": val.nev,
                                 "popupContent": popupContent,
                                 "active": val.active,
@@ -524,52 +565,68 @@
                                 "coordinates": [ val.lon , val.lat]
                             },
                         };
-                        
+
                         if( val.active == 1 ) {
-                            if( val.denomination == 'roman_catholic') {                            
+                            if( val.denomination == 'roman_catholic') {
                                 activeRomanLayer.addData(geojsonFeature);
                             } else if ( val.denomination == 'greek_catholic') {
                                 activeGreekLayer.addData(geojsonFeature);
-                            }                            
+                            }
                         } else {
                                 inactiveLayer.addData(geojsonFeature);
                         }
+                        renderedChurchIds.add( val.id );
                     }
                 });
             }
         });  
         }
          {% if dioceseslayer %}
-        // Egyházmegyéke lekérés a bbox alapján        
-        $.getJSON('/ajax/diocesesinbbox?bbox=' + params, function (data) {
+        /*
+         * #641: az egyházmegye-határokat MINDEN térképmozdításkor újra lekértük, pedig
+         * a réteg soha nem dob el semmit — a válasz nagy részét a kliens azonnal kiszűrte
+         * mint "már megvan". Mérve viszont a szerveroldal így is elvégezte a munkát:
+         * 2,3 s Budapestre, 17,9 s / 3,2 MB a Kárpát-medencére (a végpont Overpasst hív,
+         * majd egyházmegyénként Nominatimot — külső szolgáltatásokat, a térkép kritikus
+         * útján). Mostantól csak akkor kérünk, ha
+         *   - a réteg tényleg látszik, ÉS
+         *   - a nézet kilóg abból a területből, amit már egyszer lekértünk.
+         * A lekért területet megnöveljük, így a szokásos pásztázás már nem jár kéréssel.
+         */
+        var dioceseFetchedBounds = null;
 
-            // Új adatok hozzáadása a meglévő rétegekhez
-            if (data['greekcatholic']) {
-                const newGreekCatholicData = data['greekcatholic'].filter(feature => {
-                    const id = feature.id || feature.properties.id; // Azonosító lekérése
-                    if (!addedGreekCatholicIds.has(id)) {
-                        addedGreekCatholicIds.add(id); // Hozzáadás az ID-k listájához
-                        console.log('New Greekcatholic Diocese:', 'https://openstreetmap.org/' + id);
-                        return true; // Új adat
-                    }
-                    return false; // Már létező adat
-                });
-                diocesesGreekcatholicLayer.addData(newGreekCatholicData); // Csak az új adatok hozzáadása
-            }
+        function refreshDioceses(mapBounds) {
+            var visible = mymap.hasLayer(diocesesRomanCatholicLayer) || mymap.hasLayer(diocesesGreekcatholicLayer);
+            if (!visible) { return; }
+            if (dioceseFetchedBounds && dioceseFetchedBounds.contains(mapBounds)) { return; }
 
-            if (data['roman_catholic']){
-                const newRomanCatholicData = data['roman_catholic'].filter(feature => {
-                    const id = feature.id || feature.properties.id; // Azonosító lekérése
-                    if (!addedRomanCatholicIds.has(id)) {
-                        addedRomanCatholicIds.add(id); // Hozzáadás az ID-k listájához
-                        console.log('New Roman Catholic Diocese:', 'https://openstreetmap.org/' + id);
-                        return true; // Új adat
-                    }
-                    return false; // Már létező adat
-                });
-                diocesesRomanCatholicLayer.addData(newRomanCatholicData); // Csak az új adatok hozzáadása
-            }
-        });
+            // A tényleges nézetnél nagyobb területet kérünk, hogy a pásztázás ne kérjen újra.
+            var padded = mapBounds.pad(0.5);
+            var box = padded.getSouthWest().lat + ";" + padded.getSouthWest().lng + ";"
+                    + padded.getNorthEast().lat + ";" + padded.getNorthEast().lng;
+
+            $.getJSON('/ajax/diocesesinbbox?bbox=' + box, function (data) {
+                // Csak sikeres válasz után jegyezzük fel — különben hiba esetén
+                // azt hinnénk, hogy megvan az a terület.
+                dioceseFetchedBounds = padded;
+
+                addDioceses(data['greekcatholic'], addedGreekCatholicIds, diocesesGreekcatholicLayer);
+                addDioceses(data['roman_catholic'], addedRomanCatholicIds, diocesesRomanCatholicLayer);
+            });
+        }
+
+        function addDioceses(features, seenIds, layer) {
+            if (!features || !features.length) { return; }
+            var fresh = features.filter(function (feature) {
+                var id = feature.id || (feature.properties && feature.properties.id);
+                if (seenIds.has(id)) { return false; }
+                seenIds.add(id);
+                return true;
+            });
+            if (fresh.length) { layer.addData(fresh); }
+        }
+
+        refreshDioceses(box);
         {% endif %}
 
 
@@ -669,8 +726,11 @@
     mymap.on('moveend', onMapMoved);
 
     // Kapcsolatok réteg frissítése, amikor be/ki kapcsolják
+    // #641: az egyházmegye-rétegeket is csak akkor töltjük, ha tényleg bekapcsolják.
     mymap.on('overlayadd', function(e) {
-        if (e.name === 'Egyházi kapcsolatok') {
+        if (e.name === 'Egyházi kapcsolatok'
+            || e.name === 'Római katolikus egyházmegyék'
+            || e.name === 'Görögkatolikus egyházmegyék') {
             onMapMoved.call(mymap);
         }
     });
@@ -680,6 +740,11 @@
     setInitialView();
                 
     function onEachFeature(feature, layer) {
+        // #641: a templom azonosítója a rétegre kerül, hogy mozgatáskor pont a
+        // képernyőről kikerülteket tudjuk levenni (és csak azokat).
+        if (feature.properties && typeof feature.properties.id !== 'undefined') {
+            layer._churchId = feature.properties.id;
+        }
         // does this feature have a property named popupContent?
         if (feature.properties && feature.properties.popupContent) {
         layer.bindPopup(feature.properties.popupContent,{

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -99,9 +99,20 @@
 
 
 <script>
-    
-    var mymap = L.map('mapid');  
-        
+
+    /*
+     * #640: a térkép felállását nehéz volt nyomon követni, mert a hiba csak az ELSŐ
+     * betöltéskor jött elő, frissítésre eltűnt. A dobott hibákat ezért gyűjtjük, hogy
+     * a funkcionális teszt (MapInitializationTest) számon tudja kérni őket.
+     */
+    window.__mapErrors = [];
+    window.addEventListener('error', function (event) {
+        window.__mapErrors.push(String(event.message || event.error));
+    });
+
+    var mymap = L.map('mapid');
+    window.mymap = mymap;
+
     var logo = L.control({position: 'bottomright'});
     logo.onAdd = function(map){
         var div = L.DomUtil.create('div', 'myclass');
@@ -117,7 +128,7 @@
     // Determine initial position: check autogeolocation first
     var initialPosition = null;
     var initialZoom = 13;
-    
+
     {% if center %}
         initialPosition = [{{ center.lat }}, {{ center.lon}}];
         {% if center.zoom %} initialZoom = {{ center.zoom }}; {% endif %}
@@ -127,43 +138,53 @@
     {% else %}
         initialPosition = [47.5, 19.05]; // Budapest default
     {% endif %}
-    
+
     // Geolocation check - try to get user position before setView
     {% if enableAutoGeoLocation is not defined %}
         {% set enableAutoGeoLocation = false %}
     {% endif %}
-    
-    function initializeMapWithPosition(lat, lng) {
-        mymap.setView([lat, lng], initialZoom);
-        // Trigger the data loading
-        onMapMoved.call(mymap);
-    }
-    
-    if ({% if enableAutoGeoLocation %}true{% else %}false{% endif %} && navigator.geolocation && !{% if center %}true{% else %}false{% endif %} && !{% if location %}true{% else %}false{% endif %}) {
-        // Try to get geolocation, but don't wait too long
-        var geolocationTimer = setTimeout(function() {
-            // Fallback to initial position if geolocation takes too long
-            mymap.setView(initialPosition, initialZoom);
-            onMapMoved.call(mymap);
-        }, 3000);
-        
-        navigator.geolocation.getCurrentPosition(
-            function(position) {
-                clearTimeout(geolocationTimer);
-                initializeMapWithPosition(position.coords.latitude, position.coords.longitude);
-            },
-            function(error) {
-                // Fallback to initial position on error
-                clearTimeout(geolocationTimer);
+
+    /*
+     * #640: a nézet beállítása KÉSŐBB, a script legvégén történik — itt csak definiáljuk.
+     *
+     * A setView() szinkron elsüti a 'load' eseményt, arra pedig az onMapMoved() és a
+     * loadBoundary() van kötve (fentebb). Ha a nézetet még itt beállítjuk, ezek olyankor
+     * futnak le, amikor a rétegek (activeRomanLayer, ...) és az svgIcons még nem léteznek.
+     * Ezért kellett korábban a script végén egy külön onMapMoved() hívás — csakhogy az
+     * auto-geolokációs ágon fordítva sült el: a setView() egy aszinkron callbackben marad,
+     * így a végi hívás nézet NÉLKÜL futott, és a getBounds() eldobta a térképet
+     * ("Set map center and zoom first"). Frissítésre azért javult meg, mert akkor a
+     * gyorsítótárazott pozíció megnyerte a versenyt.
+     *
+     * A helyes sorrend: előbb minden réteg és ikon, utána kap nézetet a térkép.
+     * Az adatbetöltést így végig az események intézik ('load' + lentebb 'moveend'),
+     * nem kell külön onMapMoved()-ot hívogatni.
+     */
+    function setInitialView() {
+        if ({% if enableAutoGeoLocation %}true{% else %}false{% endif %} && navigator.geolocation && !{% if center %}true{% else %}false{% endif %} && !{% if location %}true{% else %}false{% endif %}) {
+            // Try to get geolocation, but don't wait too long
+            var geolocationTimer = setTimeout(function() {
+                // Fallback to initial position if geolocation takes too long
                 mymap.setView(initialPosition, initialZoom);
-                onMapMoved.call(mymap);
-            }
-        );
-    } else {
-        // No autogeolocation or already have center/location
-        mymap.setView(initialPosition, initialZoom);
+            }, 3000);
+
+            navigator.geolocation.getCurrentPosition(
+                function(position) {
+                    clearTimeout(geolocationTimer);
+                    mymap.setView([position.coords.latitude, position.coords.longitude], initialZoom);
+                },
+                function(error) {
+                    // Fallback to initial position on error
+                    clearTimeout(geolocationTimer);
+                    mymap.setView(initialPosition, initialZoom);
+                }
+            );
+        } else {
+            // No autogeolocation or already have center/location
+            mymap.setView(initialPosition, initialZoom);
+        }
     }
-                        
+
     //https://leaflet-extras.github.io/leaflet-providers/preview/
     var CartoDB_Voyager = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
@@ -645,17 +666,18 @@
         }
     }
     
-    // Trigger initial load after all layers are set up
-    onMapMoved.call(mymap);
-         
     mymap.on('moveend', onMapMoved);
-    
+
     // Kapcsolatok réteg frissítése, amikor be/ki kapcsolják
     mymap.on('overlayadd', function(e) {
         if (e.name === 'Egyházi kapcsolatok') {
             onMapMoved.call(mymap);
         }
     });
+
+    // #640: minden réteg és eseménykezelő megvan — MOST kaphat nézetet a térkép.
+    // Innentől a 'load' (első setView) és a 'moveend' (minden további) tölti az adatot.
+    setInitialView();
                 
     function onEachFeature(feature, layer) {
         // does this feature have a property named popupContent?
@@ -669,6 +691,13 @@
     
 
 
+ /*
+  * #640: FIGYELEM — ez `const`, tehát a deklarációja ELŐTT nem érhető el (TDZ), a
+  * layerIcon() viszont jóval fentebb használja. Ma ez rendben van, mert a layerIcon()
+  * kizárólag a $.getJSON válasz-callbackjeiből fut, azok pedig mindig e sor után.
+  * Ha valaki ide fentebb szinkron adatbetöltést tesz (pl. async:false vagy egy korai
+  * setView), visszajön a "Cannot access 'svgIcons' before initialization".
+  */
  const svgIcons = {
     rm: `<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="100%" viewBox="0 0 346 513" enable-background="new 0 0 346 513" xml:space="preserve">

--- a/webapp/tests/Functional/MapInitializationTest.php
+++ b/webapp/tests/Functional/MapInitializationTest.php
@@ -49,6 +49,45 @@ final class MapInitializationTest extends PantherTestCase {
     }
 
     /*
+     * #641: pásztázáskor eddig MINDEN templomot letöröltünk és újrarajzoltunk (villódzás).
+     * Most csak a különbséget rajzoljuk — ez a teszt azt őrzi, hogy a képen maradó
+     * gombostűk ugyanazok a DOM-elemek maradnak, tehát tényleg nem rajzolódnak újra.
+     */
+    public function testPanningKeepsTheMarkersThatStayInView(): void {
+        $client = $this->client();
+        $client->request('GET', '/terkep?map=13/47.4979/19.0402');
+
+        $client->wait(15)->until(static function ($driver) {
+            return $driver->executeScript(
+                'return document.querySelectorAll(".leaflet-marker-icon").length > 0;'
+            );
+        });
+
+        // Megjelöljük a jelenlegi gombostűket, hogy felismerjük, ha újak születnek.
+        $client->executeScript(
+            'document.querySelectorAll(".leaflet-marker-icon").forEach(function (m, i) { m.dataset.mapTestSeen = "1"; });'
+        );
+        $before = (int) $client->executeScript('return document.querySelectorAll(".leaflet-marker-icon").length;');
+        self::assertGreaterThan(0, $before, 'Nem jelent meg egyetlen templom sem a térképen.');
+
+        // Kis elmozdulás: a látható templomok túlnyomó része ugyanaz marad.
+        $client->executeScript('window.mymap.panBy([120, 0]); return true;');
+        $client->wait(15)->until(static function ($driver) {
+            return $driver->executeScript('return !window.mymap._panAnim || !window.mymap._panAnim._inProgress;');
+        });
+        usleep(1500000); // az AJAX-válasz beérkezése
+
+        $survivors = (int) $client->executeScript(
+            'return document.querySelectorAll(".leaflet-marker-icon[data-map-test-seen]").length;'
+        );
+        self::assertGreaterThan(
+            0,
+            $survivors,
+            'Pásztázás után egyetlen korábbi gombostű sem maradt meg — újrarajzolás történt.'
+        );
+    }
+
+    /*
      * A templom-adatlap kis térképe a nem-geolokációs ágat járja (kap `center`-t).
      * Itt a másik hiba (svgIcons a rétegek előtt) jött volna elő.
      */

--- a/webapp/tests/Functional/MapInitializationTest.php
+++ b/webapp/tests/Functional/MapInitializationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Symfony\Component\Panther\PantherTestCase;
+
+/**
+ * #640: a /terkep elsőre hibára futott, ctrl+R-re viszont megjavult.
+ *
+ * Két, egymást takaró sorrendi hiba volt:
+ *  - a script végén állt egy onMapMoved() hívás, ami az auto-geolokációs ágon még nézet
+ *    nélküli térképen futott -> "Set map center and zoom first",
+ *  - a 'load' esemény viszont a nem-geolokációs ágon túl KORÁN sült el, amikor a rétegek
+ *    és az svgIcons még nem léteztek -> "Cannot access 'svgIcons' before initialization".
+ * Frissítésre azért működött, mert a gyorsítótárazott pozíció megnyerte a versenyt.
+ *
+ * Ez a teszt azt őrzi, hogy a térkép ELSŐ betöltésre is hibátlanul álljon fel.
+ */
+final class MapInitializationTest extends PantherTestCase {
+
+    private function client() {
+        return static::createPantherClient(
+            ['external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000'],
+            [],
+            ['browser' => static::CHROME]
+        );
+    }
+
+    /*
+     * A /terkep az egyetlen hely, ahol az auto-geolokáció be van kapcsolva — épp ez az
+     * ág szállt el. A böngésző a tesztben nem ad pozíciót, tehát a fallback fut le.
+     */
+    public function testMapPageLoadsWithoutJavascriptErrorsOnFirstVisit(): void {
+        $client = $this->client();
+        $client->request('GET', '/terkep');
+
+        // A nézet a geolokációs fallback után áll be (3 mp-es időzítő), várjuk meg.
+        $client->wait(10)->until(static function ($driver) {
+            return $driver->executeScript('return !!(window.mymap && window.mymap._loaded);');
+        });
+
+        $errors = $client->executeScript(
+            <<<'JS'
+            return (window.__mapErrors || []).slice(0, 10);
+            JS
+        );
+        self::assertSame([], $errors, "JS-hiba a térkép betöltésekor: " . json_encode($errors));
+
+        $hasCenter = $client->executeScript('return !!window.mymap.getCenter();');
+        self::assertTrue($hasCenter, 'A térkép nézet nélkül maradt.');
+    }
+
+    /*
+     * A templom-adatlap kis térképe a nem-geolokációs ágat járja (kap `center`-t).
+     * Itt a másik hiba (svgIcons a rétegek előtt) jött volna elő.
+     */
+    public function testChurchPageMapLoadsWithoutJavascriptErrors(): void {
+        $client = $this->client();
+        $client->request('GET', '/templom/1');
+
+        $client->wait(10)->until(static function ($driver) {
+            return $driver->executeScript('return !!(window.mymap && window.mymap._loaded);');
+        });
+
+        $errors = $client->executeScript('return (window.__mapErrors || []).slice(0, 10);');
+        self::assertSame([], $errors, "JS-hiba a templom-térkép betöltésekor: " . json_encode($errors));
+    }
+}


### PR DESCRIPTION
A #653 két legkisebb, azonnal elvégezhető darabja. A nagyobbak (külön JS-fájl, lusta indítás, saját Leaflet) maradnak ott.

> ⚠️ A #648 (#641) tetejére épül — ugyanaz a `_map_leaflet.twig`. Sorrend: #645 → #648 → ez.

## 1. A 404-es kérés

```
$ curl -sIL https://unpkg.com/leaflet-polylinedecorator@1.6.0/dist/leaflet.polylinedecorator.css
HTTP 404
```

Ez a fájl **nem létezik** — a `leaflet-polylinedecorator` csomag nem szállít CSS-t. Minden térképes oldalbetöltéskor feleslegesen indítottuk, és hibára futott. Egy sor törlése; ellenőriztem, hogy a `/terkep` és a `/templom/1` továbbra is 200, és a többi négy térkép-erőforrás változatlanul ott van.

## 2. A dokumentáció

A `docs/outgoing-connections.md` eddig csak a **szerver** kimenő kapcsolatait sorolta. A böngészőből betöltött külső erőforrások viszont kimaradtak — pedig a lista célja épp az, hogy „egyenként engedélyezős környezetben ezek hiányában a telepítés ripityára esik". Ezek hiányában a térkép egyszerűen nem jelenik meg.

Külön szakaszba tettem őket, azzal a figyelmeztetéssel, hogy **szerver-oldali egress-allowlist nem fedi le őket** (a látogató gépéről mennek ki, nem a szerverről):

| Cél | Host |
|---|---|
| Leaflet (JS+CSS) | `unpkg.com` |
| Leaflet.PolylineDecorator | `unpkg.com` |
| Leaflet.TextPath | `makinacorpus.github.io` |
| CARTO Voyager csempék | `{a,b,c,d}.basemaps.cartocdn.com` |
| html5shiv, respond.js | `oss.maxcdn.com` |
| OpenLayers | `openlayers.org` |

## Amit közben találtam, és odaírtam a dokumentumba

- **Három különböző Leaflet-verziót töltünk be** három sablonból: 1.7.1 (`_map_leaflet.twig`), 1.9.3 (`stat.twig`), 1.9.4 (`church/create.twig`). Ezt egyszer érdemes egységesíteni.
- A `makinacorpus.github.io` egy **GitHub Pages, nem CDN** — nincs rendelkezésre állási ígéret rá, mégis minden térképes oldalunk függ tőle.
- A **Stamen csempeszerver halott**: a `_map_leaflet.twig`-ben lévő `stamen-tiles-*.a.ssl.fastly.net` mérve **HTTP 503**-at ad. A Stamen 2023-ban a Stadiához költözött. Ezt a réteget nem bántottam (nem tudom, választható-e még a felületen), de dokumentáltam — ha valóban használható rétegként szerepel, külön javítást érdemel.

Ha a #653 nagyobbik fele (saját kiszolgálás) megvalósul, ez a dokumentum-szakasz a csempeszerverre zsugorodik.