### PR TITLE
Megszüntetem a záró perjeles URL-ek portszivárgását (#658)

### DIFF
--- a/webapp/.htaccess
+++ b/webapp/.htaccess
@@ -5,9 +5,6 @@
 
     RewriteEngine On
 
-    # Redirect Trailing Slashes...
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
-
     RewriteBase /
 
     # #642: az OSM-ben sok helyen a régi `?templom=1254` alakú link szerepel. Erre
@@ -31,6 +28,16 @@
 
     RewriteCond %{HTTP_HOST} ^www\.(.*)$ [NC]
     RewriteRule ^(.*)$ %{ENV:PROTO}://%1/$1 [R=301,L]
+
+    # #658: a záró perjel levágása ugyanabba a csapdába esett, amit a #642 fentebb
+    # már megoldott: relatív cél + R=301 esetén az Apache maga építi fel az abszolút
+    # URL-t, és ODATESZI a saját fizikai portját meg a lecsupaszított sémát:
+    #   https://miserend.hu/templom/452/  ->  http://miserend.hu:8000/templom/452
+    # ami kívülről elérhetetlen. Ráadásul a szabály a PROTO beállítása ELŐTT állt,
+    # így az %{ENV:PROTO} akkor sem lett volna kitöltve. Ezért lejjebb hoztam, és a
+    # célt a kliens Host fejlécéből állítom össze.
+    # `.+` (nem `.*`): a puszta gyökeret ("/") nem szabad átirányítani.
+    RewriteRule ^(.+)/$ %{ENV:PROTO}://%{HTTP_HOST}/$1 [R=301,L]
 
     # Redirect query parameter ?templom=ID to path /templom/ID for Angular
     # Case 1: Only ?templom=ID (no other parameters)

--- a/webapp/tests/Integration/LegacyChurchUrlRedirectTest.php
+++ b/webapp/tests/Integration/LegacyChurchUrlRedirectTest.php
@@ -107,4 +107,58 @@ final class LegacyChurchUrlRedirectTest extends TestCase {
 
         self::assertSame('http://localhost:8000/templom/1254', $response['location']);
     }
+
+    /*
+     * #658: a záró perjelet levágó szabály ugyanebbe a csapdába esett, csak a
+     * #642-es javítás nem terjedt ki rá — relatív cél maradt, ráadásul a PROTO
+     * beállítása ELŐTT. Így minden záró perjeles URL (nem csak a templomlapok)
+     * a kívülről elérhetetlen http://miserend.hu:8000/... címre irányított.
+     */
+    public static function trailingSlashPathProvider(): array {
+        return [
+            'templomlap'  => ['/templom/1254/', 'https://miserend.hu/templom/1254'],
+            'kereses'     => ['/kereses/',      'https://miserend.hu/kereses'],
+            'mely utvonal' => ['/templom/1254/naptar/', 'https://miserend.hu/templom/1254/naptar'],
+        ];
+    }
+
+    /** @dataProvider trailingSlashPathProvider */
+    public function testTrailingSlashRedirectsToCleanHttpsUrl(string $path, string $expected): void {
+        $response = $this->head($path, [
+            'Host: miserend.hu',
+            'X-Forwarded-Proto: https',
+        ]);
+
+        self::assertSame(301, $response['status']);
+        self::assertSame($expected, $response['location']);
+    }
+
+    /** @dataProvider trailingSlashPathProvider */
+    public function testTrailingSlashRedirectNeverLeaksTheInternalPort(string $path): void {
+        $response = $this->head($path, ['Host: miserend.hu', 'X-Forwarded-Proto: https']);
+
+        self::assertStringNotContainsString(':8000', (string) $response['location']);
+    }
+
+    /* A puszta gyökeret nem szabad átirányítani (különben végtelen ciklus). */
+    public function testRootIsNotRedirected(): void {
+        $response = $this->head('/', ['Host: miserend.hu', 'X-Forwarded-Proto: https']);
+
+        self::assertSame(200, $response['status']);
+        self::assertNull($response['location']);
+    }
+
+    /* Perjel nélkül nincs átirányítás — a lapnak egyből ki kell szolgálódnia. */
+    public function testPathWithoutTrailingSlashIsServedDirectly(): void {
+        $response = $this->head('/templom/1254', ['Host: miserend.hu', 'X-Forwarded-Proto: https']);
+
+        self::assertSame(200, $response['status']);
+    }
+
+    /* Fejlesztői környezetben itt is marad a port. */
+    public function testTrailingSlashKeepsDevelopmentPort(): void {
+        $response = $this->head('/kereses/', ['Host: localhost:8000']);
+
+        self::assertSame('http://localhost:8000/kereses', $response['location']);
+    }
 }


### PR DESCRIPTION
A #658 felmérése közben találtam: **minden** záró perjeles URL kívülről elérhetetlen címre 301-el a produkción.

```
https://miserend.hu/templom/452/  ->  http://miserend.hu:8000/templom/452   (nem érhető el)
https://miserend.hu/kereses/      ->  http://miserend.hu:8000/kereses       (nem érhető el)
```

Ok: a perjelet levágó szabály relatív célt adott meg `R=301` mellett, ezért az Apache maga építette fel az abszolút URL-t, és odatette a saját fizikai portját (8000) meg a lecsupaszított sémát. Ez ugyanaz a hiba, amit a #642 a `?templom=` ágnál már megoldott — csak erre a szabályra nem terjedt ki. Ráadásul a `PROTO` beállítása *előtt* állt, így az `%{ENV:PROTO}` akkor sem lett volna kitöltve.

Megoldás: lejjebb hoztam a PROTO-blokk alá, és a célt ugyanúgy a kliens `Host` fejlécéből építem. `.*` helyett `.+`, hogy a puszta gyökér ne irányítson át.

Kimérve, proxy mögötti fejlécekkel:

| | előtte | utána |
|---|---|---|
| `/templom/452/` | `http://miserend.hu:8000/templom/452` | `https://miserend.hu/templom/452` |
| `/kereses/` | `http://miserend.hu:8000/kereses` | `https://miserend.hu/kereses` |
| `/templom/452/naptar/` | `http://miserend.hu:8000/...` | `https://miserend.hu/templom/452/naptar` |
| `/` | 200 | 200 |
| dev `localhost:8000` | port marad | port marad |

Teszt: a meglévő `LegacyChurchUrlRedirectTest`-et bővítettem. A régi `.htaccess`-szel a 6 új eset bukik, a javítottal mind a 15 zöld. Teljes készlet: 469 teszt zöld (integration/api/simple/request).

Figyelem: `.htaccess`-változás, deploykor érdemes ellenőrizni, hogy a fájl tényleg kikerül-e — a szabálysorrend számít.