### PR TITLE
Megjavítom a némán elakadó cronokat

### DIFF
--- a/webapp/classes/eloquent/cron.php
+++ b/webapp/classes/eloquent/cron.php
@@ -31,6 +31,66 @@ class Cron extends \Illuminate\Database\Eloquent\Model {
     }
 
     /**
+     * "Most esedékes" határidő. Szándékosan egy másodperccel korábbi: a scopeNextJobs
+     * szigorú `deadline_at < NOW()`-ot vár, tehát a pontosan mostani időbélyeg még egy
+     * teljes másodpercig nem esedékes.
+     */
+    private static function dueNow(): string {
+        return date('Y-m-d H:i:s', time() - 1);
+    }
+
+    /**
+     * Elakadt-e a munka? A /health eddig csak az attempts oszlopot színezte, de az egy
+     * bukott futás után is pirosodik — így nem tűnt fel, hogy volt olyan cron, ami
+     * hónapok óta nem futott le sikeresen (\User::deleteNonActivatedUsers 2026-03-27,
+     * \ExternalApi\szentsegimadasApi 2025-12-31 óta).
+     *
+     * Szándékosan DB-független és statikus, hogy unit-tesztelhető legyen.
+     *
+     * @param  string|null $lastSuccessAt  a lastsuccess_at mező nyers értéke
+     * @param  string      $frequency      strtotime-kompatibilis gyakoriság ('1 day', ...)
+     * @param  int|null    $now            időbélyeg (teszthez); null = most
+     * @return string|null                 az elakadás oka, vagy null ha rendben van
+     */
+    public static function stuckReason(?string $lastSuccessAt, string $frequency, ?int $now = null): ?string {
+        $now = $now ?? time();
+
+        // A régi sorokban a "soha" nem NULL-ként, hanem nulla-dátumként szerepel.
+        $never = $lastSuccessAt === null
+            || trim($lastSuccessAt) === ''
+            || str_starts_with(trim($lastSuccessAt), '0000-00-00');
+        if ($never) {
+            return 'soha nem futott le sikeresen';
+        }
+
+        $last = strtotime($lastSuccessAt);
+        if ($last === false) {
+            return 'értelmezhetetlen lastsuccess_at: ' . $lastSuccessAt;
+        }
+
+        // A gyakoriságot másodpercre váltjuk: 'now +1 day' - 'now'. Ha a frequency
+        // értelmezhetetlen, nem találgatunk, inkább nem jelzünk elakadást.
+        $period = strtotime('+' . $frequency, $now);
+        if ($period === false || $period <= $now) {
+            return null;
+        }
+        $periodSeconds = $period - $now;
+
+        // Háromszoros periódus a türelmi határ: egy-két kimaradt futás még belefér
+        // (ütközhetett másik jobbal, vagy kívül esett a from/until ablakon).
+        $elapsed = $now - $last;
+        if ($elapsed <= 3 * $periodSeconds) {
+            return null;
+        }
+
+        $days = (int) floor($elapsed / 86400);
+        if ($days >= 1) {
+            return $days . ' napja nem futott le sikeresen';
+        }
+        return (int) floor($elapsed / 3600) . ' órája nem futott le sikeresen';
+    }
+
+    /**
      * #638: az igényelt cron-munkák listája (webapp/fajlok/crons.php). Egyetlen forrás:
      * a MySQL-seed ezek után csak fejlesztői kezdőállapot, nem definíció.
      */
@@ -74,9 +134,29 @@ class Cron extends \Illuminate\Database\Eloquent\Model {
         $cron->attempts = 0;
         $cron->lastsuccess_at = null;
         // Azonnal esedékes: az új munka ne várjon egy teljes periódust az első futásra.
-        $cron->deadline_at = date('Y-m-d H:i:s');
+        $cron->deadline_at = self::dueNow();
         $cron->save();
         return true;
+    }
+
+    /**
+     * A NULL deadline_at-es sorok soha nem kerülnek sorra: a scopeNextJobs
+     * `deadline_at < NOW()` feltétele NULL-ra NULL-t ad, ami SQL-ben nem igaz. Egy ilyen
+     * sor csak kézzel, cron_id-vel futtatható — ezért állt évek óta az éles
+     * \Crons::rollPeriodYears() (deadline_at üres, lastsuccess_at üres, 31 próbálkozás).
+     *
+     * Csak azt bántja, aminek NINCS deadline-ja, tehát működő ütemezést nem tol el.
+     *
+     * @return string[] a most esedékessé tett munkák leírása
+     */
+    public static function healUnschedulable(): array {
+        $healed = [];
+        foreach (self::whereNull('deadline_at')->get() as $cron) {
+            $cron->deadline_at = self::dueNow();
+            $cron->save();
+            $healed[] = $cron->class . '->' . $cron->function . '()';
+        }
+        return $healed;
     }
 
     /**

--- a/webapp/classes/html/cron.php
+++ b/webapp/classes/html/cron.php
@@ -20,8 +20,13 @@ class Cron extends Html {
             echo "Új cron felvéve: " . htmlspecialchars($job) . "<br>\n";
         }
 
+        $healed = \Eloquent\Cron::healUnschedulable();
+        foreach ($healed as $job) {
+            echo "Ütemezhetővé tett cron (hiányzott a deadline_at): " . htmlspecialchars($job) . "<br>\n";
+        }
+
         if (\Request::Integer('cron_init')) {
-            if ($created === []) {
+            if ($created === [] && $healed === []) {
                 echo "Minden cron a helyén van, nem kellett újat felvenni.<br>\n";
             }
             return;
@@ -57,7 +62,11 @@ class Cron extends Html {
         $start = microtime(true);
         try {
             $this->runJob($job);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
+            // \Throwable, nem \Exception: a TypeError/Error a PHP 8-ban NEM \Exception,
+            // ezért eddig átment ezen a catch-en, megölte az egész kérést, és a job
+            // némán annyiban maradt — se hibaüzenet, se success. Így akadt el hónapokra
+            // a \User::deleteNonActivatedUsers() is.
             $this->error = true;
             echo "<strong>" . $job->class . "->" . $job->function . "() futtatása sikertelen.</strong>\n";
             $this->printExceptionVerbose($exception);

--- a/webapp/classes/html/cron.php
+++ b/webapp/classes/html/cron.php
@@ -76,8 +76,11 @@ class Cron extends Html {
             $job->success();
         }
         $elapsed = microtime(true) - $start;
+        // A `%` egészre vár, az $elapsed viszont float: PHP 8.1 óta minden cron-futás
+        // "Implicit conversion from float ... to int loses precision" figyelmeztetést
+        // hagyott maga után. fmod()-dal ugyanaz az eredmény, zaj nélkül.
         $hours = (int) floor($elapsed / 3600);
-        $minutes = (int) floor(($elapsed % 3600) / 60);
+        $minutes = (int) floor(fmod($elapsed, 3600) / 60);
         $seconds = $elapsed - ($hours * 3600) - ($minutes * 60);
         $s = round($seconds, 2);
 

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 class Health extends Html {
     public $infos;
     public $cronjobs;
+    public $stuckCronjobs;
     public $elasticsearch;
     public $churchesWithNoElasticMasses;
     public $churchesWithNoElasticMassesCount;
@@ -119,6 +120,26 @@ class Health extends Html {
 
 		// Health of CronJobs
 		$this->cronjobs = \Eloquent\Cron::orderBy('deadline_at','DESC')->get()->toArray();
+
+		// Az elakadt munkákat külön is kiemeljük: az attempts oszlop egyetlen bukott
+		// futástól is piros, ezért abban elveszett, hogy volt cron, ami hónapok óta nem
+		// futott le sikeresen.
+		$this->stuckCronjobs = [];
+		foreach ($this->cronjobs as $i => $cron) {
+			$reason = \Eloquent\Cron::stuckReason(
+				$cron['lastsuccess_at'] ?? null,
+				(string) ($cron['frequency'] ?? '')
+			);
+			$this->cronjobs[$i]['stuck_reason'] = $reason;
+			if ($reason !== null) {
+				$this->stuckCronjobs[] = [
+					'id'       => $cron['id'],
+					'name'     => $cron['class'] . '::' . $cron['function'] . '()',
+					'reason'   => $reason,
+					'attempts' => $cron['attempts'] ?? 0,
+				];
+			}
+		}
 
 		// Health of ElasticSearch database
 		$elastic = new \ExternalApi\ElasticsearchApi();

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -564,8 +564,14 @@ class User {
 			$email->send();
 			
 		}
-		$count = DB::table('user')->whereIN('uid',$ids2delete)->delete();
-									
+
+		// #239/#171: itt régen egy `whereIn('uid', $ids2delete)->delete()` állt, de a
+		// $ids2delete változó SEHOL nem kapott értéket — a törlést a fenti ciklus végzi
+		// egyesével. PHP 8 alatt a whereIn(null) TypeError-t dob, ami \Error, nem
+		// \Exception, ezért a cron-futtató catch-e sem fogta el: a job végzett a
+		// törléssel és kiküldte az értesítőket, aztán fatalra futott, így soha nem
+		// került success-be. Éles: 2026-03-27 óta nem futott le sikeresen.
+		return $countDeleted;
 	}
 	
 

--- a/webapp/fajlok/crons.php
+++ b/webapp/fajlok/crons.php
@@ -37,6 +37,9 @@ return [
     ['class' => '\ExternalApi\ElasticsearchApi',  'function' => 'updateChurches',             'frequency' => '6 hours'],
     ['class' => '\ExternalApi\ElasticsearchApi',  'function' => 'updateMasses',               'frequency' => '6 hours'],
     ['class' => '\ExternalCalendarImporter',      'function' => 'importAllExternalCalendars', 'frequency' => '1 day'],
+    // #239: éles adatbázisban régóta fut (id 39), de a registryből kimaradt — egy
+    // újrahúzott adatbázisban tehát soha nem jött volna létre.
+    ['class' => '\ExternalApi\szentsegimadasApi', 'function' => 'cron',                       'frequency' => '1 day',      'from' => '2am', 'until' => '5am'],
     ['class' => '\Crons',                         'function' => 'cleanExternalApiStats',      'frequency' => '1 day'],
     ['class' => '\Crons',                         'function' => 'cleanNotificationEmails',    'frequency' => '1 day'],
     ['class' => '\Crons',                         'function' => 'rollPeriodYears',            'frequency' => '1 month'],

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -42,6 +42,21 @@
 	<h3 id="cronjobs">Időzített feladatok</h3>
 	<p>Az időzített feladatok kézzel is futtathatóak egyesével vagy <a href="{{ base_url }}/index.php?q=cron" target="_blank">egyben itt</a>.</p>
 	<p>Most: {{ "now"|date('Y-m-d H:i:s') }}</p>
+	{% if stuckCronjobs is not empty %}
+		<div class="alert alert-danger">
+			<strong>{{ stuckCronjobs|length }} időzített feladat elakadt.</strong>
+			Ezek a gyakoriságuk háromszorosánál is régebben futottak le utoljára sikeresen —
+			vagy soha. A hibát az egyesével futtató linkre kattintva lehet megnézni.
+			<ul class="mb-0">
+				{% for cron in stuckCronjobs %}
+					<li>
+						<a href="{{ base_url }}/index.php?q=cron&cron_id={{ cron.id }}" target="_blank">{{ cron.name }}</a>
+						— {{ cron.reason }} ({{ cron.attempts }} próbálkozás)
+					</li>
+				{% endfor %}
+			</ul>
+		</div>
+	{% endif %}
 	<table class="table table-hover table-condensed table-striped">
 		<tr>
 			<th>id</th>
@@ -58,7 +73,10 @@
 				<td>{{ cron.frequency }} {% if cron.from %}({{ cron.from }} - {{ cron.until }}){% endif %}</td>
 				<td class="{% if cron.deadline_at < "now"|date("Y-m-d H:i:s") %}table-danger{% endif %}">{{ cron.deadline_at }}</td>
 				<td  style="text-align: center" class="{% if cron.attempts > 0 %}table-danger{% endif%}">{{ cron.attempts }}</td>
-				<td>{{ cron.lastsuccess_at }}</td>
+				<td class="{% if cron.stuck_reason %}table-danger{% endif %}" {% if cron.stuck_reason %}title="{{ cron.stuck_reason }}"{% endif %}>
+					{{ cron.lastsuccess_at }}
+					{% if cron.stuck_reason %}<br><small>{{ cron.stuck_reason }}</small>{% endif %}
+				</td>
 			</tr>
 		{% endfor %}
 	</table>

--- a/webapp/tests/Integration/CronResilienceTest.php
+++ b/webapp/tests/Integration/CronResilienceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * Az éles /health szerint a \User::deleteNonActivatedUsers() 2026-03-27 óta nem futott le
+ * sikeresen. Az ok egy sosem definiált $ids2delete változó volt a metódus végén: a
+ * whereIn(null) PHP 8-ban TypeError-t dob, ami \Error és nem \Exception, ezért a
+ * cron-futtató catch-e sem fogta el — a job némán fatalra futott, miután már törölte a
+ * felhasználókat és kiküldte az értesítőket.
+ */
+class CronResilienceTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /**
+     * A hibás sor akkor is lefutott, ha egyetlen törlendő felhasználó sem volt — ezért
+     * itt szándékosan kiürítjük a jelölteket: így a teszt mellékhatás (törlés, kiküldött
+     * email) nélkül fogja meg pontosan a hibát.
+     */
+    public function testDeleteNonActivatedUsersNemSzallElHaNincsTorlendo(): void {
+        DB::table('user')
+            ->where('lastlogin', '0000-00-00 00:00:00')
+            ->update(['lastlogin' => date('Y-m-d H:i:s')]);
+
+        $this->assertSame(
+            0,
+            \User::deleteNonActivatedUsers(),
+            'Nincs törlendő felhasználó, tehát 0-t kell visszaadnia — és nem fatalra futnia.'
+        );
+    }
+
+    /**
+     * A NULL deadline_at-es sorok soha nem kerülnek sorra (a scopeNextJobs
+     * `deadline_at < NOW()` feltétele NULL-ra nem igaz), ezért állt évek óta az éles
+     * \Crons::rollPeriodYears(). A healUnschedulable() ezt teszi esedékessé.
+     */
+    public function testHealUnschedulableEsedekesseTesziANullDeadlineSorokat(): void {
+        $cron = new \Eloquent\Cron();
+        $cron->class = '\TesztOsztaly';
+        $cron->function = 'tesztFuggveny';
+        $cron->frequency = '1 day';
+        $cron->attempts = 0;
+        $cron->deadline_at = null;
+        $cron->save();
+
+        $this->assertSame(
+            0,
+            \Eloquent\Cron::nextJobs()->where('id', $cron->id)->count(),
+            'NULL deadline_at mellett a munka nem kerülhet sorra.'
+        );
+
+        $healed = \Eloquent\Cron::healUnschedulable();
+        $this->assertContains('\TesztOsztaly->tesztFuggveny()', $healed);
+
+        $this->assertSame(
+            1,
+            \Eloquent\Cron::nextJobs()->where('id', $cron->id)->count(),
+            'A gyógyítás után esedékesnek kell lennie.'
+        );
+    }
+
+    public function testHealUnschedulableNemToljaElAMukodoUtemezest(): void {
+        $deadline = date('Y-m-d H:i:s', strtotime('+3 hours'));
+        $cron = new \Eloquent\Cron();
+        $cron->class = '\TesztOsztaly';
+        $cron->function = 'epFuggveny';
+        $cron->frequency = '1 day';
+        $cron->attempts = 0;
+        $cron->deadline_at = $deadline;
+        $cron->save();
+
+        \Eloquent\Cron::healUnschedulable();
+
+        $this->assertSame(
+            $deadline,
+            (string) \Eloquent\Cron::find($cron->id)->deadline_at,
+            'Akinek van deadline-ja, azt nem szabad átírni.'
+        );
+    }
+
+    /**
+     * A registry (#638) az egyetlen forrás arra, mely cronoknak kell léteznie. A
+     * szentségimádás-importáló élesben évek óta fut (id 39), de a listából kimaradt —
+     * egy újrahúzott adatbázisban tehát soha nem jött volna létre.
+     */
+    public function testSzentsegimadasCronBenneVanARegistryben(): void {
+        $registry = \Eloquent\Cron::registry();
+        $found = array_filter(
+            $registry,
+            fn($job) => ($job['class'] ?? '') === '\ExternalApi\szentsegimadasApi'
+                && ($job['function'] ?? '') === 'cron'
+        );
+        $this->assertCount(1, $found, 'A szentsegimadasApi::cron() hiányzik a registryből.');
+    }
+
+    /**
+     * A registry minden bejegyzésének létező osztályra és metódusra kell mutatnia,
+     * különben a cron-futtató "Class does not exists" hibával bukik minden futáskor.
+     */
+    public function testRegistryMindenBejegyzeseHivhato(): void {
+        foreach (\Eloquent\Cron::registry() as $job) {
+            $class = $job['class'];
+            $function = $job['function'];
+            $this->assertTrue(class_exists($class), "Nincs ilyen osztály: {$class}");
+            $this->assertTrue(
+                method_exists($class, $function),
+                "Nincs ilyen metódus: {$class}->{$function}()"
+            );
+        }
+    }
+}

--- a/webapp/tests/Unit/CronStuckDetectionTest.php
+++ b/webapp/tests/Unit/CronStuckDetectionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A /health eddig csak az attempts oszlopot színezte, ami egyetlen bukott futástól is
+ * pirosodik — emiatt évekig nem tűnt fel, hogy vannak cronok, amik hónapok óta nem
+ * futottak le sikeresen. A stuckReason() ezt a "régóta nem sikerült" állapotot ismeri fel.
+ */
+class CronStuckDetectionTest extends TestCase {
+
+    private int $now;
+
+    protected function setUp(): void {
+        parent::setUp();
+        // Fix időpont, hogy a teszt ne legyen naptárfüggő.
+        $this->now = strtotime('2026-08-09 12:00:00');
+    }
+
+    public function testFrissenLefutottMunkaNemElakadt(): void {
+        $this->assertNull(
+            \Eloquent\Cron::stuckReason('2026-08-09 06:00:00', '1 day', $this->now)
+        );
+    }
+
+    public function testEgyKimaradtFutasMegBelefer(): void {
+        // 1 napos gyakoriság, 2 napja futott: a 3x-os türelmi határon belül van.
+        $this->assertNull(
+            \Eloquent\Cron::stuckReason('2026-08-07 12:00:00', '1 day', $this->now)
+        );
+    }
+
+    public function testHaromszorosPeriodusUtanElakadtnakSzamit(): void {
+        $reason = \Eloquent\Cron::stuckReason('2026-08-05 11:00:00', '1 day', $this->now);
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('nem futott le sikeresen', $reason);
+    }
+
+    /**
+     * Az éles adatbázisban ténylegesen előfordult esetek.
+     */
+    public function testElesbenTalaltElakadtMunkak(): void {
+        // \User::deleteNonActivatedUsers — 20 perces gyakoriság, 2026-03-27 óta áll.
+        $reason = \Eloquent\Cron::stuckReason('2026-03-27 05:50:01', '20 minutes', $this->now);
+        $this->assertSame('135 napja nem futott le sikeresen', $reason);
+
+        // \ExternalApi\szentsegimadasApi::cron — napi, 2025-12-31 óta áll.
+        $reason = \Eloquent\Cron::stuckReason('2025-12-31 07:06:03', '1 day', $this->now);
+        $this->assertSame('221 napja nem futott le sikeresen', $reason);
+    }
+
+    public function testSohaNemFutottLe(): void {
+        $expected = 'soha nem futott le sikeresen';
+        $this->assertSame($expected, \Eloquent\Cron::stuckReason(null, '1 day', $this->now));
+        $this->assertSame($expected, \Eloquent\Cron::stuckReason('', '1 day', $this->now));
+        // A régi sorokban a "soha" nulla-dátumként szerepel — ez az éles
+        // \ExternalCalendarImporter és \Crons::rollPeriodYears esete.
+        $this->assertSame(
+            $expected,
+            \Eloquent\Cron::stuckReason('0000-00-00 00:00:00', '1 day', $this->now)
+        );
+    }
+
+    public function testOranyiElteresOraban(): void {
+        // 15 perces gyakoriság, 2 órája futott: 3x15 perc = 45 perc, tehát elakadt.
+        $reason = \Eloquent\Cron::stuckReason('2026-08-09 10:00:00', '15 minutes', $this->now);
+        $this->assertSame('2 órája nem futott le sikeresen', $reason);
+    }
+
+    public function testErtelmezhetetlenGyakorisagraNemTalalgat(): void {
+        $this->assertNull(
+            \Eloquent\Cron::stuckReason('2020-01-01 00:00:00', 'ez nem gyakoriság', $this->now)
+        );
+    }
+
+    public function testErtelmezhetetlenDatumotJelez(): void {
+        $reason = \Eloquent\Cron::stuckReason('nem dátum', '1 day', $this->now);
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('értelmezhetetlen', $reason);
+    }
+}


### PR DESCRIPTION
Az éles `/health` oldalt átnézve öt időzített feladat áll — közülük kettő hónapok óta, kettő pedig soha nem futott le sikeresen. Nem egy hiba van mögötte, hanem négy külön, ezért egyben javítom őket.

| cron | utolsó siker | próbálkozás |
|---|---|---|
| `\ExternalApi\szentsegimadasApi::cron()` | 2025-12-31 | 65 |
| `\User::deleteNonActivatedUsers()` | 2026-03-27 | 65 |
| `\ExternalCalendarImporter::importAllExternalCalendars()` | soha | 15 |
| `\Crons::rollPeriodYears()` | soha | 31 |
| `\OSM::syncUrlMiserendFromOSM()` | 2026-08-06 | 16 |

## 1. `deleteNonActivatedUsers` — reprodukált fatal

A metódus utolsó sora ez volt:

```php
$count = DB::table('user')->whereIN('uid',$ids2delete)->delete();
```

`$ids2delete` **sehol nem kap értéket** — maradék egy régebbi implementációból, a törlést a fölötte lévő ciklus végzi egyesével. PHP 8 alatt a `whereIn(null)` a Laravel query builderében `count(null)`-ra fut:

```
TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given
  vendor/illuminate/database/Query/Builder.php:1141
PHP Warning: Undefined variable $ids2delete in classes/user.php on line 567
```

Ezt a dev konténerben reprodukáltam. Rossz sorrend is van benne: a fatal **azután** jön, hogy a job már törölte a felhasználókat és kiküldte nekik a „töröltünk" levelet — csak a `success()` marad el.

## 2. A cron-futtató nem fogta el

```php
} catch (\Exception $exception) {
```

A `TypeError` `\Error`, nem `\Exception`. Tehát átment ezen a catch-en, megölte az egész kérést, és a job némán annyiban maradt: se hibaüzenet a képernyőn, se `success()`, se újra-ütemezés. `\Throwable`-re írom — a `printExceptionVerbose()` csak `getMessage()`/`getTrace()`-t használ, mindkettő megvan `\Throwable`-en.

## 3. `rollPeriodYears` — NULL deadline_at, ezért sosem kerül sorra

```sql
SELECT NULL < NOW();   -- NULL, tehát nem igaz
```

A `scopeNextJobs` `deadline_at < NOW()`-ot vár, így a NULL deadline-os sor **automatikusan soha nem választódik ki** — csak kézzel, `cron_id`-vel futtatható. Élesben pont ez az állapota a `rollPeriodYears`-nek (üres deadline, üres lastsuccess, 31 próbálkozás). A `Cron::init()` mostantól esedékessé teszi az ilyeneket; aminek **van** deadline-ja, ahhoz nem nyúl (van rá teszt).

Menet közben kiderült, hogy az „azonnal esedékes" határidő eddig `date('Y-m-d H:i:s')` volt, ami a szigorú `<` miatt még egy teljes másodpercig nem esedékes. Egy másodperccel korábbra teszem.

## 4. A szentségimádás-cron kimaradt a registryből

Élesben fut (id 39), de a `webapp/fajlok/crons.php`-ban nincs benne. Az a lista a #638 óta az egyetlen forrás — egy újrahúzott adatbázisban ez a cron soha nem jött volna létre. Felveszem (`1 day`, 2am–5am, ahogy élesben áll).

Mellékesen: a `szentsegimadas.hu` az én IP-mről 403-at ad, ezért a scrapert helyben nem tudtam lefuttatni. A `/health` szerint élesben **elérhető** (a külső szolgáltatók táblában OK), tehát nem a site a baj. A #239 nyitott pontja (~20 párosítatlan templom) emiatt marad, arról külön írok.

## Láthatóság

A `/health` eddig csak az `attempts` oszlopot színezte, ami **egyetlen** bukott futástól is piros — ebben veszett el, hogy volt cron, ami 220 napja állt. Mostantól van egy külön lista azokról, amik a gyakoriságuk háromszorosánál is régebben futottak le utoljára (vagy soha). A háromszoros türelmi határ azért kell, mert egy-két kimaradt futás normális: a futtató kérésenként **egy** jobot futtat, és a `from`/`until` ablak is szűkíthet.

A felismerő függvény (`Cron::stuckReason()`) szándékosan DB-független és statikus, hogy unit-tesztelhető legyen.

## Tesztek

Új: `CronStuckDetectionTest` (8 unit) + `CronResilienceTest` (5 integrációs), együtt 13 teszt / 63 assertion, zöld.

Köztük a valós éles értékek is: `stuckReason('2026-03-27 05:50:01', '20 minutes')` → `135 napja nem futott le sikeresen`. A `deleteNonActivatedUsers` regressziós tesztje szándékosan **üres** jelöltlistán fut — a hibás sor akkor is elszállt, ha nem volt mit törölni, így a teszt mellékhatás (törlés, kiküldött levél) nélkül fogja meg pontosan a hibát. Van teszt arra is, hogy a registry minden bejegyzése létező osztályra és metódusra mutat.

Kirendereltem a `health.twig`-et az éles adatokkal, a banner pontosan a fenti öt jobot listázza, és a hetente futó `\Photos::cron()`-t (4 napja futott) helyesen hagyja békén.

A teljes PHP suite nálam 457 tesztből 18-at buktat, de **ugyanaz a 18 bukik a masteren is** (`AutocompleteCombinedTest`, `LegacyChurchUrlRedirectTest` — HTTP-alapúak, a helyi környezetem miatt).

## Figyelmeztetés deploynál

A `deleteNonActivatedUsers` 4,5 hónapja nem fejezte be a futását sikeresen. A javítás után **újraindul**, és futásonként 20 aktiválatlan felhasználót töröl (1am–6am, 20 percenként), kiküldve nekik a `user_youhavebeendeleted` levelet. Ha ez alatt felgyűlt egy nagyobb adag, az most egyszerre fog lemenni. Ha ezt nem akarjuk, érdemes előtte megnézni, hányan érintettek:

```sql
SELECT COUNT(*) FROM user u
WHERE u.lastlogin = '0000-00-00 00:00:00'
  AND u.regdatum < NOW() - INTERVAL 2 WEEK
  AND EXISTS (SELECT 1 FROM emails e WHERE e.type='user_pleaseactivate'
              AND e.status='sent' AND e.to=u.email
              AND e.updated_at < NOW() - INTERVAL 2 DAY);
```

## Amit itt NEM javítok

- **89 levél `sending` státuszban ragadt** az elmúlt 30 napban (mind `user_pleaselogin`, mellette 48 `error`). A `sendQueued()` csak a `queued` sorokat szedi elő, tehát ezek soha nem mennek ki és nem is próbálkozik velük újra. Külön PR-t nyitok rá.
- A **631 misézőhely, aminek van miséje, de elastic-miséje nincs** — szintén külön.
- A `nextJobs()` `attempts ASC` rendezése miatt egy hibázó job a sor végére kerül, és gyakorlatilag csak akkor fut, ha semmi más nem esedékes. Ez szándékosnak tűnik (ne foglalja a futtatót), de a fenti esetekben ez tartotta életben a leállást. Ehhez nem nyúlok, mert ütemezési viselkedést változtatna.
