### PR TITLE
CI: a GitHub Actionök frissítése a legújabb kiadásokra

### DIFF
--- a/.github/workflows/app-release.yaml
+++ b/.github/workflows/app-release.yaml
@@ -17,13 +17,13 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # -------- DOCKER BUILD --------
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,7 +34,7 @@ jobs:
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build & push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/miserend/Dockerfile.github
@@ -47,7 +47,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
       - name: Build & push coverage image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/miserend/Dockerfile.coverage

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy over SSH
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.STAGING_SSH_HOST }}
           username: ${{ secrets.STAGING_SSH_USER }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy over SSH
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.STAGING_SSH_HOST }}
           username: ${{ secrets.STAGING_SSH_USER }}

--- a/.github/workflows/elasticsearch-data.yaml
+++ b/.github/workflows/elasticsearch-data.yaml
@@ -17,7 +17,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set image tag to current date
         id: tag
@@ -101,16 +101,16 @@ jobs:
           fi
           echo "✓ Data export successful ($(du -h elasticsearch_data.tar.gz | cut -f1))"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/elasticsearch/Dockerfile
@@ -123,7 +123,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: elasticsearch-data-${{ steps.tag.outputs.TAG }}
           name: Elasticsearch Data ${{ steps.tag.outputs.TAG }}

--- a/.github/workflows/ng-test.yml
+++ b/.github/workflows/ng-test.yml
@@ -20,10 +20,10 @@ jobs:
         working-directory: calendar
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/php-base.yaml
+++ b/.github/workflows/php-base.yaml
@@ -21,18 +21,18 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push base image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: docker/php-base
           push: true

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.tag.outputs.REF }}
 
@@ -137,7 +137,7 @@ jobs:
             docker compose $COMPOSE_FILES logs
 
       - name: Upload coverage HTML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: phpunit-coverage-html
@@ -145,7 +145,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload cobertura XML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: phpunit-coverage-cobertura
@@ -153,7 +153,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Publish Unit Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           report_paths: |
@@ -166,7 +166,7 @@ jobs:
           job_name: Unit Tests
 
       - name: Publish Functional Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           report_paths: |


### PR DESCRIPTION
A futásaink figyelmeztetést kaptak:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/upload-artifact@v4`, `mikepenz/action-junit-report@v4`

Ha már hozzányúlok, mindegyik actiont a legfrissebb kiadásra emeltem.

| action | eddig | most |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `docker/build-push-action` | v5 | **v7** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `mikepenz/action-junit-report` | v4 | **v6** |
| `softprops/action-gh-release` | v1 | **v3** |
| `appleboy/ssh-action` | v1.2.0 | **v1.2.5** |
| `shivammathur/setup-php` | v2 | v2 (a lebegő tag már a legfrissebbet követi) |

## Nem vaktában emeltem

Nagy ugrások vannak közte (a `gh-release` v1→v3), ezért **átnéztem minden major kiadási jegyzetét**, és leellenőriztem az általunk használt inputokat a legújabb `action.yml`-ekben:

- **`mikepenz/action-junit-report@v6`** — mind a hét inputunk megvan (`report_paths`, `fail_on_failure`, `detailed_summary`, `include_passed`, `annotate_only`, `check_name`, `job_name`).
- **`softprops/action-gh-release@v3`** — mind az öt megvan (`tag_name`, `name`, `body`, `draft`, `prerelease`).
- **`docker/setup-buildx-action@v4`** — a kiadási jegyzet szerint „Remove deprecated inputs/outputs", de mi `with:` blokk nélkül használjuk, tehát nem érint.
- A többi major lényegében **Node 24 + ESM** átállás, API-változás nélkül.

A `node-version: 20`-hoz **nem** nyúltam a `ng-test.yml`-ben: az az Angular buildhez használt Node, nem a runneré — annak emelése külön döntés (és külön kockázat).

## Egy dolog, amit érdemes figyelni

Az `actions/checkout@v7` egyik változása: *„block checking out fork pr for `pull_request_target` and `workflow_run`"*.

A `phpunit.yml` **használ `workflow_run`-t**, és fork-SHA-t checkoutol (`github.event.workflow_run.head_sha`). Végiggondolva ez nem érint minket:

- a mi PR-jeink a **`pull_request`** ágon futnak (`github.event.pull_request.head.sha`), az pedig nincs a korlátozott események között — ez a PR maga azonnal bizonyítja is;
- a `workflow_run` ág az „🐳 Build & publish app image" befejezésére indul, ami `push`-ra fut, tehát csak az alap-repóban — ott a head_sha nem fork-commit.

Ha mégis furcsaság lenne, a `checkout` visszavehető v5-re: az már megadja a Node 24-et (amit a figyelmeztetés kért), a fork-korlátozás nélkül.

Mind a hét workflow YAML-je szintaktikailag rendben (leellenőriztem).