### PR TITLE
Több azonosító is kérhető az api/church-től (#297)

### DIFF
--- a/webapp/classes/api/church.php
+++ b/webapp/classes/api/church.php
@@ -7,30 +7,70 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Church extends Api {
 
     public $title = 'Egy misézőhely adatai és miséi röviden';
-    public $format = 'json'; //or text	
+    public $format = 'json'; //or text
     public $requiredVersion = ['>=',4]; // API v4-től érhető el
+
+    /**
+     * #297: egyszerre több azonosító is lekérhető.
+     *
+     * A KAPP a felhasználó által meglátogatott templomokat gyűjti, és utólag akar
+     * hozzájuk adatot kérni. Eredetileg koordinátalistát akartak küldeni az
+     * api/nearby-nak, de a jegyben ez lett a megállapodás: az app a logoláskor egy
+     * nearby-jal kitalálja a templomot, és utána már csak azonosítókkal dolgozik.
+     * Így itt elég a lista fogadása, koordináta-illesztés nem kell.
+     *
+     * Az `id` ezért már nem kötelező — pontosan az egyiket kell megadni. A régi,
+     * egy-azonosítós hívások változatlanul működnek, a válaszuk alakja sem változik.
+     */
+    const MAX_IDS = 100;
 
     public $fields = [
         'id' => [
-            'required' => true, 
-            'validation' => 'integer', 
-            'description' => 'A misézőhely azonosítója, amely egyedi azonosító a rendszerben.',
+            'validation' => 'integer',
+            'description' => 'A misézőhely azonosítója, amely egyedi azonosító a rendszerben. Az „ids” helyett adható meg.',
             'example' => 7
+        ],
+        'ids' => [
+            'validation' => [
+                'list' => ['integer' => ['minimum' => 1]]
+            ],
+            'description' => 'Több misézőhely azonosítója egyszerre, legfeljebb ' . self::MAX_IDS . ' darab. Az „id” helyett adható meg.',
+            'example' => [7, 1254]
         ],
         'response_length' => [
             'validation' => [
                 'enum' => ['minimal', 'medium','full']
             ],
-            'description' =>  'A válasz részletessége', 
+            'description' =>  'A válasz részletessége',
             'default' => 'medium'
         ]
     ];
+
+    /* Pontosan az egyiket kérjük — enélkül nem tudnánk, milyen alakú választ vár a hívó. */
+    public function validateInput() {
+        $hasId  = isset($this->input['id']);
+        $hasIds = isset($this->input['ids']);
+
+        if(!$hasId && !$hasIds) {
+            throw new \Exception("Field 'id' or 'ids' is required in JSON.");
+        }
+        if($hasId && $hasIds) {
+            throw new \Exception("Field 'id' and 'ids' cannot be used together.");
+        }
+        if($hasIds && count($this->input['ids']) < 1) {
+            throw new \Exception("Field 'ids' should not be empty.");
+        }
+        if($hasIds && count($this->input['ids']) > self::MAX_IDS) {
+            throw new \Exception("Field 'ids' should not contain more than ".self::MAX_IDS." items.");
+        }
+    }
 
     public function docs() {
         $docs = [];
              
         $docs['description'] = <<<HTML
-        <p>Egy templom adatát adja vissza. Csak röviden, a legszükségesebb adatokkal. Az aktuális napi misék rendjét is hozza.</p>        
+        <p>Egy templom adatát adja vissza. Csak röviden, a legszükségesebb adatokkal. Az aktuális napi misék rendjét is hozza.</p>
+        <p>Több templom is kérhető egyszerre: az <code>id</code> helyett add meg az <code>ids</code> listát (legfeljebb 100 elem). A kettő együtt nem használható.</p>
         HTML;
 
         $docs['response'] = <<<HTML
@@ -38,6 +78,12 @@ class Church extends Api {
             <li>„error”: <strong>0</strong>, ha nincs hiba. <strong>1</strong>, ha van valami hiba.</li>
             <li>„text” (opcionális): „error:1” esetén a hiba szöveges leírása</li>
         </ul>
+        <p><strong>„ids” esetén</strong> a válasz két kulcsot tartalmaz:</p>
+        <ul>
+            <li>„templomok”: a templomok listája, a KÉRT sorrendben</li>
+            <li>„hianyzo”: azok az azonosítók, amelyekhez nincs templom — ezek nem buktatják el a kérést, csak kimaradnak a listából</li>
+        </ul>
+        <p><strong>Egyetlen „id” esetén</strong> a válasz alakja változatlan: közvetlenül a templom adatai jönnek, lista nélkül.</p>
         <p>Majd következik egy <em>templom</em> tömb és adatai.</p>
         <ul>
             <li>„id”</li>
@@ -64,9 +110,46 @@ class Church extends Api {
         parent::run();
 		
         $this->getInputJson();
-		
-		$church = \Eloquent\Church::Where('id',$this->input['id'])->get()->map->toAPIArray(isset($this->input['response_length']) ? $this->input['response_length'] : false );
-				
+
+        $responseLength = isset($this->input['response_length']) ? $this->input['response_length'] : false;
+
+        /*
+         * #297: több azonosító esetén LISTÁT adunk vissza, egy azonosítónál a régi,
+         * egyetlen objektumot — így a meglévő hívók válasza nem változik.
+         */
+        if(isset($this->input['ids'])) {
+            $ids = array_values(array_unique(array_map('intval', $this->input['ids'])));
+
+            $churches = \Eloquent\Church::whereIn('id', $ids)->get()
+                    ->keyBy('id')
+                    ->map->toAPIArray($responseLength);
+
+            /*
+             * A kért sorrendben adjuk vissza, és a nem létező azonosítót KIHAGYJUK
+             * ahelyett, hogy az egész kérést elbuktatnánk: az app gyűjtött listája
+             * tartalmazhat időközben törölt templomot, és attól még a többi adat kell.
+             * A hiányzókat külön felsoroljuk, hogy a hívó tudjon róluk.
+             */
+            $found = [];
+            $missing = [];
+            foreach($ids as $id) {
+                if(isset($churches[$id])) {
+                    $found[] = $churches[$id];
+                } else {
+                    $missing[] = $id;
+                }
+            }
+
+            $this->return = [
+                'templomok' => $found,
+                'hianyzo'   => $missing,
+            ];
+
+            return;
+        }
+
+        $church = \Eloquent\Church::Where('id',$this->input['id'])->get()->map->toAPIArray($responseLength);
+
 
         if(count($church) < 1 ) {
             $this->return = [
@@ -74,7 +157,7 @@ class Church extends Api {
                 'text' => 'Nem létezik misézőhely ezzel az asonosítóval.'
             ];
             return;
-        }       
+        }
 
        $this->return = $church[0];
 

--- a/webapp/tests/Api/ChurchIdsTest.php
+++ b/webapp/tests/Api/ChurchIdsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #297: az api/church egyszerre több azonosítót is fogad.
+ *
+ * A jegyben eredetileg koordinátalista fogadása szerepelt az api/nearby-on, de a
+ * megbeszélés oda jutott, hogy az app a logoláskor egy nearby-jal kitalálja a
+ * templomot, és utána már csak azonosítókkal dolgozik — így itt elég a lista.
+ *
+ * Valódi HTTP-hívásokkal megyünk, mert a validáció és a válasz alakja számít.
+ */
+final class ChurchIdsTest extends TestCase {
+
+    private string $baseUrl;
+
+    protected function setUp(): void {
+        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
+    }
+
+    private function post(array $payload): array {
+        $context = stream_context_create([
+            'http' => [
+                'method'  => 'POST',
+                'header'  => "Content-Type: application/json\r\n",
+                'content' => json_encode($payload),
+                'ignore_errors' => true,
+                'timeout' => 30,
+            ],
+        ]);
+
+        $body = @file_get_contents($this->baseUrl . '/api/v4/church', false, $context);
+        self::assertNotFalse($body, 'HTTP kérés nem sikerült');
+
+        $decoded = json_decode($body, true);
+        self::assertIsArray($decoded, 'a válasz nem JSON: ' . substr((string) $body, 0, 200));
+
+        return $decoded;
+    }
+
+    /* A régi, egy-azonosítós hívás alakja NEM változhat. */
+    public function testSingleIdStillReturnsASingleObject(): void {
+        $response = $this->post(['id' => 1]);
+
+        self::assertArrayNotHasKey('templomok', $response, 'egy id-nél nem listát adunk');
+        self::assertArrayHasKey('id', $response);
+        self::assertSame(1, (int) $response['id']);
+    }
+
+    /* Több azonosító -> lista, a kért sorrendben. */
+    public function testMultipleIdsReturnAListInTheRequestedOrder(): void {
+        $response = $this->post(['ids' => [1254, 1]]);
+
+        self::assertArrayHasKey('templomok', $response);
+        self::assertCount(2, $response['templomok']);
+        self::assertSame(1254, (int) $response['templomok'][0]['id']);
+        self::assertSame(1, (int) $response['templomok'][1]['id']);
+    }
+
+    /* Nem létező azonosító nem buktatja el a kérést, csak felsoroljuk. */
+    public function testMissingIdsAreReportedInsteadOfFailing(): void {
+        $response = $this->post(['ids' => [1, 99999999]]);
+
+        self::assertCount(1, $response['templomok']);
+        self::assertSame(1, (int) $response['templomok'][0]['id']);
+        self::assertSame([99999999], $response['hianyzo']);
+    }
+
+    /* Ismétlődő azonosítót egyszer adunk vissza. */
+    public function testDuplicateIdsAreCollapsed(): void {
+        $response = $this->post(['ids' => [1, 1, 1]]);
+
+        self::assertCount(1, $response['templomok']);
+    }
+
+    /* A response_length a listás ágon is érvényesül. */
+    public function testResponseLengthAppliesToTheList(): void {
+        $minimal = $this->post(['ids' => [1], 'response_length' => 'minimal']);
+        $full    = $this->post(['ids' => [1], 'response_length' => 'full']);
+
+        self::assertLessThan(
+            count($full['templomok'][0]),
+            count($minimal['templomok'][0]),
+            'a minimal válasznak kevesebb mezőt kell tartalmaznia'
+        );
+    }
+
+    /* Pontosan az egyiket kell megadni. */
+    public function testMissingBothIdAndIdsIsAnError(): void {
+        $response = $this->post(['response_length' => 'medium']);
+
+        self::assertSame('1', (string) $response['error']);
+        self::assertStringContainsString('ids', (string) $response['text']);
+    }
+
+    public function testIdAndIdsTogetherIsAnError(): void {
+        $response = $this->post(['id' => 1, 'ids' => [2]]);
+
+        self::assertSame('1', (string) $response['error']);
+        self::assertStringContainsString('together', (string) $response['text']);
+    }
+
+    public function testEmptyIdsIsAnError(): void {
+        $response = $this->post(['ids' => []]);
+
+        self::assertSame('1', (string) $response['error']);
+    }
+
+    /* Nem egész elem a listában -> tiszta hibaüzenet, nem 500. */
+    public function testNonIntegerItemIsRejected(): void {
+        $response = $this->post(['ids' => [1, 'abc']]);
+
+        self::assertSame('1', (string) $response['error']);
+        self::assertStringContainsString('integer', (string) $response['text']);
+    }
+
+    /* A felső korlát véd a túl nagy kéréstől. */
+    public function testTooManyIdsAreRejected(): void {
+        $response = $this->post(['ids' => range(1, \Api\Church::MAX_IDS + 1)]);
+
+        self::assertSame('1', (string) $response['error']);
+        self::assertStringContainsString('more than', (string) $response['text']);
+    }
+}

--- a/webapp/tests/Integration/LegacyChurchUrlRedirectTest.php
+++ b/webapp/tests/Integration/LegacyChurchUrlRedirectTest.php
@@ -33,7 +33,18 @@ final class LegacyChurchUrlRedirectTest extends TestCase {
                 'follow_location' => 0,
                 'ignore_errors' => true,
                 'header' => $headers,
-                'timeout' => 10,
+                /*
+                 * A tesztek többsége átirányítást kér, az 1 ezredmásodperc alatt
+                 * megvan. Egy viszont TELJES templomlapot tölt (annak a lényege,
+                 * hogy perjel nélkül NINCS átirányítás), és az hidegen 9-10
+                 * másodperc, mert a lap külső API-kat hív. A korábbi 10 másodperc
+                 * épp a mért időn ült, ezért a CI-ban véletlenszerűen elbukott
+                 * "HTTP kérés nem sikerült"-tel.
+                 *
+                 * A gyökérok a külső API-függés, azt a #695 rendezi; addig itt
+                 * bőven a mért idő fölé emelem a korlátot.
+                 */
+                'timeout' => 45,
             ],
         ]);
 


### PR DESCRIPTION
A jegy címe több koordinátáról szól, de a beszélgetés nem ott kötött ki. @borazslo zárása:

> Ha így van, akkor tisztességesebb lenne a logolás esetén egy nearby-al kitalálni hogy melyik templomnál vagyunk … és így nem koordinátákat hanem templom azonosítókat gyűjtene az app. És akkor már könnyű a kérés: olyan keresés ahol egy sor id-t tudok megadni.

Ezt csináltam meg — nem a koordinátalistás nearby-t. Ha mégis az kell, szólj.

## Mit tud

```json
POST /api/v4/church   {"ids": [1254, 1, 99999999]}

{
  "templomok": [ {...1254...}, {...1...} ],
  "hianyzo":   [ 99999999 ]
}
```

- `id` és `ids` közül **pontosan az egyiket** kell megadni
- legfeljebb 100 azonosító
- a válasz a **kért sorrendet** tartja
- a nem létező azonosító **nem buktatja el** a kérést, csak felsoroljuk: az app gyűjtött listájában lehet időközben törölt templom, attól még a többi adat kell
- ismétlődő azonosító egyszer jön vissza
- a `response_length` a listás ágon is érvényes

## Visszafelé kompatibilitás

Egyetlen `id` esetén a válasz alakja **bitre változatlan** — közvetlenül a templom adatai jönnek, nem lista. Erre külön teszt van, hogy később se romolhasson el.

## Teszt

10 új eset. Régi kódon 8 bukik, újjal mind zöld. Teljes készlet: api 143, integration 161, simple 151, request 51 — mind OK.