### PR TITLE
#662 Nem torlódnak egymásra a deployok

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,8 +24,11 @@ on:
     branches: [production]
   workflow_dispatch: {}
 
+# #662: a staging és a production UGYANAZON a gépen fut, és mindkét deploy teljes
+# `docker build`-et csinál. Külön csoportban egyszerre indulhattak, és a párhuzamos
+# buildek megfojtották a gépet. Közös csoport: egyszerre csak EGY deploy fut.
 concurrency:
-  group: deploy-production
+  group: deploy-server
   # Production-ben NEM töröljük a futó deployt — megvárjuk, hogy befejezze.
   cancel-in-progress: false
 
@@ -56,6 +59,22 @@ jobs:
 
             COMPOSE="docker compose -f docker/compose.yml"
 
+            # ── 0) Van-e egyáltalán mit deployolni? (#662) ───────────────────
+            # Több egymás utáni merge esetén a sorban álló futások mind ugyanazt a
+            # commitot deployolnák. Ez a rövidzár SZÁNDÉKOSAN a backup ELŐTT van: egy
+            # fölösleges futás így teljes mysqldumpot sem készít.
+            # Kézi indításnál (workflow_dispatch) mindig végigmegy.
+            git fetch --prune origin
+            # Az upstream hiánya ne buktassa a deployt (set -e): ilyenkor egyszerűen
+            # kihagyjuk az optimalizálást és végigmegyünk.
+            UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+            if [ -n "$UPSTREAM" ] \
+               && [ "${{ github.event_name }}" != "workflow_dispatch" ] \
+               && [ "$(git rev-parse HEAD)" = "$(git rev-parse "$UPSTREAM")" ]; then
+              echo "✅ Már a legfrissebb commiton vagyunk ($(git rev-parse --short HEAD)) — deploy kihagyva."
+              exit 0
+            fi
+
             # ── 1) MySQL full backup ─────────────────────────────────────────
             echo "▶ Creating MySQL backup..."
             BACKUP_DIR="/home/github_action/backups"
@@ -82,6 +101,7 @@ jobs:
 
             # ── 2) git pull (nem force, nem reset) ──────────────────────────
             echo "▶ Pulling latest changes..."
+
             if ! git pull; then
               echo "❌ git pull failed! Possible merge conflict or dirty working tree."
               echo "   The production server has NOT been updated."

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -25,9 +25,18 @@ on:
     branches: [master]
   workflow_dispatch: {}
 
+# #662: a staging ÉS a production UGYANAZON a gépen fut, és mindkét deploy teljes
+# `docker build`-et csinál (Angular + PHP multi-stage). Külön csoportban egyszerre
+# indulhattak, és több merge után egymásra torlódtak — a gép ettől elérhetetlenné vált.
+# Közös csoport: egyszerre csak EGY deploy nyúlhat a szerverhez.
+#
+# A `cancel-in-progress` szándékosan false: a job leállítása a GitHub oldalán öli meg a
+# futást, a szerveren a docker daemonban FUTÓ build viszont attól még dolgozik tovább —
+# tehát a cancel nem szabadítja fel a gépet, csak elveszti a naplót. Sorbaállítunk
+# helyette, és a lentebbi "nincs új commit" rövidzár teszi gyorssá a torlódást.
 concurrency:
-  group: deploy-staging
-  cancel-in-progress: true
+  group: deploy-server
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -49,6 +58,17 @@ jobs:
 
             # Tiszta lap: fetch + hard reset a master-re (nem 'git pull').
             git fetch --prune origin master
+
+            # #662: több merge után a sorban álló deployok mind ugyanazt a commitot
+            # építenék újra. Ha már a célállapoton vagyunk, nincs mit tenni — így egy
+            # 14 merge-ös hullámból egy-két valódi build lesz, nem tizennégy.
+            # Kézi indításnál (workflow_dispatch) mindig épít.
+            if [ "${{ github.event_name }}" != "workflow_dispatch" ] \
+               && [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)" ]; then
+              echo "✅ Már a legfrissebb commiton vagyunk ($(git rev-parse --short HEAD)) — deploy kihagyva."
+              exit 0
+            fi
+
             git reset --hard origin/master
 
             # #652: a lábléc verzió-jelzéséhez kell. Eddig egy git post-checkout hookra


### PR DESCRIPTION
Fixes #662

> „egyszer csak elérhetetlenné vált a miserend.hu és a staging.miserend.hu és még az ssh is csak várt és várt. Az a tippem, hogy valamilyen módon túlterhelődött a szerver a párhuzamos / egymás utáni deployoktól. Lehetséges ez?"

**Igen, és pontosan az történt.** Két oka van, mindkettő javítva.

## 1. A két deploy külön csoportban volt

```yaml
# staging
concurrency: { group: deploy-staging, cancel-in-progress: true }
# production
concurrency: { group: deploy-production, cancel-in-progress: false }
```

Külön csoport = a GitHub szerint nem zavarják egymást. Csakhogy **ugyanazon a gépen futnak**, és mindkettő teljes `docker build`-et csinál (a Dockerfile multi-stage buildje az Angulart is lefordítja). Két párhuzamos build simán megfojtja a gépet — innen az ssh-várakozás is.

Most közös csoportban vannak (`deploy-server`): egyszerre csak egy deploy nyúlhat a szerverhez.

## 2. A `cancel-in-progress: true` nem azt csinálta, amit vártunk

A staging eddig törölte a futó deployt, ha jött egy újabb. Ez **a GitHub oldalán** öli meg a jobot — a szerveren viszont a **docker daemonban futó build attól még dolgozik tovább**, csak épp már nem látjuk a naplóját. Vagyis a cancel nem szabadította fel a gépet, hanem *vakon* hagyott ott egy futó buildet, és közben indult rá a következő. Tizennégy gyors merge = akár tizennégy egyszerre őrlő build.

Ezért mostantól sorbaállítunk (`cancel-in-progress: false`).

## 3. Hogy a sorbaállítás ne legyen lassú

Ha csak sorbaállítanánk, egy 14 merge-ös hullám 14 egymás utáni teljes buildet jelentene. Ezért mindkét deploy elején van egy rövidzár:

```bash
git fetch --prune origin
if [ nem kézi indítás ] && [ HEAD == upstream ]; then
  echo "✅ Már a legfrissebb commiton vagyunk — deploy kihagyva."
  exit 0
fi
```

Mire a sorban a második futásra kerül a sor, a master már a legfrissebb — az épít, a maradék tizenkettő pedig másodpercek alatt kilép. **Egy-két valódi build lesz tizennégy helyett.**

A productionben ez **szándékosan a mysqldump ELŐTT** van, hogy egy fölösleges futás teljes adatbázismentést se készítsen. Kézi indításnál (`workflow_dispatch`) mindkettő végigmegy — ha valaki direkt újra akar deployolni, hadd tegye.

## Apróság, ami elronthatta volna

A production `set -euo pipefail`-lel fut, és ha nincs beállított upstream, a `git rev-parse @{u}` hibára fut — az megölte volna a deployt. Ezért az upstream lekérése hibatűrő: ha nincs, egyszerűen kihagyjuk az optimalizálást és végigmegyünk.

Mindkét workflow YAML-jét és a beágyazott shell-szkriptek szintaxisát is ellenőriztem (`bash -n`).

## Amit nem oldottam meg

Ha egy build **tényleg** elszáll félúton (pl. a runner időtúllépése), a szerveren maradhat egy árva `docker build`. Ez ellen egy „deploy előtt öld meg a régi buildeket" lépés segítene, de az veszélyes, ha épp a másik környezet legitim buildje fut. A közös csoport ezt gyakorlatilag kizárja, úgyhogy egyelőre ennyivel megállnék.