### PR TITLE
#666 + #671 Adottság-szűrő a templomkeresőben, és őszinte üzenet a hiányzó adatról

### DIFF
--- a/docker/mysql/initdb.d/03-migrations.sql
+++ b/docker/mysql/initdb.d/03-migrations.sql
@@ -40,10 +40,3 @@ CREATE TABLE IF NOT EXISTS `church_relationships` (
   CONSTRAINT `fk_cr_child`  FOREIGN KEY (`child_church_id`)
     REFERENCES `templomok` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci;
-
--- #671: az adottság-lefedettség számlálója (Church::facilityCoverage()) minden olyan
--- keresésnél lefut, ahol be van kapcsolva az akadálymentesség/gluténmentes szűrő, és
--- `key` szerint szűr. Az attributes táblán eddig csak a church_id-n volt index, tehát
--- ez teljes táblaolvasás lett volna minden ilyen keresésnél.
-ALTER TABLE `attributes`
-    ADD INDEX IF NOT EXISTS `key_church` (`key`, `church_id`);

--- a/docker/mysql/initdb.d/03-migrations.sql
+++ b/docker/mysql/initdb.d/03-migrations.sql
@@ -40,3 +40,10 @@ CREATE TABLE IF NOT EXISTS `church_relationships` (
   CONSTRAINT `fk_cr_child`  FOREIGN KEY (`child_church_id`)
     REFERENCES `templomok` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci;
+
+-- #671: az adottság-lefedettség számlálója (Church::facilityCoverage()) minden olyan
+-- keresésnél lefut, ahol be van kapcsolva az akadálymentesség/gluténmentes szűrő, és
+-- `key` szerint szűr. Az attributes táblán eddig csak a church_id-n volt index, tehát
+-- ez teljes táblaolvasás lett volna minden ilyen keresésnél.
+ALTER TABLE `attributes`
+    ADD INDEX IF NOT EXISTS `key_church` (`key`, `church_id`);

--- a/docker/mysql/initdb.d/04-attributes-index.sql
+++ b/docker/mysql/initdb.d/04-attributes-index.sql
@@ -1,0 +1,16 @@
+/*
+ * #671: index az attributes táblára.
+ *
+ * A Church::facilityCoverage() számláló minden olyan keresésnél lefut, ahol be van
+ * kapcsolva az akadálymentesség/gluténmentes szűrő, és `key` szerint szűr. Az
+ * attributes táblán eddig csak a church_id-n volt index, tehát ez teljes
+ * táblaolvasás lett volna minden ilyen keresésnél.
+ *
+ * Külön fájlban, hogy ne a 03-migrations.sql-t bővítse: a séma-konszolidáció
+ * (#669) épp onnan szedi ki a tartalmat.
+ */
+
+USE miserend;
+
+ALTER TABLE `attributes`
+    ADD INDEX IF NOT EXISTS `key_church` (`key`, `church_id`);

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1399,6 +1399,67 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         );
 
     }
+
+    /*
+     * #671: hány aktív misézőhelyről tudunk EGYÁLTALÁN valamit az adott témában.
+     *
+     * Akadálymentességnél a „nem akadálymentes" IS adat — azt is tudjuk. Ezért itt
+     * bármilyen kitöltött érték számít, nem csak a pozitív.
+     *
+     * Azért kell, mert a szűrő ma szinte üres adathalmazon dolgozik (a seedben egyetlen
+     * templomnak sincs `wheelchair` attribútuma), és a felhasználó a nulla találatot
+     * hibának hinné. Inkább mondjuk meg neki, hol tartunk.
+     */
+    public static function facilityCoverage(): array {
+        $count = function (array $keys): int {
+            return (int) \Eloquent\Attribute::whereIn('key', $keys)
+                ->whereIn('church_id', function ($q) {
+                    $q->select('id')->from('templomok')
+                      ->where('ok', 'i')->whereNull('deleted_at');
+                })
+                ->distinct()
+                ->count('church_id');
+        };
+
+        return [
+            'wheelchair' => $count(['wheelchair']),
+            'gluten_free' => $count([
+                \GlutenFreeCommunion::HOLIDAYS_KEY,
+                \GlutenFreeCommunion::WEEKDAYS_KEY,
+            ]),
+        ];
+    }
+
+    /**
+     * #671: a keresési eredményhez tartozó tájékoztató üzenetek — csak azokra a
+     * témákra, amikre a felhasználó ténylegesen szűrt.
+     *
+     * @param  bool $wheelchair  aktív-e az akadálymentesség-szűrő
+     * @param  bool $glutenFree  aktív-e a gluténmentes szűrő
+     * @return string[]
+     */
+    public static function facilityCoverageMessages(bool $wheelchair, bool $glutenFree): array {
+        if (!$wheelchair && !$glutenFree) {
+            return [];
+        }
+
+        $coverage = self::facilityCoverage();
+        $messages = [];
+
+        if ($wheelchair) {
+            $messages[] = 'Az akadálymentességi adatokat még gyűjtjük, ez nálunk új dolog: eddig '
+                . '<strong>' . $coverage['wheelchair'] . ' misézőhelyről</strong> tudjuk, hogy '
+                . 'akadálymentes-e. Most ezek között keresünk. Ha tudsz másról, küldd el nekünk észrevételként!';
+        }
+
+        if ($glutenFree) {
+            $messages[] = 'A csökkentett gluténtartalmú áldozás lehetőségeit csak nemrég kezdtük gyűjteni, '
+                . 'ezért eddig <strong>' . $coverage['gluten_free'] . ' misézőhelynek</strong> van ilyen adata. '
+                . 'Most ezek között keresünk. Ha tudsz másról, küldd el nekünk észrevételként!';
+        }
+
+        return $messages;
+    }
 	
     /*
      * What does 'M' mean?

--- a/webapp/classes/html/searchresultschurches.php
+++ b/webapp/classes/html/searchresultschurches.php
@@ -26,7 +26,12 @@ class SearchResultsChurches extends Html {
 		    'boundaries' => \Request::StringArray('boundaries', []),
 		    'church_ids' => \Request::IntegerArray('church_ids') ?: [],
 		    'lang' => \Request::StringArray('lang'),
-		    'ehm' => \Request::IntegerwDefault('ehm', 0)
+		    'ehm' => \Request::IntegerwDefault('ehm', 0),
+		    // #666: az „Adottságok" szűrő eddig csak a misekeresésre hatott, pedig a
+		    // címlap ugyanabból az űrlapból indítja a templomkeresést is — a paraméterek
+		    // tehát megérkeztek, csak nem használtuk fel őket.
+		    'wheelchair' => \Request::Text('wheelchair'),
+		    'gluten_free' => \Request::Text('gluten_free')
 		];
                         
         $search = new \Search('churches');
@@ -81,7 +86,24 @@ class SearchResultsChurches extends Html {
                 $search->filters[] = "Amelyik templomban nincs liturgia <b>" . implode('</b> se <b>', $translated) . "</b> nyelven.";                              
             }
         }
-        
+
+        // #666: adottságok (akadálymentesség, gluténmentes áldozás). A Search metódusai
+        // index-függetlenek — a misekeresőben `church.` prefixszel, itt anélkül szűrnek.
+        $wheelchairFilter = array_filter(array_map('trim', explode(',', (string) $params['wheelchair'])));
+        $glutenFreeFilter = array_filter(array_map('trim', explode(',', (string) $params['gluten_free'])));
+        if ($wheelchairFilter) {
+            $search->wheelchair($wheelchairFilter);
+        }
+        if ($glutenFreeFilter) {
+            $search->glutenFree($glutenFreeFilter);
+        }
+
+        // #671: az adottság-adat még nagyon hiányos, a nulla találatot a felhasználó
+        // hibának hinné. Mondjuk meg, hány misézőhelyről tudunk egyáltalán valamit.
+        foreach (\Eloquent\Church::facilityCoverageMessages((bool) $wheelchairFilter, (bool) $glutenFreeFilter) as $message) {
+            addMessage($message, 'info');
+        }
+
         //Let's do the search
         $offset = $this->pagination->take * $this->pagination->active;
         $limit = $this->pagination->take;        		        

--- a/webapp/classes/html/searchresultsmasses.php
+++ b/webapp/classes/html/searchresultsmasses.php
@@ -118,6 +118,21 @@ class SearchResultsMasses extends Html {
             $search->timeRange($from, $until);
         };
 
+        /*
+         * #671: az adottság-adat még nagyon hiányos (a seedben egyetlen misézőhelynek
+         * sincs `wheelchair` attribútuma), ezért a szűrt keresés könnyen nulla találatot
+         * ad — amit a felhasználó hibának hisz. Megmondjuk, hány helyről tudunk valamit.
+         *
+         * Szándékosan ITT, a closure-ön KÍVÜL: az $applyBaseFilters a 0-találatos
+         * fallback-ágon még egyszer lefut, az üzenetet viszont csak egyszer akarjuk.
+         */
+        foreach (\Eloquent\Church::facilityCoverageMessages(
+            (bool) $params['wheelchair'],
+            (bool) $params['gluten_free']
+        ) as $facilityMessage) {
+            addMessage($facilityMessage, 'info');
+        }
+
         // ---- SZŰKÍTŐ szűrők (típus / rítus / kategória) — ezeket dobjuk a fallback-ban ----
         $applyNarrowingFilters = function (\Search $search) use ($typesReq, $ritesReq, $categoriesReq) {
             if (!empty($typesReq) || !empty($ritesReq)) {

--- a/webapp/tests/Integration/FacilityCoverageTest.php
+++ b/webapp/tests/Integration/FacilityCoverageTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #671: a keresési eredmény mellé kiírt tájékoztatás arról, hány misézőhelyről
+ * tudunk egyáltalán valamit az adott témában.
+ *
+ * Azért kell, mert a szűrő szinte üres adathalmazon dolgozik (a seedben egyetlen
+ * misézőhelynek sincs `wheelchair` attribútuma), és a nulla találatot a felhasználó
+ * hibának hinné.
+ */
+final class FacilityCoverageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        DB::rollBack();
+    }
+
+    /* Olyan aktív misézőhely, amiről MÉG nem tudunk semmit az adott témában. */
+    private function churchWithoutAttribute(array $keys): int
+    {
+        $id = DB::table('templomok')
+            ->where('ok', 'i')
+            ->whereNull('deleted_at')
+            ->whereNotIn('id', function ($q) use ($keys) {
+                $q->select('church_id')->from('attributes')->whereIn('key', $keys);
+            })
+            ->value('id');
+
+        if ($id === null) {
+            self::markTestSkipped('Minden aktív misézőhelynek van már adata ebben a témában.');
+        }
+        return (int) $id;
+    }
+
+    private function setAttribute(int $churchId, string $key, string $value): void
+    {
+        \Eloquent\Attribute::updateOrCreate(
+            ['church_id' => $churchId, 'key' => $key],
+            ['value' => $value, 'fromOSM' => 0]
+        );
+    }
+
+    /* Szűrő nélkül nincs mit magyarázni — ne szemeteljük tele az oldalt. */
+    public function testNoMessageWithoutAnActiveFilter(): void
+    {
+        self::assertSame([], \Eloquent\Church::facilityCoverageMessages(false, false));
+    }
+
+    public function testOnlyTheFilteredTopicIsExplained(): void
+    {
+        $wheelchairOnly = \Eloquent\Church::facilityCoverageMessages(true, false);
+        self::assertCount(1, $wheelchairOnly);
+        self::assertStringContainsString('akadálymentes', $wheelchairOnly[0]);
+
+        $glutenOnly = \Eloquent\Church::facilityCoverageMessages(false, true);
+        self::assertCount(1, $glutenOnly);
+        self::assertStringContainsString('glutén', $glutenOnly[0]);
+
+        self::assertCount(2, \Eloquent\Church::facilityCoverageMessages(true, true));
+    }
+
+    /*
+     * Akadálymentességnél a „nem akadálymentes" IS adat: azt is tudjuk a helyről.
+     * Ezért minden kitöltött érték beleszámít, nem csak a pozitív.
+     */
+    public function testNegativeWheelchairValueCountsAsKnownData(): void
+    {
+        $church = $this->churchWithoutAttribute(['wheelchair']);
+        $before = \Eloquent\Church::facilityCoverage()['wheelchair'];
+
+        $this->setAttribute($church, 'wheelchair', 'no');
+
+        self::assertSame($before + 1, \Eloquent\Church::facilityCoverage()['wheelchair']);
+    }
+
+    /* A két gluténmentes kulcs ugyanazt a misézőhelyet ne számolja kétszer. */
+    public function testAChurchIsCountedOnceEvenWithBothGlutenKeys(): void
+    {
+        $church = $this->churchWithoutAttribute([
+            \GlutenFreeCommunion::HOLIDAYS_KEY,
+            \GlutenFreeCommunion::WEEKDAYS_KEY,
+        ]);
+        $before = \Eloquent\Church::facilityCoverage()['gluten_free'];
+
+        $this->setAttribute($church, \GlutenFreeCommunion::HOLIDAYS_KEY, 'at_end');
+        $this->setAttribute($church, \GlutenFreeCommunion::WEEKDAYS_KEY, 'always');
+
+        self::assertSame($before + 1, \Eloquent\Church::facilityCoverage()['gluten_free']);
+    }
+
+    /* Csak az aktív (ok='i') misézőhelyek számítanak — a rejtettek nem kereshetők. */
+    public function testHiddenChurchesAreNotCounted(): void
+    {
+        $hidden = DB::table('templomok')->where('ok', '!=', 'i')->value('id');
+        if ($hidden === null) {
+            self::markTestSkipped('Nincs nem-aktív templom a tesztadatban.');
+        }
+
+        $before = \Eloquent\Church::facilityCoverage()['wheelchair'];
+        $this->setAttribute((int) $hidden, 'wheelchair', 'yes');
+
+        self::assertSame($before, \Eloquent\Church::facilityCoverage()['wheelchair']);
+    }
+}


### PR DESCRIPTION
Fixes #666
Fixes #671

Egy PR-ben, mert ugyanaz a terület — és külön-külön félkész lenne: a szűrő adat nélkül csak nulla találatot adna, magyarázat nélkül.

## #666 — a szűrő a templomkeresőben is

(Btw. Pikáns egy templomi issue-t kezelni a fenevad száma alatt... 👺) 
Jó hír: **a nehezebbik fele már megvolt.** A `Search::wheelchair()` és `glutenFree()` metódusokat eleve index-függetlenre írtam:

```php
$prefix = $this->massOrChurch === "mass" ? "church." : "";
```

Ráadásul a címlap **egyetlen űrlapot** használ (két submit gombbal: „Misék" / „Templom keresése"), tehát a `wheelchair` és `gluten_free` paraméterek **eddig is megérkeztek** a templomkereséshez — csak a `SearchResultsChurches` nem vette át őket. Ennyi hiányzott.

### Mérés (teszt-adattal)

```
1 = wheelchair:yes,     ünnep:at_end,       hétköznap:no
2 = wheelchair:limited, ünnep:ask_sacristy, hétköznap:always
3 = wheelchair:no,      ünnep:no,           hétköznap:no
```

| szűrő | eredmény |
|---|---|
| nincs | 1, 2, 3 |
| `wheelchair=yes` | **1** (egy találat → a kereső átirányít a templom oldalára) |
| `wheelchair=yes,limited` | **1, 2** |
| `gluten_free=holidays` | **1, 2** |
| `gluten_free=weekdays` | **2** |
| `gluten_free=holidays,weekdays` | **2** |
| `wheelchair=yes` + `gluten_free=weekdays` | **nincs találat** |

(Az egytalálatos átirányítás a templomkereső meglévő viselkedése — és a helyes templomra visz.)

## #671 — a figyelmeztetés

Ez szerintem **fontosabb, mint maga a szűrő**, mert az adat még alig van meg:

| | seed |
|---|---:|
| `wheelchair` adat | **0** / 5050 |
| `communion:gluten_free:*` | **0** / 5050 |

Vagyis a szűrő ma bekapcsolva nulla találatot ad, és a felhasználó azt hiszi, elromlott. Ha aktív valamelyik adottság-szűrő, most `addMessage()`-ben megjelenik:

> Az akadálymentességi adatokat még gyűjtjük, ez nálunk új dolog: eddig **N misézőhelyről** tudjuk, hogy akadálymentes-e. Most ezek között keresünk. Ha tudsz másról, küldd el nekünk észrevételként!

Ahogy kérted, **az „X nem akadálymentes" is adat** — azt is tudjuk a helyről —, ezért minden kitöltött érték beleszámít, nem csak a pozitív. Teszt őrzi ezt is, meg azt is, hogy a két gluténmentes kulcs ugyanazt a helyet ne számolja kétszer, és hogy a rejtett (nem `ok=i`) templomok ne számítsanak.

Szűrő nélkül **nem** jelenik meg az üzenet — ellenőriztem, ne szemetelje tele az oldalt.

## Egy indexet is hozzátettem

A számláló minden ilyen keresésnél lefut és `key` szerint szűr, az `attributes` táblán viszont eddig csak `church_id`-n volt index — ez teljes táblaolvasás lett volna. Új: `(key, church_id)` index a `03-migrations.sql`-ben. (Éles adatbázison ezt kézzel kell lefuttatni, ahogy a többi migrációt.)

## Tesztelés

`FacilityCoverageTest` — 5 teszt, zöld. A teljes suite 449 teszt; a 18 „bukás" mind HTTP-hívós teszt (`AutocompleteCombinedTest`, `LegacyChurchUrlRedirectTest`), ami az egyszer használatos tesztkonténerben fut, ahol nincs Apache. **A futó konténerben mind a 18 zöld** — ellenőriztem.

Apropó: ezt a `docker-test.sh`-javítást a **#636** tartalmazza (a futó konténert használja), tehát annak a mergelése a helyi tesztfuttatást is rendbe teszi.