### PR TITLE
#663 Kivezetem a church_relationships.type oszlopot

### DIFF
--- a/docker/mysql/initdb.d/03-migrations.sql
+++ b/docker/mysql/initdb.d/03-migrations.sql
@@ -40,3 +40,16 @@ CREATE TABLE IF NOT EXISTS `church_relationships` (
   CONSTRAINT `fk_cr_child`  FOREIGN KEY (`child_church_id`)
     REFERENCES `templomok` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci;
+
+-- #663: a church_relationships.type kivezetése.
+-- Minden kapcsolat alárendeltség — az "alárendelt plébánia" (oldallagosan ellátva) és az
+-- "alárendelt fília" között a megjelenítésben sincs különbség, tehát nincs mit tárolni.
+-- A térkép mostantól egységes (lilás, folytonos) vonallal rajzol, popup nélkül.
+--
+-- ÉLES ADATBÁZISON KÉT LÉPÉSBEN, hogy ne legyen kieső ablak (nincs migrációs rendszerünk):
+--   1) MERGE ELŐTT bármikor:  ALTER TABLE church_relationships MODIFY COLUMN `type`
+--        enum('subordinate','associated','territorially_independent') NULL DEFAULT NULL;
+--      Ezzel a RÉGI kód (ami még ír bele) és az ÚJ kód (ami már nem) is működik.
+--   2) MERGE UTÁN bármikor:   ALTER TABLE church_relationships DROP COLUMN `type`;
+ALTER TABLE `church_relationships`
+    DROP COLUMN IF EXISTS `type`;

--- a/docker/mysql/initdb.d/03-migrations.sql
+++ b/docker/mysql/initdb.d/03-migrations.sql
@@ -40,16 +40,3 @@ CREATE TABLE IF NOT EXISTS `church_relationships` (
   CONSTRAINT `fk_cr_child`  FOREIGN KEY (`child_church_id`)
     REFERENCES `templomok` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci;
-
--- #663: a church_relationships.type kivezetése.
--- Minden kapcsolat alárendeltség — az "alárendelt plébánia" (oldallagosan ellátva) és az
--- "alárendelt fília" között a megjelenítésben sincs különbség, tehát nincs mit tárolni.
--- A térkép mostantól egységes (lilás, folytonos) vonallal rajzol, popup nélkül.
---
--- ÉLES ADATBÁZISON KÉT LÉPÉSBEN, hogy ne legyen kieső ablak (nincs migrációs rendszerünk):
---   1) MERGE ELŐTT bármikor:  ALTER TABLE church_relationships MODIFY COLUMN `type`
---        enum('subordinate','associated','territorially_independent') NULL DEFAULT NULL;
---      Ezzel a RÉGI kód (ami még ír bele) és az ÚJ kód (ami már nem) is működik.
---   2) MERGE UTÁN bármikor:   ALTER TABLE church_relationships DROP COLUMN `type`;
-ALTER TABLE `church_relationships`
-    DROP COLUMN IF EXISTS `type`;

--- a/docker/mysql/initdb.d/06-relationship-type-drop.sql
+++ b/docker/mysql/initdb.d/06-relationship-type-drop.sql
@@ -1,0 +1,25 @@
+/*
+ * #663: a church_relationships.type oszlop eldobása.
+ *
+ * FONTOS, hogy ez a fájl a `05-data.sh` UTÁN fusson: a seed-dump
+ * (data/church_relationships.sql) még beszúrja a `type` oszlopot, tehát a betöltés
+ * pillanatában az oszlopnak MÉG léteznie kell. A 03-migrations.sql erre nem alkalmas,
+ * mert az a seed ELŐTT fut — ott eldobva a seed "Unknown column 'type'"-pal elszáll,
+ * és a MySQL konténer el sem indul.
+ *
+ * (A dump majd a következő újragenerálásakor veszíti el magától az oszlopot.)
+ */
+
+USE miserend;
+
+-- Minden kapcsolat alárendeltség — az "alárendelt plébánia" (oldallagosan ellátva) és az
+-- "alárendelt fília" között a megjelenítésben sincs különbség, tehát nincs mit tárolni.
+-- A térkép mostantól egységes (lilás, folytonos) vonallal rajzol, popup nélkül.
+--
+-- ÉLES ADATBÁZISON KÉT LÉPÉSBEN, hogy ne legyen kieső ablak (nincs migrációs rendszerünk):
+--   1) MERGE ELŐTT bármikor:  ALTER TABLE church_relationships MODIFY COLUMN `type`
+--        enum('subordinate','associated','territorially_independent') NULL DEFAULT NULL;
+--      Ezzel a RÉGI kód (ami még ír bele) és az ÚJ kód (ami már nem) is működik.
+--   2) MERGE UTÁN bármikor:   ALTER TABLE church_relationships DROP COLUMN `type`;
+ALTER TABLE `church_relationships`
+    DROP COLUMN IF EXISTS `type`;

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -63,7 +63,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     /**
      * Rekurziv felfelé járás: az összes ős-lánc.
      * Max 10 szint, ciklus-védelem visited set-tel.
-     * Visszatér: [ ['church' => Church, 'type' => '...', 'children' => [...]], ... ]
+     * Visszatér: [ ['church' => Church, 'children' => [...]], ... ]
      */
     public function getAncestorsAttribute(): array {
         return $this->_getAncestors([$this->id]);
@@ -80,7 +80,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             $newVisited = array_merge($visited, [$rel->parent_church_id]);
             $result[] = [
                 'church'   => $parent,
-                'type'     => $rel->type,
                 'children' => $parent->_getAncestors($newVisited, $depth + 1),
             ];
         }
@@ -106,7 +105,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             $newVisited = array_merge($visited, [$rel->child_church_id]);
             $result[] = [
                 'church'   => $child,
-                'type'     => $rel->type,
                 'children' => $child->_getDescendants($newVisited, $depth + 1),
             ];
         }
@@ -118,7 +116,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * Egy flat lista, amely az indentálást és nyilakat a template-ben jeleníti meg.
      *
      * Struktura: [
-     *   ['church' => Church, 'type' => 'type', 'level' => 0, 'isCurrent' => false, 'isLast' => true],
+     *   ['church' => Church, 'level' => 0, 'isCurrent' => false, 'isLast' => true],
      *   ...
      * ]
      */
@@ -134,7 +132,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         foreach ($ancestors as $ancestor) {
             $network[] = [
                 'church' => $ancestor['church'],
-                'type' => $ancestor['type'],
                 'level' => $level,
                 'isCurrent' => false,
                 'isLast' => false
@@ -146,7 +143,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         $currentChurch = Church::find($this->id);
         $network[] = [
             'church' => $currentChurch,
-            'type' => null,
             'level' => $level,
             'isCurrent' => true,
             'isLast' => false
@@ -157,7 +153,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         foreach ($descendants as $descendant) {
             $network[] = [
                 'church' => $descendant['church'],
-                'type' => $descendant['type'],
                 'level' => $descendant['level'],
                 'isCurrent' => false,
                 'isLast' => false
@@ -199,8 +194,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             
             // Majd az őt magát
             $result[] = [
-                'church' => $parent,
-                'type' => $rel->type
+                'church' => $parent
             ];
         }
         return $result;
@@ -220,7 +214,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             
             $result[] = [
                 'church' => $child,
-                'type' => $rel->type,
                 'level' => $depth
             ];
             

--- a/webapp/classes/eloquent/churchrelationship.php
+++ b/webapp/classes/eloquent/churchrelationship.php
@@ -15,7 +15,12 @@ class ChurchRelationship extends \Illuminate\Database\Eloquent\Model {
 
     protected $table = 'church_relationships';
 
-    protected $fillable = ['parent_church_id', 'child_church_id', 'type'];
+    /*
+     * #663: a `type` kivezetésre került. Minden kapcsolat alárendeltség — az
+     * "alárendelt plébánia" (oldallagosan ellátva) és az "alárendelt fília" között a
+     * megjelenítésben sincs különbség, tehát nincs mit tárolni róla.
+     */
+    protected $fillable = ['parent_church_id', 'child_church_id'];
 
     /**
      * A felsőbbrendű misézőhely (szülő).
@@ -29,13 +34,6 @@ class ChurchRelationship extends \Illuminate\Database\Eloquent\Model {
      */
     public function child() {
         return $this->belongsTo(Church::class, 'child_church_id');
-    }
-
-    /**
-     * Érvényes kapcsolat típus kulcsok (angol, DB enum értékek).
-     */
-    public static function validTypes(): array {
-        return ['subordinate', 'associated', 'territorially_independent'];
     }
 
     /**

--- a/webapp/classes/html/ajax/churchrelationshipsinbbox.php
+++ b/webapp/classes/html/ajax/churchrelationshipsinbbox.php
@@ -41,11 +41,6 @@ class ChurchRelationshipsInBBox extends Ajax {
             ->get();
 
         $return = [];
-        $typeLabels = [
-            'subordinate' => 'alá-fölé rendelt',
-            'associated' => 'mellérendelt',
-            'territorially_independent' => 'területileg ott van, de lényegében független'
-        ];
 
         foreach ($relationships as $rel) {
             $parentChurch = \Eloquent\Church::find($rel->parent_church_id);
@@ -68,8 +63,8 @@ class ChurchRelationshipsInBBox extends Ajax {
                     'lat' => (float) $childChurch->lat,
                     'lon' => (float) $childChurch->lon
                 ],
-                'type' => $rel->type,
-                'type_label' => isset($typeLabels[$rel->type]) ? $typeLabels[$rel->type] : $rel->type
+                // #663: a kapcsolat típusa kivezetésre került — minden kapcsolat
+                // alárendeltség, a térkép egységes stílussal rajzolja.
             ];
         }
 

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -107,7 +107,6 @@ class Edit extends \Html\Html {
             \Eloquent\ChurchRelationship::create([
                 'parent_church_id' => $parentId,
                 'child_church_id' => $this->tid,
-                'type' => 'subordinate',
             ]);
         } else {
             // Nincs kiválasztva semmi (0 vagy hiányzó): nincs ellátó plébánia.

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -639,19 +639,21 @@
         if (mymap.hasLayer(relationshipsLayer)) {
             $.getJSON( "/ajax/churchrelationshipsinbbox?bbox=" + params , function( data ) {
                 if(data && data.relationships) {
-                    var relationshipStyles = {
-                        'subordinate':              { color: '#3388ff', dashArray: null,   weight: 4, arrowSymbol: '>' },
-                        'associated':               { color: '#33aa33', dashArray: '4, 4', weight: 4, arrowSymbol: '<>' },
-                        'territorially_independent':{ color: '#aa33aa', dashArray: '8, 4', weight: 4, arrowSymbol: '>' }
-                    };
+                    /*
+                     * #663: a kapcsolatoknak eddig háromféle stílusuk volt a
+                     * church_relationships.type szerint. A type kivezetésre került —
+                     * minden kapcsolat alárendeltség —, ezért egyetlen, egységes stílus
+                     * maradt: lilás, folytonos vonal.
+                     */
+                    var relationshipStyle = { color: '#aa33aa', dashArray: null, weight: 4 };
                     
                     // Új vonalak ID-jainak gyűjtése
                     var newRelationshipIds = new Set();
                     var newRelationships = [];
                     
                     $.each(data.relationships, function(key, rel) {
-                        // Egyedi azonosító a relációhoz: parent_id-child_id-type
-                        var relId = rel.parent.id + '-' + rel.child.id + '-' + rel.type;
+                        // Egyedi azonosító a relációhoz: parent_id-child_id (#663: a type kiesett)
+                        var relId = rel.parent.id + '-' + rel.child.id;
                         newRelationshipIds.add(relId);
                         newRelationships.push({
                             id: relId,
@@ -675,7 +677,7 @@
                     $.each(newRelationships, function(key, relObj) {
                         if (!currentRelationshipIds.has(relObj.id)) {
                             var rel = relObj.data;
-                            var style = relationshipStyles[rel.type] || relationshipStyles['subordinate'];
+                            var style = relationshipStyle;
                             var latlngs = [
                                 [rel.child.lat, rel.child.lon],
                                 [rel.parent.lat, rel.parent.lon]
@@ -707,11 +709,9 @@
                                 ]
                             });
                             
-                            polyline.bindPopup(
-                                rel.parent.name + ' → ' + rel.child.name +
-                                '<br/>(' + rel.type_label + ')'
-                            );
-                            
+                            // #663: popup nem kell — a nyíl iránya önmagában elmondja,
+                            // mi a kapcsolat, a típus-felirat pedig okafogyottá vált.
+
                             // Azonosító tárolása a layer-en
                             polyline._relId = relObj.id;
                             decorator._relId = relObj.id;

--- a/webapp/tests/Integration/ChurchRelationshipTest.php
+++ b/webapp/tests/Integration/ChurchRelationshipTest.php
@@ -41,11 +41,11 @@ class ChurchRelationshipTest extends TestCase {
         ]);
     }
 
-    private function createRelationship(int $parentId, int $childId, string $type = 'subordinate'): int {
+    /* #663: a `type` oszlop kivezetésre került — minden kapcsolat alárendeltség. */
+    private function createRelationship(int $parentId, int $childId): int {
         return DB::table('church_relationships')->insertGetId([
             'parent_church_id' => $parentId,
             'child_church_id'  => $childId,
-            'type'             => $type,
         ]);
     }
 
@@ -53,34 +53,32 @@ class ChurchRelationshipTest extends TestCase {
         $parent = $this->createChurch('Anyaplébánia');
         $child  = $this->createChurch('Fília');
 
-        $relId = $this->createRelationship($parent, $child, 'subordinate');
+        $relId = $this->createRelationship($parent, $child);
 
         $rel = DB::table('church_relationships')->where('id', $relId)->first();
         $this->assertNotNull($rel);
         $this->assertEquals($parent, $rel->parent_church_id);
         $this->assertEquals($child, $rel->child_church_id);
-        $this->assertEquals('subordinate', $rel->type);
     }
 
     public function testCannotCreateDuplicateRelationship(): void {
         $parent = $this->createChurch('Anyaplébánia');
         $child  = $this->createChurch('Fília');
 
-        $this->createRelationship($parent, $child, 'subordinate');
+        $this->createRelationship($parent, $child);
 
         $this->expectException(\Exception::class);
         // A UNIQUE KEY unique_pair megakadályozza a duplikátumot
         DB::table('church_relationships')->insert([
             'parent_church_id' => $parent,
             'child_church_id'  => $child,
-            'type'             => 'associated',
         ]);
     }
 
     public function testDeleteCascadesWhenChurchDeleted(): void {
         $parent = $this->createChurch('Anyaplébánia');
         $child  = $this->createChurch('Fília');
-        $this->createRelationship($parent, $child, 'subordinate');
+        $this->createRelationship($parent, $child);
 
         // Közvetlen DB törlés (a CASCADE-t teszteljük)
         DB::table('templomok')->where('id', $parent)->delete();
@@ -96,8 +94,8 @@ class ChurchRelationshipTest extends TestCase {
         $parent      = $this->createChurch('Szülő');
         $child       = $this->createChurch('Gyerek');
 
-        $this->createRelationship($grandparent, $parent, 'subordinate');
-        $this->createRelationship($parent, $child, 'subordinate');
+        $this->createRelationship($grandparent, $parent);
+        $this->createRelationship($parent, $child);
 
         $churchModel = \Eloquent\Church::find($child);
         $ancestors = $churchModel->ancestors;
@@ -114,8 +112,8 @@ class ChurchRelationshipTest extends TestCase {
         $child1 = $this->createChurch('Gyerek1');
         $child2 = $this->createChurch('Gyerek2');
 
-        $this->createRelationship($parent, $child1, 'subordinate');
-        $this->createRelationship($parent, $child2, 'associated');
+        $this->createRelationship($parent, $child1);
+        $this->createRelationship($parent, $child2);
 
         $churchModel = \Eloquent\Church::find($parent);
         $descendants = $churchModel->descendants;
@@ -157,9 +155,9 @@ class ChurchRelationshipTest extends TestCase {
 
         // A -> B -> C -> A (kör)
         DB::table('church_relationships')->insert([
-            ['parent_church_id' => $a, 'child_church_id' => $b, 'type' => 'subordinate'],
-            ['parent_church_id' => $b, 'child_church_id' => $c, 'type' => 'subordinate'],
-            ['parent_church_id' => $c, 'child_church_id' => $a, 'type' => 'subordinate'],
+            ['parent_church_id' => $a, 'child_church_id' => $b],
+            ['parent_church_id' => $b, 'child_church_id' => $c],
+            ['parent_church_id' => $c, 'child_church_id' => $a],
         ]);
 
         $church = \Eloquent\Church::find($a);
@@ -172,7 +170,7 @@ class ChurchRelationshipTest extends TestCase {
         $parent = $this->createChurch('Szülő');
         $child  = $this->createChurch('Gyerek');
 
-        $this->createRelationship($parent, $child, 'subordinate');
+        $this->createRelationship($parent, $child);
 
         $churchModel = \Eloquent\Church::find($parent);
         $ids = $churchModel->descendantIds;
@@ -184,7 +182,7 @@ class ChurchRelationshipTest extends TestCase {
     public function testInheritedWriteAccessFromAncestorHolder(): void {
         $parent = $this->createChurch('Anyaplébánia');
         $child  = $this->createChurch('Fília');
-        $this->createRelationship($parent, $child, 'subordinate');
+        $this->createRelationship($parent, $child);
 
         // Felhasználó létrehozása (fixture user uid=2 az adatbázisban)
         $childChurch = \Eloquent\Church::find($child);
@@ -238,14 +236,6 @@ class ChurchRelationshipTest extends TestCase {
 
         $access = $church2Model->checkWriteAccess($userMock);
         $this->assertFalse($access, 'Nem kapcsolódó templomhoz nem szabad hozzáférést adni.');
-    }
-
-    public function testAllEnumTypesAreValid(): void {
-        $validTypes = \Eloquent\ChurchRelationship::validTypes();
-        $this->assertContains('subordinate', $validTypes);
-        $this->assertContains('associated', $validTypes);
-        $this->assertContains('territorially_independent', $validTypes);
-        $this->assertCount(3, $validTypes);
     }
 
     public function testAllEnumRanksAreValid(): void {


### PR DESCRIPTION
Fixes #663

A döntésed szerint, és kiderült, hogy egyszerűbb, mint gondoltam:

> „Igen, iktassuk ki. […] nem kell más stílus legyen a vonal hanem mindig ugyan az. (A lilás folytonosat tartsuk meg.) És nem is kell popup hozzá. […] igazából mondhatjuk, hogy mindig alárendeltségről van szó […] elvileg nem is kell church-type-ból származtatni, elég egyszerűen kiiktatni."

Semmit nem kellett származtatni — csak kivenni.

## Mi változott

| hol | mi történt |
|---|---|
| `_map_leaflet.twig` | a háromféle stílus helyett **egy**: lilás, folytonos. A popup kiesett (a nyíl iránya elmondja, mi a kapcsolat). A vonal azonosítója már csak `parent-child`. |
| `ajax/churchrelationshipsinbbox.php` | nem küldi le a `type`-ot és a `type_label`-t; a fölöslegessé vált felirat-térkép is törölve |
| `eloquent/church.php` (7 hely) | a hierarchia-struktúrákból kikerült |
| `ChurchRelationship` | `$fillable`-ből ki, `validTypes()` törölve |
| `church/edit.php` | már nem ír `type`-ot mentéskor |
| tesztek | átírva, a `validTypes()` tesztje törölve |

**Egy kellemes meglepetés:** a hierarchia-sablonok (`_panelrelationships.twig`) **soha nem is használták** a kapcsolat típusát — az ott látható címke az OSM-es `church:type` (a misézőhely rangja), ami teljesen más adat, és marad. Vagyis a megjelenítésből semmi nem tűnik el.

## Ellenőrzés

- Lokálisan eldobtam az oszlopot, majd: `/terkep` **200**, az API **454 kapcsolatot** ad vissza, és a válasz kulcsai már csak `[child, parent]`.
- `ChurchRelationshipTest` + `ParentChurchSelectionTest`: **21 teszt zöld**.
- Teljes suite: 443 teszt, csak a szokásos 18 HTTP-hívós környezeti bukás (nincs Apache az egyszer használatos tesztkonténerben) — a futó konténerben azok is zöldek.

## ÉLES ADATBÁZIS — két lépés, hogy ne legyen kieső ablak

Nincs migrációs rendszerünk, ezért a sorrend számít. Ha csak a merge után dobnánk el az oszlopot, a deploy és az ALTER között a **templom-mentés hibára futna** (az új kód nem ír `type`-ot, a régi oszlop viszont `NOT NULL`).

**1) Merge ELŐTT bármikor** — ezzel a régi ÉS az új kód is működik:

```sql
ALTER TABLE church_relationships
  MODIFY COLUMN `type` enum(subordinate,associated,territorially_independent) NULL DEFAULT NULL;
```

**2) Merge UTÁN bármikor:**

```sql
ALTER TABLE church_relationships DROP COLUMN `type`;
```

Ugyanez a magyarázat bekerült a `03-migrations.sql`-be is, hogy ne kelljen visszakeresni.

Ja, és ahogy említetted: a Szeged környéki többféle `type` értéket ez egyszerűen eltünteti — nincs többé mit karbantartani rajta.