### PR TITLE
#661 Egységesítem a Leafletet és magunk szolgáljuk ki

### DIFF
--- a/docs/outgoing-connections.md
+++ b/docs/outgoing-connections.md
@@ -72,18 +72,17 @@ kimenő címet.
 
 | Cél | Host | Mire kell | Hol |
 |---|---|---|---|
-| **Leaflet** (JS + CSS) | `unpkg.com` | a térkép motorja | `_map_leaflet.twig` (1.7.1), `stat.twig` (1.9.3), `church/create.twig` (1.9.4) |
-| **Leaflet.PolylineDecorator** | `unpkg.com` | a kapcsolat-vonalak nyilai | `_map_leaflet.twig` |
-| **Leaflet.TextPath** | `makinacorpus.github.io` | vonalra írt felirat | `_map_leaflet.twig` |
 | **CARTO Voyager csempék** | `{a,b,c,d}.basemaps.cartocdn.com` | a térkép alaprétege | `_map_leaflet.twig` |
 | html5shiv, respond.js | `oss.maxcdn.com` | régi IE-polyfillek | `layout.twig` |
 | OpenLayers | `openlayers.org` | régi térkép-kód | (legacy) |
 
 Amit érdemes tudni róluk:
 
-- **Három különböző Leaflet-verziót** töltünk be három sablonból (1.7.1 / 1.9.3 / 1.9.4). Ezt
-  egységesíteni kellene.
-- A `makinacorpus.github.io` egy GitHub Pages, **nem CDN** — nincs rendelkezésre állási ígéret rá.
+- **A Leaflet és bővítményei már NEM külső forrásból jönnek** (#661): a `webapp/package.json`-ból
+  telepítjük és magunk szolgáljuk ki őket (`/node_modules/leaflet/...`), egységesen **1.9.4**
+  verzióban. Korábban három sablon háromféle verziót töltött be az unpkg-ról (1.7.1 / 1.9.3 /
+  1.9.4), a Leaflet.TextPath pedig egy GitHub Pages-ről (`makinacorpus.github.io`) — az nem is CDN.
+  Ezzel öt külső kérés és két idegen hoszt esett ki a térképes oldalak kritikus útjáról.
 - A `leaflet.polylinedecorator.css` hivatkozás **HTTP 404** volt (nem létezik az unpkg-n); a #653-ban
   töröltük.
 - A **Stamen csempeszerver** (`stamen-tiles-*.a.ssl.fastly.net`) mérve **HTTP 503**-at adott: a Stamen

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -17,6 +17,9 @@
         "jquery": "3.7.*",
         "jquery-colorbox": "1.5.*",
         "jquery-ui": "1.13.*",
+        "leaflet": "1.9.*",
+        "leaflet-polylinedecorator": "1.6.*",
+        "leaflet-textpath": "1.2.*",
         "lightbox2": "2.*",
         "requirejs": "2.1.11"
       }
@@ -105,6 +108,36 @@
       "license": "MIT",
       "dependencies": {
         "jquery": ">=1.8.0 <4.0.0"
+      }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet-polylinedecorator": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/leaflet-polylinedecorator/-/leaflet-polylinedecorator-1.6.0.tgz",
+      "integrity": "sha512-kn3krmZRetgvN0wjhgYL8kvyLS0tUogAl0vtHuXQnwlYNjbl7aLQpkoFUo8UB8gVZoB0dhI4Tb55VdTJAcYzzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "leaflet-rotatedmarker": "^0.2.0"
+      }
+    },
+    "node_modules/leaflet-rotatedmarker": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.0.tgz",
+      "integrity": "sha512-yc97gxLXwbZa+Gk9VCcqI0CkvIBC9oNTTjFsHqq4EQvANrvaboib4UdeQLyTnEqDpaXHCqzwwVIDHtvz2mUiDg==",
+      "license": "MIT"
+    },
+    "node_modules/leaflet-textpath": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/leaflet-textpath/-/leaflet-textpath-1.2.3.tgz",
+      "integrity": "sha512-mPb5m2MlihNkLlo762j8S8FJCUyLvDU2fJTjjmDWKfqqyUQkV3ca3IzrxwsfzYz2DXrV2ytCVHb5+DjQymF+8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
       }
     },
     "node_modules/lightbox2": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -3,17 +3,20 @@
   "version": "1.1.3",
   "private": true,
   "dependencies": {
-    "jquery": "3.7.*",
-    "jquery-ui": "1.13.*",
-    "bootstrap": "5.3.*",
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "@popperjs/core": "2.11.*",
-    "requirejs": "2.1.11",
-    "jquery-colorbox": "1.5.*",
+    "bootstrap": "5.3.*",
+    "clockpicker": "^0.0.7",
     "composer": "*",
     "jqplot": "1.0.*",
-    "@fortawesome/fontawesome-free": "^6.7.2",
+    "jquery": "3.7.*",
+    "jquery-colorbox": "1.5.*",
+    "jquery-ui": "1.13.*",
+    "leaflet": "1.9.*",
+    "leaflet-polylinedecorator": "1.6.*",
+    "leaflet-textpath": "1.2.*",
     "lightbox2": "2.*",
-    "clockpicker": "^0.0.7"
+    "requirejs": "2.1.11"
   },
   "config": {
     "unsafe-perm": true

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -1,14 +1,12 @@
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
-   integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
-   crossorigin=""/>
-         <!-- Make sure you put this AFTER Leaflet's CSS -->
- <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
-   integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
-   crossorigin=""></script>
-    <script src="https://makinacorpus.github.io/Leaflet.TextPath/leaflet.textpath.js"></script>
-    <script src="https://unpkg.com/leaflet-polylinedecorator@1.6.0/dist/leaflet.polylinedecorator.js"></script>
-    {# A leaflet-polylinedecorator CSS-e itt volt behivatkozva, de nem létezik: az unpkg
-       HTTP 404-et ad rá. Minden térképes oldalbetöltéskor feleslegesen kértük. (#653) #}
+{# #661/#653: a Leafletet és a bővítményeit saját magunk szolgáljuk ki a
+   webapp/package.json-ból, nem az unpkg-ról és nem egy GitHub Pages-ről.
+   Így nincs két idegen hoszt a térképes oldalak kritikus útján, és nem
+   tölthetünk be háromféle Leaflet-verziót három sablonból (itt 1.7.1 volt,
+   a stat.twig-ben 1.9.3, a church/create.twig-ben 1.9.4). Egységesen 1.9.4. #}
+<link rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css"/>
+<script src="/node_modules/leaflet/dist/leaflet.js"></script>
+<script src="/node_modules/leaflet-textpath/leaflet.textpath.js"></script>
+<script src="/node_modules/leaflet-polylinedecorator/dist/leaflet.polylineDecorator.js"></script>
 
 <style>
     /* Map Popup Weekend Masses Styling */

--- a/webapp/templates/church/create.twig
+++ b/webapp/templates/church/create.twig
@@ -116,8 +116,8 @@
     <script language="javascript" type="text/javascript" src="/vendor/tinymce/tinymce/tinymce.min.js"></script>
     <script language="javascript" type="text/javascript" src="/js/tiny_mce_init.js"></script>
     
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin=""/>
+    <script src="/node_modules/leaflet/dist/leaflet.js"></script>
+    <link rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css"/>
 
     <script>
   $( function() {

--- a/webapp/templates/stat.twig
+++ b/webapp/templates/stat.twig
@@ -14,10 +14,8 @@
 <script type="text/javascript" src="/js/jqplot.logAxisRenderer.js"></script>
 
 
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
-    integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI=" crossorigin="" />
-    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
-    integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM=" crossorigin=""></script>
+    <link rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css" />
+    <script src="/node_modules/leaflet/dist/leaflet.js"></script>
     <style>
         #map { width: 100%; height: 400px; }
         #map-massrightnow { width: 100%; height: 400px; }


### PR DESCRIPTION
Fixes #661
Kapcsolódik: #653 (ennek a harmadik pontja)

## Mi volt

Három sablon **háromféle Leaflet-verziót** töltött be, mind az unpkg-ról:

| sablon | verzió |
|---|---|
| `_map_leaflet.twig` | 1.7.1 |
| `stat.twig` | 1.9.3 |
| `church/create.twig` | 1.9.4 |

A Leaflet.TextPath ráadásul a `makinacorpus.github.io`-ról jött — az egy **GitHub Pages, nem CDN**, nincs rá rendelkezésre állási ígéret, mégis minden térképes oldalunk függött tőle.

Összesen öt külső kérés két idegen hoszthoz, a térképes oldalak kritikus útján: két extra DNS+TLS kör, és ha az unpkg akadozik, akadozik a mi oldalunk is.

## Mi lett

Mindhárom csomag a `webapp/package.json`-ból jön, és magunk szolgáljuk ki — **a minta már megvolt**, a jQuery, a Bootstrap és a FontAwesome is így működik, a `.htaccess` pedig eleve átengedi a `node_modules/`-t.

```
leaflet                    1.9.4
leaflet-polylinedecorator  1.6.0
leaflet-textpath           1.2.3
```

Egységesen **1.9.4** mindhárom sablonban (ez volt amúgy is a legmagasabb használt verzió, és egyben a legfrissebb kiadás).

## Egy csapda

Az npm-csomagban a fájl neve **`leaflet.polylineDecorator.js` nagy D-vel**, a CDN-en kisbetűs volt (`leaflet.polylinedecorator.js`). Jó, hogy ellenőriztem, mert így némán 404 lett volna belőle.

## Ellenőrzés

Mind a négy fájl HTTP-n:

```
200  147552B  /node_modules/leaflet/dist/leaflet.js
200   14806B  /node_modules/leaflet/dist/leaflet.css
200   15983B  /node_modules/leaflet-polylinedecorator/dist/leaflet.polylineDecorator.js
200    5770B  /node_modules/leaflet-textpath/leaflet.textpath.js
```

`/terkep`, `/templom/1`, `/stat` — mind **200**, és a lapokon már egyetlen `unpkg.com` vagy `makinacorpus` hivatkozás sincs.

## Mergelési sorrend

Ez az ág és a **#677** (`church_relationships.type`) ugyanazt a `_map_leaflet.twig`-et szerkeszti, de **különböző részeit**: a #677 a kapcsolat-rajzolást (~640. sortól), ez a fájl legelejét (a script/link sorokat).

Kipróbáltam: ráraktam ezt a #677 tetejére — **nincs konfliktus**, és utána mindkét változás ott van. Tehát bármelyik mehet előbb, nem kell sorrendet tartani.

## Ami a #653-ból még hátravan

Ez a harmadik pont volt. Marad:
1. a ~56–59 KB beágyazott térkép-JS külön, cache-elhető fájlba,
2. a térkép lusta indítása (csak görgetésre/kattintásra).

Azok jönnek külön PR-ben — a beágyazott JS-ben Twig-feltételek vannak (`{% if church_id %}`, `{% if dioceseslayer %}`), amiket futásidejű konfiggá kell alakítani, és az önmagában elég egy külön átnézésre.