### PR TITLE
#646 Kijavítom a cal_masses hivatkozási hibáit

### DIFF
--- a/docker/mysql/initdb.d/06-data-integrity.sql
+++ b/docker/mysql/initdb.d/06-data-integrity.sql
@@ -1,0 +1,42 @@
+/*
+ * #646: a seed-adat integritás-javításai.
+ *
+ * FONTOS a sorrend: ez a fájl a `05-data.sh` UTÁN fut (a docker-entrypoint névsorrendben
+ * dolgozza fel az initdb.d tartalmát), tehát a már betöltött seed-adaton javít. A
+ * `03-migrations.sql` erre nem alkalmas, mert az még a betöltés ELŐTT fut.
+ *
+ * A seed a dump fejlécében FOREIGN_KEY_CHECKS=0-val töltődik be, ezért az alábbi két
+ * hiba be tudott csúszni annak ellenére, hogy a `fk_cal_masses_period_id` idegen kulcs
+ * létezik.
+ */
+
+USE miserend;
+
+/*
+ * 1) period_id = 0  ->  NULL
+ *
+ * A 0 nem "törölt időszak", hanem eleve érvénytelen érték: a `cal_periods` id-tartománya
+ * 1-től indul. Szemantikailag azt akarja jelenteni, hogy "nincs időszak", amire a NULL való.
+ *
+ * Miért veszélyes a 0: a kódban jellemzően `isset()` dönti el, van-e időszak — a 0-ra pedig
+ * az IGAZ. Így a kód elindul lekérni a nem létező időszakot:
+ *     CalPeriod::find(0) -> null -> "Call to a member function toArray() on null"
+ * Ez döntötte le a misekeresés teljes találati oldalát (HTTP 500) a #636-ban.
+ *
+ * A seedben 70 ilyen sor van, 38 VALÓDI templomhoz — ezeket javítani kell, nem törölni.
+ */
+UPDATE `cal_masses` SET `period_id` = NULL WHERE `period_id` = 0;
+
+/*
+ * 2) Nem létező templomra hivatkozó misék törlése
+ *
+ * A seedben 17 ilyen sor van, a 5422-5435 church_id tartományban. Ezek teszt-maradékok:
+ * a `templomok` tábla legnagyobb valódi id-ja 5419, az integrációs tesztek pedig 5420-tól
+ * kaptak auto-increment id-t (lásd a ChurchRelationshipTest megjegyzését). A templomok
+ * eltűntek, a miséik viszont belekerültek a dumpba.
+ *
+ * A `Church::find()` ezekre null-t ad (a `templomok` soft-delete-es, tehát még egy
+ * soft-deleted templom is null-t adna), amitől szintén elszállt a találati lista.
+ */
+DELETE FROM `cal_masses`
+ WHERE `church_id` NOT IN (SELECT `id` FROM `templomok`);

--- a/webapp/tests/Integration/CalMassIntegrityTest.php
+++ b/webapp/tests/Integration/CalMassIntegrityTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #646: a `cal_masses` hivatkozási épsége.
+ *
+ * Ez nem kódot tesztel, hanem az ADATOT — pontosan azt a két hibát, ami a #636-ban
+ * HTTP 500-zal levitte a misekeresés találati oldalát:
+ *
+ *   - `period_id = 0`: nem NULL, hanem nulla szentinel. Az `isset()` igaznak látja,
+ *     ezért a kód elindul lekérni a nem létező időszakot -> `toArray() on null`.
+ *   - nem létező templomra hivatkozó mise: a `Church::find()` null-t ad rá.
+ *
+ * A seedet a `06-data-integrity.sql` javítja betöltés után; ez a teszt őrzi, hogy egy
+ * új dump ne hozza vissza csendben ugyanezt.
+ */
+final class CalMassIntegrityTest extends TestCase
+{
+    public function testNoMassUsesZeroAsPeriodId(): void
+    {
+        $count = DB::table('cal_masses')->where('period_id', 0)->count();
+
+        self::assertSame(
+            0,
+            $count,
+            "$count mise hivatkozik period_id=0-ra. A 'nincs időszak' jelölése NULL, "
+            . "a 0-t viszont az isset() igaznak látja, és a kód nem létező időszakot keres."
+        );
+    }
+
+    public function testEveryMassPointsToAnExistingChurch(): void
+    {
+        $orphans = DB::table('cal_masses as m')
+            ->leftJoin('templomok as t', 't.id', '=', 'm.church_id')
+            ->whereNull('t.id')
+            ->count();
+
+        self::assertSame(
+            0,
+            $orphans,
+            "$orphans mise hivatkozik nem létező templomra. A Church::find() ezekre null-t "
+            . "ad, amitől a találati lista összeállítása elszáll."
+        );
+    }
+
+    public function testEveryMassPeriodExists(): void
+    {
+        $dangling = DB::table('cal_masses as m')
+            ->leftJoin('cal_periods as p', 'p.id', '=', 'm.period_id')
+            ->whereNotNull('m.period_id')
+            ->whereNull('p.id')
+            ->count();
+
+        self::assertSame(0, $dangling, "$dangling mise hivatkozik nem létező időszakra.");
+    }
+}


### PR DESCRIPTION
Fixes #646

Ez a #636-ban talált 500-as hiba **adat-oldali** gyökere. A kód már elviseli (a #636 óta kihagyja az elavult sorokat), de az adat javítatlan volt.

## Mi a két hiba, és miért nem ugyanaz a kezelésük

**1. `period_id = 0` — 70 sor, JAVÍTANI kell**

A 0 nem „törölt időszak", hanem eleve érvénytelen: a `cal_periods` id-tartománya 1-től indul. Szemantikailag azt jelenti, hogy „nincs időszak" — arra a NULL való.

Azért veszélyes, mert a kódban `isset()` dönti el, van-e időszak, és **a 0-ra az igaz**:

```php
if (isset($result->mass["periodId"])) {
    $result->period = \Eloquent\CalPeriod::find(0)->toArray();  // -> null->toArray()
}
```

Ezek a misék **68 VALÓDI templomhoz tartoznak**, tehát nem szemét — javítani kell őket, nem törölni. `UPDATE ... SET period_id = NULL`.

**2. 17 nem létező templomra hivatkozó mise — TÖRÖLNI kell**

Ezek teszt-maradékok, és ezt sikerült bizonyítani:

| | |
|---|---|
| `templomok` legnagyobb valódi id | **5419** |
| az árva misék church_id-jai | **5422–5435** |
| létezik-e bármelyik (soft-deletedként sem) | **nem** |
| `templomok` auto_increment jelenleg | 6678 |

Vagyis integrációs tesztek által létrehozott templomokhoz tartoztak (a `ChurchRelationshipTest` megjegyzése is erről ír: „a teszt-templomok auto-increment id-t kapnak (friss init: 5420-tól)"), a templomok eltűntek, a miséik viszont belekerültek a dumpba.

## Hova került a javítás

`docker/mysql/initdb.d/06-data-integrity.sql` — **a `05-data.sh` UTÁN fut**, tehát a már betöltött seed-adaton javít. A `03-migrations.sql` erre nem alkalmas: az még a betöltés előtt fut, akkor még nincs mit javítani.

Mellékesen ez magyarázza, hogyan csúszhatott be egyáltalán: a seed a dump fejlécében `FOREIGN_KEY_CHECKS=0`-val töltődik be, ezért a meglévő `fk_cal_masses_period_id` idegen kulcs nem szólt.

## Ellenőrzés

Írtam egy `CalMassIntegrityTest`-et, ami **a javítás előtt bukott**:

```
70 mise hivatkozik period_id=0-ra.
17 mise hivatkozik nem létező templomra.
70 mise hivatkozik nem létező időszakra.
```

Lefuttattam az SQL-t a fejlesztői adatbázison, utána **3/3 zöld**, és a számok kiadják egymást: 11 590 − 17 = 11 573 mise maradt, a NULL period_id 57-ről 123-ra nőtt (57 eredeti + 70 javított − 4, ami az árva sorokkal együtt törlődött).

A teljes PHP-suite változatlan (a 12 ismert `AutocompleteCombinedTest` bukás lokális környezeti gond, CI-ban zöld).

## ÉLES ADATBÁZIS — kézi lépés

Nincs migrációs rendszerünk, ezért éles adatbázison **kézzel kell lefuttatni** ugyanezt a két utasítást (a `manual_experiod` precedens szerint):

```sql
UPDATE cal_masses SET period_id = NULL WHERE period_id = 0;
DELETE FROM cal_masses WHERE church_id NOT IN (SELECT id FROM templomok);
```

Előtte érdemes megnézni, mennyi érintett sor van élesben — nem biztos, hogy ugyanannyi, mint a seedben:

```sql
SELECT COUNT(*) FROM cal_masses WHERE period_id = 0;
SELECT COUNT(*) FROM cal_masses m LEFT JOIN templomok t ON t.id = m.church_id WHERE t.id IS NULL;
```

Ha az árva sorok élesben NEM a 5420 feletti tartományban vannak, akkor ott nem teszt-maradékról van szó, és a törlés előtt érdemes ránézni — szólj, és megnézzük együtt.