### PR TITLE
#593 Felveszem a keresztutat szertartástípusnak

### DIFF
--- a/calendar/public/i18n/hu.json
+++ b/calendar/public/i18n/hu.json
@@ -111,6 +111,7 @@
     "CONFESSION": "Gyóntatás",
     "BREVIARY": "Zsolozsma",
     "LITANY": "Litánia",
+    "STATIONS_OF_THE_CROSS": "Keresztút",
     "ROSARY": "Rózsafüzér",
     "DIVINE_LITURGY": "Szent Liturgia",
     "LITURGY_OF_THE_PRESANCTIFIED_GIFTS": "Előszenteltek liturgiája",

--- a/calendar/src/app/data/mass-definitions.ts
+++ b/calendar/src/app/data/mass-definitions.ts
@@ -200,6 +200,17 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
     },
 
     {
+      // #593: keresztút. A bejelentésben a kenyérmegáldás is szerepelt, azt borazslo
+      // elvetette ("Jó lenne minél lejjebb tartani a szertartástípusok számát"), a
+      // keresztutat viszont jóváhagyta.
+      key: 'STATIONS_OF_THE_CROSS',
+      category: MassTitleCategory.OTHER,
+      rites: [Rite.ROMAN_CATHOLIC],
+      description: 'Stations of the Cross (Way of the Cross) devotion',
+      specialUsage: null
+    },
+
+    {
       key: 'MATINS',
       category: MassTitleCategory.OTHER,
       rites: [Rite.GREEK_CATHOLIC],

--- a/webapp/i18n/hu.json
+++ b/webapp/i18n/hu.json
@@ -111,6 +111,7 @@
     "CONFESSION": "Gyóntatás",
     "BREVIARY": "Zsolozsma",
     "LITANY": "Litánia",
+    "STATIONS_OF_THE_CROSS": "Keresztút",
     "ROSARY": "Rózsafüzér",
     "DIVINE_LITURGY": "Szent Liturgia",
     "LITURGY_OF_THE_PRESANCTIFIED_GIFTS": "Előszenteltek liturgiája",

--- a/webapp/mass-definitions.json
+++ b/webapp/mass-definitions.json
@@ -172,6 +172,15 @@
       "specialUsage": null
     },
     {
+      "key": "STATIONS_OF_THE_CROSS",
+      "category": "OTHER",
+      "rites": [
+        "ROMAN_CATHOLIC"
+      ],
+      "description": "Stations of the Cross (Way of the Cross) devotion",
+      "specialUsage": null
+    },
+    {
       "key": "MATINS",
       "category": "OTHER",
       "rites": [
@@ -211,6 +220,7 @@
       "MASS_TITLE.BREVIARY",
       "MASS_TITLE.ROSARY",
       "MASS_TITLE.LITANY",
+      "MASS_TITLE.STATIONS_OF_THE_CROSS",
       "MASS_TITLE.MATINS",
       "MASS_TITLE.VESPRES"
     ]
@@ -226,7 +236,8 @@
       "MASS_TITLE.CONFESSION",
       "MASS_TITLE.BREVIARY",
       "MASS_TITLE.ROSARY",
-      "MASS_TITLE.LITANY"
+      "MASS_TITLE.LITANY",
+      "MASS_TITLE.STATIONS_OF_THE_CROSS"
     ],
     "GREEK_CATHOLIC": [
       "MASS_TITLE.DIVINE_LITURGY",


### PR DESCRIPTION
Fixes #593 (részben — lásd lent)

Csak a **keresztutat** vettem fel, mert abban egyetértettetek:

> [borazslo]: „A keresztút az oké. A kenyérmegáldás biztos nem. […] Jó lenne minél lejjebb tartani a szertartástípusok számát mert burjánoznak elfele."

A kenyérmegáldáshoz és az „egyéb" típushoz nem nyúltam — az még nyitott kérdés köztetek (vlacko0930 augusztus 20-i ökumenikus alkalmat említett, te pedig azt, hogy mise után elég a megjegyzés mező). Ha megegyeztek, az külön PR.

## Amit csináltam

`STATIONS_OF_THE_CROSS` az `OTHER` kategóriába, római katolikus rítussal — a rózsafüzér és a litánia mellé, mert azok is ugyanilyen ájtatosságok.

A `calendar/src/app/data/mass-definitions.ts` az egyetlen forrás; a `webapp/mass-definitions.json` ebből **generálódik** a build során (16 definíció lett a 15 helyett). A fordítás mindkét i18n-fájlba bekerült (`webapp/i18n/hu.json` és `calendar/public/i18n/hu.json`), mert a PHP és az Angular külön olvassa őket.

## Ellenőrzés

- `npm run build` → a generált JSON-ben ott az új definíció, `OTHER` kategóriával.
- PHP-oldali fordítás a konténerben: `t("MASS_TITLE.STATIONS_OF_THE_CROSS")` → **„Keresztút"**.
- `MassDefinitionsTest` (PHP): 4/4 zöld.
- Angular tesztek: 176 SUCCESS.

Egy megjegyzés: a keresztút jellemzően nagyböjti, tehát a legtöbb templomnál időszakhoz kötve fog megjelenni — ez a #594-ben felvetett „hónap kontra egész év" kérdéssel érintkezik, de azt nem érinti.