### PR TITLE
Eltárolom az országkódot a határon (#498)

### DIFF
--- a/docker/mysql/initdb.d/07-boundaries-iso.sql
+++ b/docker/mysql/initdb.d/07-boundaries-iso.sql
@@ -1,0 +1,30 @@
+/*
+ * #498: az országkód tárolása a határon.
+ *
+ * Eddig az „ország -> kód" leképezés KIZÁRÓLAG a régi `templomok.orszag` oszlopon
+ * keresztül létezett (az `orszagok` táblában nincs ISO-kód, csak `telkod`). Ezért
+ * az oszlop kivezetése magával vitte volna a statisztikát (`stat.php`: orszag=12)
+ * és az Angular naptárnak átadott országkódot is.
+ *
+ * Az OSM országrelációi viszont hordozzák, ellenőrizve:
+ *   rel/21335 Magyarország  ISO3166-1=HU
+ *   rel/90689 România       ISO3166-1=RO
+ *   rel/14296 Slovensko     ISO3166-1=SK
+ *
+ * Ez a fájl a MEGLÉVŐ adatbázisokhoz kell (a 02-schema már eleve tartalmazza az
+ * oszlopot az újonnan létrehozottaknál).
+ *
+ * ÉLES ADATBÁZISON KÉZZEL, mert nincs migrációs rendszerünk:
+ *   ALTER TABLE boundaries ADD COLUMN IF NOT EXISTS `iso3166_1` varchar(2) NULL DEFAULT NULL;
+ *   ALTER TABLE boundaries ADD INDEX IF NOT EXISTS `index3` (`iso3166_1`);
+ * Az oszlop a következő boundary-szinkronnál töltődik fel magától; addig NULL,
+ * amit minden hívó kezel.
+ */
+
+USE miserend;
+
+ALTER TABLE `boundaries`
+    ADD COLUMN IF NOT EXISTS `iso3166_1` varchar(2) NULL DEFAULT NULL AFTER `denomination`;
+
+ALTER TABLE `boundaries`
+    ADD INDEX IF NOT EXISTS `index3` (`iso3166_1`);

--- a/docker/mysql/initdb.d/07-boundaries-iso.sql
+++ b/docker/mysql/initdb.d/07-boundaries-iso.sql
@@ -11,14 +11,19 @@
  *   rel/90689 România       ISO3166-1=RO
  *   rel/14296 Slovensko     ISO3166-1=SK
  *
- * Ez a fájl a MEGLÉVŐ adatbázisokhoz kell (a 02-schema már eleve tartalmazza az
- * oszlopot az újonnan létrehozottaknál).
+ * FONTOS, hogy ez a fájl a `05-data.sh` UTÁN fusson, és hogy az oszlop NE kerüljön
+ * bele a `02-schema.sql`-be — ugyanaz a csapda, amit a 06-os fájl is leír. A seed
+ * dump (`data/boundaries.sql`) oszloplista NÉLKÜLI `INSERT INTO boundaries VALUES`
+ * alakot használ, tehát a betöltés pillanatában a táblának PONTOSAN a dumpban lévő
+ * oszlopszámmal kell rendelkeznie. Ha az oszlopot a sémába tesszük, a seed
+ * "Column count doesn't match value count"-tal elszáll, és a MySQL konténer el sem
+ * indul. (Kimértem: pontosan ez történt.)
  *
  * ÉLES ADATBÁZISON KÉZZEL, mert nincs migrációs rendszerünk:
  *   ALTER TABLE boundaries ADD COLUMN IF NOT EXISTS `iso3166_1` varchar(2) NULL DEFAULT NULL;
  *   ALTER TABLE boundaries ADD INDEX IF NOT EXISTS `index3` (`iso3166_1`);
  * Az oszlop a következő boundary-szinkronnál töltődik fel magától; addig NULL,
- * amit minden hívó kezel.
+ * amit a Church::countryCode() és minden hívó kezel. Adatvesztés nincs.
  */
 
 USE miserend;

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1395,8 +1395,37 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             fn($boundary) => (int) ($boundary['admin_level'] ?? 0) !== 4
         ));
     }
-	
-	
+
+    /**
+     * #498: a templom országkódja (ISO 3166-1 alpha-2) az OSM-határból.
+     *
+     * A `templomok.orszag` oszlop kivezetésének az volt az egyik akadálya, hogy az
+     * „ország -> kód" leképezés kizárólag rajta keresztül létezett: az `orszagok`
+     * táblában nincs ISO-kód, csak `telkod`. A statisztika (`stat.php`, orszag=12)
+     * és az Angular naptárnak átadott országkód is emiatt ragadt hozzá.
+     *
+     * Az OSM országrelációi hordozzák az `ISO3166-1` taget, ezt a boundary-szinkron
+     * mostantól eltárolja. Itt csak kiolvassuk.
+     *
+     * NULL-t ad, ha a templomnak nincs országhatára (nincs koordinátája, vagy a
+     * szinkron még nem ért oda), illetve ha a szinkron az oszlop bevezetése óta még
+     * nem futott le rá. A hívónak KEZELNIE kell a NULL-t — ezért nem esünk vissza
+     * csendben a régi oszlopra, hogy a hiányzó lefedettség látható maradjon.
+     */
+    public function countryCode(): ?string {
+        $code = $this->boundaries()
+                ->where('boundary', 'administrative')
+                ->where('admin_level', 2)
+                ->whereNotNull('iso3166_1')
+                ->orderBy('boundaries.id')
+                ->value('iso3166_1');
+
+        $code = strtoupper(trim((string) $code));
+
+        return $code === '' ? null : $code;
+    }
+
+
 	public function getKozossegekAttribute($value) {
 		$api = new \ExternalApi\KozossegekApi();		
 		$api->query = "miserend/".$this->id;

--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -125,6 +125,20 @@ class OSM {
                 $changed = true;
             }
 
+            /*
+             * #498: az országkód. A fenti hurok nem tudja átvenni, mert az OSM-tag
+             * neve kötőjeles (`ISO3166-1`), az oszlopnév viszont nem lehet az.
+             * Csak a level-2 határokon van értelme; ott viszont mindig ott van.
+             */
+            $isoTag = $element->tags->{'ISO3166-1'} ?? $element->tags->{'ISO3166-1:alpha2'} ?? null;
+            if($isoTag !== null) {
+                $iso = strtoupper(substr(trim((string) $isoTag), 0, 2));
+                if($iso !== '' AND $iso != $boundary->iso3166_1) {
+                    $boundary->iso3166_1 = $iso;
+                    $changed = true;
+                }
+            }
+
             // Ensure name is set - use boundary type as default if no name is provided
             if(empty($boundary->name)) {
                 $boundary->name = $boundary->boundary ?: 'Unnamed Boundary';

--- a/webapp/tests/Integration/CountryCodeTest.php
+++ b/webapp/tests/Integration/CountryCodeTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #498: az országkód az OSM-határról jön, nem a régi `templomok.orszag` oszlopról.
+ *
+ * A tárolt értékek nem kitaláltak — az Overpassból ellenőriztem, hogy az OSM
+ * országrelációi tényleg hordozzák az `ISO3166-1` taget:
+ *   rel/21335 Magyarország HU | rel/90689 România RO | rel/14296 Slovensko SK
+ */
+final class CountryCodeTest extends TestCase {
+
+    private array $createdBoundaryIds = [];
+    private ?int $churchId = null;
+
+    protected function tearDown(): void {
+        if ($this->churchId !== null) {
+            DB::table('lookup_boundary_church')->where('church_id', $this->churchId)->delete();
+        }
+        if ($this->createdBoundaryIds) {
+            DB::table('boundaries')->whereIn('id', $this->createdBoundaryIds)->delete();
+        }
+        $this->createdBoundaryIds = [];
+    }
+
+    /** Létrehoz egy határt és rákapcsolja a templomra. */
+    private function attach(int $churchId, int $level, string $name, ?string $iso): void {
+        $this->churchId = $churchId;
+
+        $id = DB::table('boundaries')->insertGetId([
+            'boundary'     => 'administrative',
+            'admin_level'  => $level,
+            'name'         => $name,
+            'iso3166_1'    => $iso,
+            'osmtype'      => 'relation',
+            'osmid'        => 900000 + $level,
+        ]);
+        $this->createdBoundaryIds[] = $id;
+
+        DB::table('lookup_boundary_church')->insert([
+            'church_id'   => $churchId,
+            'boundary_id' => $id,
+        ]);
+    }
+
+    private function church(int $id): \Eloquent\Church {
+        return \Eloquent\Church::find($id);
+    }
+
+    public function testReturnsTheIsoCodeOfTheCountryBoundary(): void {
+        $this->attach(1, 2, 'Magyarország', 'HU');
+
+        self::assertSame('HU', $this->church(1)->countryCode());
+    }
+
+    /* Határon túl is — ez a lényeg, a régi oszlop ott a leggyengébb. */
+    public function testWorksForForeignChurches(): void {
+        $this->attach(1, 2, 'România', 'RO');
+
+        self::assertSame('RO', $this->church(1)->countryCode());
+    }
+
+    /* Csak a level-2 határ számít, a megye/település nem. */
+    public function testIgnoresNonCountryBoundaries(): void {
+        $this->attach(1, 6, 'Pest vármegye', 'XX');
+        $this->attach(1, 8, 'Szentendre', 'YY');
+
+        self::assertNull($this->church(1)->countryCode());
+    }
+
+    /* Ha a szinkron még nem töltötte fel, NULL — nem üres string, nem szemét. */
+    public function testReturnsNullWhenTheCodeIsNotSyncedYet(): void {
+        $this->attach(1, 2, 'Magyarország', null);
+
+        self::assertNull($this->church(1)->countryCode());
+    }
+
+    /* Határ nélküli templom (nincs koordináta, vagy a szinkron nem ért oda). */
+    public function testReturnsNullWithoutAnyBoundary(): void {
+        $this->churchId = 1;
+        DB::table('lookup_boundary_church')->where('church_id', 1)->delete();
+
+        self::assertNull($this->church(1)->countryCode());
+    }
+
+    /* A kódot nagybetűsítve adjuk vissza, akárhogy is került be. */
+    public function testNormalisesTheCaseOfTheStoredCode(): void {
+        $this->attach(1, 2, 'Slovensko', 'sk');
+
+        self::assertSame('SK', $this->church(1)->countryCode());
+    }
+}


### PR DESCRIPTION
A #498 felmérésében ez jött ki blokkolónak, ez az önálló első lépés.

## Miért kell

Az „ország -> kód" leképezés ma **kizárólag** a régi `templomok.orszag` oszlopon keresztül létezik:

```
orszagok tábla:   id | nev | telkod | ok | kiemelt     <- nincs ISO-kód
boundaries tábla: boundary | admin_level | name | ...  <- szintén nincs
```

Ezért az oszlop kivezetése magával vitte volna a statisztikát (`stat.php:184`, `where(orszag,12)`) és az Angular naptárnak átadott országkódot is.

## Mit csinál

Az OSM országrelációi hordozzák az `ISO3166-1` taget, ezt a boundary-szinkron mostantól eltárolja. A tagot a meglévő tagmásoló hurok nem tudta átvenni, mert a neve kötőjeles (`ISO3166-1`), az oszlopnév viszont nem lehet az — ezért külön ág kezeli, `ISO3166-1:alpha2` fallbackkel.

Kiolvasni a templomon: `countryCode()`.

## Mérés

Valódi Overpass-adattal, a szinkron tényleges lefuttatásával három koordinátán:

```
Szentendre        -> ország=Magyarország  ISO=HU
Alvinc (RO)       -> ország=Románia       ISO=RO
Fülekpüspöki (SK) -> ország=Szlovákia     ISO=SK
```

Teszt: 6 új eset (határon túli templom, csak level-2 számít, még nem szinkronizált érték, határ nélküli templom, kisbetűs kód normalizálása). Teljes készlet zöld: integration 161, api 133, simple 151, request 51.

## Deploy

`ALTER TABLE` kell élesben, nincs migrációs rendszerünk. A `07-boundaries-iso.sql`-ben szó szerint benne van:

```sql
ALTER TABLE boundaries ADD COLUMN IF NOT EXISTS `iso3166_1` varchar(2) NULL DEFAULT NULL;
ALTER TABLE boundaries ADD INDEX IF NOT EXISTS `index3` (`iso3166_1`);
```

Az oszlop a következő boundary-szinkronnál töltődik fel magától; addig NULL, amit a `countryCode()` és minden hívó kezel. **Adatvesztés nincs, visszafordítható.**

Szándékosan NEM írtam át a `stat.php`-t és a naptárt — az a következő lépés, amikor a lefedettség már megvan.