### PR TITLE
#670 Templom mentésekor frissítem a miséit is az indexben

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1628,5 +1628,44 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             // Ha a templom nem engedélyezett (ok != 'i'), akkor töröljük az Elasticsearchből
             ElasticsearchApi::deleteChurches([$this->id]);
         }
+
+        // A parent::save() visszatérési értéke eddig elveszett: a save() null-lal tért
+        // vissza bool helyett, tehát a hívó nem tudta megnézni, sikerült-e a mentés.
+        return $return;
+    }
+
+    /*
+     * #670: a templom adatai a mise-indexbe is BE VANNAK ÁGYAZVA (a mass_index minden
+     * dokumentumában ott ül a templom `church` alobjektumként). A save() csak a
+     * `churches` indexet frissíti, ezért mentés után a MISE-kereső még a régi
+     * templom-adatot látta — pl. az újonnan felvitt gluténmentes vagy akadálymentességi
+     * adatra nem talált rá, amíg a napi cron le nem futott.
+     *
+     * SZÁNDÉKOSAN NEM a save()-ben van: azt az OSM-szinkron (akár több ezer templom) és a
+     * boundary-cron (50 templom / 5 perc) is hívja, a mise-újraindexelés viszont mérve
+     * ~0,5 másodperc templomonként — ott ez órákat jelentene. A felhasználói mentés-
+     * útvonalak (/edit, /editosm) hívják, ahol egy ember épp most írt át valamit, és
+     * joggal várja, hogy a kereső is tudjon róla.
+     *
+     * Hiba esetén csak naplózunk: egy ES-akadás ne buktassa a templom mentését.
+     */
+    /**
+     * Tiszta döntés (se DB, se ES), hogy tesztelhető legyen: van-e értelme frissíteni.
+     * Nem engedélyezett templom miséi nincsenek is az indexben — ott nincs mit tenni.
+     */
+    public static function shouldRefreshMassSearchIndex(?string $ok): bool {
+        return $ok === 'i';
+    }
+
+    public function refreshMassSearchIndex(): void {
+        if (!self::shouldRefreshMassSearchIndex($this->ok)) {
+            return;
+        }
+        try {
+            ElasticsearchApi::updateMasses([], [$this->id], function ($msg) {});
+        } catch (\Throwable $e) {
+            error_log('[#670] a misék újraindexelése nem sikerült a(z) ' . $this->id
+                . ' templomnál: ' . $e->getMessage());
+        }
     }
 }

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -136,6 +136,12 @@ class Edit extends \Html\Html {
         $latLonChanged = $this->church->isDirty('lat') || $this->church->isDirty('lon');
         $this->church->save();
 
+        // #670: a templom adatai a mise-indexbe is be vannak ágyazva, ezért a mentés után
+        // a MISE-kereső még a régi adatot látná (pl. a most felvitt gluténmentes vagy
+        // akadálymentességi információt). Mérve ~0,5 mp templomonként — kézi mentésnél ez
+        // belefér, cron-útvonalon szándékosan nem fut.
+        $this->church->refreshMassSearchIndex();
+
         // #44: koordináta-módosításkor újraszámoljuk a szomszédságot (distances), különben
         // a szomszédok listája elavulna az új pozícióhoz képest. Az esetleges hiba ne buktassa
         // a mentést.

--- a/webapp/classes/html/church/editosm.php
+++ b/webapp/classes/html/church/editosm.php
@@ -194,6 +194,10 @@ class EditOsm extends \Html\Html {
 				);
 			}			
 						
+			// #670: az OSM-tagok (pl. wheelchair) a templom keresési adatai közé kerülnek,
+			// és a mise-indexbe is beágyazódnak — frissítsük, hogy a kereső rögtön lássa.
+			$this->church->refreshMassSearchIndex();
+
 			addMessage ('Közvelenül OSM adatokat is módosítottunk. Nagyon izgalmas. <a href="'.$messageurl.'">changeset/'.$changesetID.'</a>','success');
 			
 		}

--- a/webapp/tests/Unit/MassSearchIndexRefreshTest.php
+++ b/webapp/tests/Unit/MassSearchIndexRefreshTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #670: a templom adatai a mise-indexbe is be vannak ágyazva, ezért a templom mentése
+ * után a MISE-kereső még a régi adatot látta (pl. az újonnan felvitt gluténmentes vagy
+ * akadálymentességi információt nem találta meg a napi cron lefutásáig).
+ *
+ * A frissítés mérve ~0,5 mp templomonként, ezért SZÁNDÉKOSAN nem a Church::save()-ben
+ * fut: azt az OSM-szinkron (több ezer templom) és a boundary-cron (50 templom / 5 perc)
+ * is hívja. Csak a felhasználói mentés-útvonalak (/edit, /editosm) indítják.
+ */
+final class MassSearchIndexRefreshTest extends TestCase
+{
+    public function testEnabledChurchIsRefreshed(): void
+    {
+        self::assertTrue(\Eloquent\Church::shouldRefreshMassSearchIndex('i'));
+    }
+
+    /* Nem engedélyezett templom miséi nincsenek is az indexben — nincs mit frissíteni. */
+    public function testDisabledChurchIsNotRefreshed(): void
+    {
+        foreach (['n', 'f', '', null] as $ok) {
+            self::assertFalse(
+                \Eloquent\Church::shouldRefreshMassSearchIndex($ok),
+                'A(z) ' . var_export($ok, true) . " státuszú templomnál nem kell újraindexelni."
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #670

> „Vagy már lefut?"

**Nem futott le.** Megnéztem: a `Church::save()` frissíti a `churches` indexet…

```php
if ($this->ok === "i") { ElasticsearchApi::updateChurches([$this->id]); }
```

…de a **miséket nem**. A templom adatai viszont a mise-indexbe is **be vannak ágyazva**: minden `mass_index` dokumentum tartalmazza a templomot `church` alobjektumként. Ezért a mentés után a **mise-kereső** még a régi templom-adatot látta — pontosan az a példa, amit írtál: a most felvitt gluténmentes adatra a kereső nem talált rá, amíg a napi cron le nem futott.

Ez a #644-es adottság-szűrőt közvetlenül érinti, mert az a `church.wheelchair` / `church.gluten_free_*` mezőkre szűr a mise-indexben.

## „Vagy nem túl sok erőforrás, hogy mindig lefusson?"

Lemértem: **0,5–0,6 másodperc templomonként** (`updateMasses([], [id])`, ~600 mise-időpont). Összehasonlításul a `updateChurches([id])` 0,02 mp.

Kézi mentésnél ez belefér. **A `save()`-be tenni viszont veszélyes lenne**, és ezért nem oda tettem:

| hívó | mennyi templom | mit jelentene |
|---|---|---|
| OSM-szinkron (`syncUrlMiserendFromOSM`) | akár több ezer | **órák** |
| boundary-cron (`checkBoundaries`) | 50 / 5 perc | +25 mp minden futásban |
| `/edit`, `/editosm` | 1, ember indítja | +0,5 mp — rendben |

Ezért a **felhasználói mentés-útvonalak** hívják: `Html\\Church\\Edit::modify()` és `EditOsm::modify()`. Ott egy ember épp most írt át valamit, és joggal várja, hogy a kereső is tudjon róla. ES-hiba nem buktatja a mentést, csak naplózunk.

Válaszolva a kérdésed másik felére („lehet nézegetni, melyik adat hat a mass-ra"): gyakorlatilag **minden**. A `toElasticArray()` szinte a teljes templom-rekordot beágyazza (nevek, város, egyházmegye, nyelvek, akadálymentesség, gluténmentes, koordináta, boundaries). Ráadásul az attribútumok külön táblában vannak, tehát a modell `isDirty()`-je nem is látná a változásukat. Így a „melyik mező változott" szűrés nem hozna érdemi megtakarítást — a hívási hely megválasztása viszont igen.

## Ellenőrzés

Átírtam a 2-es templom `wheelchair` értékét `limited`-ről `yes`-re, majd:

```
refreshMassSearchIndex: 0,62 mp
templom 2 wheelchair a mass_index-ben: yes
```

A döntési rész (`shouldRefreshMassSearchIndex`) tiszta függvényben van, `MassSearchIndexRefreshTest` fedi.

## Egy régi hiba, ami közben előkerült

A `Church::save()` kiszámolta a `parent::save()` visszatérési értékét, de **nem adta vissza** — a hívó `null`-t kapott `bool` helyett. Javítva.