### PR TITLE
Törölhesse magát a felhasználó (#110)

### DIFF
--- a/webapp/classes/html/user/delete.php
+++ b/webapp/classes/html/user/delete.php
@@ -4,42 +4,76 @@ namespace Html\User;
 
 class Delete extends \Html\Html {
 
+    public $user2delete;
+    public $isSelf = false;
+    public $input = [];
+
     public function __construct() {
+        global $user;
 
         $this->title = 'Felhasználó törlése';
-        $this->template = 'layout.twig';
+        $this->template = 'user/delete.twig';
         $this->input['uid'] = \Request::IntegerRequired('uid');
 
         $this->user2delete = new \User($this->input['uid']);
         if ($this->user2delete->uid == 0) {
-            addMessage("Nincs ilyen felhasználó!", danger);
+            addMessage("Nincs ilyen felhasználó!", 'danger');
+            return;
+        }
+
+        // #110: eddig csak a `user` joggal rendelkező adminisztrátor törölhetett bárkit,
+        // magát senki. Mostantól a saját fiókját mindenki törölheti.
+        $this->isSelf = ($user->uid > 0 AND $user->uid == $this->user2delete->uid);
+        if (!$user->checkRole('user') AND !$this->isSelf) {
+            throw new \Exception("Hiányzó jogosultság miatt nem lehetséges a törlése!");
+        }
+
+        if ($this->isSelf) {
+            $this->deleteSelf();
             return;
         }
 
         $this->input['confirmation'] = \Request::SimpleText('confirmation');
         if (!$this->input['confirmation']) {
-            $this->askConfirmation();
             return;
-        } else {
-            $this->delete();
         }
-    }
 
-    function delete() {
-        global $user;
-        if (!$user->checkRole('user')) {
-            throw new \Exception("Hiányzó jogosultság miatt nem lehetséges a törlése!");
-        }
         $this->user2delete->delete();
         header("Location: /user/catalogue");
     }
 
-    function askConfirmation() {
-        $kiir = "\n<span class=kiscim>Biztosan törölni akarod a következő felhasználót?</span>";
-        $kiir.="\n<br><br><span class=alap>" . $this->user2delete->username . " (" . $this->user2delete->nev . ")</span>";
-        $kiir.="<br><br><a href='/user/" . $this->user2delete->uid . "/delete?confirmation=confirmed' class=link>Igen</a> - <a href='/user/" . $this->user2delete->uid . "/edit' class=link>NEM</a>";
+    /**
+     * A saját fiók törlése visszafordíthatatlan, ezért nem elég egy linkre kattintani:
+     * POST kell hozzá és a saját jelszó. A jelszó nem csak elgépelés ellen véd — CSRF
+     * ellen is, mert egy idegen oldal el tudna küldeni egy formot a nevünkben, a
+     * jelszavunkat viszont nem tudja. (A projektben nincs CSRF-token mechanizmus.)
+     */
+    private function deleteSelf() {
+        global $user;
 
-        $this->content = $kiir;
+        if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+            return;
+        }
+
+        $password = \Request::get('password');
+        if (!is_string($password) OR $password === '') {
+            addMessage('A törléshez add meg a jelszavadat.', 'danger');
+            return;
+        }
+
+        if (!$this->user2delete->verifyPassword($password)) {
+            addMessage('Hibás jelszó — a fiókot nem töröltük.', 'danger');
+            return;
+        }
+
+        $this->user2delete->delete();
+
+        // A tokent is el kell dobni, különben törölt uid-dal maradnánk "bejelentkezve".
+        \Token::delete();
+        $user = new \User();
+
+        addMessage('A fiókodat töröltük. Köszönjük, hogy velünk voltál!', 'success');
+        header("Location: /");
     }
 
 }

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -353,7 +353,10 @@ class User {
         if ($this->uid == 0)
             return false;
 
-        \Eloquent\ChurchHolder::where('user_id',$this->uid)->delete();
+        // #110: a ChurchHolder soft-delete-es, tehát a sima delete() csak deleted_at-et
+        // ír — a sor a user_id-vel együtt ottmaradt egy olyan felhasználóra hivatkozva,
+        // aki már nincs. Fiók törlésekor tényleg tűnjön el.
+        \Eloquent\ChurchHolder::withTrashed()->where('user_id',$this->uid)->forceDelete();
         \Eloquent\Favorite::where('uid',$this->uid)->delete();
         
         \Eloquent\Remark::where('login', $this->username)->update([
@@ -498,6 +501,21 @@ class User {
         $user->loggedin = true;
         $user->active();
         return $user;
+    }
+
+    /**
+     * #110: jelszó-ellenőrzés mellékhatás nélkül. A login() ugyanezt csinálja, de közben
+     * tokent is cserél és lastlogin-t ír — a "biztosan te vagy az?" kérdéshez (saját
+     * fiók törlése) ezek nem kellenek.
+     */
+    function verifyPassword($password) {
+        if ($this->uid == 0 OR !is_string($password) OR $password === '') {
+            return false;
+        }
+        if (!isset($this->jelszo) OR !is_string($this->jelszo) OR $this->jelszo === '') {
+            return false;
+        }
+        return password_verify($password, $this->jelszo);
     }
 
     static function login($name, $password) {

--- a/webapp/templates/user/delete.twig
+++ b/webapp/templates/user/delete.twig
@@ -1,0 +1,50 @@
+{% extends "layout.twig" %}
+
+{% block content %}
+
+{% if not user2delete or user2delete.uid == 0 %}
+	<p>Nincs ilyen felhasználó.</p>
+
+{% elseif isSelf %}
+	<h2>Fiókod törlése</h2>
+
+	<div class="alert alert-warning">
+		<p><strong>Ez a lépés nem vonható vissza.</strong></p>
+		<p>Ha törlöd a fiókodat:</p>
+		<ul class="mb-0">
+			<li>a <strong>bejelentkezési adataid és személyes adataid</strong> (név, becenév, e-mail cím) törlődnek;</li>
+			<li>a <strong>kedvenc templomaid</strong> törlődnek;</li>
+			<li>a <strong>gondnokságaid</strong> megszűnnek — az általad kezelt templomokat innentől más gondozza;</li>
+			<li>a <strong>beküldött észrevételeid és miserend-javaslataid megmaradnak</strong>, de névtelenné válnak.
+				Ezekre a templomok felelőseinek szükségük lehet, ezért nem töröljük őket, csak leválasztjuk rólad.</li>
+		</ul>
+	</div>
+
+	<p>Ha ezután mégis használnád az oldalt, bármikor regisztrálhatsz újra — de a régi adataidat
+		nem tudjuk visszaadni.</p>
+
+	<form method="post" action="/user/{{ user2delete.uid }}/delete">
+		<div class="form-group">
+			<label for="password">A megerősítéshez add meg a jelszavadat:</label>
+			<input type="password" class="form-control" id="password" name="password"
+			       autocomplete="current-password" required style="max-width: 22em;">
+		</div>
+		<p>
+			<button type="submit" class="btn btn-danger">Véglegesen törlöm a fiókomat</button>
+			<a href="/user/{{ user2delete.uid }}/edit" class="btn btn-secondary">Mégsem</a>
+		</p>
+	</form>
+
+{% else %}
+	<h2>Felhasználó törlése</h2>
+
+	<p>Biztosan törölni akarod a következő felhasználót?</p>
+	<p><strong>{{ user2delete.username }}</strong> ({{ user2delete.nev }})</p>
+
+	<p>
+		<a href="/user/{{ user2delete.uid }}/delete?confirmation=confirmed" class="btn btn-danger">Igen</a>
+		<a href="/user/{{ user2delete.uid }}/edit" class="btn btn-secondary">Nem</a>
+	</p>
+{% endif %}
+
+{% endblock %}

--- a/webapp/templates/user/edit.twig
+++ b/webapp/templates/user/edit.twig
@@ -185,5 +185,16 @@
 
 		<input class="form-control" type="submit" name="submit" value="{% if new %}Létrehoz{% else %}Módosít{% endif %}"/>	    
 	</form>
+
+	{# #110: a saját fiók törlése eddig sehonnan nem volt elérhető — csak adminisztrátor
+	   tudott felhasználót törölni. A link csak a saját adatlapon jelenik meg. #}
+	{% if edit and user.uid > 0 and user.uid == edituser.uid %}
+		<hr>
+		<p class="text-muted">
+			Ha nem szeretnéd tovább használni a Miserendet,
+			<a href="/user/{{ edituser.uid }}/delete">törölheted a fiókodat</a>.
+			A törlés nem vonható vissza; a következő oldalon leírjuk, mi történik az adataiddal.
+		</p>
+	{% endif %}
         {% endif %}
 {% endblock %}

--- a/webapp/tests/Integration/UserSelfDeleteTest.php
+++ b/webapp/tests/Integration/UserSelfDeleteTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #110: a felhasználó törölhesse magát.
+ *
+ * Eddig csak a `user` joggal rendelkező adminisztrátor törölhetett bárkit — magát senki,
+ * és a saját adatlapról semmilyen út nem vezetett a törléshez.
+ *
+ * Az issue nyitott kérdése az volt, mi legyen az észrevételekkel. A \User::delete() már
+ * eddig is névtelenítette őket (a törlés helyett), és ez a helyes: a beküldött
+ * észrevételekre és miserend-javaslatokra a templomok felelőseinek szükségük lehet, a
+ * személyes adat viszont lekerül róluk. Az itteni tesztek ezt rögzítik.
+ */
+class UserSelfDeleteTest extends TestCase {
+
+    private array $createdUids = [];
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function createUser(string $password = 'Titk0sJelsz0'): \User {
+        $login = 'sdt' . bin2hex(random_bytes(4));
+        $uid = DB::table('user')->insertGetId([
+            'login'     => $login,
+            'jelszo'    => password_hash($password, PASSWORD_DEFAULT),
+            'jogok'     => '',
+            'email'     => $login . '@example.invalid',
+            'nev'       => 'Teszt Elek',
+            'becenev'   => 'teszt',
+            'regdatum'  => date('Y-m-d H:i:s'),
+            'lastlogin' => date('Y-m-d H:i:s'),
+        ]);
+        $this->createdUids[] = $uid;
+        return new \User($uid);
+    }
+
+    public function testAJoJelszotElfogadja(): void {
+        $user = $this->createUser('Titk0sJelsz0');
+        $this->assertTrue($user->verifyPassword('Titk0sJelsz0'));
+    }
+
+    public function testARosszJelszotElutasitja(): void {
+        $user = $this->createUser('Titk0sJelsz0');
+        $this->assertFalse($user->verifyPassword('masik'));
+        $this->assertFalse($user->verifyPassword(''));
+        $this->assertFalse($user->verifyPassword(null));
+    }
+
+    public function testNemLetezoFelhasznaloraSosemIgaz(): void {
+        $guest = new \User();
+        $this->assertSame(0, (int) $guest->uid);
+        $this->assertFalse($guest->verifyPassword('barmi'));
+    }
+
+    public function testATorlesElviszAKedvenceketEsAGondnoksagot(): void {
+        $user = $this->createUser();
+        $churchId = DB::table('templomok')->value('id');
+
+        DB::table('favorites')->insert(['uid' => $user->uid, 'tid' => $churchId]);
+        DB::table('church_holders')->insert([
+            'church_id'  => $churchId,
+            'user_id'    => $user->uid,
+            'status'     => 'allowed',
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        $uid = $user->uid;
+        $user->delete();
+
+        $this->assertSame(0, DB::table('user')->where('uid', $uid)->count());
+        $this->assertSame(0, DB::table('favorites')->where('uid', $uid)->count());
+        // A ChurchHolder soft-delete-es: a sima delete() csak deleted_at-et írna, és a
+        // sor a user_id-vel együtt ottmaradna egy már nem létező felhasználóra mutatva.
+        $this->assertSame(
+            0,
+            DB::table('church_holders')->where('user_id', $uid)->count(),
+            'A gondnokság sorának tényleg el kell tűnnie, nem csak deleted_at-et kapnia.'
+        );
+    }
+
+    /**
+     * Az issue nyitott kérdése: az észrevétel NEM tűnik el, csak névtelenné válik.
+     */
+    public function testAzEszrevetelMegmaradDeNevtelenLesz(): void {
+        $user = $this->createUser();
+        $churchId = DB::table('templomok')->value('id');
+
+        $remarkId = DB::table('remarks')->insertGetId([
+            'church_id' => $churchId,
+            'login'     => $user->username,
+            'nev'       => 'Teszt Elek',
+            'email'     => $user->email,
+            'leiras'    => 'Ez az észrevétel maradjon meg.',
+        ]);
+
+        $user->delete();
+
+        $remark = DB::table('remarks')->where('id', $remarkId)->first();
+        $this->assertNotNull($remark, 'Az észrevételt nem szabad törölni.');
+        $this->assertSame('Ez az észrevétel maradjon meg.', $remark->leiras);
+        $this->assertSame('deleted_user', $remark->login);
+        $this->assertSame('*törölt felhasználó*', $remark->nev);
+        $this->assertStringNotContainsString('@example.invalid', (string) $remark->email);
+    }
+
+    public function testAMiserendJavaslatIsNevtelenLesz(): void {
+        $user = $this->createUser();
+
+        $packageId = DB::table('cal_suggestion_packages')->insertGetId([
+            'church_id'      => DB::table('templomok')->value('id'),
+            'sender_user_id' => $user->uid,
+            'sender_email'   => $user->email,
+            'sender_name'    => 'Teszt Elek',
+            'state'          => 'PENDING',
+        ]);
+
+        $user->delete();
+
+        $package = DB::table('cal_suggestion_packages')->where('id', $packageId)->first();
+        $this->assertNotNull($package, 'A javaslatot nem szabad törölni.');
+        $this->assertSame(0, (int) $package->sender_user_id);
+        $this->assertSame('*törölt felhasználó*', $package->sender_name);
+    }
+}


### PR DESCRIPTION
Fixes #110

> A felhasználó törölhesse magát, ha gondolja.

Eddig nem tudta: a `/user/{uid}/delete` oldal `checkRole('user')`-t követelt, ami **adminisztrátori** jog (felhasználó-kezelés), nem „be vagy jelentkezve". A saját adatlapról ráadásul semmilyen link nem vezetett a törléshez.

## Az issue nyitott kérdése

> Mi legyen / minek kell lennie az észrevételeivel? Névtelenítés (anonymus / random)? Törlés?

A `User::delete()` **már eddig is névtelenített** — csak ezt nem tudta senki, mert a funkció elérhetetlen volt. Szerintem ez a helyes válasz, és így is hagytam: a beküldött észrevételekre és miserend-javaslatokra a templomok felelőseinek szükségük lehet (gyakran ezekből derül ki, miért olyan a miserend, amilyen), a személyes adat viszont lekerül róluk.

Amit a törlés csinál, és amit a törlő oldal előre le is ír a felhasználónak:

| adat | mi történik |
|---|---|
| belépési és személyes adatok (név, becenév, e-mail) | **törlődik** |
| kedvenc templomok | **törlődik** |
| gondnokságok | **megszűnik** |
| észrevételek | **megmarad, névtelenül** (`deleted_user` / `*törölt felhasználó*`) |
| miserend-javaslatok | **megmarad, névtelenül** |

## Jelszó a megerősítéshez

A törlés visszafordíthatatlan, ezért nem elég egy linkre kattintani: **POST kell hozzá és a saját jelszó.**

A jelszó nem csak elgépelés ellen véd. A projektben **nincs CSRF-token mechanizmus** (végignéztem, sehol), a meglévő admin-törlés pedig egy sima GET link `?confirmation=confirmed`-del — vagyis egy idegen oldal egy `<img>` taggel törölni tudna. Ezt a lyukat nem akartam kiszélesíteni a saját törlésre: a jelszót az idegen oldal nem tudja.

*(Az admin-ág GET-es megerősítését szándékosan nem nyúltam át — az önálló kérdés, és nagyobb változás, mint ez a PR.)*

Törlés után a tokent is eldobom. Enélkül törölt uid-dal maradnánk „bejelentkezve": a `User::load()` a token alapján `new \User($token->uid)`-ot csinál, majd **feltétel nélkül** `loggedin = true`-t állít — tehát egy nem létező felhasználó is bejelentkezettnek látszana.

## Egy hiba, ami közben kiderült

A `ChurchHolder` soft-delete-es (`use SoftDeletes`), tehát a `User::delete()`-ben lévő `delete()` csak `deleted_at`-et írt. A sor a `user_id`-vel együtt ottmaradt, egy már nem létező felhasználóra mutatva. Fiók törlésekor ez most `forceDelete()` — van rá teszt, ez volt az egyetlen, ami elsőre elbukott.

## Hogy teszteltem

**Integrációs tesztek** (`UserSelfDeleteTest`, 6 teszt, tranzakcióban): jelszó-ellenőrzés jó/rossz/üres/`null` esetre és nem létező felhasználóra; a kedvencek és a gondnokság tényleges eltűnése; és külön-külön, hogy az észrevétel és a miserend-javaslat **megmarad, de névtelen lesz**.

**Végigvittem élőben is** a dev stacken, valódi felhasználóval:

| lépés | eredmény |
|---|---|
| belépés | HTTP 200, bejelentkezve |
| saját adatlap | ott a „törölheted a fiókodat" link |
| `GET /user/188/delete` | HTTP 200, űrlap — **nem töröl** |
| `POST` rossz jelszóval | „Hibás jelszó" — **nem töröl** |
| `POST` jó jelszóval | HTTP 302, a felhasználó eltűnt |
| utána a főoldal | belépő űrlap; a token a cookie-ból és a DB-ből is eltűnt |

És a jogosultság, két hétköznapi felhasználóval:

| lépés | eredmény |
|---|---|
| tesztA `GET`-tel törölné tesztB-t | „Hiányzó jogosultság" |
| tesztA `POST`-tal törölné tesztB-t | „Hiányzó jogosultság", tesztB megvan |
| tesztA törli **saját magát** | HTTP 302, törölve |

Teljes suite: 450 teszt, 18 bukás — **ugyanaz a 18, ami a masteren is** (`AutocompleteCombinedTest`, `LegacyChurchUrlRedirectTest`, HTTP-alapúak, a helyi környezetem miatt).
