### PR TITLE
Behúzom a level-4 határt, ahol nincs level-6 (#496, #497, #498)

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1313,16 +1313,64 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         /* Adminisrative Boundaries(Country,County, City, District) */
         $boundaries = $this->boundaries()
                 ->where('boundary','administrative')
-                ->whereIn('admin_level',[2,6,8,9,10])
-                ->orderBy('admin_level')              
+                ->whereIn('admin_level',[2,4,6,8,9,10])
+                ->orderBy('admin_level')
                 ->get()->toArray();
+
+        $boundaries = self::pickAdministrativeBoundaries($boundaries);
 
         if(array_key_exists(0, $boundaries)) $location->country = $boundaries[0];
         if(array_key_exists(1, $boundaries)) $location->county = $boundaries[1];
-        if(array_key_exists(2, $boundaries)) $location->city = $boundaries[2];   
-        if(array_key_exists(3, $boundaries)) $location->district = $boundaries[3];        
-                
+        if(array_key_exists(2, $boundaries)) $location->city = $boundaries[2];
+        if(array_key_exists(3, $boundaries)) $location->district = $boundaries[3];
+
         return $location;
+    }
+
+    /**
+     * #496/#497/#498: az admin_level ország/megye/település sorrendbe rendezése.
+     *
+     * A location() pozíció szerint címkéz: a rendezett lista 0., 1., 2., 3. eleme
+     * lesz az ország, megye, település, kerület. Ez addig működik, amíg minden
+     * ország ugyanazokat a szinteket használja — de nem használják:
+     *
+     *   Magyarország  2 ország | 4 nagyrégió | 6 vármegye | 8 település | 9 kerület
+     *   Szlovákia     2 ország | 4 kraj      | 6 okres    | 8 obec
+     *   Szerbia       2 ország | 4 tartomány | 6 okrug    | 8 opstina    | 9 település
+     *   Ukrajna       2 ország | 4 oblaszty  | 6 rajon    |              | 9 település
+     *   Románia       2 ország | 4 judet     |    -       | 8 comuna/oras
+     *
+     * Romániában NINCS 6-os szint: a megyét a 4-es hordozza. A korábbi
+     * whereIn([2,6,8,9,10]) ezt kizárta, így a román templomoknál a lista
+     * [ország, település] lett — vagyis a TELEPÜLÉS csúszott a megye helyére,
+     * a location->city pedig NULL maradt. Ez 538 templomot érint (a határon túli
+     * állomány 80%-a), és mindenhová továbbgyűrűzik, ahol location.city-t
+     * használunk (home.twig ajánló, szomszédos templomok panel, Angular naptár).
+     *
+     * Ezért a 4-es szintet is behúzzuk, de CSAK akkor hagyjuk bent, ha nincs
+     * 6-os. Magyarországon van 6-os (vármegye), így a nagyrégió kiesik és a
+     * viselkedés bitre azonos marad a korábbival — a templomok 87%-át ez a
+     * változás nem érinti.
+     *
+     * @param array $boundaries admin_level szerint növekvőn rendezve
+     */
+    static function pickAdministrativeBoundaries(array $boundaries): array {
+        $hasCounty = false;
+        foreach ($boundaries as $boundary) {
+            if ((int) ($boundary['admin_level'] ?? 0) === 6) {
+                $hasCounty = true;
+                break;
+            }
+        }
+
+        if (!$hasCounty) {
+            return array_values($boundaries);
+        }
+
+        return array_values(array_filter(
+            $boundaries,
+            fn($boundary) => (int) ($boundary['admin_level'] ?? 0) !== 4
+        ));
     }
 	
 	

--- a/webapp/tests/Integration/AdminLevelMappingTest.php
+++ b/webapp/tests/Integration/AdminLevelMappingTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #496/#497/#498: a location() pozíció szerint címkézi az ország/megye/település
+ * hármast, de az admin_level jelentése országonként eltér. A lenti szintkészletek
+ * nem kitaláltak: az OSM Overpass `is_in` lekérdezésével mértem ki őket egy-egy
+ * valódi templomunk koordinátáján, 2026-08-09-én.
+ *
+ * A függvény DB nélkül fut, ezért közvetlenül hívható.
+ */
+final class AdminLevelMappingTest extends TestCase {
+
+    /** Az Overpass által visszaadott szintekből épít boundary-tömböt. */
+    private static function boundaries(array $levelsAndNames): array {
+        $out = [];
+        foreach ($levelsAndNames as $level => $name) {
+            $out[] = ['admin_level' => $level, 'name' => $name, 'osmtype' => 'relation', 'osmid' => $level];
+        }
+        return $out;
+    }
+
+    private static function names(array $boundaries): array {
+        return array_column($boundaries, 'name');
+    }
+
+    /*
+     * Magyarország: van 6-os (vármegye), tehát a 4-es nagyrégiónak ki kell esnie.
+     * Ez a templomok 87%-a — itt semmi nem változhat.
+     */
+    public function testHungarianRegionIsDroppedInFavourOfTheCounty(): void {
+        $input = self::boundaries([
+            2 => 'Magyarország',
+            4 => 'Közép-Magyarország',
+            6 => 'Pest vármegye',
+            8 => 'Szentendre',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame(['Magyarország', 'Pest vármegye', 'Szentendre'], self::names($result));
+    }
+
+    /* Budapest: a kerület és a városrész is a helyén marad. */
+    public function testBudapestKeepsDistrictLevels(): void {
+        $input = self::boundaries([
+            2 => 'Magyarország',
+            4 => 'Közép-Magyarország',
+            6 => 'Budapest',
+            8 => 'Budapest',
+            9 => 'V. kerület',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame(['Magyarország', 'Budapest', 'Budapest', 'V. kerület'], self::names($result));
+    }
+
+    /*
+     * A bejelentett hiba: Romániában nincs 6-os szint, a megyét a 4-es judet
+     * hordozza. Korábban a lista [ország, település] lett, vagyis a település
+     * csúszott a megye helyére, a city pedig üresen maradt.
+     */
+    public function testRomanianCountyComesFromLevelFour(): void {
+        $input = self::boundaries([
+            2 => 'România',
+            4 => 'Alba',
+            8 => 'Vințu de Jos',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame(['România', 'Alba', 'Vințu de Jos'], self::names($result));
+    }
+
+    /* Ugyanaz a lényeg, a hívó szemszögéből: a település a 3. helyre kerül. */
+    public function testRomanianSettlementIsNoLongerLabelledAsCounty(): void {
+        $input = self::boundaries([
+            2 => 'România',
+            4 => 'Alba',
+            8 => 'Vințu de Jos',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame('Alba', $result[1]['name'], 'a megye helyén megyének kell állnia');
+        self::assertArrayHasKey(2, $result, 'a település nem eshet ki');
+        self::assertSame('Vințu de Jos', $result[2]['name']);
+    }
+
+    /* Szlovákia: az OSM ma 6-on tartja az okrest, tehát a kraj kiesik. */
+    public function testSlovakKrajIsDroppedBecauseOkresIsLevelSix(): void {
+        $input = self::boundaries([
+            2 => 'Slovensko',
+            4 => 'Banskobystrický kraj',
+            6 => 'okres Lučenec',
+            8 => 'Boľkovce',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame(['Slovensko', 'okres Lučenec', 'Boľkovce'], self::names($result));
+    }
+
+    /* Szerbia: van 6-os okrug, a tartomány kiesik. */
+    public function testSerbianProvinceIsDropped(): void {
+        $input = self::boundaries([
+            2 => 'Србија',
+            4 => 'Војводина',
+            6 => 'Севернобачки управни округ',
+            8 => 'Општина Бачка Топола',
+            9 => 'Бачка Топола',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame(
+            ['Србија', 'Севернобачки управни округ', 'Општина Бачка Топола', 'Бачка Топола'],
+            self::names($result)
+        );
+    }
+
+    /* Ukrajna: van 6-os rajon, az oblaszty kiesik. */
+    public function testUkrainianOblastIsDropped(): void {
+        $input = self::boundaries([
+            2 => 'Україна',
+            4 => 'Закарпатська область',
+            6 => 'Берегівський район',
+            9 => 'Берегове',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame(['Україна', 'Берегівський район', 'Берегове'], self::names($result));
+    }
+
+    /* Bécs: nincs 6-os, így a Bundesland kerül a megye helyére. */
+    public function testViennaFallsBackToTheBundesland(): void {
+        $input = self::boundaries([
+            2 => 'Österreich',
+            4 => 'Wien',
+            9 => 'Innere Stadt',
+            10 => 'Katastralgemeinde Innere Stadt',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame(
+            ['Österreich', 'Wien', 'Innere Stadt', 'Katastralgemeinde Innere Stadt'],
+            self::names($result)
+        );
+    }
+
+    /* Ha csak ország van, ne essen szét. */
+    public function testCountryOnlyIsLeftAlone(): void {
+        $input = self::boundaries([2 => 'România']);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame(['România'], self::names($result));
+    }
+
+    /* Üres bemenetre üres kimenet, nem hiba. */
+    public function testEmptyInputStaysEmpty(): void {
+        self::assertSame([], \Eloquent\Church::pickAdministrativeBoundaries([]));
+    }
+
+    /* A kulcsoknak 0-tól folytonosnak kell lenniük, mert a hívó indexel. */
+    public function testResultKeysAreSequential(): void {
+        $input = self::boundaries([
+            2 => 'Magyarország',
+            4 => 'Közép-Magyarország',
+            6 => 'Pest vármegye',
+            8 => 'Szentendre',
+        ]);
+
+        $result = \Eloquent\Church::pickAdministrativeBoundaries($input);
+
+        self::assertSame([0, 1, 2], array_keys($result));
+    }
+}


### PR DESCRIPTION
A #496/#497/#498 felmérése közben találtam. Mindhárom jegy premisszája az, hogy „a boundaries biztosabban tartalmazza, és nem csak Magyarországra” — ez igaz, de **jelenleg a kód nem tudja kiolvasni** határon túl.

## Ok

A `location()` pozíció szerint címkéz a rendezett határlistából (0=ország, 1=megye, 2=település, 3=kerület), a lekérdezés viszont csak a `[2,6,8,9,10]` szinteket engedte be. Az `admin_level` jelentése viszont országonként más — Overpass `is_in`-nel mértem ki, egy-egy valódi templomunk koordinátáján:

| ország | 2 | 4 | 6 | 8 | 9 |
|---|---|---|---|---|---|
| Magyarország | ország | nagyrégió | **vármegye** | **település** | kerület |
| Szlovákia | ország | kraj | **okres** | **obec** | |
| Szerbia | ország | tartomány | **okrug** | **opstina** | település |
| Ukrajna | ország | oblaszty | **rajon** | | **település** |
| Románia | ország | **judet** | *nincs* | **comuna/oras** | |

Romániában nincs 6-os szint. Így a lista `[ország, település]` lett: a **település csúszott a megye helyére**, a `location->city` pedig NULL maradt.

Végponttól végpontig, valódi OSM-határokkal bekötve:

```
előtte:  #3054 | ország=România | megye=Vințu de Jos | település=NULL
utána:   #3054 | ország=România | megye=Alba         | település=Vințu de Jos
```

538 templomot érint (a határon túli állomány 80%-a), és továbbgyűrűzik mindenhová, ahol `location.city`-t használunk: `home.twig` képajánló, szomszédos templomok panel, az Angular naptárnak átadott `city`.

## Megoldás

Behúzom a 4-es szintet, de **csak akkor hagyom bent, ha nincs 6-os**. Ez a lényeg: Magyarországon a 4-es a statisztikai nagyrégió („Közép-Magyarország”), és van 6-os vármegye — így a nagyrégió kiesik.

Naiv „engedjük be a 4-est” megoldás elrontaná a magyar templomokat, ezért nem azt csináltam.

A döntést tiszta, adatbázis nélkül hívható statikus függvénybe emeltem (`pickAdministrativeBoundaries`), így unit-tesztelhető.

## Mérés

Magyar regresszió nincs — a valódi `location()`-t futtattam négy magyar templomra a javítás előtt és után, a kimenet bitre azonos:

```
#1     | Magyarország | Pest vármegye              | Szentendre | -
#37    | Magyarország | Budapest                   | Budapest   | V. kerület
#452   | Magyarország | Komárom-Esztergom vármegye | Dad        | -
#1254  | Magyarország | Csongrád-Csanád vármegye   | Szeged     | -
```

Teszt: 11 új eset a hat ország valós szintkészletével. Régi kódon mind a 11 bukik, javítottal zöld. Teljes készlet: integration 142 -> 153, plus api 128, simple 133, request 51 — mind OK.

## Amit ez nem old meg

- A tárolt szlovák határaink elavultak: nálunk 8=okres/9=obec, az OSM ma 6=okres/8=obec. Újraszinkron kell.
- A mintában a szlovák templomok 23%-ának egyáltalán nincs határa (a magyaroknál 3%). Ez szinkron-lefedettségi hiány, külön kérdés.
- A `megye` oszlop határon túl 669/670-nél üres — a #496-ot ez önmagában is indokolja.