### PR TITLE
Kiszabadítom a "sending"-ben ragadt leveleket

### DIFF
--- a/webapp/classes/eloquent/email.php
+++ b/webapp/classes/eloquent/email.php
@@ -27,6 +27,8 @@ class Email extends \Illuminate\Database\Eloquent\Model {
      * használja, ezt a metódust pedig cron hívja batchenként korlátozva.
      */
     static function sendQueued($limit = 20) {
+        self::requeueStuck();
+
         $queued = self::where('status', 'queued')
             ->orderBy('created_at')
             ->limit($limit)
@@ -35,6 +37,50 @@ class Email extends \Illuminate\Database\Eloquent\Model {
             $email->send();
         }
         return true;
+    }
+
+    /**
+     * A send() legelső dolga, hogy 'sending'-re állítja a sort, és csak utána próbálkozik
+     * az SMTP-vel. Ha a folyamat közben hal meg (időkorlát, OOM, konténer-újraindulás),
+     * a sor örökre 'sending'-ben marad: a sendQueued() csak a 'queued' státuszt szedi
+     * elő, tehát az ilyen levél soha nem megy ki és soha nem is próbálkozik vele senki.
+     * Élesen 89 ilyen sor gyűlt össze egyetlen hónap alatt.
+     *
+     * Itt visszatesszük őket a sorba. Aki viszont már régóta ezt csinálja, azt 'error'-ba
+     * tesszük, hogy egy önmagában végzetes levél ne pörögjön a végtelenségig.
+     *
+     * @param  string $stuckAfter   ennyi idő után tekintjük beragadtnak (strtotime)
+     * @param  string $giveUpAfter  ennyi idős sorral már nem próbálkozunk (strtotime)
+     * @return array{requeued:int,failed:int}
+     */
+    static function requeueStuck($stuckAfter = '1 hour', $giveUpAfter = '3 days') {
+        $stuckBefore = date('Y-m-d H:i:s', strtotime('-' . $stuckAfter));
+        $giveUpBefore = date('Y-m-d H:i:s', strtotime('-' . $giveUpAfter));
+
+        $failed = self::where('status', 'sending')
+            ->where('updated_at', '<', $stuckBefore)
+            ->where('created_at', '<', $giveUpBefore)
+            ->update(['status' => 'error']);
+
+        $requeued = self::where('status', 'sending')
+            ->where('updated_at', '<', $stuckBefore)
+            ->update(['status' => 'queued']);
+
+        return ['requeued' => $requeued, 'failed' => $failed];
+    }
+
+    /**
+     * Azok a státuszok, amik "már megpróbáltuk értesíteni" jelentésűek.
+     *
+     * A felhasználó-értesítő cronok eddig csak a 'queued' és 'sent' sorokat nézték, így
+     * egy 'sending'-ben ragadt vagy 'error'-ra futott levél láthatatlan volt számukra —
+     * a következő futás ezért újra kiküldte ugyanazt. Élesben ez adta a
+     * 89 'sending' + 48 'error' + 47 'sent' arányt a user_pleaselogin típusnál.
+     *
+     * @return string[]
+     */
+    public static function attemptedStatuses(): array {
+        return ['queued', 'sending', 'sent', 'error'];
     }
     
     function send($to = false) {

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -584,7 +584,9 @@ class User {
 			$lastEmail = DB::table('emails')
 				->where('type','user_pleaseactivate')
 				->where('to',$user->email)
-				->whereIn('status',['queued','sent'])				
+				// A 'sending'/'error' is megpróbált értesítés: ha kimaradnának, a következő
+				// futás újra kiküldené ugyanazt a levelet ugyanannak. (l. Email::attemptedStatuses)
+				->whereIn('status', \Eloquent\Email::attemptedStatuses())
 				->orderBy('updated_at','desc')				
 				->first();
 					
@@ -626,7 +628,9 @@ class User {
 			$lastEmail = DB::table('emails')
 				->where('type','user_pleaselogin')
 				->where('to',$user->email)
-				->whereIn('status',['queued','sent'])				
+				// A 'sending'/'error' is megpróbált értesítés: ha kimaradnának, a következő
+				// futás újra kiküldené ugyanazt a levelet ugyanannak. (l. Email::attemptedStatuses)
+				->whereIn('status', \Eloquent\Email::attemptedStatuses())
 				->orderBy('updated_at','desc')				
 				->first();
 					
@@ -685,7 +689,7 @@ class User {
 					FROM emails
 					WHERE
 						`type` = 'user_pleaseupdate' AND 
-						`status` IN ('sent','queued') AND
+						`status` IN ('sent','queued','sending','error') AND
 						emails.to = user.email AND
 						updated_at > '".date('Y-m-d H:i:s',strtotime('-2 weeks'))."'
 						ORDER BY updated_at DESC
@@ -792,7 +796,7 @@ class User {
 			->select('user.*')
 			->join('church_holders', 'templomok.id', '=', 'church_holders.church_id')
 			->join('user', 'user.uid', '=', 'church_holders.user_id')
-			->whereRaw(" NOT EXISTS ( SELECT 1 FROM emails WHERE `type` = ? AND `status` IN ('sent','queued') AND emails.to = user.email AND updated_at > ? LIMIT 1 ) ",
+			->whereRaw(" NOT EXISTS ( SELECT 1 FROM emails WHERE `type` = ? AND `status` IN ('sent','queued','sending','error') AND emails.to = user.email AND updated_at > ? LIMIT 1 ) ",
 				[$type, date('Y-m-d H:i:s', strtotime('-2 weeks'))])
 			->where('church_holders.status', 'allowed')
 			->whereNull('church_holders.deleted_at')

--- a/webapp/tests/Integration/EmailStuckRequeueTest.php
+++ b/webapp/tests/Integration/EmailStuckRequeueTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * Az éles /health szerint az elmúlt 30 napban 89 levél ragadt 'sending' státuszban
+ * (mind user_pleaselogin, mellette 48 'error' és csak 47 'sent').
+ *
+ * Két, egymást erősítő hiba volt mögötte:
+ *
+ *  1. A send() legelső dolga 'sending'-re állítani a sort, és csak utána próbálkozik az
+ *     SMTP-vel. Ha a folyamat közben hal meg, a sor örökre 'sending' marad — a
+ *     sendQueued() csak a 'queued' sorokat szedi elő, tehát soha többé nem próbálkozik
+ *     vele senki.
+ *  2. Az értesítő cronok dedup-lekérdezése csak a 'queued'/'sent' sorokat nézte, így egy
+ *     beragadt levél láthatatlan volt: a következő futás újraküldte ugyanazt.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class EmailStuckRequeueTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function makeEmail(string $status, string $createdAt, string $updatedAt): int {
+        return DB::table('emails')->insertGetId([
+            'type'       => 'teszt_tipus',
+            'to'         => 'teszt@example.com',
+            'subject'    => 'Teszt',
+            'body'       => 'Teszt törzs',
+            'status'     => $status,
+            'created_at' => $createdAt,
+            'updated_at' => $updatedAt,
+        ]);
+    }
+
+    private function statusOf(int $id): string {
+        return (string) DB::table('emails')->where('id', $id)->value('status');
+    }
+
+    public function testABeragadtLevelVisszakerulASorba(): void {
+        $id = $this->makeEmail(
+            'sending',
+            date('Y-m-d H:i:s', strtotime('-2 hours')),
+            date('Y-m-d H:i:s', strtotime('-2 hours'))
+        );
+
+        $result = \Eloquent\Email::requeueStuck();
+
+        $this->assertSame('queued', $this->statusOf($id));
+        $this->assertGreaterThanOrEqual(1, $result['requeued']);
+    }
+
+    public function testAzEppKuldesAlattLevoLevelhezNemNyulunk(): void {
+        $id = $this->makeEmail(
+            'sending',
+            date('Y-m-d H:i:s', strtotime('-2 minutes')),
+            date('Y-m-d H:i:s', strtotime('-2 minutes'))
+        );
+
+        \Eloquent\Email::requeueStuck();
+
+        $this->assertSame(
+            'sending',
+            $this->statusOf($id),
+            'Egy percek óta küldés alatt álló levelet nem szabad kettéküldeni.'
+        );
+    }
+
+    public function testARegotaProbalkozoLevelHibaraKerul(): void {
+        // Négy napja jött létre, azóta is 'sending' — ezzel már nem próbálkozunk tovább,
+        // különben egy önmagában végzetes levél a végtelenségig pörögne a sorban.
+        $id = $this->makeEmail(
+            'sending',
+            date('Y-m-d H:i:s', strtotime('-4 days')),
+            date('Y-m-d H:i:s', strtotime('-4 days'))
+        );
+
+        $result = \Eloquent\Email::requeueStuck();
+
+        $this->assertSame('error', $this->statusOf($id));
+        $this->assertGreaterThanOrEqual(1, $result['failed']);
+    }
+
+    public function testMasStatuszokatNemBantja(): void {
+        $sent   = $this->makeEmail('sent',   date('Y-m-d H:i:s', strtotime('-2 days')), date('Y-m-d H:i:s', strtotime('-2 days')));
+        $error  = $this->makeEmail('error',  date('Y-m-d H:i:s', strtotime('-2 days')), date('Y-m-d H:i:s', strtotime('-2 days')));
+        $queued = $this->makeEmail('queued', date('Y-m-d H:i:s', strtotime('-2 days')), date('Y-m-d H:i:s', strtotime('-2 days')));
+
+        \Eloquent\Email::requeueStuck();
+
+        $this->assertSame('sent', $this->statusOf($sent));
+        $this->assertSame('error', $this->statusOf($error));
+        $this->assertSame('queued', $this->statusOf($queued));
+    }
+
+    /**
+     * A dedup a 'sending' és 'error' sorokat is megpróbált értesítésnek tekinti, különben
+     * ugyanannak a felhasználónak minden futásban újra kimenne a levél.
+     */
+    public function testADedupASendingEsErrorSorokatIsSzamolja(): void {
+        $statuses = \Eloquent\Email::attemptedStatuses();
+        $this->assertContains('sending', $statuses);
+        $this->assertContains('error', $statuses);
+        $this->assertContains('queued', $statuses);
+        $this->assertContains('sent', $statuses);
+    }
+
+    /**
+     * Ez a teszt a valós élettörténetet játssza le: a felhasználó kapott egy levelet, ami
+     * 'sending'-ben ragadt. A régi dedup ('queued','sent') nem látta, tehát a cron
+     * újraküldte volna.
+     */
+    public function testABeragadtLevelUtanNemMegyKiUjra(): void {
+        DB::table('emails')->insert([
+            'type'       => 'user_pleaselogin',
+            'to'         => 'ragadt@example.com',
+            'subject'    => 'Teszt',
+            'body'       => 'Teszt törzs',
+            'status'     => 'sending',
+            'created_at' => date('Y-m-d H:i:s', strtotime('-2 days')),
+            'updated_at' => date('Y-m-d H:i:s', strtotime('-2 days')),
+        ]);
+
+        $regi = DB::table('emails')
+            ->where('type', 'user_pleaselogin')
+            ->where('to', 'ragadt@example.com')
+            ->whereIn('status', ['queued', 'sent'])
+            ->first();
+        $this->assertNull($regi, 'A régi dedup tényleg nem látta a beragadt levelet.');
+
+        $uj = DB::table('emails')
+            ->where('type', 'user_pleaselogin')
+            ->where('to', 'ragadt@example.com')
+            ->whereIn('status', \Eloquent\Email::attemptedStatuses())
+            ->first();
+        $this->assertNotNull($uj, 'Az új dedupnak látnia kell, hogy már próbálkoztunk.');
+    }
+}


### PR DESCRIPTION
Az éles `/health` levélstatisztikájában a `user_pleaselogin` típus így néz ki az elmúlt 30 napban:

| státusz | darab |
|---|---|
| `sending` | **89** |
| `error` | 48 |
| `sent` | 47 |

Tehát a levelek háromnegyede nem ért célba, és a legnagyobb csoport egy olyan státuszban áll, amiből nincs kiút. Két, egymást erősítő hiba van mögötte.

## 1. A `sending` státusz zsákutca

A `send()` legelső dolga ez:

```php
$this->status = 'sending';
$this->save();
```

…és csak utána próbálkozik az SMTP-vel. A kivételeket a #610 óta rendesen elkapjuk (`catch (\Throwable)` → `fail()` → `error`), de az igazi fatal — időkorlát, OOM, konténer-újraindulás — nem elkapható. Olyankor a sor `sending`-ben marad, a `sendQueued()` viszont csak a `queued` státuszt szedi elő:

```php
$queued = self::where('status', 'queued')->orderBy('created_at')->limit($limit)->get();
```

Ezzel a levél soha nem megy ki, és soha nem is próbálkozik vele senki többé.

**Megoldás:** `Email::requeueStuck()`, amit a `sendQueued()` hív le minden futás elején.
- egy óránál régebben `sending`-ben álló sor → vissza `queued`-be
- ha a sor már **három napnál régebbi** és még mindig ezt csinálja → `error`, hogy egy önmagában végzetes levél (túl nagy törzs, mérgező címzett) ne pörögjön a végtelenségig

A két küszöb paraméter, tehát kézzel máshogy is meghívható.

## 2. A dedup nem látta a bukott próbálkozásokat

```php
$lastEmail = DB::table('emails')
    ->where('type','user_pleaselogin')
    ->where('to',$user->email)
    ->whereIn('status',['queued','sent'])   // <-- 'sending' és 'error' kimarad
    ->orderBy('updated_at','desc')
    ->first();
```

Egy `sending`-ben ragadt vagy `error`-ra futott levél emiatt **láthatatlan** volt: a lekérdezés vagy egy jóval régebbi `sent` sort talált, vagy semmit — és a cron mindkét esetben kiküldött egy újat ugyanannak a felhasználónak. Az meg megint beragadt. Innen a 89-es szám.

Ugyanez a minta négy helyen volt meg (`sendActivationNotification`, `sendInactivityNotification`, `sendUpdateNotification`, `sendHolidayReminder`). Mindegyik mostantól az `Email::attemptedStatuses()`-t használja: `queued`, `sending`, `sent`, `error` — vagyis "már megpróbáltuk értesíteni".

A `deleteNonActivatedUsers`-hez **nem** nyúltam: az szándékosan csak `sent` sorra hajlandó törölni, és ez így helyes.

## Egy szándékos viselkedésváltozás

A `sendInactivityNotification` törlés-ága így néz ki:

```php
elseif ($lastEmail->status == 'sent' AND strtotime($lastEmail->updated_at) < strtotime('-3 week')) {
    // ...user törlése
}
```

Mivel `$lastEmail` mostantól lehet `sending`/`error` is, a törlés csak akkor fut le, ha a **legutolsó** értesítő tényleg kiment. Eddig egy régebbi sikeres levél alapján akkor is törölt, ha az azóta indított próbálkozás elbukott — vagyis törölhetett olyan felhasználót, akit valójában nem sikerült figyelmeztetni. Ez a változás szigorúbb; szerintem így helyes, de jelzem, mert felhasználó-törlésről van szó.

## Tesztek

Új: `EmailStuckRequeueTest`, 6 integrációs teszt (tranzakcióban, rollbackkel):
- egy két órája álló `sending` visszakerül `queued`-be
- egy két perce induló `sending`-hez **nem** nyúlunk (nem küldjük ki kétszer)
- egy négy napos `sending` `error`-ba kerül
- `sent`/`error`/`queued` sorokat nem bánt
- a régi dedup tényleg nem látta a beragadt levelet, az új látja

A teljes suite: 450 teszt, 18 bukás — **ugyanaz a 18, ami a masteren is** (`AutocompleteCombinedTest`, `LegacyChurchUrlRedirectTest`, HTTP-alapúak, a helyi környezetem miatt).

## Deploy után

A 89 beragadt levél a következő `Eloquent\Email::sendQueued()` futáskor visszakerül a sorba, és 20-asával elindul. Ha ezt nem akarjuk (régi, már nem aktuális emlékeztetők), előtte érdemes kézzel lezárni őket:

```sql
UPDATE emails SET status='error'
WHERE status='sending' AND created_at < NOW() - INTERVAL 3 DAY;
```

Amúgy a `requeueStuck()` ezt magától is megteszi velük, hiszen mind régebbi három napnál — tehát alapesetben **nem** fognak kimenni, csak `error`-ba kerülnek. Kimenni csak az fog, ami az elmúlt három napban ragadt be.

Kapcsolódik: #683 (a némán elakadó cronok).
