### PR TITLE
Kereshető szentségimádás és gyóntatás az API-ban (#299)

### DIFF
--- a/webapp/classes/api/search.php
+++ b/webapp/classes/api/search.php
@@ -12,9 +12,10 @@ class Search extends Api {
 
     public $fields = [
         'q' => [
-            'required' => true, 
-            'validation' => 'string', 
-            'description' => 'a keresőkifejezés',
+            // #299: a kötelezőséget a validateInput() dönti el, mert az a `categories`
+            // értékétől függ. A hibaüzenet változatlan.
+            'validation' => 'string',
+            'description' => 'a keresőkifejezés. Kötelező, kivéve ha a `categories` mise nélküli szolgálatra szűkít (pl. csak szentségimádásra) — ott a kategória maga is elég szűk halmaz',
             'example' => 'Szent István'
         ],
         'offset' => [
@@ -44,8 +45,19 @@ class Search extends Api {
             ],
             'description' => 'csak az adott napi misék megjelenítése',
             'default' => false
+        ],
+        'categories' => [
+            'validation' => [
+                'list' => ['enum' => ['MASS', 'ADORATION', 'CONFESSION', 'OTHER']]
+            ],
+            'description' => 'mely eseményfajtákra keresünk: MASS (misefélék), ADORATION (szentségimádás), CONFESSION (gyóntatás), OTHER (egyéb imaalkalom). Megadás nélkül mindegyikre',
+            'example' => ['ADORATION'],
+            'default' => false
         ]
     ];
+
+    /** A `q` nélkül is értelmes kategóriák: ezek önmagukban elég szűk halmazt adnak. */
+    const CATEGORIES_WITHOUT_KEYWORD = ['ADORATION', 'CONFESSION'];
 
      public function docs() {
 
@@ -53,6 +65,11 @@ class Search extends Api {
 	 
         $docs['description'] = <<<HTML
         <p>Templomok között lehet keresni egy (akár összetett) keresőszó megadásával.</p>
+        <p>A <code>categories</code> megadásával nem csak misére kereshetsz, hanem
+        szentségimádásra (<code>ADORATION</code>), gyóntatásra (<code>CONFESSION</code>) vagy
+        egyéb imaalkalomra (<code>OTHER</code>) is — ezek ugyanolyan naptáresemények, mint a
+        mise, csak más a fajtájuk. Például <code>{"categories":["ADORATION"],"when":"today"}</code>
+        megadja, hol van ma szentségimádás.</p>
         HTML;
 
         $docs['response'] = <<<HTML
@@ -75,10 +92,23 @@ class Search extends Api {
 		$limit = isset($this->input['limit']) ? $this->input['limit'] : 10;
 		
         $search = new \Search('masses');
-        $search->keyword($this->input['q']);				
-        if (isset($this->input['when']) && $this->input['when']) {            
-            $search->day($this->input['when']);            
-        } 
+        $search->keyword(isset($this->input['q']) ? $this->input['q'] : '');
+        if (isset($this->input['when']) && $this->input['when']) {
+            $search->day($this->input['when']);
+        }
+
+        // #299: a szentségimádás és a gyóntatás ugyanolyan cal_masses-esemény, mint a mise
+        // — csak más a címe. Tehát nem külön adatforrás és nem külön válaszszerkezet kell,
+        // hanem egy cím-szűrő ugyanazon a mise-indexen. A cím-alakokat a \MassDefinitions
+        // adja, ugyanaz, amit a webes keresés (searchresultsmasses) használ.
+        $categories = $this->selectedCategories();
+        if (!empty($categories)) {
+            $titleFilters = (new \MassDefinitions())->titleFiltersByCategories($categories);
+            if (!empty($titleFilters)) {
+                $search->query['bool']['must'][] = [ 'terms' => ['title.keyword' => $titleFilters] ];
+            }
+        }
+
 		$results = $search->getResults($offset, $limit, true);
             
         $this->return = [
@@ -120,6 +150,38 @@ class Search extends Api {
         }
 
         return;
+    }
+
+    /**
+     * #299: a kulcsszó akkor hagyható el, ha a kategóriaszűrő önmagában elég szűk.
+     *
+     * Misére (és kategória nélkül, ami ugyanaz, csak tágabb) továbbra is kötelező: a
+     * mise-index több millió időpont, kulcsszó nélkül a találathalmaz értelmetlen — és
+     * a lapozás miatt drága is. Szentségimádásra és gyóntatásra viszont épp az a
+     * tipikus kérdés, hogy „hol van MA egyáltalán", tehát ott kulcsszó nélkül is
+     * értelmes a válasz.
+     */
+    public function validateInput() {
+        if (isset($this->input['q'])) {
+            return;
+        }
+
+        $categories = $this->selectedCategories();
+        if (empty($categories) || array_diff($categories, self::CATEGORIES_WITHOUT_KEYWORD)) {
+            // Ugyanaz a hibaüzenet, mint eddig — a meglévő kliensek nem vesznek észre semmit.
+            $this->requiredInput(['q']);
+        }
+    }
+
+    /**
+     * @return string[] a kért kategóriák; üres tömb, ha nincs szűkítés
+     */
+    private function selectedCategories(): array {
+        if (!isset($this->input['categories']) || !is_array($this->input['categories'])) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter($this->input['categories'], 'is_string')));
     }
 
 }

--- a/webapp/classes/html/searchresultsmasses.php
+++ b/webapp/classes/html/searchresultsmasses.php
@@ -218,21 +218,14 @@ class SearchResultsMasses extends Html {
             if (!empty($categoriesReq)) {
                 $selectedCategories = array_filter(array_map('trim', explode(',', $categoriesReq)));
 
-                $allTitles = (new \MassDefinitions())->titlesByCategories($selectedCategories);
-                if (!empty($allTitles)) {
-                    foreach ($allTitles as $title) {
-                        $cleanTitle = preg_replace('/^MASS_TITLE\./', '', $title);
-                        $allTitles[] = $title;
-                        $translatedTitle = t('MASS_TITLE.' . $cleanTitle);
-                        $allTitles[] = $translatedTitle;
-                    }
-                    $titleFilters = array_unique($allTitles);
-                    $titleFilters = array_values($titleFilters);
-                    if (!empty($titleFilters)) {
-                        $search->query['bool']['must'][] = [ 'terms' => ['title.keyword' => $titleFilters] ];
-                        $translatedCategoryNames = array_map(function($c){ return t('MASS_TITLE_CATEGORY.' . $c); }, $selectedCategories);
-                        $search->filters[] = "Kategóriák: <b>" . implode('</b> vagy <b>', $translatedCategoryNames) . "</b>";
-                    }
+                // #299: a cím-alakok előállítása átkerült a \MassDefinitions-be, mert az
+                // API-nak (api/search.php `categories`) is pontosan ugyanez kell. Egy
+                // implementáció, két hívó — így a kettő nem tud szétcsúszni.
+                $titleFilters = (new \MassDefinitions())->titleFiltersByCategories($selectedCategories);
+                if (!empty($titleFilters)) {
+                    $search->query['bool']['must'][] = [ 'terms' => ['title.keyword' => $titleFilters] ];
+                    $translatedCategoryNames = array_map(function($c){ return t('MASS_TITLE_CATEGORY.' . $c); }, $selectedCategories);
+                    $search->filters[] = "Kategóriák: <b>" . implode('</b> vagy <b>', $translatedCategoryNames) . "</b>";
                 }
             }
         };

--- a/webapp/classes/massdefinitions.php
+++ b/webapp/classes/massdefinitions.php
@@ -64,6 +64,40 @@ final class MassDefinitions
         return array_values(array_unique($titles));
     }
 
+    /**
+     * #299: a kategóriákhoz tartozó összes cím-alak, ahogy az a `cal_masses.title`-ben
+     * (és így az Elasticsearch `title` mezőjében) előfordulhat.
+     *
+     * Kétféle alak van, mert az adat kétfelől jön: a naptárszerkesztő a definíciókulcsot
+     * írja be (`MASS_TITLE.ADORATION`), a régebbi, kézzel felvitt sorokban viszont a
+     * lefordított cím áll (`Szentségimádás`). Aki kategóriára szűr, mindkettőt akarja.
+     *
+     * @param  string[] $categories  MASS, ADORATION, CONFESSION, OTHER
+     * @return string[]              `title.keyword` terms-szűrőnek való értékek
+     */
+    public function titleFiltersByCategories(array $categories): array
+    {
+        $filters = [];
+
+        // Szándékosan a magyar szótár, nem a felhasználó nyelve: a `cal_masses.title`-ben
+        // magyar címek állnak, akkor is, ha valaki angolul nézi az oldalt. (A t() a felület
+        // nyelvét követné, és angol nézetben egyetlen sorra sem illeszkedne.) Az init()
+        // idempotens, tehát a webes kérésben, ahol a load.php már inicializálta, nem csinál
+        // semmit — CLI-ben és tesztben viszont ettől lesz kiszámítható a viselkedés.
+        \Translator::init('hu');
+
+        foreach ($this->titlesByCategories($categories) as $title) {
+            $filters[] = $title;
+
+            $translated = \Translator::translate($title);
+            if (is_string($translated) && $translated !== '') {
+                $filters[] = $translated;
+            }
+        }
+
+        return array_values(array_unique($filters));
+    }
+
     private function arrayValue(string $key): array
     {
         return isset($this->data[$key]) && is_array($this->data[$key])

--- a/webapp/tests/Api/SearchCategoriesTest.php
+++ b/webapp/tests/Api/SearchCategoriesTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Api\Search;
+
+require_once __DIR__ . '/../../classes/MockPhpInputStreamWrapper.php';
+
+/**
+ * #299: az /api/v4/search `categories` szűrője.
+ *
+ * A szentségimádás és a gyóntatás ugyanolyan naptáresemény, mint a mise, csak más a
+ * fajtája — tehát nem külön végpont és nem külön adatforrás, hanem cím-szűrő ugyanazon a
+ * mise-keresésen. Itt a bemenet-ellenőrzést teszteljük (Elasticsearch nélkül): a mezőt,
+ * a `q` feltételes kötelezőségét és a kategórianevek szigorát.
+ *
+ * A tényleges szűrés (hogy a `terms` a `title.keyword`-re valóban rákerül, és mit ad
+ * vissza) az integrációs tesztben van: Integration/SearchCategoriesFilterTest.
+ */
+class SearchCategoriesTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $_REQUEST = [];
+        $_REQUEST['v'] = 4;
+    }
+
+    protected function tearDown(): void {
+        parent::tearDown();
+        $_REQUEST = [];
+        MockPhpInputStreamWrapper::restorePhpInput();
+    }
+
+    private function parse(array $input): Search {
+        MockPhpInputStreamWrapper::mockPhpInput(json_encode($input));
+        $search = new Search();
+        $search->getInputJson();
+        return $search;
+    }
+
+    public function testCategoriesFieldExists(): void {
+        $search = new Search();
+
+        self::assertArrayHasKey('categories', $search->fields);
+        self::assertSame(
+            ['MASS', 'ADORATION', 'CONFESSION', 'OTHER'],
+            $search->fields['categories']['validation']['list']['enum']
+        );
+    }
+
+    /* A kategória nélküli hívás viselkedése nem változhat: q továbbra is kötelező. */
+    public function testKeywordStaysRequiredWithoutCategories(): void {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Field 'q' is required in JSON.");
+
+        $this->parse(['limit' => 3]);
+    }
+
+    /* Misére sem enged el kulcsszó nélkül: a mise-index több millió időpont. */
+    public function testKeywordStaysRequiredForMassCategory(): void {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Field 'q' is required in JSON.");
+
+        $this->parse(['categories' => ['MASS']]);
+    }
+
+    /* Vegyes kérésnél is kötelező, mert a MASS ott van a halmazban. */
+    public function testKeywordStaysRequiredWhenMassIsMixedIn(): void {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Field 'q' is required in JSON.");
+
+        $this->parse(['categories' => ['ADORATION', 'MASS']]);
+    }
+
+    /* A LÉNYEG: „hol van ma egyáltalán szentségimádás" kulcsszó nélkül is kérdés. */
+    public function testKeywordIsOptionalForAdoration(): void {
+        $search = $this->parse(['categories' => ['ADORATION'], 'when' => 'today']);
+
+        self::assertSame(['ADORATION'], $search->input['categories']);
+        self::assertArrayNotHasKey('q', $search->input);
+    }
+
+    public function testKeywordIsOptionalForConfession(): void {
+        $search = $this->parse(['categories' => ['CONFESSION']]);
+
+        self::assertSame(['CONFESSION'], $search->input['categories']);
+    }
+
+    public function testKeywordIsOptionalForAdorationAndConfessionTogether(): void {
+        $search = $this->parse(['categories' => ['ADORATION', 'CONFESSION']]);
+
+        self::assertSame(['ADORATION', 'CONFESSION'], $search->input['categories']);
+    }
+
+    /* Az OTHER (zsolozsma, rózsafüzér…) tág, ezért ott marad a kulcsszókényszer. */
+    public function testKeywordStaysRequiredForOtherCategory(): void {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Field 'q' is required in JSON.");
+
+        $this->parse(['categories' => ['OTHER']]);
+    }
+
+    public function testUnknownCategoryIsRejected(): void {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Field 'categories' should be one of");
+
+        $this->parse(['q' => 'Szent István', 'categories' => ['SZENTSEGIMADAS']]);
+    }
+
+    public function testCategoriesMustBeAList(): void {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Field 'categories' should be a list/array.");
+
+        $this->parse(['q' => 'Szent István', 'categories' => 'ADORATION']);
+    }
+
+    /* Kulcsszóval együtt is használható: a kategória tovább szűkít. */
+    public function testKeywordAndCategoryTogetherAreAccepted(): void {
+        $search = $this->parse(['q' => 'Szent István', 'categories' => ['ADORATION']]);
+
+        self::assertSame('Szent István', $search->input['q']);
+        self::assertSame(['ADORATION'], $search->input['categories']);
+    }
+}

--- a/webapp/tests/Integration/SearchCategoriesFilterTest.php
+++ b/webapp/tests/Integration/SearchCategoriesFilterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #299: a kategóriaszűrő valós Elasticsearch ellen.
+ *
+ * A szentségimádás és a gyóntatás ugyanolyan `cal_masses` esemény, mint a mise, csak más
+ * a címe — tehát ugyanaz a mise-index szolgálja ki, ugyanazzal a válaszszerkezettel. Ezt
+ * mockolni értelmetlen volna: pont az a kérdés, hogy a `title.keyword` szűrő illeszkedik-e
+ * a ténylegesen indexelt címekre.
+ */
+class SearchCategoriesFilterTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        if (!(new \ExternalApi\ElasticsearchApi())->isexistsIndex('mass_index')) {
+            $this->markTestSkipped('Nincs mass_index ebben a környezetben.');
+        }
+    }
+
+    private function totalFor(array $categories): int {
+        $search = new \Search('masses');
+        $search->keyword('');
+
+        if (!empty($categories)) {
+            $filters = (new \MassDefinitions())->titleFiltersByCategories($categories);
+            $search->query['bool']['must'][] = [ 'terms' => ['title.keyword' => $filters] ];
+        }
+
+        $search->getResults(0, 1, true);
+        return (int) $search->total;
+    }
+
+    public function testAdorationIsFoundInTheMassIndex(): void {
+        $adorations = $this->totalFor(['ADORATION']);
+
+        if ($adorations === 0) {
+            $this->markTestSkipped('Ebben az adatbázisban nincs szentségimádás-esemény.');
+        }
+
+        self::assertGreaterThan(0, $adorations);
+    }
+
+    /* A szűrő tényleg szűkít: a kategóriára szűrt halmaz kisebb, mint a szűretlen. */
+    public function testTheFilterNarrowsTheResultSet(): void {
+        $all = $this->totalFor([]);
+        $adorations = $this->totalFor(['ADORATION']);
+
+        if ($adorations === 0) {
+            $this->markTestSkipped('Ebben az adatbázisban nincs szentségimádás-esemény.');
+        }
+
+        self::assertLessThan($all, $adorations, 'a szűrő nem szűkített semmit');
+    }
+
+    /* A mise és a szentségimádás két külön halmaz — nem folyhatnak egymásba. */
+    public function testMassAndAdorationDoNotOverlap(): void {
+        $mass = $this->totalFor(['MASS']);
+        $adorations = $this->totalFor(['ADORATION']);
+        $together = $this->totalFor(['MASS', 'ADORATION']);
+
+        if ($adorations === 0) {
+            $this->markTestSkipped('Ebben az adatbázisban nincs szentségimádás-esemény.');
+        }
+
+        self::assertSame($mass + $adorations, $together, 'átfedés van a két kategória között');
+    }
+
+    /*
+     * A találatok tényleg szentségimádások: a szűrt keresés első lapjának minden
+     * dokumentuma a kategóriához tartozó címek egyikét viseli.
+     */
+    public function testEveryHitCarriesAnAdorationTitle(): void {
+        $expected = (new \MassDefinitions())->titleFiltersByCategories(['ADORATION']);
+
+        $elastic = new \ExternalApi\ElasticsearchApi();
+        $elastic->buildQuery('mass_index/_search', json_encode([
+            'size'  => 20,
+            'query' => ['bool' => ['must' => [['terms' => ['title.keyword' => $expected]]]]],
+            '_source' => ['includes' => ['title']],
+        ]));
+        $elastic->run();
+
+        $hits = $elastic->jsonData->hits->hits ?? [];
+        if (empty($hits)) {
+            $this->markTestSkipped('Ebben az adatbázisban nincs szentségimádás-esemény.');
+        }
+
+        foreach ($hits as $hit) {
+            self::assertContains($hit->_source->title, $expected);
+        }
+    }
+}

--- a/webapp/tests/Unit/MassDefinitionsTitleFiltersTest.php
+++ b/webapp/tests/Unit/MassDefinitionsTitleFiltersTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #299: kategóriából cím-szűrő.
+ *
+ * Kétféle cím-alak létezik az adatban, mert kétfelől jön: a naptárszerkesztő a
+ * definíciókulcsot írja be (`MASS_TITLE.ADORATION`), a régi, kézzel felvitt sorokban
+ * viszont a magyar cím áll (`Szentségimádás`). Aki kategóriára szűr, mindkettőt akarja —
+ * ha az egyik kimarad, néma módon tűnnek el találatok.
+ */
+class MassDefinitionsTitleFiltersTest extends TestCase {
+
+    public function testAdorationCoversBothTheKeyAndTheHungarianTitle(): void {
+        $filters = (new \MassDefinitions())->titleFiltersByCategories(['ADORATION']);
+
+        self::assertContains('MASS_TITLE.ADORATION', $filters);
+        self::assertContains('Szentségimádás', $filters);
+    }
+
+    public function testConfessionCoversBothForms(): void {
+        $filters = (new \MassDefinitions())->titleFiltersByCategories(['CONFESSION']);
+
+        self::assertContains('MASS_TITLE.CONFESSION', $filters);
+        self::assertContains('Gyóntatás', $filters);
+    }
+
+    /*
+     * A magyar címre azért kell ragaszkodni, mert az adatbázisban az van: az élő indexben
+     * ~7000 „Szentségimádás" című esemény szerepel, „MASS_TITLE.ADORATION" címmel viszont
+     * gyakorlatilag egy sem. Ha a felület nyelvét követnénk, angol nézetben a szűrő
+     * egyetlen sorra sem illeszkedne.
+     */
+    public function testHungarianTitleDoesNotDependOnTheInterfaceLanguage(): void {
+        $filters = (new \MassDefinitions())->titleFiltersByCategories(['ADORATION']);
+
+        self::assertContains('Szentségimádás', $filters);
+        self::assertNotContains('Adoration', $filters);
+    }
+
+    public function testMassCategoryCoversEveryMassKind(): void {
+        $filters = (new \MassDefinitions())->titleFiltersByCategories(['MASS']);
+
+        self::assertContains('Szentmise', $filters);
+        self::assertContains('Szent Liturgia', $filters);
+        self::assertContains('MASS_TITLE.HOLY_MASS', $filters);
+    }
+
+    public function testSeveralCategoriesAreMerged(): void {
+        $filters = (new \MassDefinitions())->titleFiltersByCategories(['ADORATION', 'CONFESSION']);
+
+        self::assertContains('Szentségimádás', $filters);
+        self::assertContains('Gyóntatás', $filters);
+        self::assertNotContains('Szentmise', $filters, 'a mise nem tartozik ebbe a két kategóriába');
+    }
+
+    public function testUnknownCategoryGivesNoFilterInsteadOfEverything(): void {
+        self::assertSame([], (new \MassDefinitions())->titleFiltersByCategories(['SZENTSEGIMADAS']));
+        self::assertSame([], (new \MassDefinitions())->titleFiltersByCategories([]));
+    }
+
+    public function testFiltersAreUnique(): void {
+        $filters = (new \MassDefinitions())->titleFiltersByCategories(['ADORATION', 'ADORATION']);
+
+        self::assertSame(array_values(array_unique($filters)), $filters);
+    }
+}


### PR DESCRIPTION
Fixes #299

> Kéne hogy ne csak misékre lehessen keresni, hanem — ha már vannak — szentségimádásra és gyóntatásra is.

Az `/api/v4/search` kap egy `service` paramétert: `mass` (alapértelmezés, **változatlan viselkedés**), `adoration`, `confession`.

## ⚠️ Előbb a rossz hír

**Élesben ma egyik szolgálatnak sincs adata.** Végigkérdeztem az éles API-t kilenc templomra — köztük mind a négyre, amelyik a szentségimádás-betöltő kézi listájában név szerint szerepel:

| id | templom | adoraciok | gyontatas |
|---|---|---|---|
| 37 | Szent István-bazilika | `[]` | `false` |
| 2499 | Szent László-templom | `[]` | `false` |
| 1682 | Szentháromság-templom | `[]` | `false` |
| 922 | Szentháromság-templom | `[]` | `false` |
| 135 | Karmelita templom | `[]` | `false` |
| … | (még 4) | `[]` | `false` |

Az ok a #683-ban is előjött: a `\ExternalApi\szentsegimadasApi::cron()` **2025-12-31 óta nem futott le sikeresen**, a tábla pedig csak jövőbeli alkalmakat tárol — amik azóta mind a múltba kerültek. A gyóntatás meg a templomba szerelt LoRaWAN-kapcsolóktól jön, azokból nagyon kevés van.

Tehát ez a végpont **üres listát fog adni**, amíg a #239 betöltője helyre nem áll. A szerződés viszont készen lesz a KAPP-nak, és abban a pillanatban működik, ahogy az adat visszajön. Ezt tudatosan vállalom, nem véletlen.

## Hogyan működik

A két új szolgálat nincs az Elasticsearchben:
- **szentségimádás** → `szentsegimadasok` tábla (a szentsegimadas.hu-ról töltjük), vannak jövőbeli időpontjai
- **gyóntatás** → a templomba szerelt kapcsoló állapota, tehát **csak jelen ideje van**

Ezért a szűkítés az adatbázisból jön, és a kulcsszavas keresés a **templom**-indexen fut a megmaradt körre. A válasz szerkezete nem változik — a `templomok` tömb elemei már eddig is hozták az `adoraciok` és `gyontatas` mezőket.

## A `q` ennél a kettőnél nem kötelező

Épp az a tipikus kérdés, hogy „hol van **ma** egyáltalán szentségimádás". Misére továbbra is kötelező, mert a mise-index önmagában több millió időpont — kulcsszó nélkül értelmetlen a találathalmaz.

## Egy csapda, amit külön kezelek

A gyóntatásnál **a legutolsó jelzés számít**, nem akármelyik `ON`. Ha csak `status = 'ON'`-ra szűrnék, egy régi bekapcsolás örökre „gyóntatnak most" állapotban hagyná a templomot. A `when`-t itt szándékosan figyelmen kívül hagyom: a kapcsolónak nincs jövő ideje.

A `Search::day()` dátumfeloldását kiemeltem `resolveDate()`-be, hogy a szentségimádás-szűrés pontosan ugyanazt a `when` értelmezést használja (`today`, `tomorrow`, napnév, `YYYY-MM-DD`) — így a kétféle keresés nem tud szétcsúszni.

## Hogy teszteltem

**Integrációs** (`ServiceSearchTest`, 8 teszt) a szűkítő rétegre: dátumra szűrés, „minden jövőbeli", ugyanaz a templom többször csak egyszer, és a gyóntatásnál külön az, hogy egy **későbbi OFF felülírja a korábbi ON-t**, illetve hogy a 20 óránál régebbi jelzés már nem számít.

**Unit** (`SearchResolveDateTest`, 5+ eset) a dátumfeloldásra.

**Végponttól végpontig, valódi HTTP-hívásokkal** a dev stacken, felvetett tesztadattal (37 és 135 ma, 388 három nap múlva; 135-ön a kapcsoló ON, 37-en ON majd OFF):

| kérés | eredmény |
|---|---|
| `{"service":"adoration"}` | 3 találat: 37, 135, 388 |
| `{"service":"adoration","when":"today"}` | 2 találat: 37, 135 |
| `{"service":"adoration","when":"+3 nap"}` | 1 találat: 388 |
| `{"service":"adoration","when":"tomorrow"}` | 0 találat |
| `{"service":"confession"}` | 1 találat: **135** (37 kimarad, mert az ON-ját OFF követte) |
| `{"q":"Szent István","service":"adoration"}` | 2 találat: 37, 135 — a kulcsszó tovább szűkít |
| `{"q":"Szent István"}` | mise, 859 051 találat — változatlan |
| `{"limit":3}` (mise, `q` nélkül) | `error: 1`, „Field 'q' is required" — változatlan |
| `{"service":"gyertyagyujtas"}` | `error: 1`, „should be one of: mass, adoration, confession" |

A dev adatbázisból a tesztadatot utána kitöröltem.

Teljes suite: 461 teszt, 18 bukás — **ugyanaz a 18, ami a masteren is** (`AutocompleteCombinedTest`, `LegacyChurchUrlRedirectTest`, HTTP-alapúak, a helyi környezetem miatt).
