### PR TITLE
Felviszem a webpack-dev-servert 5.2.6-ra, Angular 21 alatt (#665)

### DIFF
--- a/calendar/package-lock.json
+++ b/calendar/package-lock.json
@@ -14731,9 +14731,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14755,7 +14755,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",

--- a/calendar/package.json
+++ b/calendar/package.json
@@ -50,5 +50,8 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
     "typescript": "~5.9.0"
+  },
+  "overrides": {
+    "webpack-dev-server": "5.2.6"
   }
 }


### PR DESCRIPTION
A #665 helyett. Azt a PR-t érdemes lezárni, ha ez bemegy.

## Miért bukik a #665

A dependabot a `webpack-dev-server`-t akarja 5.2.5 → 5.2.6-ra emelni. A `@angular-devkit/build-angular@21.2.20` viszont **pontosan** `5.2.5`-öt köt ki (nem tartomány), ezért a dependabot az őst is emelte: 21.2.20 → **22.1.3**.

Csakhogy a 22-es `@angular/compiler-cli@^22.0.0`-t vár, a keretrendszer viszont mindenütt 21-es:

```
npm error ERESOLVE could not resolve
npm error Found: @angular/compiler-cli@21.2.19
npm error peer @angular/compiler-cli@"^22.0.0" from @angular-devkit/build-angular@22.1.3
```

Az `npm ci` tehát elhasal, az `ng-test` job el sem indul.

## Mit csinálok helyette

npm `overrides`-szal emelem a `webpack-dev-server`-t, a toolchain marad 21-en:

```json
"overrides": {
  "webpack-dev-server": "5.2.6"
}
```

Ez azért helyes, és nem kerülőút:

- A `webpack-dev-server` **csak az `ng serve` alatt fut**. Éles buildbe nem kerül bele, a konténer sem használja.
- Az 5.2.6 javítása épp a dev-szerver saját útvonalainak (`/webpack-dev-server/invalidate`, `/open-editor`) CSRF-védelme, plusz a hibás `Host`/`Origin` fejlécek kezelése. Tehát pontosan azt kapjuk meg, amiért a frissítés kell.
- Az Angular 21 → 22 lépés önálló, tudatos feladat, nem egy patch-szintű dependabot-PR mellékterméke. Ráadásul **nem is ebbe az irányba vezet**: a `@angular-devkit/build-angular` 22-es kiadása maga is deprecated („Angular's Webpack support is deprecated. Use the esbuild and Vite-based `@angular/build` package instead"), tehát a dependabot javaslatát követve egy elavuló csomagra lépnénk át — közben az egész keretrendszert is emelnünk kellene.

## Hogy ellenőriztem

A lockfile a kívánt állapotba került:

| csomag | verzió |
|---|---|
| `webpack-dev-server` | **5.2.6** |
| `@angular-devkit/build-angular` | 21.2.20 |
| `@angular/cli` | 21.2.20 |
| `@angular/compiler-cli` | 21.2.19 |

Aztán üres `node_modules`-ról:

- `npm ci` — **hibátlan** (ezen bukott a #665)
- `npx ng test --watch=false --browsers=ChromeHeadless` — **176 teszt zöld**
- `npx ng build --configuration=production` — hibátlan

## Ha később mégis kell a 22

Akkor az egész Angulart együtt kell emelni (`@angular/*`, `@angular/cli`, `@angular/compiler-cli`, `typescript`), és érdemes ugyanabban a lépésben a `@angular-devkit/build-angular`-ról a `@angular/build`-re váltani, hogy ne egy deprecated builderre álljunk át. Az override akkor törölhető.
