### PR TITLE
Egy helyre teszem az érték-ellenőrzést (#393)

### DIFF
--- a/webapp/classes/api/api.php
+++ b/webapp/classes/api/api.php
@@ -148,13 +148,12 @@ class Api {
         if($type == 'integer') {
             $this->validateInteger($name, $details, $input);
         } elseif($type == 'boolean') {
-            if(!is_bool($input)) {
-                throw new \Exception("Field '".$name."' should be a boolean.");
-            }
+            $this->throwIf($name, \Validate::booleanError($input));
         } elseif($type == 'date') {
-            if(!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/", $input)) {
-                throw new \Exception("Field '".$name."' should be a date (yyyy-mm-dd).");
-            }
+            // #393: eddig puszta reguláris kifejezés volt, ezért az API elfogadta a
+            // 2023-02-29-et, a 2023-02-31-et és a 2026-04-31-et is — miközben ugyanezeket
+            // a \Request naptár-tudatos ellenőrzése helyesen visszautasította.
+            $this->throwIf($name, \Validate::dateError($input));
         } elseif($type == 'float') {
             $this->validateFloat($name, $details, $input);
         } elseif($type == 'string') {
@@ -176,43 +175,27 @@ class Api {
         }
     }
 
-    public function validateFloat($field, $details, $input) {        
-        if(!is_numeric($input) || floatval($input) != $input) {
-            throw new \Exception("Field '".$field."' should be a float.");
+    /**
+     * #393: a tényleges ellenőrzés a közös \Validate-ben él (ugyanazt a tudást a
+     * \Request is használja). Itt már csak a hibaüzenet formája marad, hogy az API
+     * válaszai változatlanok legyenek.
+     */
+    private function throwIf($field, ?string $error) {
+        if ($error !== null) {
+            throw new \Exception("Field '".$field."' ".$error);
         }
-        if(isset($details['minimum']) && $input < $details['minimum']) {
-            throw new \Exception("Field '".$field."' should be at least ".$details['minimum'].".");
-        }
-        if(isset($details['maximum']) && $input > $details['maximum']) {
-            throw new \Exception("Field '".$field."' should be at most ".$details['maximum'].".");
-        }
-    }   
+    }
 
-    public function validateInteger($fieldName, $details, $input) {        
-        if(!is_numeric($input) || intval($input) != $input) {
-            throw new \Exception("Field '".$fieldName."' should be an integer.");
-        }
-        if(isset($details['minimum']) && $input < $details['minimum']) {
-            throw new \Exception("Field '".$fieldName."' should be at least ".$details['minimum'].".");
-        }
-        if(isset($details['maximum']) && $input > $details['maximum']) {
-            throw new \Exception("Field '".$fieldName."' should be at most ".$details['maximum'].".");
-        }
-    }   
+    public function validateFloat($field, $details, $input) {
+        $this->throwIf($field, \Validate::floatError($input, (array) $details));
+    }
+
+    public function validateInteger($fieldName, $details, $input) {
+        $this->throwIf($fieldName, \Validate::integerError($input, (array) $details));
+    }
 
     public function validateString($field, $details, $input) {
-        if(!is_string($input)) {
-            throw new \Exception("Field '".$field."' should be a string.");
-        }
-        if(isset($details['minLength']) && strlen($input) < $details['minLength']) {
-            throw new \Exception("Field '".$field."' should be at least ".$details['minLength']." characters long.");
-        }
-        if(isset($details['maxLength']) && strlen($input) > $details['maxLength']) {
-            throw new \Exception("Field '".$field."' should be at most ".$details['maxLength']." characters long.");
-        }
-        if(isset($details['pattern']) && !preg_match('/'.$details['pattern'].'/', $input)) {
-            throw new \Exception("Field '".$field."' does not match the required pattern.");
-        }
+        $this->throwIf($field, \Validate::stringError($input, (array) $details));
     }
 
     public function validateEnum($field, $details, $input) {

--- a/webapp/classes/request.php
+++ b/webapp/classes/request.php
@@ -2,9 +2,12 @@
 
 class Request {
 
+    // #393: a "mi számít egésznek/dátumnak" tudás a közös \Validate-ben él, ugyanazt
+    // használja az \Api validate* is. A hibaüzenetek itt szándékosan a megszokottak
+    // maradnak, hogy a hívók viselkedése ne változzon.
     static function Integer($name) {
-        $value = self::get($name);    
-        if ($value <> '' AND !is_numeric($value)) {
+        $value = self::get($name);
+        if ($value <> '' AND \Validate::integerError($value) !== null) {
             throw new Exception("Required '$name' is not an Integer.");
         }
         return $value;
@@ -12,7 +15,7 @@ class Request {
 
     static function IntegerRequired($name) {
         $value = self::getRequired($name);
-        if (!is_numeric($value)) {
+        if (\Validate::integerError($value) !== null) {
             throw new Exception("Required '$name' is not an Integer.");
         }
         return $value;
@@ -20,7 +23,7 @@ class Request {
 
     static function IntegerwDefault($name, $default = false) {
         $value = self::getwDefault($name, $default);
-        if (!is_numeric($value)) {
+        if (\Validate::integerError($value) !== null) {
             throw new Exception("Required '$name' is not an Integer.");
         }
         return $value;
@@ -250,17 +253,9 @@ class Request {
     }
 
      static function validateDateFormat($value) {
-        // Strict YYYY-mm-dd format validation
-        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
-            return false;
-        }
-        
-        // Use DateTime::createFromFormat to strictly validate the date
-        // This will reject invalid dates like 2023-02-29
-        $date = DateTime::createFromFormat('Y-m-d', $value);
-        
-        // Check if the date is valid and matches the format exactly
-        return $date && $date->format('Y-m-d') === $value;
+        // #393: a naptár-tudatos ellenőrzés a közös \Validate-be került, hogy az API is
+        // ugyanazt használja (az ott korábban puszta reguláris kifejezés volt).
+        return \Validate::isDate($value);
     }
 
     static function Date($name) {

--- a/webapp/classes/validate.php
+++ b/webapp/classes/validate.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * #393: egyetlen hely, ami tudja, mi számít egésznek, tizedestörtnek, szövegnek,
+ * dátumnak — és teljesíti-e a megkötéseit.
+ *
+ * Eddig ez a tudás kétszer élt: az \Api validate* metódusaiban (JSON-törzsből érkező
+ * érték + séma) és a \Request metódusaiban ($_GET/$_POST-ból olvasott érték). A kettő
+ * el is csúszott egymástól: az API dátumellenőrzése puszta reguláris kifejezés volt,
+ * ezért elfogadta a 2023-02-29-et, a 2023-02-31-et és a 2026-04-31-et is, miközben a
+ * \Request ugyanezeket helyesen visszautasította.
+ *
+ * A metódusok szándékosan NEM dobnak, hanem a hibaüzenet-töredéket adják vissza (vagy
+ * null-t, ha rendben van). Így mindkét hívó a saját, megszokott szövegével dobhat:
+ * az \Api "Field 'x' should be an integer.", a \Request "Required 'x' is not an
+ * Integer." — a kliensek felé látható üzenetek nem változnak.
+ *
+ * Se szuperglobális, se adatbázis: tiszta, közvetlenül unit-tesztelhető.
+ */
+class Validate {
+
+    /** @return string|null null = rendben */
+    public static function integerError($value, array $rules = []): ?string {
+        if (!is_numeric($value) || intval($value) != $value) {
+            return 'should be an integer.';
+        }
+        return self::rangeError($value, $rules);
+    }
+
+    /** @return string|null null = rendben */
+    public static function floatError($value, array $rules = []): ?string {
+        if (!is_numeric($value) || floatval($value) != $value) {
+            return 'should be a float.';
+        }
+        return self::rangeError($value, $rules);
+    }
+
+    /** @return string|null null = rendben */
+    public static function stringError($value, array $rules = []): ?string {
+        if (!is_string($value)) {
+            return 'should be a string.';
+        }
+        if (isset($rules['minLength']) && strlen($value) < $rules['minLength']) {
+            return 'should be at least ' . $rules['minLength'] . ' characters long.';
+        }
+        if (isset($rules['maxLength']) && strlen($value) > $rules['maxLength']) {
+            return 'should be at most ' . $rules['maxLength'] . ' characters long.';
+        }
+        if (isset($rules['pattern']) && !preg_match('/' . $rules['pattern'] . '/', $value)) {
+            return 'does not match the required pattern.';
+        }
+        return null;
+    }
+
+    /** @return string|null null = rendben */
+    public static function booleanError($value): ?string {
+        return is_bool($value) ? null : 'should be a boolean.';
+    }
+
+    /** @return string|null null = rendben */
+    public static function dateError($value): ?string {
+        return self::isDate($value) ? null : 'should be a date (yyyy-mm-dd).';
+    }
+
+    /**
+     * Naptár-tudatos dátumellenőrzés: nem elég a 4-2-2 alak, a napnak léteznie is kell.
+     * A DateTime::createFromFormat magától "átfordítja" a túlcsorduló napot (2023-02-31
+     * → 2023-03-03), ezért vetjük össze a visszaformázott értéket az eredetivel.
+     */
+    public static function isDate($value): bool {
+        if (!is_string($value) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+            return false;
+        }
+        $date = \DateTime::createFromFormat('Y-m-d', $value);
+        return $date && $date->format('Y-m-d') === $value;
+    }
+
+    private static function rangeError($value, array $rules): ?string {
+        if (isset($rules['minimum']) && $value < $rules['minimum']) {
+            return 'should be at least ' . $rules['minimum'] . '.';
+        }
+        if (isset($rules['maximum']) && $value > $rules['maximum']) {
+            return 'should be at most ' . $rules['maximum'] . '.';
+        }
+        return null;
+    }
+}

--- a/webapp/tests/Api/ApiTest.php
+++ b/webapp/tests/Api/ApiTest.php
@@ -380,6 +380,39 @@ class ApiTest extends TestCase {
         $api->validateVariable('date', 'testField', [], '2026-13-45');
     }
 
+    /**
+     * #393: az API dátumellenőrzése puszta reguláris kifejezés volt, ezért elfogadta a
+     * naptárban nem létező napokat is — miközben ugyanezeket a \Request helyesen
+     * visszautasította. A közös \Validate óta ugyanazt a szigorú ellenőrzést kapja.
+     *
+     * @dataProvider nemLetezoDatumok
+     */
+    public function testValidateVariableRejectsNonExistentDate($value) {
+        $api = new Api();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Field 'testField' should be a date (yyyy-mm-dd).");
+
+        $api->validateVariable('date', 'testField', [], $value);
+    }
+
+    public static function nemLetezoDatumok(): array {
+        return [
+            'nem szökőév'     => ['2023-02-29'],
+            'február 31.'     => ['2023-02-31'],
+            'április 31.'     => ['2026-04-31'],
+            'november 31.'    => ['2026-11-31'],
+        ];
+    }
+
+    public function testValidateVariableAcceptsLeapDay() {
+        $api = new Api();
+
+        $api->validateVariable('date', 'testField', [], '2024-02-29');
+
+        $this->assertTrue(true); // nem dobott
+    }
+
     public function testValidateVariableValidatesList() {
         $api = new Api();
         

--- a/webapp/tests/Unit/ValidateTest.php
+++ b/webapp/tests/Unit/ValidateTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #393: az \Api validate* metódusai és a \Request ugyanazt a tudást hordozták kétszer —
+ * és el is csúsztak egymástól. A közös \Validate tiszta (se szuperglobális, se DB),
+ * ezért itt közvetlenül tesztelhető.
+ */
+class ValidateTest extends TestCase {
+
+    public function testEgeszSzam(): void {
+        $this->assertNull(\Validate::integerError(5));
+        $this->assertNull(\Validate::integerError('5'));
+        $this->assertNull(\Validate::integerError(0));
+        $this->assertNull(\Validate::integerError(-3));
+
+        $this->assertSame('should be an integer.', \Validate::integerError('alma'));
+        $this->assertSame('should be an integer.', \Validate::integerError(null));
+        $this->assertSame('should be an integer.', \Validate::integerError(1.5));
+        $this->assertSame('should be an integer.', \Validate::integerError('1.5'));
+        $this->assertSame('should be an integer.', \Validate::integerError([]));
+    }
+
+    public function testEgeszSzamHatarok(): void {
+        $this->assertNull(\Validate::integerError(10, ['minimum' => 10, 'maximum' => 100]));
+        $this->assertNull(\Validate::integerError(100, ['minimum' => 10, 'maximum' => 100]));
+        $this->assertSame('should be at least 10.', \Validate::integerError(9, ['minimum' => 10]));
+        $this->assertSame('should be at most 100.', \Validate::integerError(101, ['maximum' => 100]));
+    }
+
+    public function testTizedestort(): void {
+        $this->assertNull(\Validate::floatError(1.5));
+        $this->assertNull(\Validate::floatError('1.5'));
+        $this->assertNull(\Validate::floatError(2));
+        $this->assertSame('should be a float.', \Validate::floatError('alma'));
+        $this->assertSame('should be at least 10.5.', \Validate::floatError(10.4, ['minimum' => 10.5]));
+        $this->assertSame('should be at most 100.5.', \Validate::floatError(100.6, ['maximum' => 100.5]));
+    }
+
+    public function testSzoveg(): void {
+        $this->assertNull(\Validate::stringError('alma'));
+        $this->assertSame('should be a string.', \Validate::stringError(5));
+        $this->assertSame(
+            'should be at least 5 characters long.',
+            \Validate::stringError('abc', ['minLength' => 5])
+        );
+        $this->assertSame(
+            'should be at most 10 characters long.',
+            \Validate::stringError('abcdefghijk', ['maxLength' => 10])
+        );
+        $this->assertSame(
+            'does not match the required pattern.',
+            \Validate::stringError('abc', ['pattern' => '^[0-9]+$'])
+        );
+        $this->assertNull(\Validate::stringError('123', ['pattern' => '^[0-9]+$']));
+    }
+
+    public function testLogikai(): void {
+        $this->assertNull(\Validate::booleanError(true));
+        $this->assertNull(\Validate::booleanError(false));
+        $this->assertSame('should be a boolean.', \Validate::booleanError('true'));
+        $this->assertSame('should be a boolean.', \Validate::booleanError(1));
+    }
+
+    /**
+     * A lényeg: a naptárban nem létező nap NEM dátum. Az API korábbi, puszta reguláris
+     * kifejezésen alapuló ellenőrzése ezeket mind elfogadta.
+     */
+    public function testNemLetezoNapokatElutasit(): void {
+        $this->assertFalse(\Validate::isDate('2023-02-29'), '2023 nem szökőév.');
+        $this->assertFalse(\Validate::isDate('2023-02-31'));
+        $this->assertFalse(\Validate::isDate('2026-04-31'), 'Áprilisnak 30 napja van.');
+        $this->assertFalse(\Validate::isDate('2026-06-31'));
+        $this->assertFalse(\Validate::isDate('2026-11-31'));
+    }
+
+    public function testLetezoDatumokatElfogad(): void {
+        $this->assertTrue(\Validate::isDate('2026-01-15'));
+        $this->assertTrue(\Validate::isDate('2024-02-29'), '2024 szökőév.');
+        $this->assertTrue(\Validate::isDate('2026-12-31'));
+    }
+
+    public function testRosszAlakuDatumok(): void {
+        $this->assertFalse(\Validate::isDate('2026-1-1'));
+        $this->assertFalse(\Validate::isDate('2026-13-01'));
+        $this->assertFalse(\Validate::isDate('2026-00-10'));
+        $this->assertFalse(\Validate::isDate('2026.01.15'));
+        $this->assertFalse(\Validate::isDate(''));
+        $this->assertFalse(\Validate::isDate(null));
+        $this->assertFalse(\Validate::isDate(20260115));
+    }
+
+    /**
+     * A \Request::validateDateFormat() megmaradt, csak már a közösre mutat — a hívói
+     * (Date, DateRequired, DatewDefault) ne törjenek el.
+     */
+    public function testARequestUgyanaztAzEredmenytAdja(): void {
+        foreach (['2026-01-15', '2024-02-29', '2023-02-29', '2023-02-31', '2026-1-1', ''] as $value) {
+            $this->assertSame(
+                \Validate::isDate($value),
+                \Request::validateDateFormat($value),
+                "Eltérés a(z) '{$value}' értéknél."
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #393

> Az api-ban van egy csomó validate függvény, ami tökre az mint a \Request. És pont azért is kell.

Így van — és nemcsak duplikáció volt, hanem a két másolat el is csúszott egymástól.

## A konkrét eltérés

Az `\Api::validateVariable('date', …)` puszta reguláris kifejezéssel dolgozott:

```php
preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/", $input)
```

Ez a 4-2-2 alakot nézi, a naptárat nem. A `\Request::validateDateFormat()` viszont `DateTime::createFromFormat`-tal ellenőriz, tehát tudja, hány napos egy hónap. Lefuttatva a kettőt ugyanazokon az értékeken:

| érték | API | Request |
|---|---|---|
| `2026-01-15` | OK | OK |
| `2023-02-29` | **OK** | hiba |
| `2024-02-29` | OK | OK |
| `2023-02-31` | **OK** | hiba |
| `2026-04-31` | **OK** | hiba |
| `2026-13-01` | hiba | hiba |

Vagyis az API elfogadott a naptárban nem létező napokat, a webes réteg ugyanazokat visszautasította.

## Mit csinálok

Új `\Validate` osztály: egyetlen hely, ami tudja, mi számít egésznek, tizedestörtnek, szövegnek, dátumnak — és teljesíti-e a megkötéseit (`minimum`/`maximum`/`minLength`/`maxLength`/`pattern`). Tiszta: se szuperglobális, se adatbázis.

A metódusok szándékosan **nem dobnak**, hanem a hibaüzenet-töredéket adják vissza (vagy `null`-t). Így mindkét hívó a saját, megszokott szövegével dobhat:

- `\Api` → `Field 'x' should be an integer.`
- `\Request` → `Required 'x' is not an Integer.`

Tehát a kliensek felé látható üzenetek **nem változnak** — csak egy helyen él a tudás. A `validateFloat`/`validateInteger`/`validateString` és a `\Request::validateDateFormat` publikus aláírása is megmarad, hívóknak nem kell hozzányúlni.

Az `\Api` `date` ága ezzel megkapja a szigorú, naptár-tudatos ellenőrzést.

## Egy szándékos szigorítás

A `\Request` Integer-jei eddig `is_numeric()`-kel néztek, tehát az `"1.5"` átment rajtuk és úgy is jött vissza. Mostantól nem: a `\Validate::integerError()` az `intval($v) == $v`-t is megköveteli. A metódus neve amúgy is ezt ígérte, és a teljes suite-ban semmi nem támaszkodott a régi viselkedésre.

## Amit nem vontam össze

A `\Request::InArray` és az `\Api::validateEnum` közös nevezőre hozását kihagytam. Az `InArray` egy egyszerű `in_array()`, a `validateEnum` viszont típusos szabályokat is enged az enum-értékeken belül (`['integer' => ['minimum' => …]]`) — a kettő csak névben hasonlít, az összegyúrásuk bonyolultabb lenne, mint amennyit ér.

## Tesztek

Új `ValidateTest` (9 teszt, 40+ assertion) az összes típusra és határra, külön kiemelve a nem létező napokat (`2023-02-29`, `2023-02-31`, `2026-04-31`, `2026-06-31`, `2026-11-31`) és a szökőnapot.

Az `ApiTest`-be bekerült egy dataProvideres teszt, ami pont ezekre a dátumokra várja az API elutasítását, plusz egy, ami a `2024-02-29`-et elfogadtatja. A meglévő `ApiTest`/`RequestTest` (116 teszt) változatlanul zöld — ez volt a lényeg, hiszen a hibaüzenetekre több teszt is épít.

Teljes suite: 458 teszt, 18 bukás — **ugyanaz a 18, ami a masteren is** (`AutocompleteCombinedTest`, `LegacyChurchUrlRedirectTest`, HTTP-alapúak, a helyi környezetem miatt).
