### PR TITLE
#570 Láthatóvá teszem, hány templom kereshető területre

### DIFF
--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -196,10 +196,29 @@ class Health extends Html {
 			)
 			->first();
 		
+		/*
+		 * #570: „ellenőrizve" != „van boundaryja". A checkBoundariesForOne() akkor is
+		 * megjelöli a templomot ellenőrzöttként, ha az Overpass hibázott vagy nem adott
+		 * eredményt — a templom mégis boundary NÉLKÜL marad. A területi (települési,
+		 * egyházmegyei) keresés viszont KIZÁRÓLAG a lookup_boundary_church alapján szűr,
+		 * ezért pontosan ez a szám mondja meg, hány templom TALÁLHATÓ MEG így egyáltalán.
+		 *
+		 * Enélkül a fenti „soha nem ellenőrzött" sor félrevezető: lehet 0, miközben a
+		 * templomok fele mégsem kereshető területre.
+		 */
+		$churchesWithBoundary = DB::table('lookup_boundary_church')
+			->join('templomok', 'templomok.id', '=', 'lookup_boundary_church.church_id')
+			->where('templomok.ok', 'i')
+			->whereNull('templomok.deleted_at')
+			->distinct()
+			->count('lookup_boundary_church.church_id');
+
 		$this->boundariesStats = [
 			'with_osm' => [
 				'count' => $churchBoundaryStats->count ?? 0,
 				'never_checked_count' => $churchBoundaryStats->never_checked_count ?? 0,
+				'with_boundary_count' => $churchesWithBoundary,
+				'without_boundary_count' => max(0, ($churchBoundaryStats->count ?? 0) - $churchesWithBoundary),
 				'avg_days_old' => $churchBoundaryStats->avg_days_old ? round($churchBoundaryStats->avg_days_old, 2) : 0,
 				'newest' => $churchBoundaryStats->newest ?? null,
 				'oldest' => $churchBoundaryStats->oldest ?? null

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -190,6 +190,29 @@
 			<td>{{ boundariesStats.with_osm.avg_days_old }} nap</td>
 		</tr>
 		<tr>
+			{# #570: ez a döntő szám — a területi keresés CSAK azokat találja meg,
+			   amiknek van boundary-kapcsolatuk. Az „ellenőrizve" nem elég: az Overpass
+			   hibája vagy üres válasza után is ellenőrzöttnek számít a templom. #}
+			<td><strong>Területre kereshető (van boundary-kapcsolata)</strong></td>
+			<td>
+				{% set covered = boundariesStats.with_osm.with_boundary_count %}
+				{% set total = boundariesStats.with_osm.count %}
+				{% set ratio = total > 0 ? (100 * covered / total)|round : 0 %}
+				{% if ratio >= 95 %}
+					<span class="badge bg-success">{{ covered }}</span>
+				{% elseif ratio >= 60 %}
+					<span class="badge bg-warning">{{ covered }}</span>
+				{% else %}
+					<span class="badge bg-danger">{{ covered }}</span>
+				{% endif %}
+				/ {{ total }} ({{ ratio }}%)
+				{% if boundariesStats.with_osm.without_boundary_count > 0 %}
+					<br/><small class="text-muted">{{ boundariesStats.with_osm.without_boundary_count }} misézőhely NEM jön ki
+					település/egyházmegye szerinti keresésre.</small>
+				{% endif %}
+			</td>
+		</tr>
+		<tr>
 			<td><strong>Misézőhelyek amiknek nem kerestük még soha</strong> </td>
 			<td>
 				{% if boundariesStats.with_osm.never_checked_count == 0 %}


### PR DESCRIPTION
Kapcsolódik: #570

Nem a végleges javítás, hanem az, ami nélkül nem lehet dönteni: **láthatóvá teszem a hiányzó számot.**

## A mechanizmus

A területi (települési, egyházmegyei) keresés **kizárólag** a `lookup_boundary_church` alapján szűr — egy templom csak akkor jön ki „Pécs"-re, ha a `checkBoundaries` cron már hozzárendelte a Pécs-boundaryt. Ez tehát nem keresési, hanem **adatlefedettségi** kérdés, ahogy te is tippelted az issue-ban.

## Miért volt vak a /health

A `/health` eddig azt mutatta, hány templomot „nem kerestünk még soha". Ez **félrevezető**, mert az „ellenőrizve" nem jelenti azt, hogy „van boundaryja":

```php
// checkBoundariesForOne()
$boundaries = $this->downloadBoundaries($church->lat, $church->lon);

// Mindig jelöljük, hogy megpróbáltuk – akár sikeres volt, akár nem (pl. Overpass 503).
\Eloquent\Church::where(id, $church->id)->update([boundaries_checked_at => date(...)]);

if ($boundaries === null || count($boundaries) < 1) return;   // <-- boundary NÉLKÜL marad
```

Vagyis egy Overpass-hiba után a templom **ellenőrzöttnek** számít, de továbbra sem található meg területre. A „soha nem ellenőrzött" szám így akár 0 is lehet, miközben a templomok fele kimarad a keresésből.

## Amit most mutat

Új sor a `/health`-en, színkóddal:

> **Területre kereshető (van boundary-kapcsolata):** `3 / 5035 (0%)`
> *5032 misézőhely NEM jön ki település/egyházmegye szerinti keresésre.*

(Ez a fejlesztői adatbázis; élesben nyilván más. **Épp ez a lényeg: eddig nem lehetett tudni, mennyi.**)

## Amit a számok mellé érdemes tudni

A cron 5 percenként **50** templomot dolgoz fel, és templomonként egy Overpass-hívást igényel. 5050 templomnál ez **~8,4 óra** egy teljes kör. Mivel a hibázó templom is „most ellenőrizve" bélyeget kap, egy átmeneti Overpass-hiba **8+ órára** kiejti a templomot a területi keresésből — és ha az Overpass tartósan akadozik (amit az issue-ban említettél), akár többször egymás után.

## Két lehetséges valódi javítás — ez döntés, ezért nem csináltam meg vakon

1. **Adatoldal:** a hibázó templom ne kerüljön a sor végére. Pl. sikertelenségnél rövidebb visszalépés, hogy ~1 órán belül újra sorra kerüljön, ne 8+ óra múlva. Kockázat: Overpass-kimaradáskor ez többszörös terhelést jelentene egy amúgy is fuldokló szolgáltatásnak.
2. **Keresésoldal:** a boundary-szűrő mellé egy név-alapú tartalék (a boundary neve = `varos`), hogy a még be nem mappelt templomok is kijöjjenek. Kockázat: túl-találat (pl. „Pécs" kontra „Pécsvárad"), tehát pontos egyezéssel kellene.

Nekem a **2. tűnik jobbnak** felhasználói szempontból (azonnal javul a találati lista, nem függ az Overpass hangulatától), de ez a keresés jelentésén változtat, ezért a te döntésed. Szólj, melyiket csináljam — vagy mindkettőt.

Élesben egyébként az első dolog, amit érdemes megnézni: mit ír most a `/health` ezen az új soron. Ha ott 95% fölött van, akkor a Pécs-eset másban gyökerezik, és tovább kell nyomozni.