### PR TITLE
A funkcionális tesztek ne függjenek külső szolgáltatástól

### DIFF
--- a/docker/compose.coverage.yml
+++ b/docker/compose.coverage.yml
@@ -1,6 +1,13 @@
 services:
   miserend:
     image: ghcr.io/szentjozsefhackathon/miserend.hu-coverage:${COVERAGE_IMAGE_TAG:-latest}
+    # A CI a FUTÓ konténer ellen futtatja a Panther-teszteket (PANTHER_EXTERNAL_BASE_URI),
+    # tehát az oldalt ez a szolgáltatás szolgálja ki. A templom-oldal külső API-kat hívna
+    # (kozossegek.hu, Overpass); üres cache-sel ez másodperceket vesz, és a WebDriver
+    # 180 másodperces korlátját is átlépheti — ettől bukott véletlenszerűen a
+    # ChurchDetailPageTest és a ChurchRemarkFormTest. Teszt alatt nincs kifelé menő hálózat.
+    environment:
+      - EXTERNAL_APIS_OFFLINE=1
     volumes:
       - ../webapp:/miserend/webapp
       - vendor_data:/miserend/webapp/vendor

--- a/docker/compose.test.yml
+++ b/docker/compose.test.yml
@@ -19,3 +19,7 @@ services:
       # A 11025 a hoston publikált port; a compose-hálózaton belül a mailcatcher 1025-ön hallgat.
       - SMTP_PORT=1025
       - MISEREND_WEBAPP_ENVIRONMENT=testing
+      # A funkcionális tesztek a valódi oldalt töltik be; a templom-oldal külső
+      # szolgáltatásokat hívna (kozossegek.hu, Overpass), ami üres cache-sel másodperceket
+      # vesz és a CI-ban időtúllépést okozott. Teszt alatt nincs kifelé menő hálózat.
+      - EXTERNAL_APIS_OFFLINE=1

--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -13,6 +13,15 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 	
 	public $q; // Ez a solr keresőben a query, nem pedig az API-ban a query
     public $data;
+
+	/**
+	 * Az Elasticsearch a SAJÁT infrastruktúránk (compose-hálózat), nem harmadik fél —
+	 * az EXTERNAL_APIS_OFFLINE kapcsoló nem vonatkozik rá. Enélkül a tesztek alatt a
+	 * kereső is elnémulna.
+	 */
+	protected function isInternalService(): bool {
+		return true;
+	}
 			
 	function run() {					
 		$this->curl_setopt(CURLOPT_HTTPHEADER ,['Content-Type: application/json']);		 	

--- a/webapp/classes/externalapi/externalapi.php
+++ b/webapp/classes/externalapi/externalapi.php
@@ -34,7 +34,52 @@ class ExternalApi {
         $this->runQuery();
     }
 
+    /**
+     * Ki van-e kapcsolva a kifelé menő hálózat?
+     *
+     * A funkcionális (Panther) tesztek a VALÓDI oldalt töltik be, a templom-oldal pedig
+     * külső szolgáltatásokat hív (kozossegek.hu, Overpass) — üres cache-sel ez helyben is
+     * ~12 másodperc, a CI-ban pedig a WebDriver 180 másodperces korlátját is átlépheti.
+     * Így bukott véletlenszerűen a ChurchDetailPageTest és a ChurchRemarkFormTest, olyan
+     * PR-eken is, amik hozzá se értek a kódhoz.
+     *
+     * A kapcsoló SZÁNDÉKOSAN opt-in: alapból nincs bekapcsolva, tehát dev és production
+     * viselkedése nem változik. A teszt-compose-ok állítják be (l. compose.test.yml,
+     * compose.coverage.yml).
+     */
+    public static function isOffline(): bool {
+        $value = env('EXTERNAL_APIS_OFFLINE', '');
+        return in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'on'], true);
+    }
+
+    /**
+     * Ez a szolgáltatás a saját infrastruktúránk-e?
+     *
+     * Az Elasticsearch ugyanezen az ősosztályon keresztül beszél, pedig a compose-hálózaton
+     * belül van — nem harmadik fél. Az offline kapcsoló SEM vonatkozhat rá, különben a
+     * kereső is elnémulna a tesztek alatt (ezt a saját tesztjeim fogták meg: az
+     * ElasticsearchApiLoggerTest azonnal elbukott az első próbálkozásnál).
+     */
+    protected function isInternalService(): bool {
+        return false;
+    }
+
     function runQuery() {
+        // Offline módban meg sem próbálkozunk: se hálózat, se cache-írás. A hívók a
+        // szokásos „üres válasz" ágon mennek tovább, pontosan úgy, mintha a külső
+        // szolgáltatás nem adott volna adatot.
+        if (self::isOffline() && !$this->isInternalService()) {
+            $this->responseCode = 0;
+            $this->rawData = '';
+            if ($this->format == 'json') $this->jsonData = json_decode('[]');
+            if ($this->format == 'xml')  $this->xmlData = false;
+            $this->error = 'A külső API-k ki vannak kapcsolva (EXTERNAL_APIS_OFFLINE).';
+            if (isset($this->isTesting) and $this->isTesting == true) {
+                throw new \Exception($this->error);
+            }
+            return false;
+        }
+
 		if(isset($this->rawData)) unset($this->rawData);
         try {
         


### PR DESCRIPTION
A CI-ban visszatérően bukott két Panther-teszt olyan PR-eken is, amik nem értek hozzá a kódhoz (#559, #693):

```
Tests\Functional\ChurchDetailPageTest::testChurchPageLoadsWithoutError
Tests\Functional\ChurchRemarkFormTest::testRemarkInstructionTextDisplayed

WebDriverCurlException: Curl error thrown for POST /session/.../url
  {"url":"http://127.0.0.1:8000/templom/2474"}
Operation timed out after 180002 milliseconds
```

Eddig flake-nek néztem. Nem az.

## A mérés

```
/templom/37    →  0,05 s
/templom/2474  → 11,77 s   ← első betöltés
/templom/2474  →  0,06 s   ← második
/templom/2474  →  0,06 s
```

Nem az adatmennyiség: a 2474-nek 16 miséje és 0 észrevétele van, míg az 1-es templomnak 306 észrevétele — és az gyors. A különbség a **cache**. Az első betöltés után frissen ott vannak a `kozossegek_*.json` és `overpass_*.json` fájlok: a templom-oldal a `Church::getKozossegekAttribute()`-on át **kifelé hálózatozik**.

A CI minden futása üres cache-sel indul, a runner lassabb, és a külső szolgáltatás válaszideje változékony. Ha átlépi a WebDriver 180 másodperces korlátját, a teszt elhasal — a kódtól teljesen függetlenül.

## A javítás

`EXTERNAL_APIS_OFFLINE` kapcsoló az `ExternalApi::runQuery()` elején: bekapcsolva a hívás **meg sem indul**, a hívók a szokásos „üres válasz" ágon mennek tovább, és **a cache-be sem írunk** (különben a `[]` beragadna).

Szándékosan **opt-in**: alapból nincs bekapcsolva, tehát dev és production viselkedése nem változik. A két teszt-compose állítja be:
- `compose.test.yml` — a helyi `docker-test-panther.sh`
- `compose.coverage.yml` — a CI (ez szolgálja ki a `PANTHER_EXTERNAL_BASE_URI`-t)

## Egy hiba a saját javításomban

Első nekifutásra **azonnal elbukott hat teszt** (`ElasticsearchApiLoggerTest`, `OsmBoundariesTest`), mert az `ElasticsearchApi` ugyanezen az ősosztályon beszél — így a kapcsoló a **keresőt is elnémította**.

Az ES viszont a saját infrastruktúránk a compose-hálózaton, nem harmadik fél. Bevezettem az `isInternalService()`-t, amit az `ElasticsearchApi` felülír. A kapcsoló csak a valódi külső szolgáltatásokra hat.

## Ellenőrzés

| | eredmény |
|---|---|
| teljes suite offline **nélkül** | 454 teszt, **0 bukás** |
| teljes suite offline **módban** | 454 teszt, **0 bukás** |
| `Church->kozossegek` offline, üres cache | 0,03 mp, 0 elem — nincs hálózat |
| `toAPIArray` offline | ép: név, 2 mise, `nyelvek=hu` |
| ES elérhető offline módban | **igen** (ez a lényeg) |

A templom-oldal tehát offline módban is hiánytalan, csak a közösségek listája marad üres — ami pontosan ugyanaz az ág, mint amikor a kozossegek.hu nem válaszol.

## A merge biztonságos — élesben semmi nem változik

A kapcsoló **opt-in**, és sem az éles, sem a dev compose nem állítja be. Ellenőrizve:

| compose | `EXTERNAL_APIS_OFFLINE` |
|---|---|
| `compose.yml` (ezt használja a deploy) | **nincs beállítva** |
| `compose.yml` + `compose.dev.yml` | **nincs beállítva** |
| + `compose.coverage.yml` (CI) | `1` |
| + `compose.test.yml` (helyi Panther) | `1` |

Beállítás nélkül az `ExternalApi::isOffline()` `false`-t ad, tehát a kód pontosan úgy viselkedik, mint eddig — a futó dev konténerben is ezt mértem.

Egyetlen dolgot ne csináljunk: **ne írjuk bele az éles `.env`-be**. Akkor a közösségek és az OSM-adatok némán eltűnnének, és a `/health` minden külső szolgáltatót elérhetetlennek mutatna. A PR mergelése viszont nem kapcsolja be sehol.

Ez a javítás nem old meg mindent: a `/templom/2474` első betöltése éles környezetben továbbra is másodpercekig tarthat, ha a kozossegek.hu lassú. Az önmagában is megérne egy jegyet (a hívás áthelyezése aszinkronba vagy cronba), de az termékdöntés — ide nem húztam be.
