### PR TITLE
Megszüntetem a saját átirányítás-tesztem véletlenszerű bukását

### DIFF
--- a/webapp/tests/Integration/LegacyChurchUrlRedirectTest.php
+++ b/webapp/tests/Integration/LegacyChurchUrlRedirectTest.php
@@ -33,7 +33,18 @@ final class LegacyChurchUrlRedirectTest extends TestCase {
                 'follow_location' => 0,
                 'ignore_errors' => true,
                 'header' => $headers,
-                'timeout' => 10,
+                /*
+                 * A tesztek többsége átirányítást kér, az 1 ezredmásodperc alatt
+                 * megvan. Egy viszont TELJES templomlapot tölt (annak a lényege,
+                 * hogy perjel nélkül NINCS átirányítás), és az hidegen 9-10
+                 * másodperc, mert a lap külső API-kat hív. A korábbi 10 másodperc
+                 * épp a mért időn ült, ezért a CI-ban véletlenszerűen elbukott
+                 * "HTTP kérés nem sikerült"-tel.
+                 *
+                 * A gyökérok a külső API-függés, azt a #695 rendezi; addig itt
+                 * bőven a mért idő fölé emelem a korlátot.
+                 */
+                'timeout' => 45,
             ],
         ]);
 


### PR DESCRIPTION
Ma két független PR-em bukott el ugyanezen az egy teszten (#702, #703), pedig egyik sem nyúlt hozzá. A hiba a #698-ban felvett saját tesztemben van, ami már bent van a masteren.

```
LegacyChurchUrlRedirectTest::testPathWithoutTrailingSlashIsServedDirectly
HTTP kérés nem sikerült: /templom/1254
```

## Ok

A fájl tesztjeinek többsége átirányítást kér, az azonnal megvan. Ez az egy viszont **teljes templomlapot tölt** — pont az a lényege, hogy perjel nélkül *nincs* átirányítás, tehát a lapnak ki kell szolgálódnia. A lap hidegen külső API-kat hív, a közös segédfüggvény időkorlátja viszont 10 másodperc volt.

Kimértem, friss konténeren:

```
/templom/1254   -> 200   9.88 s
/templom/1254   -> 200   8.91 s
/templom/1254   -> 200   3.38 s   (már melegen)
/templom/1254/  -> 301   0.001 s  (átirányítás, ezt csinálja a többi teszt)
```

A 10 másodperc **épp a mért időn ült**. Ezért nem bukott a #698 saját futásán, és ezért bukik most.

## Megoldás

45 másodperc, bőven a mért idő fölé. A gyökérok a külső API-függés — azt a **#695** rendezi (az teszi offline-ossá a funkcionális teszteket); amíg az nincs bent, ez a korlát a helyes megoldás.

Ezzel a #702 és a #703 is zöldre fordul, ha rájuk rebase-elem.