### PR TITLE
Megjavítom a seedet, ami megállítja a staging-deployt

### DIFF
--- a/docker/mysql/initdb.d/05-data.sh
+++ b/docker/mysql/initdb.d/05-data.sh
@@ -45,7 +45,18 @@ for file in "$DATA_DIR"/*.sql; do
   echo "Importing data for table $table..."
   # A betöltést külön kezeljük: ha EZ a fájl hibázik, hangosan jelezzük, de a
   # ciklus MEGY tovább a következő táblára — egy rossz seed ne bénítsa az egészet.
-  if ! import_err=$($MYSQL_CMD < "$file" 2>&1); then
+  #
+  # #669/#706: idegenkulcs-ellenőrzés KIKAPCSOLVA a betöltés idejére. A ciklus
+  # BETŰRENDBEN halad, a hivatkozási irány viszont nem betűrend szerinti: az
+  # `external_calendars` a `templomok`-ra hivatkozik, de jóval előtte jön, ezért
+  # a betöltése "Cannot add or update a child row" hibával elhasalt. Mivel a
+  # szkript a végén exit 1-gyel zár, a MariaDB entrypoint fatálisnak vette, a
+  # konténer meghalt, és a staging-deploy "mysql is unhealthy"-vel megállt.
+  #
+  # Sorrendezés helyett kapcsoljuk ki az ellenőrzést: a seed egy önmagában
+  # konzisztens dump, és minden új idegen kulcs újra elrontaná a kézzel tákolt
+  # sorrendet. Ugyanezt teszi egy mysqldump-visszatöltés is.
+  if ! import_err=$( { echo "SET foreign_key_checks=0;"; cat "$file"; } | $MYSQL_CMD 2>&1); then
     echo "############################################################" >&2
     echo "SEED HIBA: '$table' ($file) betöltése MEGHIÚSULT." >&2
     echo "A TÖBBI tábla betöltése FOLYTATÓDIK (nem szakítjuk meg az egészet)." >&2


### PR DESCRIPTION
**A master staging-deployja jelenleg bukik.** A #669 merge óta, kétszer egymás után.

## Mi történik

A #669 az `initdb.d/03-external-calendars.sql`-t a `data/` alá mozgatta. Ezzel kikerült a `03`-as pozícióból (ahol a `templomok` seedje ELŐTT futott, még üres táblákkal) és bekerült a `05-data.sh` **betűrendes** ciklusába — ahol `external_calendars` jóval a `templomok` ELŐTT jön.

Idegen kulccsal hivatkozik rá:

```
ERROR 1452 (23000) at line 4: Cannot add or update a child row: a foreign key
constraint fails (`miserend`.`external_calendars`, CONSTRAINT
`fk_external_calendars_church_id` FOREIGN KEY (`church_id`) REFERENCES `templomok` (`id`))
```

A `05-data.sh` a végén `exit 1`-gyel zár, ha bármelyik tábla hibázott — a MariaDB entrypoint pedig a bukó initdb-szkriptet **fatálisnak** veszi. A konténer meghal, és mivel a staging **minden deploynál `down -v`-t csinál**, a hiba minden alkalommal újra előjön:

```
Container miserend-staging-mysql-1  Error
dependency failed to start: container miserend-staging-mysql-1 is unhealthy
```

Helyben reprodukáltam. Előtte:

```
SEED ÖSSZEGZÉS: 1 tábla betöltése HIBÁZOTT: external_calendars
RestartCount: 1        external_calendars: 0 sor
```

## Megoldás

Kikapcsolom az idegenkulcs-ellenőrzést a betöltés idejére.

Nem sorrendezek, mert a hivatkozási irány soha nem fog betűrendet követni, és minden új idegen kulcs újra elrontaná a kézzel tákolt sorrendet. Egy `mysqldump`-visszatöltés is pontosan ezt teszi — a borazslo által a #706-ba illesztett éles dump is `SET foreign_key_checks = 0;`-val kezdődik.

Utána:

```
Seed complete: minden meglévő, üres tábla betöltve.
RestartCount: 0        external_calendars: betöltve, árva sor 0
```

Tesztek: integration 197, api 133, simple 151, request 51 — mind zöld.

@borazslo — ez a #669-ből esett ki, nem a te hibád volt látható a PR-ben: a fájlmozgatás önmagában ártalmatlannak tűnik, a seed-ciklus betűrendje teszi azzá.