### PR TITLE
A beragadt CI-futás bukjon el, ne lógjon órákig

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,6 +13,22 @@ on:
         required: true
         default: latest
 
+# A futás ragadjon be helyett bukjon el, és egy ág egyszerre csak egyszer fusson.
+#
+# Két baj volt egyszerre:
+#  1. Nincs `concurrency`, ezért új pusholás NEM állította le a korábbi futást. Egy
+#     beragadt job így a GitHub 6 órás alaplimitjéig lógott, foglalta a sort, és a
+#     PR-en „függőben" maradt az ellenőrzés akkor is, ha az új futás már zöld volt.
+#  2. Nincs `timeout-minutes`, ezért a beakadás nem is derült ki: a funkcionális
+#     (Panther/Chrome) lépés normálisan ~80 másodperc, beragadva viszont órákig ült.
+#
+# `cancel-in-progress: true` — itt szándékosan más, mint a deploy-workflow-knál: ott
+# a félbehagyott deploy sérült állapotot hagyna, egy tesztfutás megszakítása viszont
+# ártalmatlan.
+concurrency:
+  group: phpunit-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   COMPOSE_FILES: -f docker/compose.yml -f docker/compose.dev.yml -f docker/compose.coverage.yml
   TEST_RESULTS_PATH: ${{ github.workspace }}
@@ -20,6 +36,8 @@ env:
 jobs:
   phpunit:
     runs-on: ubuntu-latest
+    # Az egész job felső korlátja; a sikeres futás ma ~5 perc.
+    timeout-minutes: 30
     # Only run if workflow_run was successful or if triggered by other events
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
@@ -108,6 +126,9 @@ jobs:
           fi
 
       - name: Run functional tests
+        # Normálisan ~80 másodperc. Ha a böngésző beakad, itt bukjon el, ne a job
+        # felső korlátjánál — így a Docker-naplós lépés is lefut és látszik az ok.
+        timeout-minutes: 12
         working-directory: webapp/tests
         env:
           PANTHER_EXTERNAL_BASE_URI: http://127.0.0.1:8000


### PR DESCRIPTION
Ma több PR-en is beragadt a PHPUnit futás a funkcionális (Panther/Chrome) lépésnél. Két hiányzó beállítás okozta.

**Nincs `concurrency`.** Új pusholás nem állította le a korábbi futást. Konkrét eset: a #699-en a 14:07-es futás beakadt, rebase után 14:27-kor indult egy új, ami **zöld lett** — a 14:07-es viszont még fél órával később is `in_progress` volt, foglalta a sort, és a PR-en függőben tartotta az ellenőrzést. Leállítani nem lehet, ahhoz admin jog kell a repón.

**Nincs `timeout-minutes`.** Ezért a beakadás nem bukásként jelentkezett, hanem lógásként a GitHub 6 órás alaplimitjéig. A funkcionális lépés mért ideje sikeres futásokon 77–89 másodperc (#89, #391, #658 ágakon), tehát a 12 perces korlát bőven fölötte van.

Megoldás: ágankénti concurrency `cancel-in-progress: true`-val, a jobra 30, a funkcionális lépésre 12 perc.

A deploy-workflow-k szándékosan maradnak `cancel-in-progress: false` mellett — ott a félbehagyott deploy sérült állapotot hagyna, egy tesztfutás megszakítása viszont ártalmatlan.

Mellékhatás: a funkcionális lépés bukásakor a „Show Docker logs on failure" lépés is lefut, tehát legközelebb látni fogjuk, min akadt el.