### PR TITLE
A konténer maga ütemezze a cront (#171)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,17 @@ PROJECT=miserend-dev
 # Az adatbázis NEVE nem állítható: a séma- és migrációs fájlok `USE miserend;`-del
 # kezdődnek, tehát az mindig `miserend`.
 
+# Cron a konténeren belül (#171).
+#
+# Alapból KI van kapcsolva, mert az éles telepítés ma a hosztról ütemez
+# (`*/5 * * * * php …/index.php q=cron`). Ha mindkettő menne, kétszer futna minden
+# munka. Átállás sorrendje: előbb a hoszt crontab sorát kivenni, és CSAK UTÁNA
+# CRON_ENABLED=1.
+#
+# A kimenet a konténer naplójába megy: `docker compose logs -f miserend`.
+#CRON_ENABLED=1
+#CRON_INTERVAL=300
+
 # SMTP (#610). Dev/test alatt üresen hagyható: ott a mailcatcher az alapértelmezés.
 # Production-ben KÖTELEZŐ, különben nem megy ki egyetlen levél sem (a /health pirosan jelzi).
 # A production compose ezeket a `docker/.env` fájlból olvassa (a compose.yml mellől).

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -118,6 +118,10 @@ services:
       # alapértéke érvényesült, és az .env-ben hiába állított volna bárki mást.
       - MYSQL_MISEREND_USER=${MYSQL_MISEREND_USER:-root}
       - MYSQL_MISEREND_PASSWORD=${MYSQL_MISEREND_PASSWORD:-pw}
+      # #171: a konténer maga ütemezze-e a cront. Alapból ki: az éles telepítés ma a
+      # hosztról ütemez, és ha mindkettő menne, kétszer futna minden munka.
+      - CRON_ENABLED=${CRON_ENABLED:-0}
+      - CRON_INTERVAL=${CRON_INTERVAL:-300}
       - SMTP_HOST=${SMTP_HOST:-}
       - SMTP_PORT=${SMTP_PORT:-25}
       - SMTP_USER=${SMTP_USER:-}

--- a/docker/miserend/Dockerfile
+++ b/docker/miserend/Dockerfile
@@ -76,4 +76,8 @@ RUN a2dissite 000-default \
     
 # Entrypoint
 COPY docker/miserend/entrypoint.sh /entrypoint.sh
+# #171: a konténeren belüli cron-kopogtató. Nem a cron démon: az roothoz kötött, a
+# konténer viszont www-data-ként fut. Alapból ki van kapcsolva, l. CRON_ENABLED.
+COPY docker/miserend/cron-loop.sh /cron-loop.sh
+RUN chmod +x /entrypoint.sh /cron-loop.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/miserend/Dockerfile.test
+++ b/docker/miserend/Dockerfile.test
@@ -78,4 +78,7 @@ RUN a2dissite 000-default \
     
 # Entrypoint
 COPY docker/miserend/entrypoint.sh /entrypoint.sh
+# #171: az entrypoint hivatkozik rá, ha a CRON_ENABLED be van kapcsolva.
+COPY docker/miserend/cron-loop.sh /cron-loop.sh
+RUN chmod +x /entrypoint.sh /cron-loop.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/miserend/cron-loop.sh
+++ b/docker/miserend/cron-loop.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# #171: a cron-futtatás a konténeren belülről.
+#
+# Eddig a hosztról kellett ütemezni (`*/5 * * * * php …/index.php q=cron`), tehát a
+# konténer önmagában nem volt teljes: aki felhúzta, annak külön kellett tudnia róla.
+#
+# Szándékosan NEM a cron démon: a konténer www-data-ként fut (l. compose.yml), a cron
+# démonhoz viszont root kell, és crontab-fájlt sem kell szerkeszteni benne (ezért nem
+# kell szövegszerkesztő sem az image-be). Az ütemezést amúgy is az alkalmazás végzi —
+# a crons tábla frequency/from/until mezői —, ide csak egy rendszeres kopogás kell.
+#
+# A futások szándékosan sorosak: a következő kör csak az előző után indul, tehát egy
+# hosszú munka (mise-újraindexelés) nem torlódik önmagára.
+#
+#   CRON_ENABLED   1 = fusson (alapból KI, l. lentebb)
+#   CRON_INTERVAL  két kopogás között ennyi másodperc (default 300, mint a régi */5)
+set -u
+
+INTERVAL="${CRON_INTERVAL:-300}"
+ENVIRONMENT="${MISEREND_WEBAPP_ENVIRONMENT:-production}"
+
+echo "[cron] indul, ${INTERVAL} másodpercenként, env=${ENVIRONMENT}"
+
+while true; do
+    # A kimenetet a konténer naplójába írjuk (docker logs / docker compose logs),
+    # hogy ne kelljen külön logfájlt forgatni. A cron-oldal HTML-t ír (a böngészőből is
+    # futtatható), ezért a tageket és az entitásokat kiszedjük — különben
+    # "\Api\Sqlite-&gt;cron()" alakban olvasnánk a naplót. Az &amp; szándékosan utolsó.
+    php /miserend/webapp/index.php q=cron "env=${ENVIRONMENT}" 2>&1 \
+        | sed -e 's|<[^>]*>||g' \
+              -e 's/&gt;/>/g' -e 's/&lt;/</g' -e 's/&quot;/"/g' -e "s/&#039;/'/g" \
+              -e 's/&amp;/\&/g' \
+        | grep -v '^[[:space:]]*$' \
+        | sed -e 's/^/[cron] /'
+
+    sleep "$INTERVAL"
+done

--- a/docker/miserend/entrypoint.sh
+++ b/docker/miserend/entrypoint.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 set -e
 
+# #171: opcionálisan a konténer maga ütemezi a cront. Alapból KI van kapcsolva, mert az
+# éles telepítés ma a hosztról ütemez — ha mindkettő menne, kétszer futna minden munka.
+# Átállás: előbb a hoszt crontab sorát kell kivenni, és csak utána CRON_ENABLED=1.
+if [ "${CRON_ENABLED:-0}" = "1" ]; then
+    /cron-loop.sh &
+fi
+
 exec apache2-foreground


### PR DESCRIPTION
Fixes #171

A konténer eddig nem volt önmagában teljes: a cront a hosztról kellett ütemezni (`*/5 * * * * php …/index.php q=cron`). Aki felhúzta a compose-t, annak külön kellett tudnia erről — dev és staging alatt tehát gyakorlatilag soha nem futott le semmi.

## Miért nem a cron démon

Az issue a `cron` telepítését és egy szövegszerkesztőt említ. Egyiket sem teszem bele, két okból:

1. A konténer **`www-data`-ként fut** (`user: "www-data"` a compose.yml-ben), a cron démonhoz viszont root kell. Vagy jogosultságot lazítanánk, vagy supervisord-t húznánk be — mindkettő több, mint amennyit ez megér.
2. **Az ütemezést már az alkalmazás végzi**: a `crons` tábla `frequency`/`from`/`until` mezői döntik el, mi mikor esedékes. A rendszernek nem cron-kifejezésekre van szüksége, hanem rendszeres kopogtatásra.

Ezért egy soros shell-ciklus indul az entrypointból. Crontab-fájl nincs, tehát szövegszerkesztő sem kell az image-be.

A ciklus szándékosan **soros**: a következő kör csak az előző befejezése után indul, tehát egy hosszú munka (mise-újraindexelés) nem torlódik önmagára.

## Napló

A kimenet a konténer naplójába megy (`docker compose logs -f miserend`), nem külön fájlba — így nincs mit forgatni. A cron-oldal HTML-t ír (böngészőből is futtatható), ezért a tageket és az entitásokat kiszedem; enélkül `\Api\Sqlite-&gt;cron()` alakban olvasnánk:

```
[cron] indul, 60 másodpercenként, env=development
[cron] Cron job \ExternalApi\OverpassApi->clearOldCache() completed in 0 seconds.
[cron] Cron job \Distance->updateSome() completed in 3.59 seconds.
[cron] Cron job \Crons->rollPeriodYears() completed in 0.02 seconds.
```

## Alapból ki van kapcsolva

`CRON_ENABLED` default `0`. **Az éles telepítés ma a hosztról ütemez, és ha mindkettő menne, kétszer futna minden munka.** Az átállás sorrendje (ez benne van az `.env.example`-ben is):

1. a hoszt crontab sorát kivenni,
2. és **csak utána** `CRON_ENABLED=1`.

`CRON_INTERVAL` a két kopogás közti másodperc, default `300` — pont a régi `*/5`.

Érdemes tudni: a futtató **kérésenként egyetlen** munkát futtat. 22 regisztrált cron mellett az 5 perc óránként 12 lehetőséget ad, ami szűkös; konténeren belül nyugodtan mehet sűrűbben is (`CRON_INTERVAL=60`).

## Hogy teszteltem

Külön `PROJECT`-ű stacket húztam fel (`--build`), `CRON_ENABLED=1`, `CRON_INTERVAL=60`:

- a ciklus elindult, felvette a hiányzó cronokat a registryből, majd sorban futtatta a munkákat
- a `crons.lastsuccess_at` ténylegesen frissült az adatbázisban
- az Apache közben végig kiszolgált (`HTTP 200`) — a háttérciklus nem zavarja
- `CRON_ENABLED=0`-val (az alapértelmezés) **egyetlen** `[cron]` sor sincs a naplóban, az app ugyanúgy megy

A `Dockerfile.test`-be is bekerült a másolás, hogy az entrypoint ott se hivatkozzon hiányzó fájlra.

## Mellékesen

A naplóban láthatóvá vált egy régi PHP-figyelmeztetés, ami eddig minden cron-futásnál keletkezett:

```
PHP Deprecated: Implicit conversion from float 3.5949490070343018 to int loses precision
  in /miserend/webapp/classes/html/cron.php on line 71
```

Ezt a #683-ban javítom, mert az a PR amúgy is a cron-futtatót módosítja — így nem ütközik a két ág.
