### PR TITLE
Pótolom a keresésből kimaradt miséket

### DIFF
--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -184,9 +184,22 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return true;
 	}
 
+	/**
+	 * Az imént beírt dokumentumokat azonnal kereshetővé teszi. Alapból ~1 másodperc telik
+	 * el, addig egy visszaellenőrző lekérdezés hamis "üres" eredményt adna.
+	 */
+	function refreshIndex($name) {
+		$this->clearRequestBody();
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "POST");
+		$this->buildQuery($name . '/_refresh');
+		$this->run();
+
+		return $this->responseCode == 200;
+	}
+
 	function deleteIndex($name) {
-		
-		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"DELETE");		
+
+		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"DELETE");
 		$this->buildQuery($name);
 		$this->run();
 
@@ -452,11 +465,130 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 			$elastic->setIndexMeta('mass_index', [
 				'full_reindex_at' => date('Y-m-d H:i:s'),
 				'years' => array_values(array_map('intval', $years)),
+				// A "tényleg nincs idei miséje" lista szándékosan NEM öröklődik át: friss
+				// teljes indexépítés után újra ellenőrizzük, hátha közben lett miséjük.
+				'churches_without_masses' => [],
 			]);
 		} catch (\Throwable $e) {
 			// A vízjel hiánya csak annyit jelent, hogy legközelebb újra lefutunk.
 			$log("#627: az index vízjelét nem sikerült kiírni (" . $e->getMessage() . ").");
 		}
+	}
+
+	/**
+	 * Mely templomokat érdemes pótindexelni?
+	 *
+	 * A /health régóta mutatja, hogy vannak misézőhelyek, amiknek van miserendjük az
+	 * adatbázisban, de az idei évre egyetlen dokumentumuk sincs a mass_indexben (élesben
+	 * 631 ilyen volt). Ez a kereséseikből egyszerűen kihagyja őket.
+	 *
+	 * A lista nem tisztán hiba: van, akinek tényleg nincs idei miséje (lejárt vagy csak
+	 * múltbeli miserend). Ezeket a pótindexelés után megjegyezzük, és nem próbálkozunk
+	 * velük újra és újra — különben minden futás ugyanazon a néhány száz templomon
+	 * pörögne feleslegesen.
+	 *
+	 * Szándékosan tiszta függvény (se DB, se ES), hogy unit-tesztelhető legyen.
+	 *
+	 * @param  int[] $churchIdsWithRules  templomok, amiknek VAN miserendjük
+	 * @param  int[] $indexedChurchIds    templomok, amiknek van idei indexelt miséjük
+	 * @param  int[] $knownEmptyChurchIds akikről már tudjuk, hogy tényleg nincs idei miséjük
+	 * @param  int   $limit               egy futásban ennyivel próbálkozunk
+	 * @return int[]
+	 */
+	public static function massReindexCandidates(
+		array $churchIdsWithRules,
+		array $indexedChurchIds,
+		array $knownEmptyChurchIds,
+		int $limit = 100
+	): array {
+		if ($limit <= 0) {
+			return [];
+		}
+
+		$skip = array_flip(array_map('intval', array_merge($indexedChurchIds, $knownEmptyChurchIds)));
+
+		$candidates = [];
+		foreach ($churchIdsWithRules as $id) {
+			$id = (int) $id;
+			if (isset($skip[$id])) {
+				continue;
+			}
+			$candidates[$id] = $id;
+			if (count($candidates) >= $limit) {
+				break;
+			}
+		}
+
+		return array_values($candidates);
+	}
+
+	/**
+	 * Pótolja a hiányzó mise-dokumentumokat: megkeresi azokat a templomokat, amiknek van
+	 * miserendjük, de nincs idei indexelt miséjük, és csak őket indexeli újra.
+	 *
+	 * Nem a teljes újraindexelés helyett van, hanem mellette: a teljes futás akkor is
+	 * hagyhat lyukat, ha közben elhasal valami, ez pedig magától összevarrja.
+	 *
+	 * @return array{candidates:int,reindexed:int,still_empty:int}
+	 */
+	static function reindexMissingMasses(int $limit = 100, ?callable $logger = null): array {
+		$log = $logger ?? function($msg) {};
+		$elastic = new \ExternalApi\ElasticsearchApi();
+
+		if (!$elastic->isexistsIndex('mass_index')) {
+			$log("Nincs mass_index — a pótindexelésnek nincs mit tennie.");
+			return ['candidates' => 0, 'reindexed' => 0, 'still_empty' => 0];
+		}
+
+		$yearStart = date('Y-01-01');
+		$yearEnd   = date('Y-12-31');
+
+		$indexed = $elastic->churchIdsWithMassesInPeriod($yearStart, $yearEnd);
+		$meta = $elastic->getIndexMeta('mass_index');
+		$knownEmpty = array_map('intval', $meta['churches_without_masses'] ?? []);
+
+		$withRules = \Eloquent\Church::where('ok', 'i')->has('massrules')->orderBy('id')->pluck('id')->toArray();
+
+		$candidates = self::massReindexCandidates($withRules, $indexed, $knownEmpty, $limit);
+		if (empty($candidates)) {
+			$log("Nincs pótolni való: minden miserenddel rendelkező templomnak van idei indexelt miséje.");
+			return ['candidates' => 0, 'reindexed' => 0, 'still_empty' => 0];
+		}
+
+		$log("Pótindexelés " . count($candidates) . " templomra.");
+		self::updateMasses([], $candidates, $logger);
+
+		// A bulk insert alapból ~1 másodperc múlva válik kereshetővé, addig a
+		// visszaellenőrzés hamis "üres" eredményt adna.
+		$elastic->refreshIndex('mass_index');
+
+		$indexedAfter = array_flip(array_map('intval', $elastic->churchIdsWithMassesInPeriod($yearStart, $yearEnd)));
+		$stillEmpty = [];
+		$reindexed = 0;
+		foreach ($candidates as $id) {
+			if (isset($indexedAfter[$id])) {
+				$reindexed++;
+			} else {
+				$stillEmpty[] = $id;
+			}
+		}
+
+		if (!empty($stillEmpty)) {
+			$log(count($stillEmpty) . " templomnak a pótindexelés után sincs idei miséje — ezekkel nem próbálkozunk újra a következő teljes indexépítésig.");
+			$merged = array_values(array_unique(array_merge($knownEmpty, $stillEmpty)));
+			sort($merged);
+			$meta['churches_without_masses'] = $merged;
+			if (!$elastic->setIndexMeta('mass_index', $meta)) {
+				$log("A vízjelet nem sikerült frissíteni — legközelebb újra megpróbáljuk ezeket.");
+			}
+		}
+
+		$log("Pótindexelés kész: " . $reindexed . " templom került be, " . count($stillEmpty) . " maradt üres.");
+		return [
+			'candidates'  => count($candidates),
+			'reindexed'   => $reindexed,
+			'still_empty' => count($stillEmpty),
+		];
 	}
 
 	/*
@@ -532,9 +664,31 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 
 		$chunksize = 100;
 		if (is_array($tids) && count($tids) > $chunksize) {
-			foreach (array_chunk($tids,  $chunksize) as $chunk) {
-				static::updateMasses($years, $chunk, $logger);
+			// Egy elhasaló templom eddig az EGÉSZ hátralévő újraindexelést megölte: a
+			// rekurzív hívás kivétele kibuborékolt, a soron következő több ezer templom
+			// pedig sosem került sorra. Mostantól a hibás darab kimarad, a többi lefut,
+			// és a végén dobunk — így a cron továbbra is hibásnak látszik, de nem
+			// hagyunk magunk után nagy lyukat az indexben.
+			$failedChunks = [];
+			foreach (array_chunk($tids,  $chunksize) as $index => $chunk) {
+				try {
+					static::updateMasses($years, $chunk, $logger);
+				} catch (\Throwable $e) {
+					$failedChunks[] = ($index + 1) . '. darab (templomok: '
+						. implode(', ', array_slice($chunk, 0, 5))
+						. (count($chunk) > 5 ? ', …' : '') . '): ' . $e->getMessage();
+					$log("Hibás darab kihagyva: " . end($failedChunks));
+				}
 			}
+
+			if (!empty($failedChunks)) {
+				// Vízjelet ilyenkor SZÁNDÉKOSAN nem írunk: az index hiányos, a következő
+				// futásnak újra neki kell futnia.
+				throw new \Exception(
+					count($failedChunks) . " darab újraindexelése hibázott:\n" . implode("\n", $failedChunks)
+				);
+			}
+
 			if ($isFullRun) self::markFullReindex($years, $log);
 			return;
 		}

--- a/webapp/fajlok/crons.php
+++ b/webapp/fajlok/crons.php
@@ -36,6 +36,9 @@ return [
     ['class' => '\Api\NearBy',                    'function' => 'cleanOldLogs',               'frequency' => '1 day'],
     ['class' => '\ExternalApi\ElasticsearchApi',  'function' => 'updateChurches',             'frequency' => '6 hours'],
     ['class' => '\ExternalApi\ElasticsearchApi',  'function' => 'updateMasses',               'frequency' => '6 hours'],
+    // A teljes indexépítés akkor is hagyhat lyukat, ha közben elhasal valami; ez varrja
+    // össze. Élesben 631 misézőhely maradt ki így a keresésből.
+    ['class' => '\ExternalApi\ElasticsearchApi',  'function' => 'reindexMissingMasses',       'frequency' => '6 hours'],
     ['class' => '\ExternalCalendarImporter',      'function' => 'importAllExternalCalendars', 'frequency' => '1 day'],
     ['class' => '\Crons',                         'function' => 'cleanExternalApiStats',      'frequency' => '1 day'],
     ['class' => '\Crons',                         'function' => 'cleanNotificationEmails',    'frequency' => '1 day'],

--- a/webapp/tests/Integration/MassIndexReconcileTest.php
+++ b/webapp/tests/Integration/MassIndexReconcileTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A pótindexelés valós Elasticsearch ellen: a jelöltválasztást a
+ * MassReindexCandidatesTest fedi, itt az köré épülő I/O megy — a friss dokumentumok
+ * azonnali kereshetősége és az "ennek tényleg nincs idei miséje" vízjel.
+ */
+class MassIndexReconcileTest extends TestCase {
+
+    private \ExternalApi\ElasticsearchApi $elastic;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->elastic = new \ExternalApi\ElasticsearchApi();
+        if (!$this->elastic->isexistsIndex('mass_index')) {
+            $this->markTestSkipped('Nincs mass_index ebben a környezetben.');
+        }
+    }
+
+    /**
+     * A bulk insert alapból ~1 másodperc múlva válik kereshetővé. A pótindexelés
+     * visszaellenőrzése enélkül hamis "üres" eredményt adna, és minden éppen most
+     * pótolt templomot tévesen "tényleg nincs miséje" listára tenne.
+     */
+    public function testARefreshLefut(): void {
+        $this->assertTrue(
+            $this->elastic->refreshIndex('mass_index'),
+            'Az index frissítésének sikerülnie kell.'
+        );
+    }
+
+    public function testAFrissenIndexeltMiseAzonnalMegtalalhato(): void {
+        $churchId = \Eloquent\Church::where('ok', 'i')->has('massrules')->value('id');
+        if (!$churchId) {
+            $this->markTestSkipped('Nincs miserenddel rendelkező templom a teszt-adatbázisban.');
+        }
+
+        \ExternalApi\ElasticsearchApi::updateMasses([(int) date('Y')], [$churchId], null);
+        $this->elastic->refreshIndex('mass_index');
+
+        $indexed = array_map('intval', $this->elastic->churchIdsWithMassesInPeriod(date('Y-01-01'), date('Y-12-31')));
+
+        $this->assertContains(
+            (int) $churchId,
+            $indexed,
+            'A refresh után az imént indexelt templomnak szerepelnie kell az aggregációban.'
+        );
+    }
+
+    /**
+     * A vízjel körbejárása: amit "tényleg üres"-nek jelöltünk, azt vissza kell tudni
+     * olvasni, különben a pótindexelés minden futásban újrapróbálná ugyanazokat.
+     */
+    public function testAzUresTemplomokListajaVisszaolvashato(): void {
+        $eredeti = $this->elastic->getIndexMeta('mass_index');
+
+        try {
+            $ujMeta = $eredeti;
+            $ujMeta['churches_without_masses'] = [111111, 222222];
+            $this->assertTrue($this->elastic->setIndexMeta('mass_index', $ujMeta));
+
+            $vissza = $this->elastic->getIndexMeta('mass_index');
+            $this->assertSame([111111, 222222], array_map('intval', $vissza['churches_without_masses']));
+
+            // A jelöltválasztás ténylegesen kihagyja őket.
+            $this->assertSame(
+                [333333],
+                \ExternalApi\ElasticsearchApi::massReindexCandidates(
+                    [111111, 222222, 333333],
+                    [],
+                    array_map('intval', $vissza['churches_without_masses']),
+                    100
+                )
+            );
+        } finally {
+            // Az _meta PUT a teljes tartalmat lecseréli, ezért az eredetit írjuk vissza.
+            $this->elastic->setIndexMeta('mass_index', $eredeti);
+        }
+    }
+
+    /**
+     * A pótindexelés akkor se boruljon, ha épp nincs mit tenni.
+     */
+    public function testNincsMitTenniEsetenIsRendbenFutLe(): void {
+        $result = \ExternalApi\ElasticsearchApi::reindexMissingMasses(0, null);
+
+        $this->assertSame(0, $result['candidates']);
+        $this->assertSame(0, $result['reindexed']);
+        $this->assertSame(0, $result['still_empty']);
+    }
+}

--- a/webapp/tests/Unit/MassReindexCandidatesTest.php
+++ b/webapp/tests/Unit/MassReindexCandidatesTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A /health régóta mutatja, hogy vannak misézőhelyek, amiknek van miserendjük az
+ * adatbázisban, de az idei évre egyetlen dokumentumuk sincs a mass_indexben — élesben
+ * 631 ilyen volt, vagyis ennyi templom egyszerűen kimaradt a keresésekből.
+ *
+ * A pótindexelés jelöltválasztása szándékosan tiszta függvény (se DB, se ES), így itt
+ * mockok nélkül tesztelhető.
+ */
+class MassReindexCandidatesTest extends TestCase {
+
+    public function testCsakAzokMaradnakAkiknekNincsIndexeltMiseje(): void {
+        $candidates = \ExternalApi\ElasticsearchApi::massReindexCandidates(
+            [1, 2, 3, 4, 5],   // van miserendjük
+            [1, 3],            // ezeknek van idei indexelt miséjük
+            [],                // nincs ismert üres
+            100
+        );
+
+        $this->assertSame([2, 4, 5], $candidates);
+    }
+
+    public function testAzIsmertenUresTemplomokatNemProbaljukUjra(): void {
+        // Ha nem hagynánk ki őket, minden futás ugyanazon a néhány száz templomon
+        // pörögne, amiknek tényleg nincs idei miséjük.
+        $candidates = \ExternalApi\ElasticsearchApi::massReindexCandidates(
+            [1, 2, 3, 4, 5],
+            [1],
+            [3, 5],
+            100
+        );
+
+        $this->assertSame([2, 4], $candidates);
+    }
+
+    public function testALimitBetartasa(): void {
+        $withRules = range(1, 500);
+        $candidates = \ExternalApi\ElasticsearchApi::massReindexCandidates($withRules, [], [], 100);
+
+        $this->assertCount(100, $candidates);
+        $this->assertSame(1, $candidates[0]);
+        $this->assertSame(100, $candidates[99]);
+    }
+
+    public function testHaMindenIndexelveVanNincsJelolt(): void {
+        $this->assertSame(
+            [],
+            \ExternalApi\ElasticsearchApi::massReindexCandidates([1, 2, 3], [1, 2, 3], [], 100)
+        );
+    }
+
+    /**
+     * Az ES aggregáció stringként is adhat vissza kulcsot, a DB pluck() int-et — a
+     * kettőt össze kell tudni vetni, különben minden templom "hiányzónak" látszana.
+     */
+    public function testStringEsIntAzonositokatIsOsszeveti(): void {
+        $candidates = \ExternalApi\ElasticsearchApi::massReindexCandidates(
+            ['1', '2', '3'],
+            ['2'],
+            ['3'],
+            100
+        );
+
+        $this->assertSame([1], $candidates);
+    }
+
+    /**
+     * Nulla (vagy negatív) limit = ne csinálj semmit. A naiv "adjuk hozzá, aztán
+     * ellenőrizzük a darabszámot" ciklus itt épp egy jelöltet adna vissza.
+     */
+    public function testNullaLimitreNincsJelolt(): void {
+        $this->assertSame(
+            [],
+            \ExternalApi\ElasticsearchApi::massReindexCandidates([1, 2, 3], [], [], 0)
+        );
+        $this->assertSame(
+            [],
+            \ExternalApi\ElasticsearchApi::massReindexCandidates([1, 2, 3], [], [], -5)
+        );
+    }
+
+    public function testDuplikatumokatNemAdVisszaKetszer(): void {
+        $candidates = \ExternalApi\ElasticsearchApi::massReindexCandidates(
+            [7, 7, 8, 8, 8],
+            [],
+            [],
+            100
+        );
+
+        $this->assertSame([7, 8], $candidates);
+    }
+}


### PR DESCRIPTION
Az éles `/health` évek óta mutatja ezt a számot, és senki nem tudta, mit kezdjen vele:

> Misézőhelyek misékkel, de elastic-misék nélkül: **631**

Ez azt jelenti, hogy 631 templomnak van miserendje az adatbázisban, de az idei évre egyetlen dokumentuma sincs a `mass_index`ben — tehát **kimarad a keresésekből**. A saját oldala rendben megjelenik, csak nem lehet rátalálni.

Nálam dev-ben ugyanez a szám **2**, tehát nem általános logikai hiba, hanem az éles index sérült.

## Hogyan keletkezik a lyuk

Az `updateMasses()` 100-as darabokban dolgozik, és minden darabnál **előbb töröl, aztán generál**:

```php
$elastic->deleteMasses($tids); // Sajnos egyszerre törlük több templomét, de ha aztán
                               // a legenárálás elhasal valamelyiknél, akkor elvesztettünk csomót.
```

A kommentet nem én írtam — a kód szerzője pontosan tudta, mi a kockázat. Amit viszont nem kezelt: a darabolás rekurzív hívásait **semmi nem fogta el**:

```php
foreach (array_chunk($tids, $chunksize) as $chunk) {
    static::updateMasses($years, $chunk, $logger);   // ha ez dob, vége mindennek
}
```

Egyetlen templomnál elszálló bulk insert (`throw new \Exception("Could not insert mass data for church ID …")`) tehát:
- üresen hagyja azt a darabot, amiből már törölt,
- és **az összes hátralévő darabot meg sem próbálja**.

Ötezer templomnál ez ötven darab; ha a hetediknél hasal el, negyvennégy soha nem kerül sorra.

## Mit csinálok

**1. A hibás darab ne vigye magával a többit.** A darab köré `try/catch`, a hibákat összegyűjtöm, a végén dobok. Így a cron továbbra is hibásnak látszik (és a #683 után a hibaüzenet ki is íródik), de a többi templom rendben újraindexelődik. Vízjelet ilyenkor szándékosan **nem** írok — az index hiányos, a következő futásnak neki kell futnia.

**2. Pótindexelés a már meglévő hiányra.** Az 1. pont csak azt akadályozza meg, hogy új lyuk keletkezzen. A meglévő 631-hez kell egy önjavító lépés, ezért új cron: `ElasticsearchApi::reindexMissingMasses()` (6 óránként).

Megkeresi, kinek van miserendje idei indexelt mise nélkül, és **csak őket** generálja újra, futásonként százasával.

**3. Ami tényleg üres, az ne pörögjön örökké.** A 631 nem mind hiba: van, akinek valóban nincs idei miséje (lejárt vagy csak múltbeli miserend). Ha ezt nem kezelném, minden futás ugyanazon a néhány száz templomon dolgozna feleslegesen. A pótindexelés ezért **visszaellenőrzi magát**, és aki utána is üres, bekerül az index `_meta` vízjelébe (`churches_without_masses`). A következő teljes indexépítés a listát nullázza, tehát ha közben lesz miséjük, újra sorra kerülnek.

**4. `refreshIndex()`.** A bulk insert alapból csak ~1 másodperc múlva válik kereshetővé. Enélkül a 3. pont visszaellenőrzése **mindenkit** tévesen üresnek látna, és az imént pótolt templomokat is felvenné a „tényleg üres" listára.

## Amit szándékosan nem csinálok

Nem építem át a törlés–generálás sorrendjét templomonkéntire. Az lenne az igazi megoldás (egy hibás templom csak magát vinné), de a generálás darabszinten, mise-periódusonként dolgozik, nem templomonként — az átszervezés nagyobb és kockázatosabb, mint amit ez a hiba indokol. A darab-izoláció a lyukat 5000-ről legfeljebb 100 templomra viszi le, a pótindexelés meg azt is összevarrja.

## Hogy teszteltem

**Unit** (`MassReindexCandidatesTest`, 7 teszt): a jelöltválasztás szándékosan tiszta függvény. Fedve: az ismerten üresek kihagyása, a limit betartása, a `0`/negatív limit (a naiv „adjuk hozzá, aztán számoljunk" ciklus itt épp egy jelöltet adna vissza), duplikátumok, és hogy az ES aggregáció **string** kulcsait össze kell tudni vetni a DB `pluck()` **int**-jeivel — enélkül minden templom hiányzónak látszana.

**Integrációs** (`MassIndexReconcileTest`, 4 teszt, valós ES ellen): a `refreshIndex()` lefut; a frissen indexelt mise a refresh után azonnal megtalálható az aggregációban; a vízjel körbejárható és tényleg kihagyja a jelölteket (az `_meta` PUT a teljes tartalmat lecseréli, ezért a teszt visszaírja az eredetit).

**Végponttól végpontig, kézzel a dev stacken** — ez volt a lényeg. Kivettem három templom (36, 92, 2413) miséit az indexből, pontosan azt szimulálva, amit egy félbeszakadt darab hagy maga után:

```
Kiinduló állapot: 3413 templomnak van idei indexelt miséje.
Kiürítem az indexből: 36, 92, 2413
Most 3410 van (3 tűnt el).

--- pótindexelés ---
  Pótindexelés 4 templomra.
  Nos hát szépen minden napra szét bontva így lett nekünk már 16755 misénk.
  1 templomnak a pótindexelés után sincs idei miséje — ezekkel nem próbálkozunk újra…
  Pótindexelés kész: 3 templom került be, 1 maradt üres.
  (6.0 mp)

  - 36 visszakerült?   IGEN
  - 92 visszakerült?   IGEN
  - 2413 visszakerült? IGEN
vízjel churches_without_masses: 1 templom
```

A negyedik jelölt a dev-ben eleve meglévő hiány volt — a pótindexelés kiderítette, hogy annak tényleg nincs idei miséje, és bejegyezte a vízjelbe.

A teljes suite: 455 teszt, 18 bukás — **ugyanaz a 18, ami a masteren is** (`AutocompleteCombinedTest`, `LegacyChurchUrlRedirectTest`, HTTP-alapúak, a helyi környezetem miatt).

## Deploy után

A cron 6 óránként fut, futásonként 100 templommal, darabonként pár másodperc. A 631 tehát nagyjából másfél nap alatt fogy el magától; közben a `/health` számán látszani fog a csökkenés. Ha gyorsabban kell, kézzel is futtatható a `/health` cron-listájából.

Kapcsolódik: #683 (a némán elakadó cronok) — annak a `\Throwable`-catch-e nélkül ennek a cronnak a hibája se látszana.
