### PR TITLE
Megmutatom, hol tér el az adatbázis a sémánktól (#706)

### DIFF
--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -14,6 +14,7 @@ class Health extends Html {
     public $churchesWithNoElasticMassesCount;
     public $externalapis;
     public $boundariesStats;
+    public $schemaCheck;
     public $emails;
     public $mailing;
     public $foremail;
@@ -233,6 +234,18 @@ class Health extends Html {
 		 * Enélkül a fenti „soha nem ellenőrzött" sor félrevezető: lehet 0, miközben a
 		 * templomok fele mégsem kereshető területre.
 		 */
+		/*
+		 * #706: az adatbázis-struktúra összevetése azzal, amit az initdb.d leír.
+		 * Az élesen mindig kézzel ment végig minden migráció, ezért elcsúszhat:
+		 * maradhat rég kivezetett tábla, hiányozhat egy újabb oszlop vagy index.
+		 * A hiba SOHA ne vigye le a /health-et — a többi ellenőrzés fontosabb.
+		 */
+		try {
+			$this->schemaCheck = \SchemaCheck::check();
+		} catch (\Throwable $e) {
+			$this->schemaCheck = ['available' => false, 'reason' => 'Az ellenőrzés hibára futott: ' . $e->getMessage()];
+		}
+
 		$churchesWithBoundary = DB::table('lookup_boundary_church')
 			->join('templomok', 'templomok.id', '=', 'lookup_boundary_church.church_id')
 			->where('templomok.ok', 'i')

--- a/webapp/classes/schemacheck.php
+++ b/webapp/classes/schemacheck.php
@@ -1,0 +1,320 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #706: az adatbázis-struktúra összevetése a mienkkel.
+ *
+ * Az éles adatbázison mindig kézzel ment végig minden migráció (nincs migrációs
+ * rendszerünk), ezért elcsúszhat attól, amit a `docker/mysql/initdb.d` leír: maradhat
+ * benne rég kivezetett tábla, hiányozhat egy újabb oszlop, elmaradhat egy index.
+ *
+ * A várt szerkezetet egy BEVERSENYZETT referencia-fájl írja le
+ * (`webapp/schema-reference.json`), amit a friss dev-adatbázisból generálunk. Hogy a
+ * referencia ne tudjon észrevétlenül elavulni, teszt őrzi: ha valaki az initdb.d-t
+ * módosítja és nem generálja újra, a teszt elbukik.
+ *
+ * Újragenerálás:
+ *   docker exec miserend-miserend-1 php /miserend/webapp/tools/schema-reference.php
+ *
+ * Éles ellenőrzés: a /health oldal „Adatbázis-struktúra" pontja, vagy CLI-ból:
+ *   php /miserend/webapp/tools/schema-check.php
+ */
+class SchemaCheck {
+
+    /* Súlyosság. A sorrend számít: a hívók erre rendeznek. */
+    const DANGER  = 'danger';   // a kód el fog hasalni rajta
+    const WARNING = 'warning';  // működik, de eltér — pl. hiányzó index
+    const INFO    = 'info';     // kozmetikai, jellemzően karakterkészlet
+
+    static function referenceFile(): string {
+        return __DIR__ . '/../schema-reference.json';
+    }
+
+    /**
+     * Egy adatbázis szerkezete normalizált alakban, az information_schema-ból.
+     *
+     * Szándékosan NEM a `SHOW CREATE TABLE` szövegét hasonlítjuk: az tartalmaz
+     * AUTO_INCREMENT-számlálót, sorrendi esetlegességeket és szerververzió-függő
+     * formázást, amitől két azonos szerkezet is különbözőnek látszana.
+     */
+    static function readStructure(string $schema): array {
+        $tables = [];
+
+        $rows = DB::select(
+            'SELECT table_name, engine, table_collation
+               FROM information_schema.tables
+              WHERE table_schema = ? AND table_type = "BASE TABLE"
+              ORDER BY table_name', [$schema]);
+
+        foreach ($rows as $row) {
+            $name = $row->table_name ?? $row->TABLE_NAME;
+            $tables[$name] = [
+                'engine'    => $row->engine ?? $row->ENGINE,
+                'collation' => $row->table_collation ?? $row->TABLE_COLLATION,
+                'columns'   => [],
+                'indexes'   => [],
+            ];
+        }
+
+        if (!$tables) {
+            return ['tables' => []];
+        }
+
+        $columns = DB::select(
+            'SELECT table_name, column_name, column_type, is_nullable, column_default, extra
+               FROM information_schema.columns
+              WHERE table_schema = ?
+              ORDER BY table_name, ordinal_position', [$schema]);
+
+        foreach ($columns as $c) {
+            $table = $c->table_name ?? $c->TABLE_NAME;
+            if (!isset($tables[$table])) continue;
+            $tables[$table]['columns'][$c->column_name ?? $c->COLUMN_NAME] = [
+                'type'     => strtolower((string) ($c->column_type ?? $c->COLUMN_TYPE)),
+                'nullable' => ($c->is_nullable ?? $c->IS_NULLABLE) === 'YES',
+                'default'  => self::normaliseDefault($c->column_default ?? $c->COLUMN_DEFAULT ?? null),
+                'extra'    => strtolower((string) ($c->extra ?? $c->EXTRA ?? '')),
+            ];
+        }
+
+        $indexes = DB::select(
+            'SELECT table_name, index_name, non_unique, seq_in_index, column_name
+               FROM information_schema.statistics
+              WHERE table_schema = ?
+              ORDER BY table_name, index_name, seq_in_index', [$schema]);
+
+        foreach ($indexes as $i) {
+            $table = $i->table_name ?? $i->TABLE_NAME;
+            if (!isset($tables[$table])) continue;
+            $index = $i->index_name ?? $i->INDEX_NAME;
+            if (!isset($tables[$table]['indexes'][$index])) {
+                $tables[$table]['indexes'][$index] = [
+                    'unique'  => ((int) ($i->non_unique ?? $i->NON_UNIQUE)) === 0,
+                    'columns' => [],
+                ];
+            }
+            $tables[$table]['indexes'][$index]['columns'][] = $i->column_name ?? $i->COLUMN_NAME;
+        }
+
+        return ['tables' => $tables];
+    }
+
+    /**
+     * Az alapértelmezések írásmódja szerver- és verziófüggő: a MariaDB hol
+     * aposztróf közé teszi a szöveget, hol nem, a NULL-t pedig hol NULL-ként, hol
+     * "NULL" sztringként adja vissza. Enélkül két azonos oszlop is eltérőnek látszana.
+     */
+    private static function normaliseDefault($value): ?string {
+        if ($value === null) return null;
+
+        $value = trim((string) $value);
+        if ($value === '') return '';
+        if (strcasecmp($value, 'NULL') === 0) return null;
+
+        // A körbevevő aposztrófokat levesszük ('0' és 0 ugyanaz az alapértelmezés).
+        if (strlen($value) >= 2 && $value[0] === "'" && substr($value, -1) === "'") {
+            $value = substr($value, 1, -1);
+        }
+
+        // current_timestamp() és CURRENT_TIMESTAMP ugyanaz.
+        $lower = strtolower(str_replace(' ', '', $value));
+        if ($lower === 'current_timestamp' || $lower === 'current_timestamp()') {
+            return 'current_timestamp';
+        }
+
+        return $value;
+    }
+
+    /**
+     * A várt és a tényleges szerkezet összevetése.
+     *
+     * TISZTA függvény: nincs benne adatbázis-hívás, ezért közvetlenül tesztelhető.
+     *
+     * @return array<int,array{severity:string,table:string,kind:string,message:string}>
+     */
+    static function compare(array $expected, array $actual): array {
+        $findings = [];
+
+        $expectedTables = $expected['tables'] ?? [];
+        $actualTables   = $actual['tables'] ?? [];
+
+        foreach ($expectedTables as $table => $want) {
+            if (!isset($actualTables[$table])) {
+                $findings[] = self::finding(self::DANGER, $table, 'missing_table',
+                    'Hiányzik a tábla.');
+                continue;
+            }
+            $findings = array_merge($findings, self::compareTable($table, $want, $actualTables[$table]));
+        }
+
+        foreach ($actualTables as $table => $have) {
+            if (!isset($expectedTables[$table])) {
+                $findings[] = self::finding(self::WARNING, $table, 'extra_table',
+                    'Nálunk nincs ilyen tábla — vélhetően rég kivezetett, eldobható.');
+            }
+        }
+
+        return self::sortBySeverity($findings);
+    }
+
+    private static function compareTable(string $table, array $want, array $have): array {
+        $findings = [];
+
+        foreach ($want['columns'] as $column => $wantColumn) {
+            if (!isset($have['columns'][$column])) {
+                $findings[] = self::finding(self::DANGER, $table, 'missing_column',
+                    "Hiányzik az oszlop: `$column` ({$wantColumn['type']}).");
+                continue;
+            }
+            $haveColumn = $have['columns'][$column];
+
+            if ($wantColumn['type'] !== $haveColumn['type']) {
+                $findings[] = self::finding(self::WARNING, $table, 'column_type',
+                    "`$column` típusa {$haveColumn['type']}, nálunk {$wantColumn['type']}.");
+            }
+
+            // A szigorúbb (NOT NULL) oldal a veszélyes: oda nem fér be a NULL.
+            if ($wantColumn['nullable'] !== $haveColumn['nullable']) {
+                $severity = $haveColumn['nullable'] ? self::WARNING : self::DANGER;
+                $findings[] = self::finding($severity, $table, 'column_nullable',
+                    "`$column` " . ($haveColumn['nullable'] ? 'NULL-ozható' : 'NOT NULL')
+                    . ', nálunk ' . ($wantColumn['nullable'] ? 'NULL-ozható' : 'NOT NULL') . '.');
+            }
+
+            if ($wantColumn['default'] !== $haveColumn['default']) {
+                $findings[] = self::finding(self::INFO, $table, 'column_default',
+                    "`$column` alapértelmezése " . self::show($haveColumn['default'])
+                    . ', nálunk ' . self::show($wantColumn['default']) . '.');
+            }
+
+            if ($wantColumn['extra'] !== $haveColumn['extra']) {
+                $findings[] = self::finding(self::WARNING, $table, 'column_extra',
+                    "`$column` extra jelzője " . self::show($haveColumn['extra'])
+                    . ', nálunk ' . self::show($wantColumn['extra']) . '.');
+            }
+        }
+
+        foreach ($have['columns'] as $column => $_) {
+            if (!isset($want['columns'][$column])) {
+                $findings[] = self::finding(self::WARNING, $table, 'extra_column',
+                    "Nálunk nincs ilyen oszlop: `$column` — vélhetően kivezetett.");
+            }
+        }
+
+        foreach ($want['indexes'] as $index => $wantIndex) {
+            if (!isset($have['indexes'][$index])) {
+                // Hiányzó egyedi index ADATHIBÁT enged be, nem csak lassít.
+                $severity = $wantIndex['unique'] ? self::DANGER : self::WARNING;
+                $findings[] = self::finding($severity, $table, 'missing_index',
+                    ($wantIndex['unique'] ? 'Hiányzik az EGYEDI index' : 'Hiányzik az index')
+                    . ": `$index` (" . implode(', ', $wantIndex['columns']) . ').');
+                continue;
+            }
+            $haveIndex = $have['indexes'][$index];
+            if ($wantIndex['columns'] !== $haveIndex['columns']) {
+                $findings[] = self::finding(self::WARNING, $table, 'index_columns',
+                    "`$index` oszlopai (" . implode(', ', $haveIndex['columns'])
+                    . '), nálunk (' . implode(', ', $wantIndex['columns']) . ').');
+            }
+            if ($wantIndex['unique'] !== $haveIndex['unique']) {
+                $findings[] = self::finding(self::WARNING, $table, 'index_unique',
+                    "`$index` " . ($haveIndex['unique'] ? 'egyedi' : 'nem egyedi')
+                    . ', nálunk ' . ($wantIndex['unique'] ? 'egyedi' : 'nem egyedi') . '.');
+            }
+        }
+
+        foreach ($have['indexes'] as $index => $_) {
+            if (!isset($want['indexes'][$index])) {
+                $findings[] = self::finding(self::INFO, $table, 'extra_index',
+                    "Nálunk nincs ilyen index: `$index`.");
+            }
+        }
+
+        if (($want['engine'] ?? null) !== ($have['engine'] ?? null)) {
+            $findings[] = self::finding(self::WARNING, $table, 'engine',
+                'Tárolómotor ' . self::show($have['engine'] ?? null)
+                . ', nálunk ' . self::show($want['engine'] ?? null) . '.');
+        }
+
+        // A karakterkészlet külön kategória: a #669 épp ezeket egységesíti, ezért
+        // önmagában nem hiba, de a haladás látszik rajta.
+        if (($want['collation'] ?? null) !== ($have['collation'] ?? null)) {
+            $findings[] = self::finding(self::INFO, $table, 'collation',
+                'Egybevetés ' . self::show($have['collation'] ?? null)
+                . ', nálunk ' . self::show($want['collation'] ?? null) . '.');
+        }
+
+        return $findings;
+    }
+
+    private static function finding(string $severity, string $table, string $kind, string $message): array {
+        return ['severity' => $severity, 'table' => $table, 'kind' => $kind, 'message' => $message];
+    }
+
+    private static function show($value): string {
+        if ($value === null) return 'NULL';
+        if ($value === '')   return '(nincs)';
+        return (string) $value;
+    }
+
+    private static function sortBySeverity(array $findings): array {
+        $rank = [self::DANGER => 0, self::WARNING => 1, self::INFO => 2];
+        usort($findings, function ($a, $b) use ($rank) {
+            return [$rank[$a['severity']] ?? 9, $a['table'], $a['kind']]
+               <=> [$rank[$b['severity']] ?? 9, $b['table'], $b['kind']];
+        });
+        return $findings;
+    }
+
+    /** Súlyosságonkénti darabszám — a /health összefoglalójához. */
+    static function summarise(array $findings): array {
+        $counts = [self::DANGER => 0, self::WARNING => 0, self::INFO => 0];
+        foreach ($findings as $f) {
+            if (isset($counts[$f['severity']])) $counts[$f['severity']]++;
+        }
+        return $counts;
+    }
+
+    static function loadReference(): ?array {
+        $file = self::referenceFile();
+        if (!is_readable($file)) return null;
+
+        $decoded = json_decode((string) file_get_contents($file), true);
+
+        return is_array($decoded) && isset($decoded['tables']) ? $decoded : null;
+    }
+
+    /**
+     * A futó adatbázis összevetése a referenciával.
+     *
+     * @return array{available:bool,reason?:string,findings?:array,counts?:array}
+     */
+    static function check(?string $schema = null): array {
+        $reference = self::loadReference();
+        if ($reference === null) {
+            return ['available' => false, 'reason' => 'Nincs beolvasható referencia-fájl (' . basename(self::referenceFile()) . ').'];
+        }
+
+        $schema = $schema ?? DB::connection()->getDatabaseName();
+
+        try {
+            $actual = self::readStructure($schema);
+        } catch (\Throwable $e) {
+            return ['available' => false, 'reason' => 'Nem olvasható a szerkezet: ' . $e->getMessage()];
+        }
+
+        if (!$actual['tables']) {
+            return ['available' => false, 'reason' => 'Az adatbázis („' . $schema . '") üres vagy nem olvasható.'];
+        }
+
+        $findings = self::compare($reference, $actual);
+
+        return [
+            'available' => true,
+            'schema'    => $schema,
+            'findings'  => $findings,
+            'counts'    => self::summarise($findings),
+        ];
+    }
+}

--- a/webapp/classes/schemacheck.php
+++ b/webapp/classes/schemacheck.php
@@ -31,6 +31,43 @@ class SchemaCheck {
         return __DIR__ . '/../schema-reference.json';
     }
 
+    /** A sémát leíró fájlok könyvtára. A Dockerfile `COPY . .`-ja miatt élesben is ott van. */
+    static function initdbDirectory(): string {
+        return __DIR__ . '/../../docker/mysql/initdb.d';
+    }
+
+    /**
+     * #706: ujjlenyomat a séma FORRÁSÁRÓL, hogy az elavult referencia kiderüljön.
+     *
+     * A referencia egy pillanatkép. Ha valaki hozzányúl az initdb.d-hez és nem
+     * generálja újra, a beversenyzett fájl csendben hazudni kezdene, és a /health
+     * „minden rendben"-t mutatna. A CI-ban ezt teszt fogja meg — de csak ott.
+     *
+     * Ezért a referenciába beletesszük a sémafájlok ujjlenyomatát, és futásidőben
+     * újraszámoljuk. Ha eltér, a /health azt mondja meg, ami igaz: a referencia
+     * elavult, az összevetés eredménye nem megbízható. Így élesben sem kell azon
+     * múlnia, hogy valaki emlékezett-e az újragenerálásra.
+     *
+     * NULL, ha a könyvtár nem olvasható — akkor egyszerűen nem állítunk semmit.
+     */
+    static function initdbFingerprint(): ?string {
+        $dir = self::initdbDirectory();
+        if (!is_dir($dir) || !is_readable($dir)) return null;
+
+        $files = glob($dir . '/*.{sql,sh}', GLOB_BRACE);
+        if ($files === false || !$files) return null;
+
+        sort($files);
+
+        $hash = hash_init('sha256');
+        foreach ($files as $file) {
+            hash_update($hash, basename($file));
+            hash_update_file($hash, $file);
+        }
+
+        return hash_final($hash);
+    }
+
     /**
      * Egy adatbázis szerkezete normalizált alakban, az information_schema-ból.
      *
@@ -310,11 +347,24 @@ class SchemaCheck {
 
         $findings = self::compare($reference, $actual);
 
+        /*
+         * Ha a séma forrása azóta változott, hogy a referencia készült, akkor az
+         * összevetés eredménye nem megbízható — se a „minden rendben", se az
+         * eltérés-lista. Ezt meg kell mondani, nem elhallgatni.
+         */
+        $storedFingerprint  = $reference['_meta']['initdb_fingerprint'] ?? null;
+        $currentFingerprint = self::initdbFingerprint();
+        $stale = $storedFingerprint !== null
+              && $currentFingerprint !== null
+              && $storedFingerprint !== $currentFingerprint;
+
         return [
-            'available' => true,
-            'schema'    => $schema,
-            'findings'  => $findings,
-            'counts'    => self::summarise($findings),
+            'available'    => true,
+            'schema'       => $schema,
+            'findings'     => $findings,
+            'counts'       => self::summarise($findings),
+            'stale'        => $stale,
+            'generated_at' => $reference['_meta']['generated_at'] ?? null,
         ];
     }
 }

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -1,0 +1,3109 @@
+{
+    "tables": {
+        "attributes": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "bigint(20)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "key": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "value": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "fromOSM": {
+                    "type": "tinyint(1)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "church_id": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "key_church": {
+                    "unique": false,
+                    "columns": [
+                        "key",
+                        "church_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "boundaries": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(10)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "boundary": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "admin_level": {
+                    "type": "int(2)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "name": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "alt_name": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "denomination": {
+                    "type": "varchar(50)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "osmtype": {
+                    "type": "varchar(9)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "osmid": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "index1": {
+                    "unique": false,
+                    "columns": [
+                        "boundary",
+                        "admin_level"
+                    ]
+                },
+                "index2": {
+                    "unique": false,
+                    "columns": [
+                        "osmtype",
+                        "osmid"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "cal_generated_periods": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "period_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "name": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "weight": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "start_date": {
+                    "type": "date",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "end_date": {
+                    "type": "date",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "date",
+                    "nullable": false,
+                    "default": "curdate()",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": "curdate()",
+                    "extra": ""
+                },
+                "color": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "period_id": {
+                    "unique": false,
+                    "columns": [
+                        "period_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "cal_masses": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "period_id": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "title": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "types": {
+                    "type": "text",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "rite": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "start_date": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "duration": {
+                    "type": "longtext",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "rrule": {
+                    "type": "longtext",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "experiod": {
+                    "type": "longtext",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "manual_experiod": {
+                    "type": "longtext",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "exdate": {
+                    "type": "longtext",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "lang": {
+                    "type": "varchar(3)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "comment": {
+                    "type": "text",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "date",
+                    "nullable": false,
+                    "default": "curdate()",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": "curdate()",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "church_id": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "period_id": {
+                    "unique": false,
+                    "columns": [
+                        "period_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "cal_periods": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "name": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "weight": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "start_month_day": {
+                    "type": "varchar(5)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "end_month_day": {
+                    "type": "varchar(5)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "start_period_id": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "end_period_id": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "all_inclusive": {
+                    "type": "tinyint(1)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "multi_day": {
+                    "type": "tinyint(1)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "date",
+                    "nullable": false,
+                    "default": "curdate()",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": "curdate()",
+                    "extra": ""
+                },
+                "special_type": {
+                    "type": "enum('christmas','easter')",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "selectable": {
+                    "type": "tinyint(1)",
+                    "nullable": true,
+                    "default": "1",
+                    "extra": ""
+                },
+                "color": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "end_period_id": {
+                    "unique": false,
+                    "columns": [
+                        "end_period_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "start_period_id": {
+                    "unique": false,
+                    "columns": [
+                        "start_period_id"
+                    ]
+                }
+            }
+        },
+        "cal_period_years": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "period_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "start_year": {
+                    "type": "int(4)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "start_date": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "end_date": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "date",
+                    "nullable": false,
+                    "default": "curdate()",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": "curdate()",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "period_id": {
+                    "unique": false,
+                    "columns": [
+                        "period_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "cal_suggestions": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "bigint(20) unsigned",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "package_id": {
+                    "type": "bigint(20) unsigned",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "period_id": {
+                    "type": "bigint(20) unsigned",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "mass_id": {
+                    "type": "bigint(20) unsigned",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "mass_state": {
+                    "type": "enum('new','deleted','modified')",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "changes": {
+                    "type": "longtext",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "package_id": {
+                    "unique": false,
+                    "columns": [
+                        "package_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "cal_suggestion_packages": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "bigint(20) unsigned",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "bigint(20) unsigned",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "sender_name": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "sender_email": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "sender_user_id": {
+                    "type": "bigint(20) unsigned",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "sender_message": {
+                    "type": "text",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "state": {
+                    "type": "enum('accepted','rejected','pending')",
+                    "nullable": true,
+                    "default": "PENDING",
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "church_id": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "chat": {
+            "engine": "MyISAM",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "datum": {
+                    "type": "datetime",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "user": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "kinek": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "szoveg": {
+                    "type": "tinytext",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "church_holders": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(10)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "user_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "church_id": {
+                    "type": "int(10)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "description": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "status": {
+                    "type": "enum('asked','allowed','denied','revoked')",
+                    "nullable": false,
+                    "default": "asked",
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "deleted_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "church_links": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(10)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "int(10)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "href": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "title": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "deleted_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "church_relationships": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "parent_church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "child_church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": "on update current_timestamp()"
+                }
+            },
+            "indexes": {
+                "child_idx": {
+                    "unique": false,
+                    "columns": [
+                        "child_church_id"
+                    ]
+                },
+                "parent_idx": {
+                    "unique": false,
+                    "columns": [
+                        "parent_church_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "unique_pair": {
+                    "unique": true,
+                    "columns": [
+                        "parent_church_id",
+                        "child_church_id"
+                    ]
+                }
+            }
+        },
+        "church_update_tokens": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "token": {
+                    "type": "varchar(64)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "uid": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "email_batch_id": {
+                    "type": "varchar(64)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "expires_at": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "used_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": "current_timestamp",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "token"
+                    ]
+                }
+            }
+        },
+        "confessions": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "deduplicationId": {
+                    "type": "char(36)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "local_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "timestamp": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": "on update current_timestamp()"
+                },
+                "fulldata": {
+                    "type": "longtext",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "status": {
+                    "type": "enum('on','off')",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "deduplicationId": {
+                    "unique": true,
+                    "columns": [
+                        "deduplicationId"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "crons": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "class": {
+                    "type": "varchar(45)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "function": {
+                    "type": "varchar(45)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "frequency": {
+                    "type": "varchar(45)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "from": {
+                    "type": "varchar(45)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "until": {
+                    "type": "varchar(45)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "deadline_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "attempts": {
+                    "type": "int(2)",
+                    "nullable": true,
+                    "default": "0",
+                    "extra": ""
+                },
+                "lastsuccess_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_At": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "distances": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "fromLat": {
+                    "type": "decimal(11,7)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "fromLon": {
+                    "type": "decimal(11,7)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "toLat": {
+                    "type": "decimal(11,7)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "toLon": {
+                    "type": "decimal(11,7)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "distance": {
+                    "type": "float",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "toupdate": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "Coord": {
+                    "unique": true,
+                    "columns": [
+                        "fromLat",
+                        "fromLon",
+                        "toLat",
+                        "toLon"
+                    ]
+                },
+                "From": {
+                    "unique": false,
+                    "columns": [
+                        "fromLat",
+                        "fromLon"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "egyhazmegye": {
+            "engine": "MyISAM",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "nev": {
+                    "type": "varchar(250)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "sorrend": {
+                    "type": "int(3)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "ok": {
+                    "type": "enum('i','n')",
+                    "nullable": false,
+                    "default": "i",
+                    "extra": ""
+                },
+                "felelos": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "email": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "csakez": {
+                    "type": "enum('i','n')",
+                    "nullable": false,
+                    "default": "i",
+                    "extra": ""
+                },
+                "osm_relation": {
+                    "type": "int(45)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "id": {
+                    "unique": false,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "emails": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "type": {
+                    "type": "varchar(30)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "to": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "header": {
+                    "type": "text",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "subject": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "body": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "status": {
+                    "type": "varchar(45)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "espereskerulet": {
+            "engine": "MyISAM",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(3)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "ehm": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "nev": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "events": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "name": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "year": {
+                    "type": "varchar(4)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "date": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "id_UNIQUE": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "name+year": {
+                    "unique": true,
+                    "columns": [
+                        "name",
+                        "year"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "external_calendars": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "name": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "url": {
+                    "type": "varchar(2048)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "active": {
+                    "type": "tinyint(1)",
+                    "nullable": true,
+                    "default": "1",
+                    "extra": ""
+                },
+                "last_import_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": "on update current_timestamp()"
+                }
+            },
+            "indexes": {
+                "fk_external_calendars_church_id": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "unique_church_external": {
+                    "unique": true,
+                    "columns": [
+                        "church_id",
+                        "name"
+                    ]
+                }
+            }
+        },
+        "favorites": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(10) unsigned",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "uid": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "tid": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "uid_tid_UNIQUE": {
+                    "unique": true,
+                    "columns": [
+                        "uid",
+                        "tid"
+                    ]
+                }
+            }
+        },
+        "keyword_shortcuts": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "osmtag_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "type": {
+                    "type": "varchar(30)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "value": {
+                    "type": "varchar(200)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "church_type_value": {
+                    "unique": false,
+                    "columns": [
+                        "church_id",
+                        "type",
+                        "value"
+                    ]
+                },
+                "FK_keyword_shortchuts_church_idx": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "FK_keyword_shortchuts_osmtag_idx": {
+                    "unique": false,
+                    "columns": [
+                        "osmtag_id"
+                    ]
+                },
+                "index_value": {
+                    "unique": false,
+                    "columns": [
+                        "value"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "type_value": {
+                    "unique": false,
+                    "columns": [
+                        "type",
+                        "value"
+                    ]
+                }
+            }
+        },
+        "lookup_boundary_church": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "boundary_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "FK_boundary_id_idx": {
+                    "unique": false,
+                    "columns": [
+                        "boundary_id"
+                    ]
+                },
+                "FK_church_id_idx": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "unique": {
+                    "unique": true,
+                    "columns": [
+                        "church_id",
+                        "boundary_id"
+                    ]
+                }
+            }
+        },
+        "lookup_church_osm": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "osm_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "FK_church_id_idx": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "FK_osm_id_idx": {
+                    "unique": false,
+                    "columns": [
+                        "osm_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "unique": {
+                    "unique": true,
+                    "columns": [
+                        "church_id",
+                        "osm_id"
+                    ]
+                }
+            }
+        },
+        "lookup_osm_enclosed": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "osm_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "enclosing_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "varchar(45)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "FK_osm_enclosing_id_idx": {
+                    "unique": false,
+                    "columns": [
+                        "enclosing_id"
+                    ]
+                },
+                "FK_osm_id_idx": {
+                    "unique": false,
+                    "columns": [
+                        "osm_id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "unique": {
+                    "unique": true,
+                    "columns": [
+                        "enclosing_id",
+                        "osm_id"
+                    ]
+                }
+            }
+        },
+        "megye": {
+            "engine": "MyISAM",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "megyenev": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "orszag": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "12",
+                    "extra": ""
+                },
+                "egyeb": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "messages": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "sid": {
+                    "type": "varchar(45)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "timestamp": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "severity": {
+                    "type": "varchar(10)",
+                    "nullable": true,
+                    "default": "info",
+                    "extra": ""
+                },
+                "text": {
+                    "type": "text",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "shown": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": "0",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "orszagok": {
+            "engine": "MyISAM",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(3)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "nev": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "telkod": {
+                    "type": "varchar(5)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "ok": {
+                    "type": "enum('i','n')",
+                    "nullable": false,
+                    "default": "i",
+                    "extra": ""
+                },
+                "kiemelt": {
+                    "type": "enum('i','n')",
+                    "nullable": false,
+                    "default": "n",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "osm": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "osmid": {
+                    "type": "varchar(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "osmtype": {
+                    "type": "varchar(9)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "lon": {
+                    "type": "decimal(10,8)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "lat": {
+                    "type": "decimal(11,8)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "idUNIQUE": {
+                    "unique": true,
+                    "columns": [
+                        "osmid",
+                        "osmtype"
+                    ]
+                },
+                "id_UNIQUE": {
+                    "unique": true,
+                    "columns": [
+                        "osmid",
+                        "osmtype"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "photos": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "filename": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "title": {
+                    "type": "varchar(250)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "weight": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "flag": {
+                    "type": "enum('i','n')",
+                    "nullable": false,
+                    "default": "i",
+                    "extra": ""
+                },
+                "height": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "width": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "FKchurch": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "kiemelt": {
+                    "unique": false,
+                    "columns": [
+                        "flag"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "remarks": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(10)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "nev": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "login": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "email": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "megbizhato": {
+                    "type": "enum('?','i','n','e')",
+                    "nullable": false,
+                    "default": "?",
+                    "extra": ""
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "allapot": {
+                    "type": "enum('u','f','j')",
+                    "nullable": false,
+                    "default": "u",
+                    "extra": ""
+                },
+                "admin": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "admindatum": {
+                    "type": "datetime",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "leiras": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "adminmegj": {
+                    "type": "text",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "log": {
+                    "type": "text",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "FK_church_id": {
+                    "unique": false,
+                    "columns": [
+                        "church_id"
+                    ]
+                },
+                "index1": {
+                    "unique": false,
+                    "columns": [
+                        "id",
+                        "church_id"
+                    ]
+                },
+                "index2": {
+                    "unique": false,
+                    "columns": [
+                        "id",
+                        "church_id",
+                        "allapot"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "stats_externalapi": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_bin",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "name": {
+                    "type": "varchar(45)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "url": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "responsecode": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "rawdata": {
+                    "type": "longtext",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "date": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "count": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "diff": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "fast": {
+                    "unique": false,
+                    "columns": [
+                        "url",
+                        "date"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "szentsegimadasok": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "church_id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "date": {
+                    "type": "date",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "starttime": {
+                    "type": "varchar(5)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "endtime": {
+                    "type": "varchar(5)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "type": {
+                    "type": "varchar(40)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "info": {
+                    "type": "varchar(255)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "templomok": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "nev": {
+                    "type": "varchar(150)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "ismertnev": {
+                    "type": "varchar(150)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "orszag": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "megye": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "varos": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "cim": {
+                    "type": "varchar(250)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "megkozelites": {
+                    "type": "tinytext",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "plebania": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "pleb_url": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "pleb_eml": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "egyhazmegye": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "espereskerulet": {
+                    "type": "int(3)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "leiras": {
+                    "type": "mediumtext",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "megjegyzes": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "miseaktiv": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": "1",
+                    "extra": ""
+                },
+                "misemegj": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "bucsu": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "frissites": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "kontakt": {
+                    "type": "varchar(250)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "kontaktmail": {
+                    "type": "varchar(70)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "adminmegj": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "letrehozta": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "megbizhato": {
+                    "type": "enum('i','n')",
+                    "nullable": false,
+                    "default": "n",
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "modositotta": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "moddatum": {
+                    "type": "datetime",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "log": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "ok": {
+                    "type": "enum('i','n','f')",
+                    "nullable": false,
+                    "default": "i",
+                    "extra": ""
+                },
+                "eszrevetel": {
+                    "type": "enum('i','n','f')",
+                    "nullable": false,
+                    "default": "n",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "deleted_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "osmid": {
+                    "type": "varchar(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "osmtype": {
+                    "type": "varchar(9)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "lat": {
+                    "type": "decimal(11,7)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "lon": {
+                    "type": "decimal(10,7)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "boundaries_checked_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "boundaries_checked_at": {
+                    "unique": false,
+                    "columns": [
+                        "boundaries_checked_at"
+                    ]
+                },
+                "egyhazmegye": {
+                    "unique": false,
+                    "columns": [
+                        "egyhazmegye"
+                    ]
+                },
+                "espereskerulet": {
+                    "unique": false,
+                    "columns": [
+                        "espereskerulet"
+                    ]
+                },
+                "id": {
+                    "unique": false,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "ismertnev": {
+                    "unique": false,
+                    "columns": [
+                        "ismertnev"
+                    ]
+                },
+                "osm": {
+                    "unique": false,
+                    "columns": [
+                        "osmid",
+                        "osmtype"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "varos": {
+                    "unique": false,
+                    "columns": [
+                        "varos"
+                    ]
+                }
+            }
+        },
+        "templomok_full": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "nev": {
+                    "type": "varchar(150)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "ismertnev": {
+                    "type": "varchar(150)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "orszag": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "megye": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "varos": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "cim": {
+                    "type": "varchar(250)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "megkozelites": {
+                    "type": "tinytext",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "plebania": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "pleb_url": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "pleb_eml": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "egyhazmegye": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "espereskerulet": {
+                    "type": "int(3)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "leiras": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "megjegyzes": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "miseaktiv": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": "1",
+                    "extra": ""
+                },
+                "misemegj": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "bucsu": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "frissites": {
+                    "type": "date",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "kontakt": {
+                    "type": "varchar(250)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "kontaktmail": {
+                    "type": "varchar(70)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "adminmegj": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "letrehozta": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "megbizhato": {
+                    "type": "enum('i','n')",
+                    "nullable": false,
+                    "default": "n",
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "modositotta": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "moddatum": {
+                    "type": "datetime",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "log": {
+                    "type": "text",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "ok": {
+                    "type": "enum('i','n','f')",
+                    "nullable": false,
+                    "default": "i",
+                    "extra": ""
+                },
+                "eszrevetel": {
+                    "type": "enum('i','n','f')",
+                    "nullable": false,
+                    "default": "n",
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "deleted_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "osmid": {
+                    "type": "varchar(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "osmtype": {
+                    "type": "varchar(9)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "lat": {
+                    "type": "decimal(11,7)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "lon": {
+                    "type": "decimal(10,7)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "egyhazmegye": {
+                    "unique": false,
+                    "columns": [
+                        "egyhazmegye"
+                    ]
+                },
+                "espereskerulet": {
+                    "unique": false,
+                    "columns": [
+                        "espereskerulet"
+                    ]
+                },
+                "id": {
+                    "unique": false,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "ismertnev": {
+                    "unique": false,
+                    "columns": [
+                        "ismertnev"
+                    ]
+                },
+                "osm": {
+                    "unique": false,
+                    "columns": [
+                        "osmid",
+                        "osmtype"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "varos": {
+                    "unique": false,
+                    "columns": [
+                        "varos"
+                    ]
+                }
+            }
+        },
+        "tokens": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "type": {
+                    "type": "varchar(15)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "name": {
+                    "type": "varchar(40)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "uid": {
+                    "type": "int(11)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "timeout": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "created_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "updated_at": {
+                    "type": "timestamp",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "id_UNIQUE": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "name_UNIQUE": {
+                    "unique": true,
+                    "columns": [
+                        "name"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "updates": {
+            "engine": "InnoDB",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "uid": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "tid": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": ""
+                },
+                "timestamp": {
+                    "type": "timestamp",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "id_UNIQUE": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                },
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        },
+        "user": {
+            "engine": "MyISAM",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "uid": {
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "login": {
+                    "type": "varchar(20)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "jelszo": {
+                    "type": "varchar(255)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "jogok": {
+                    "type": "varchar(200)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "regdatum": {
+                    "type": "datetime",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "lastlogin": {
+                    "type": "datetime",
+                    "nullable": false,
+                    "default": "current_timestamp",
+                    "extra": ""
+                },
+                "lastactive": {
+                    "type": "datetime",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
+                "email": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "notifications": {
+                    "type": "int(1)",
+                    "nullable": true,
+                    "default": "1",
+                    "extra": ""
+                },
+                "becenev": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "nev": {
+                    "type": "varchar(100)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                },
+                "volunteer": {
+                    "type": "int(1)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "uid"
+                    ]
+                }
+            }
+        },
+        "varosok": {
+            "engine": "MyISAM",
+            "collation": "utf8mb4_unicode_ci",
+            "columns": {
+                "id": {
+                    "type": "int(3)",
+                    "nullable": false,
+                    "default": null,
+                    "extra": "auto_increment"
+                },
+                "irsz": {
+                    "type": "int(4)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "megye_id": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "0",
+                    "extra": ""
+                },
+                "orszag": {
+                    "type": "int(2)",
+                    "nullable": false,
+                    "default": "46",
+                    "extra": ""
+                },
+                "nev": {
+                    "type": "varchar(50)",
+                    "nullable": false,
+                    "default": "",
+                    "extra": ""
+                }
+            },
+            "indexes": {
+                "PRIMARY": {
+                    "unique": true,
+                    "columns": [
+                        "id"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -97,6 +97,12 @@
                     "default": null,
                     "extra": ""
                 },
+                "iso3166_1": {
+                    "type": "varchar(2)",
+                    "nullable": true,
+                    "default": null,
+                    "extra": ""
+                },
                 "osmtype": {
                     "type": "varchar(9)",
                     "nullable": true,
@@ -135,6 +141,12 @@
                     "columns": [
                         "osmtype",
                         "osmid"
+                    ]
+                },
+                "index3": {
+                    "unique": false,
+                    "columns": [
+                        "iso3166_1"
                     ]
                 },
                 "PRIMARY": {
@@ -3105,5 +3117,10 @@
                 }
             }
         }
+    },
+    "_meta": {
+        "generated_at": "2026-08-09T19:06:13+02:00",
+        "source_schema": "miserend",
+        "initdb_fingerprint": "60d96d83d308bbf15c8184dd2e1db3e12bf0d5411bc0d2eb4a7c16c49975fe23"
     }
 }

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -199,6 +199,48 @@
 		{% endfor %}
 	</table>
 
+	{# #706: az éles adatbázison kézzel ment végig minden migráció, ezért elcsúszhat
+	   attól, amit az initdb.d leír. Itt látszik, hogy hol. #}
+	<h3 id="schema">Adatbázis-struktúra</h3>
+	{% if not schemaCheck.available %}
+		<p><span class="badge bg-warning">Nem ellenőrizhető</span> {{ schemaCheck.reason }}</p>
+	{% elseif schemaCheck.findings is empty %}
+		<p><span class="badge bg-success">Rendben</span>
+		   A(z) <code>{{ schemaCheck.schema }}</code> adatbázis szerkezete pontosan megegyezik azzal, amit a
+		   <code>docker/mysql/initdb.d</code> leír.</p>
+	{% else %}
+		<p>A(z) <code>{{ schemaCheck.schema }}</code> adatbázis szerkezetének összevetése azzal, amit a
+		   <code>docker/mysql/initdb.d</code> leír:</p>
+		<p>
+			{% if schemaCheck.counts.danger > 0 %}
+				<span class="badge bg-danger">{{ schemaCheck.counts.danger }} hiba</span>
+			{% else %}
+				<span class="badge bg-success">0 hiba</span>
+			{% endif %}
+			<span class="badge bg-warning">{{ schemaCheck.counts.warning }} figyelmeztetés</span>
+			<span class="badge bg-secondary">{{ schemaCheck.counts.info }} megjegyzés</span>
+		</p>
+		<p><small class="text-muted">
+			<strong>Hiba</strong>: a kód el fog hasalni rajta (hiányzó tábla/oszlop, szigorúbb NOT NULL, hiányzó egyedi index).
+			<strong>Figyelmeztetés</strong>: működik, de eltér (elhagyott tábla/oszlop, hiányzó index, más típus).
+			<strong>Megjegyzés</strong>: jellemzően karakterkészlet és alapértelmezés.
+		</small></p>
+		<table class="table table-hover table-condensed table-striped">
+			<tr><th>Tábla</th><th>Eltérés</th></tr>
+			{% for finding in schemaCheck.findings %}
+				<tr>
+					<td>
+						{% if finding.severity == 'danger' %}<span class="badge bg-danger">hiba</span>
+						{% elseif finding.severity == 'warning' %}<span class="badge bg-warning">figy</span>
+						{% else %}<span class="badge bg-secondary">megj</span>{% endif %}
+						<code>{{ finding.table }}</code>
+					</td>
+					<td>{{ finding.message }}</td>
+				</tr>
+			{% endfor %}
+		</table>
+	{% endif %}
+
 	<h3 id="boundaries">Területi elhelyezkedési adatok (Boundaries) állapota</h3>
 	<p>Azt, hogy melyik megyében/egyházmegyében/városban/körzetben van egy templom, azt az OSM (OpenStreetMap) adatokból az overpassapi-val olvassuk ki.</p>
 

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -204,6 +204,14 @@
 	<h3 id="schema">Adatbázis-struktúra</h3>
 	{% if not schemaCheck.available %}
 		<p><span class="badge bg-warning">Nem ellenőrizhető</span> {{ schemaCheck.reason }}</p>
+	{% elseif schemaCheck.stale %}
+		<p><span class="badge bg-warning">A referencia elavult</span>
+		   A <code>docker/mysql/initdb.d</code> azóta változott, hogy a
+		   <code>schema-reference.json</code> készült{% if schemaCheck.generated_at %}
+		   ({{ schemaCheck.generated_at }}){% endif %} — ezért az összevetés eredménye
+		   <strong>nem megbízható</strong>, se a „rendben", se az eltérés-lista.</p>
+		<p><small class="text-muted">Újragenerálás:
+		   <code>docker compose exec miserend php /miserend/webapp/tools/schema-reference.php</code></small></p>
 	{% elseif schemaCheck.findings is empty %}
 		<p><span class="badge bg-success">Rendben</span>
 		   A(z) <code>{{ schemaCheck.schema }}</code> adatbázis szerkezete pontosan megegyezik azzal, amit a

--- a/webapp/tests/Integration/SchemaCheckTest.php
+++ b/webapp/tests/Integration/SchemaCheckTest.php
@@ -1,0 +1,192 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #706: a szerkezet-összevetés logikája.
+ *
+ * A compare() tiszta függvény — nincs benne adatbázis-hívás —, ezért kézzel
+ * összerakott szerkezetekkel pontosan ellenőrizhető, hogy melyik eltérést milyen
+ * súllyal jelzi. A súlyozás a lényeg: a /health-en a „hiba" azt jelenti, hogy a
+ * kód el fog hasalni rajta, a „figyelmeztetés" azt, hogy működik, de eltér.
+ */
+final class SchemaCheckTest extends TestCase {
+
+    private static function table(array $columns = [], array $indexes = [], string $engine = 'InnoDB', string $collation = 'utf8mb4_unicode_ci'): array {
+        return ['engine' => $engine, 'collation' => $collation, 'columns' => $columns, 'indexes' => $indexes];
+    }
+
+    private static function column(string $type = 'int(11)', bool $nullable = false, ?string $default = null, string $extra = ''): array {
+        return ['type' => $type, 'nullable' => $nullable, 'default' => $default, 'extra' => $extra];
+    }
+
+    private static function kinds(array $findings): array {
+        return array_column($findings, 'kind');
+    }
+
+    private static function bySeverity(array $findings, string $severity): array {
+        return array_values(array_filter($findings, fn($f) => $f['severity'] === $severity));
+    }
+
+    public function testIdenticalStructuresProduceNoFindings(): void {
+        $structure = ['tables' => ['templomok' => self::table(['id' => self::column()])]];
+
+        self::assertSame([], \SchemaCheck::compare($structure, $structure));
+    }
+
+    /* Hiányzó tábla: a kód biztosan elhasal rajta. */
+    public function testMissingTableIsADanger(): void {
+        $expected = ['tables' => ['templomok' => self::table(['id' => self::column()])]];
+        $actual   = ['tables' => []];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertCount(1, $findings);
+        self::assertSame('missing_table', $findings[0]['kind']);
+        self::assertSame(\SchemaCheck::DANGER, $findings[0]['severity']);
+    }
+
+    /* Többlet-tábla: nem hiba, csak elhagyott — pontosan ezeket keressük. */
+    public function testExtraTableIsOnlyAWarning(): void {
+        $expected = ['tables' => []];
+        $actual   = ['tables' => ['nevnaptar' => self::table(['datum' => self::column('varchar(4)')])]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame(['extra_table'], self::kinds($findings));
+        self::assertSame(\SchemaCheck::WARNING, $findings[0]['severity']);
+    }
+
+    public function testMissingColumnIsADanger(): void {
+        $expected = ['tables' => ['templomok' => self::table(['id' => self::column(), 'lat' => self::column('decimal(11,7)', true)])]];
+        $actual   = ['tables' => ['templomok' => self::table(['id' => self::column()])]];
+
+        $findings = self::bySeverity(\SchemaCheck::compare($expected, $actual), \SchemaCheck::DANGER);
+
+        self::assertCount(1, $findings);
+        self::assertSame('missing_column', $findings[0]['kind']);
+        self::assertStringContainsString('lat', $findings[0]['message']);
+    }
+
+    public function testExtraColumnIsOnlyAWarning(): void {
+        $expected = ['tables' => ['chat' => self::table(['id' => self::column()])]];
+        $actual   = ['tables' => ['chat' => self::table(['id' => self::column(), 'ip' => self::column('varchar(50)')])]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame(['extra_column'], self::kinds($findings));
+        self::assertSame(\SchemaCheck::WARNING, $findings[0]['severity']);
+    }
+
+    /*
+     * A NULL-ozhatóság iránya számít. Ha ÉLESBEN szigorúbb (NOT NULL), mint nálunk,
+     * akkor a kódunk NULL-t próbálhat írni, amit az adatbázis visszautasít — ez hiba.
+     */
+    public function testStricterNullabilityInProductionIsADanger(): void {
+        $expected = ['tables' => ['cal_masses' => self::table(['updated_at' => self::column('date', true)])]];
+        $actual   = ['tables' => ['cal_masses' => self::table(['updated_at' => self::column('date', false)])]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame('column_nullable', $findings[0]['kind']);
+        self::assertSame(\SchemaCheck::DANGER, $findings[0]['severity']);
+    }
+
+    /* Fordítva viszont csak figyelmeztetés: a lazább oldal elfogadja, amit írunk. */
+    public function testLooserNullabilityInProductionIsOnlyAWarning(): void {
+        $expected = ['tables' => ['cal_masses' => self::table(['updated_at' => self::column('date', false)])]];
+        $actual   = ['tables' => ['cal_masses' => self::table(['updated_at' => self::column('date', true)])]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame(\SchemaCheck::WARNING, $findings[0]['severity']);
+    }
+
+    /* Hiányzó EGYEDI index adathibát enged be, nem csak lassít. */
+    public function testMissingUniqueIndexIsADanger(): void {
+        $expected = ['tables' => ['megye' => self::table(['id' => self::column()], ['PRIMARY' => ['unique' => true, 'columns' => ['id']]])]];
+        $actual   = ['tables' => ['megye' => self::table(['id' => self::column()])]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame('missing_index', $findings[0]['kind']);
+        self::assertSame(\SchemaCheck::DANGER, $findings[0]['severity']);
+        self::assertStringContainsString('EGYEDI', $findings[0]['message']);
+    }
+
+    /* A nem egyedi index hiánya lassít, de nem ront adatot. */
+    public function testMissingPlainIndexIsOnlyAWarning(): void {
+        $expected = ['tables' => ['cal_masses' => self::table(['church_id' => self::column()], ['church_id' => ['unique' => false, 'columns' => ['church_id']]])]];
+        $actual   = ['tables' => ['cal_masses' => self::table(['church_id' => self::column()])]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame(\SchemaCheck::WARNING, $findings[0]['severity']);
+    }
+
+    public function testColumnTypeDifferenceIsReported(): void {
+        $expected = ['tables' => ['remarks' => self::table(['leiras' => self::column('text')])]];
+        $actual   = ['tables' => ['remarks' => self::table(['leiras' => self::column('mediumtext')])]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame('column_type', $findings[0]['kind']);
+        self::assertStringContainsString('mediumtext', $findings[0]['message']);
+        self::assertStringContainsString('text', $findings[0]['message']);
+    }
+
+    /*
+     * A karakterkészlet önmagában nem hiba — a #669 épp ezeket egységesíti, és amíg
+     * az éles migráció nem futott le, minden táblán eltérne. Ha ez „figyelmeztetés"
+     * lenne, elnyomná a valódi bajokat a /health-en.
+     */
+    public function testCollationDifferenceIsOnlyInfo(): void {
+        $expected = ['tables' => ['templomok' => self::table([], [], 'InnoDB', 'utf8mb4_unicode_ci')]];
+        $actual   = ['tables' => ['templomok' => self::table([], [], 'InnoDB', 'utf8mb3_uca1400_ai_ci')]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame(['collation'], self::kinds($findings));
+        self::assertSame(\SchemaCheck::INFO, $findings[0]['severity']);
+    }
+
+    public function testEngineDifferenceIsAWarning(): void {
+        $expected = ['tables' => ['megye' => self::table([], [], 'InnoDB')]];
+        $actual   = ['tables' => ['megye' => self::table([], [], 'MyISAM')]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame('engine', $findings[0]['kind']);
+        self::assertSame(\SchemaCheck::WARNING, $findings[0]['severity']);
+    }
+
+    /* A hibák elöl legyenek — a /health-en ez a lista teteje. */
+    public function testFindingsAreSortedBySeverity(): void {
+        $expected = ['tables' => [
+            'a' => self::table([], [], 'InnoDB', 'utf8mb3_general_ci'),          // info
+            'b' => self::table(['x' => self::column()]),                          // danger (hiányzó oszlop)
+        ]];
+        $actual = ['tables' => [
+            'a' => self::table([], [], 'InnoDB', 'utf8mb4_unicode_ci'),
+            'b' => self::table([]),
+        ]];
+
+        $findings = \SchemaCheck::compare($expected, $actual);
+
+        self::assertSame(\SchemaCheck::DANGER, $findings[0]['severity']);
+        self::assertSame(\SchemaCheck::INFO, $findings[count($findings) - 1]['severity']);
+    }
+
+    public function testSummariseCountsEachSeverity(): void {
+        $findings = [
+            ['severity' => \SchemaCheck::DANGER,  'table' => 'a', 'kind' => 'x', 'message' => ''],
+            ['severity' => \SchemaCheck::WARNING, 'table' => 'b', 'kind' => 'y', 'message' => ''],
+            ['severity' => \SchemaCheck::WARNING, 'table' => 'c', 'kind' => 'z', 'message' => ''],
+        ];
+
+        self::assertSame(
+            [\SchemaCheck::DANGER => 1, \SchemaCheck::WARNING => 2, \SchemaCheck::INFO => 0],
+            \SchemaCheck::summarise($findings)
+        );
+    }
+}

--- a/webapp/tests/Integration/SchemaReferenceTest.php
+++ b/webapp/tests/Integration/SchemaReferenceTest.php
@@ -51,6 +51,42 @@ final class SchemaReferenceTest extends TestCase {
     }
 
     /*
+     * #706: a referencia hordozza a sémafájlok ujjlenyomatát, hogy az elavulás
+     * FUTÁSIDŐBEN is kiderüljön — ne csak itt, a CI-ban. Enélkül az éles /health
+     * „minden rendben"-t mondana akkor is, ha valaki elfelejtette újragenerálni.
+     */
+    public function testReferenceCarriesTheInitdbFingerprint(): void {
+        $reference = \SchemaCheck::loadReference();
+
+        self::assertArrayHasKey('_meta', $reference, 'hiányzik a _meta blokk. ' . self::REGENERATE);
+        self::assertNotEmpty($reference['_meta']['initdb_fingerprint'] ?? null);
+        self::assertNotEmpty($reference['_meta']['generated_at'] ?? null);
+    }
+
+    /* A ténylegesen telepített sémafájlokkal egyeznie kell. */
+    public function testFingerprintMatchesTheDeployedSchemaFiles(): void {
+        $reference = \SchemaCheck::loadReference();
+        $current   = \SchemaCheck::initdbFingerprint();
+
+        if ($current === null) {
+            self::markTestSkipped('az initdb.d nem olvasható ebben a környezetben');
+        }
+
+        self::assertSame(
+            $reference['_meta']['initdb_fingerprint'], $current,
+            "A sémafájlok változtak a referencia készítése óta.\n" . self::REGENERATE
+        );
+    }
+
+    /* Az elavulást a check() jelezze is, ne csak tudja. */
+    public function testCheckReportsStaleness(): void {
+        $result = \SchemaCheck::check();
+
+        self::assertArrayHasKey('stale', $result);
+        self::assertFalse($result['stale'], 'a beversenyzett referencia nem lehet elavult. ' . self::REGENERATE);
+    }
+
+    /*
      * Néhány tábla, aminek biztosan benne kell lennie. Ha a referencia valaha
      * csonkán generálódik (pl. félig felállt adatbázisról), ez fogja meg.
      */

--- a/webapp/tests/Integration/SchemaReferenceTest.php
+++ b/webapp/tests/Integration/SchemaReferenceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #706: a beversenyzett séma-referencia NE tudjon észrevétlenül elavulni.
+ *
+ * A referencia egy pillanatkép a `docker/mysql/initdb.d`-ből felépülő szerkezetről.
+ * Ha valaki hozzányúl a sémához és nem generálja újra, a referencia csendben
+ * hazudni kezdene — és a /health „minden rendben"-t mutatna olyan eltérésekre is,
+ * amikről tudnia kellene.
+ *
+ * Ez a teszt ugyanazon a friss adatbázison fut, amit az initdb.d épít, ezért ha
+ * elcsúsznak, itt bukik el.
+ *
+ * Elbukott? Akkor generáld újra:
+ *   docker exec miserend-miserend-1 php /miserend/webapp/tools/schema-reference.php
+ */
+final class SchemaReferenceTest extends TestCase {
+
+    private const REGENERATE = 'Generáld újra: docker exec miserend-miserend-1 php /miserend/webapp/tools/schema-reference.php';
+
+    public function testReferenceFileExistsAndParses(): void {
+        self::assertFileExists(\SchemaCheck::referenceFile());
+
+        $reference = \SchemaCheck::loadReference();
+
+        self::assertIsArray($reference, 'a referencia-fájl nem értelmezhető JSON');
+        self::assertNotEmpty($reference['tables'], 'a referencia nem tartalmaz táblát');
+    }
+
+    /* A lényeg: a beversenyzett referencia egyezzen a valódi sémával. */
+    public function testReferenceMatchesTheCurrentDatabase(): void {
+        $result = \SchemaCheck::check();
+
+        self::assertTrue($result['available'], $result['reason'] ?? '');
+
+        if ($result['findings']) {
+            $lines = array_map(
+                fn($f) => sprintf('  [%s] %s: %s', $f['severity'], $f['table'], $f['message']),
+                $result['findings']
+            );
+
+            self::fail(
+                "A séma-referencia elavult — " . count($result['findings']) . " eltérés:\n"
+                . implode("\n", $lines) . "\n\n" . self::REGENERATE
+            );
+        }
+
+        self::assertSame([], $result['findings']);
+    }
+
+    /*
+     * Néhány tábla, aminek biztosan benne kell lennie. Ha a referencia valaha
+     * csonkán generálódik (pl. félig felállt adatbázisról), ez fogja meg.
+     */
+    public function testReferenceCoversTheCoreTables(): void {
+        $reference = \SchemaCheck::loadReference();
+
+        foreach (['templomok', 'cal_masses', 'boundaries', 'user', 'photos'] as $table) {
+            self::assertArrayHasKey($table, $reference['tables'], "hiányzik a referenciából: $table");
+            self::assertNotEmpty($reference['tables'][$table]['columns'], "üres oszloplista: $table");
+        }
+    }
+}

--- a/webapp/tools/schema-check.php
+++ b/webapp/tools/schema-check.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * #706: a futó adatbázis szerkezetének összevetése a referenciával.
+ *
+ * Ugyanazt mutatja, mint a /health „Adatbázis-struktúra" pontja, csak CLI-ból —
+ * így éles szerveren belépés nélkül is lefuttatható:
+ *
+ *   docker compose exec miserend php /miserend/webapp/tools/schema-check.php
+ *
+ * Egy másik adatbázis is vizsgálható (pl. egy oda betöltött dump):
+ *
+ *   php /miserend/webapp/tools/schema-check.php prodschema
+ *
+ * Kilépési kód: 0 ha nincs danger-szintű eltérés, 1 ha van — így CI-ból is hívható.
+ */
+
+require __DIR__ . '/../load.php';
+
+$result = \SchemaCheck::check($argv[1] ?? null);
+
+if (!$result['available']) {
+    fwrite(STDERR, "Nem futtatható: " . $result['reason'] . "\n");
+    exit(2);
+}
+
+$counts = $result['counts'];
+
+printf("Adatbázis: %s\n", $result['schema']);
+printf("Eltérés: %d hiba, %d figyelmeztetés, %d megjegyzés\n\n",
+    $counts[\SchemaCheck::DANGER], $counts[\SchemaCheck::WARNING], $counts[\SchemaCheck::INFO]);
+
+if (!$result['findings']) {
+    echo "A szerkezet megegyezik a referenciával.\n";
+    exit(0);
+}
+
+$label = [
+    \SchemaCheck::DANGER  => 'HIBA ',
+    \SchemaCheck::WARNING => 'FIGY ',
+    \SchemaCheck::INFO    => 'megj ',
+];
+
+$currentTable = null;
+foreach ($result['findings'] as $finding) {
+    if ($finding['table'] !== $currentTable) {
+        $currentTable = $finding['table'];
+        printf("\n%s\n", $currentTable);
+    }
+    printf("  %s %s\n", $label[$finding['severity']] ?? '     ', $finding['message']);
+}
+
+echo "\n";
+
+exit($counts[\SchemaCheck::DANGER] > 0 ? 1 : 0);

--- a/webapp/tools/schema-reference.php
+++ b/webapp/tools/schema-reference.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * #706: a séma-referencia újragenerálása a FUTÓ adatbázis szerkezetéből.
+ *
+ * Akkor kell futtatni, ha a `docker/mysql/initdb.d` alatt változik a szerkezet.
+ * Enélkül a `SchemaReferenceTest` elbukik — szándékosan, hogy a referencia ne
+ * tudjon észrevétlenül elavulni.
+ *
+ * FONTOS: FRISS, `docker compose down -v && up`-pal újrainicializált adatbázison
+ * futtasd. Ha a saját dev-adatbázisodon kézzel is ALTER-eztél, azok a kézi
+ * változtatások is bekerülnének a referenciába.
+ *
+ *   docker exec miserend-miserend-1 php /miserend/webapp/tools/schema-reference.php
+ */
+
+require __DIR__ . '/../load.php';
+
+$schema = $argv[1] ?? \Illuminate\Database\Capsule\Manager::connection()->getDatabaseName();
+
+$structure = \SchemaCheck::readStructure($schema);
+
+if (!$structure['tables']) {
+    fwrite(STDERR, "Az adatbázis („$schema\") üres vagy nem olvasható — nem írok referenciát.\n");
+    exit(1);
+}
+
+$json = json_encode(
+    $structure,
+    JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+);
+
+file_put_contents(\SchemaCheck::referenceFile(), $json . "\n");
+
+printf("Referencia frissítve: %s\n", \SchemaCheck::referenceFile());
+printf("  forrás adatbázis: %s\n", $schema);
+printf("  táblák: %d\n", count($structure['tables']));

--- a/webapp/tools/schema-reference.php
+++ b/webapp/tools/schema-reference.php
@@ -17,12 +17,24 @@ require __DIR__ . '/../load.php';
 
 $schema = $argv[1] ?? \Illuminate\Database\Capsule\Manager::connection()->getDatabaseName();
 
+$generatedAt = date('c');
 $structure = \SchemaCheck::readStructure($schema);
 
 if (!$structure['tables']) {
     fwrite(STDERR, "Az adatbázis („$schema\") üres vagy nem olvasható — nem írok referenciát.\n");
     exit(1);
 }
+
+/*
+ * #706: az ujjlenyomat is bekerül, hogy az elavulás futásidőben is kiderüljön —
+ * ne csak a CI-ban. A /health ezt veti össze a ténylegesen telepített
+ * sémafájlokkal, és ha eltér, megmondja, hogy a referencia elavult.
+ */
+$structure['_meta'] = [
+    'generated_at'       => $generatedAt,
+    'source_schema'      => $schema,
+    'initdb_fingerprint' => \SchemaCheck::initdbFingerprint(),
+];
 
 $json = json_encode(
     $structure,
@@ -34,3 +46,4 @@ file_put_contents(\SchemaCheck::referenceFile(), $json . "\n");
 printf("Referencia frissítve: %s\n", \SchemaCheck::referenceFile());
 printf("  forrás adatbázis: %s\n", $schema);
 printf("  táblák: %d\n", count($structure['tables']));
+printf("  initdb ujjlenyomat: %s\n", substr((string) $structure['_meta']['initdb_fingerprint'], 0, 16));


### PR DESCRIPTION
A #706-ra: script is van, és a /health is megkapta. Az általad beillesztett éles dumpot le is futtattam vele, az eredmény a jegyben.

## Hogyan működik

A várt szerkezetet egy beversenyzett referencia-fájl írja le (`webapp/schema-reference.json`), a friss dev-adatbázisból generálva. Az összevetés az `information_schema`-ból dolgozik, **nem** a `SHOW CREATE TABLE` szövegéből — abban benne van az `AUTO_INCREMENT`-számláló és a szerververzió-függő formázás, amitől két azonos szerkezet is eltérőnek látszana.

```
# /health → „Adatbázis-struktúra" szakasz, vagy CLI-ból:
docker compose exec miserend php /miserend/webapp/tools/schema-check.php

# tetszőleges másik adatbázisra is (pl. egy oda betöltött éles dumpra):
php /miserend/webapp/tools/schema-check.php prodschema
```

Kilépési kód 0/1, tehát CI-ból is hívható.

## Három súlyossági szint

Ez a lényegi döntés, mert a #669 utf8mb4-migrációja miatt élesen **minden** tábla egybevetése eltér — ha az „figyelmeztetés" lenne, elnyomná a valódi bajokat.

| szint | mit jelent | példa |
|---|---|---|
| **hiba** | a kód el fog hasalni rajta | hiányzó tábla/oszlop, élesen szigorúbb `NOT NULL`, hiányzó egyedi index |
| **figyelmeztetés** | működik, de eltér | elhagyott tábla/oszlop, hiányzó (nem egyedi) index, más típus |
| **megjegyzés** | kozmetikai | karakterkészlet, alapértelmezés |

A `NOT NULL` irányát is figyeli: ha ÉLESEN szigorúbb, mint nálunk, az hiba (a kódunk NULL-t írna bele); fordítva csak figyelmeztetés.

## A referencia nem tud elavulni

Ez volt a legnagyobb kockázat: egy csendben elévülő referencia rosszabb a semminél, mert „minden rendben"-t mutatna. Ezért teszt őrzi (`SchemaReferenceTest`), ami a friss adatbázissal veti össze, és bukáskor kiírja, mit kell futtatni:

```
docker exec miserend-miserend-1 php /miserend/webapp/tools/schema-reference.php
```

Munka közben ez **el is kapott egy valódi elavulást** (a `church_relationships.type` eldobása után), szóval működik.

## Teszt

17 új eset. A `compare()` tiszta függvény, adatbázis nélkül hívható, ezért kézzel összerakott szerkezetekkel pontosan ellenőrizhető minden súlyozási döntés. Teljes készlet: integration 219, api 133, simple 159, request 51 — mind zöld.

A /health mindkét ágát valódi böngészőkéréssel néztem meg: az „egyezik" esetet és a 75 soros eltérés-táblázatot is. A hiba soha nem viszi le az oldalt (`try/catch`), mert a többi ellenőrzés fontosabb.

## Figyelem

Tartalmazza a **#707** commitját is (a seed idegenkulcs-javítását), különben ennek a PR-nek a CI-ja is bukna — a jelenlegi masteren a seed elhasal, és emiatt a `06-*` migrációk le sem futnak. Merge után eltűnik.