### PR TITLE
#652 Kiírom a commit hasht a láblécben

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -90,6 +90,11 @@ jobs:
             fi
             echo "✅ git pull succeeded"
 
+            # #652: a lábléc verzió-jelzéséhez kell. Eddig egy git post-checkout hookra
+            # bíztuk, de a hookok nem verziókövetettek, és a `git pull` amúgy sem indít
+            # post-checkoutot — ezért a fájl élesben soha nem jött létre, a lábléc üres volt.
+            bash scripts/write-git-hash.sh || echo "⚠ A git_hash kiírása nem sikerült — a lábléc verzió nélkül marad."
+
             # ── 3) Docker image újraépítése ──────────────────────────────────
             echo "▶ Building Docker image..."
             docker build \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,6 +51,11 @@ jobs:
             git fetch --prune origin master
             git reset --hard origin/master
 
+            # #652: a lábléc verzió-jelzéséhez kell. Eddig egy git post-checkout hookra
+            # bíztuk, de a hookok nem verziókövetettek, és a `git pull` amúgy sem indít
+            # post-checkoutot — ezért a fájl élesben soha nem jött létre, a lábléc üres volt.
+            bash scripts/write-git-hash.sh || echo "⚠ A git_hash kiírása nem sikerült — a lábléc verzió nélkül marad."
+
             # A staging env-értékek (projekt-név, image-tag, portok) betöltése.
             set -a
             . .env.staging

--- a/scripts/write-git-hash.sh
+++ b/scripts/write-git-hash.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# #652: kiírja az aktuális commit rövid hashét a webapp/fajlok/git_hash fájlba.
+#
+# Ebből olvassa a \Html\Html::getGitHash(), és ez jelenik meg a lábléc­ben
+# („verzió: abc1234"), hogy egy hibajelentésnél látszódjon, benne van-e már a javítás.
+#
+# Eddig ezt egy git post-checkout hookra bíztuk. A hookok viszont NEM verziókövetettek,
+# és a szerveren a deploy `git pull`-t használ, ami post-checkoutot nem is indít — ezért
+# a fájl élesben soha nem jött létre, és a lábléc üresen maradt.
+#
+# A deploy-workflowk ezt a szkriptet hívják; fejlesztéskor kézzel futtatható:
+#   bash scripts/write-git-hash.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$REPO_ROOT/webapp/fajlok/git_hash"
+
+if ! git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "write-git-hash: nem git-munkakönyvtár ($REPO_ROOT) — kihagyva." >&2
+  exit 0
+fi
+
+# A getGitHash() 7-8 alfanumerikus karaktert vár, ezért fixen 8-at kérünk:
+# a `--short` alapértéke a repó méretétől függően nőhet.
+HASH="$(git -C "$REPO_ROOT" rev-parse --short=8 HEAD)"
+
+mkdir -p "$(dirname "$TARGET")"
+printf '%s' "$HASH" > "$TARGET"
+echo "write-git-hash: $HASH -> $TARGET"

--- a/webapp/classes/html/html.php
+++ b/webapp/classes/html/html.php
@@ -194,7 +194,9 @@ class Html {
     function getGitHash() {
         //GIT version        ;
         // exec('git rev-parse --verify --short HEAD 2> /dev/null', $v);
-        $gitHashFile = 'fajlok/git_hash';        
+        // #652: abszolút út — relatívként csak akkor talált célba, ha a futó folyamat
+        // munkakönyvtára épp a webapp volt (a webkiszolgálónál igen, CLI-ból nem).
+        $gitHashFile = PATH . 'fajlok/git_hash';
         // Ellenőrizni, hogy a fájl létezik-e
         if (!file_exists($gitHashFile)) {
             return false;


### PR DESCRIPTION
Fixes #652

> „Régen látszott alul a commit hash… Jó lenne, ha a honlapon alul most is látszódna."

Jó hír: **a fele már megvolt**. A `footer.twig` ma is kiírja a verziót (`{% if githash %}`), a `\Html\Html::getGitHash()` is megvan, és a `/health` oldal is használja. Egyetlen dolog hiányzott: a `webapp/fajlok/git_hash` fájl, amiből olvas.

## Miért nem jött létre soha

A kódban ez a megjegyzés áll a függvény mellett: `// See: (.)git/hooks/post-checkout`. Vagyis egy **git hookra** volt bízva. Csakhogy:

- a git hookok **nem verziókövetettek** — aki klónozza a repót, nem kapja meg;
- a production deploy `git pull`-t használ, a staging `git reset --hard`-ot, és a **`git pull` nem indít `post-checkout`-ot** (legfeljebb `post-merge`-öt);
- a fájl ráadásul `.gitignore`-ban van, tehát a repóból sem érkezhet.

Így élesben a `getGitHash()` mindig `false`-szal tért vissza, a `{% if githash %}` sosem teljesült, és a lábléc üresen maradt.

## Javítás

`scripts/write-git-hash.sh` — kiírja a rövid hasht, és **a deploy hívja meg** (staging és production is, közvetlenül a git-frissítés után). Fejlesztéskor kézzel futtatható.

Fixen **8 karaktert** kérünk (`--short=8`), mert a `--short` alapértéke a repó méretével nőhet, a `getGitHash()` validációja pedig 7-8-at fogad el — 9-nél némán elbukna.

Egy mellékes javítás: a `getGitHash()` **relatív úton** kereste a fájlt (`fajlok/git_hash`), ami csak akkor talál célba, ha a folyamat munkakönyvtára épp a webapp. A webkiszolgálónál igen, CLI-ból (cron!) nem. Most abszolút út, a `PATH` konstanssal.

## Ellenőrzés

Helyben lefuttattam a szkriptet, és a lábléc kiírta:

```html
- <small>verzió: <a href="https://github.com/borazslo/miserend.hu/commit/b05d908e">b05d908</a></small>
```

Mind a desktop, mind a mobil láblécben megjelenik (a `footer.twig` mindkettőt tartalmazza). A `webapp` a compose-ban bind-mountolt (`../webapp:/miserend/webapp`), tehát a szerveren kiírt fájlt a konténer azonnal látja — nem kell hozzá image-újraépítés.