### PR TITLE
Ne mondjuk a gondnoknak, hogy nem láthatja a saját templomát (#409)

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1421,6 +1421,52 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         $this->religious_administration->parish = $parish;
     }
 
+    /**
+     * #409: mit írjunk ki a nem-publikus templom oldalán, és kinek?
+     *
+     * A jogosultság maga rendben volt: a checkWriteAccess() SOHA nem nézi az `ok`-ot,
+     * tehát egy `allowed` gondnok (vagy ős-templom gondnoka, vagy egyházmegyei felelős)
+     * eddig is szerkeszthette a nem-publikus templomát. Csak épp azt olvasta közben, hogy
+     * „Csak adminisztrátorok számára látható ez az oldal" — ami neki egyszerűen nem igaz,
+     * és pont az ellenkezőjét hitette el vele.
+     *
+     * Szándékosan tiszta, statikus függvény (se DB, se globális), hogy tesztelhető legyen.
+     *
+     * @param  string $ok             a templom `ok` mezője: i = nyilvános, f = áttekintésre vár, n = letiltva
+     * @param  bool   $isAdmin        van-e `miserend` jogosultsága
+     * @param  bool   $hasWriteAccess szerkesztheti-e (gondnok / egyházmegyei felelős / admin)
+     * @return array{0:string,1:string}|null  [üzenet, szint] vagy null, ha nincs mit mondani
+     */
+    public static function visibilityNotice(string $ok, bool $isAdmin, bool $hasWriteAccess): ?array {
+        if ($ok === 'i') {
+            return null;
+        }
+
+        // Akinek nincs írási joga, az ide amúgy sem jut be (checkReadAccess), de ha
+        // mégis, maradjon a régi, semleges szöveg.
+        if ($isAdmin || !$hasWriteAccess) {
+            if ($ok === 'n') {
+                return ['Ez a templom le van tiltva! Csak adminisztrátorok számára látható ez az oldal.', 'warning'];
+            }
+            return ['Ez a templom áttekintésre vár. Csak adminisztrátorok számára látható ez az oldal.', 'warning'];
+        }
+
+        if ($ok === 'n') {
+            return [
+                'Ez a misézőhely jelenleg le van tiltva, ezért a látogatók nem látják. '
+                . 'Te gondnokként látod és szerkesztheted; ha szerinted tévedés, jelezd az adminisztrátoroknak.',
+                'warning'
+            ];
+        }
+
+        return [
+            'Ez a misézőhely még nem nyilvános: áttekintésre vár, ezért egyelőre csak te '
+            . 'és az adminisztrátorok látjátok. Nyugodtan szerkeszd — a jóváhagyás után '
+            . 'ezek az adatok jelennek meg a látogatóknak.',
+            'info'
+        ];
+    }
+
     function checkReadAccess($_user) {
         $access = false;
         if ($this->ok == 'i')

--- a/webapp/classes/html/church/church.php
+++ b/webapp/classes/html/church/church.php
@@ -92,10 +92,16 @@ class Church extends \Html\Html {
             throw new \Exception("Read access denied to church tid = '$tid'");
         }
 
-        if($church->ok == 'n') {
-            addMessage('Ez a templom le van tiltva! Csak adminisztrátorok számára látható ez az oldal.', 'warning');
-        } elseif($church->ok == 'f') {
-            addMessage('Ez a templom áttekintésre vár. Csak adminisztrátorok számára látható ez az oldal.', 'warning');
+        // #409: a gondnok eddig is szerkeszthette a nem-publikus templomát, de azt
+        // olvasta közben, hogy „Csak adminisztrátorok számára látható" — neki mást kell
+        // mondani, mint egy adminisztrátornak.
+        $notice = \Eloquent\Church::visibilityNotice(
+            (string) $church->ok,
+            (bool) $user->checkRole('miserend'),
+            (bool) $church->writeAccess
+        );
+        if ($notice !== null) {
+            addMessage($notice[0], $notice[1]);
         }
 
         $church->photos = $church->photos()->get();

--- a/webapp/tests/Unit/ChurchVisibilityNoticeTest.php
+++ b/webapp/tests/Unit/ChurchVisibilityNoticeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #409: „Templom gondnok kezelhesse saját nem publikus templomát."
+ *
+ * A jogosultság maga rendben volt: a Church::checkWriteAccess() SOHA nem nézi az `ok`
+ * mezőt, tehát egy `allowed` gondnok eddig is megnyithatta és szerkeszthette a
+ * nem-publikus templomát. Csak épp azt olvasta közben, hogy „Csak adminisztrátorok
+ * számára látható ez az oldal" — ami neki nem igaz, és pont az ellenkezőjét hitette el.
+ *
+ * A visibilityNotice() dönti el, kinek mit írunk ki. Tiszta függvény, itt közvetlenül
+ * tesztelhető.
+ */
+class ChurchVisibilityNoticeTest extends TestCase {
+
+    public function testNyilvanosTemplomnalNincsUzenet(): void {
+        $this->assertNull(\Eloquent\Church::visibilityNotice('i', false, false));
+        $this->assertNull(\Eloquent\Church::visibilityNotice('i', true, true));
+        $this->assertNull(\Eloquent\Church::visibilityNotice('i', false, true));
+    }
+
+    public function testAdminnakAMegszokottSzoveg(): void {
+        [$uzenet, $szint] = \Eloquent\Church::visibilityNotice('f', true, true);
+        $this->assertStringContainsString('Csak adminisztrátorok számára látható', $uzenet);
+        $this->assertSame('warning', $szint);
+
+        [$uzenet] = \Eloquent\Church::visibilityNotice('n', true, true);
+        $this->assertStringContainsString('le van tiltva', $uzenet);
+        $this->assertStringContainsString('Csak adminisztrátorok számára látható', $uzenet);
+    }
+
+    /**
+     * A lényeg: a gondnoknak NEM azt mondjuk, hogy csak adminisztrátorok látják.
+     */
+    public function testGondnoknakNemAztMondjukHogyNemLathatja(): void {
+        [$uzenet, $szint] = \Eloquent\Church::visibilityNotice('f', false, true);
+
+        $this->assertStringNotContainsString('Csak adminisztrátorok', $uzenet);
+        $this->assertStringContainsString('nem nyilvános', $uzenet);
+        $this->assertStringContainsString('szerkeszd', $uzenet);
+        $this->assertSame('info', $szint, 'Ez nem hiba, csak állapot — ne piros figyelmeztetés legyen.');
+    }
+
+    public function testLetiltottTemplomGondnokanakSajatSzoveg(): void {
+        [$uzenet, $szint] = \Eloquent\Church::visibilityNotice('n', false, true);
+
+        $this->assertStringNotContainsString('Csak adminisztrátorok', $uzenet);
+        $this->assertStringContainsString('le van tiltva', $uzenet);
+        $this->assertStringContainsString('gondnokként', $uzenet);
+        $this->assertSame('warning', $szint, 'A letiltás tényleg figyelmeztetés.');
+    }
+
+    /**
+     * Írási jog nélkül ide amúgy sem lehet bejutni (checkReadAccess), de ha mégis,
+     * maradjon a semleges szöveg.
+     */
+    public function testIrasiJogNelkulAMegszokottSzoveg(): void {
+        [$uzenet] = \Eloquent\Church::visibilityNotice('f', false, false);
+        $this->assertStringContainsString('Csak adminisztrátorok számára látható', $uzenet);
+    }
+
+    /**
+     * Ismeretlen `ok` értéknél se maradjon néma az oldal.
+     */
+    public function testIsmeretlenAllapotnalIsAdUzenetet(): void {
+        $this->assertNotNull(\Eloquent\Church::visibilityNotice('x', false, true));
+    }
+}


### PR DESCRIPTION
Fixes #409

## A jogosultság már eddig is jó volt

A `Church::checkWriteAccess()` **soha nem nézi az `ok` mezőt**. Egy `allowed` gondnok (vagy ős-templom gondnoka, vagy egyházmegyei felelős) tehát eddig is megnyithatta és szerkeszthette a nem-publikus templomát — a `checkReadAccess()` is átengedi, mert az írási jog olvasásit is ad.

Ezt le is ellenőriztem: csináltam egy `ok='f'` templomot és egy **nem admin** felhasználót `allowed` gondnokként.

```
ok=f  admin=nem  writeAccess=IGEN  readAccess=IGEN
GET /templom/7826        -> HTTP 200
GET /templom/7826/edit   -> HTTP 200, semmilyen jogosultsági hiba
```

## Akkor mi volt a baj

Ez fogadta a saját templomán:

> Ez a templom áttekintésre vár. **Csak adminisztrátorok számára látható ez az oldal.**

Ez neki egyszerűen nem igaz — épp ő nézi, nem adminisztrátorként. És pont az ellenkezőjét hiteti el vele, mint ami a valóság: azt hiszi, nem az ő dolga, nem is próbálja szerkeszteni. Az issue címe („kezelhesse saját nem publikus templomát") így nem jogosultsági, hanem közlési hiba volt.

## Mit csinálok

A láthatósági üzenet mostantól tudja, kinek beszél:

| állapot | adminisztrátor | **gondnok** |
|---|---|---|
| `ok='i'` | *(nincs üzenet)* | *(nincs üzenet)* |
| `ok='f'` | „Ez a templom áttekintésre vár. Csak adminisztrátorok számára látható ez az oldal." | „Ez a misézőhely még nem nyilvános: áttekintésre vár, ezért egyelőre csak te és az adminisztrátorok látjátok. **Nyugodtan szerkeszd** — a jóváhagyás után ezek az adatok jelennek meg a látogatóknak." (`info`) |
| `ok='n'` | „Ez a templom le van tiltva! Csak adminisztrátorok számára látható ez az oldal." | „Ez a misézőhely jelenleg le van tiltva, ezért a látogatók nem látják. **Te gondnokként látod és szerkesztheted**; ha szerinted tévedés, jelezd az adminisztrátoroknak." (`warning`) |

A „még nem nyilvános" eset szándékosan `info` és nem `warning`: ez nem hiba, hanem állapot — a gondnok épp azt csinálja, amit kell.

A döntést tiszta, statikus függvénybe tettem (`Church::visibilityNotice()`), se DB, se globális — így unit-tesztelhető.

## Hogy teszteltem

Mind a négy kombinációt végigvittem **valódi HTTP-kérésekkel**, bejelentkezett gondnokkal és adminisztrátorral:

```
── ADMIN,   ok=f ──  Ez a templom áttekintésre vár. Csak adminisztrátorok számára látható…
── GONDNOK, ok=n ──  Ez a misézőhely jelenleg le van tiltva… Te gondnokként látod és szerkesztheted…
── ADMIN,   ok=n ──  Ez a templom le van tiltva! Csak adminisztrátorok számára látható…
── GONDNOK, ok=i ──  (nincs láthatósági üzenet)
```

**Unit tesztek** (`ChurchVisibilityNoticeTest`, 6 teszt): nyilvános templomnál nincs üzenet; adminnak a megszokott szöveg; a gondnoknak **kifejezetten nem** az, hogy „Csak adminisztrátorok"; a letiltott eset külön szövege és `warning` szintje; írási jog nélkül a semleges szöveg; és hogy ismeretlen `ok` értéknél se maradjon néma az oldal.

Teljes suite: 450 teszt, **0 bukás** (1024 assertion). A tesztadatot utána kitöröltem a dev adatbázisból.

## Amit nem találtam

Megnéztem, hogy egy frissen feltöltött templom feltöltője kap-e automatikusan gondnokságot — de a templom-létrehozás (`Html\Church\Create`) `miserend` jogot követel, tehát csak adminisztrátor hozhat létre templomot, aki amúgy is hozzáfér. Ebben az ágban tehát nincs hiba.

> **Megjegyzés a futtatásról:** ezen az ágon a teljes suite csak akkor zöld, ha a HTTP-alapú tesztek elérik az appot. A #693 ezt orvosolja a `scripts/docker-test.sh`-ban; itt kézzel adtam meg a `PANTHER_EXTERNAL_BASE_URI=http://miserend:8000`-et.
