### PR TITLE
A /health Nominatim-pirosa a saját lekérdezésünk hibája volt

### DIFF
--- a/docs/outgoing-connections.md
+++ b/docs/outgoing-connections.md
@@ -10,7 +10,7 @@
 | Cél | Host | Port | Mire kell | Forrás (osztály) |
 |---|---|---|---|---|
 | **OSM Nominatim** | `nominatim.openstreetmap.org` | 443 | Cím vagy terület neve → koordináta keresés (geocoding) | `\ExternalApi\NominatimApi` |
-| **OSM Overpass** | `overpass-api.de` | 80 | Templom-elemek és határok lekérése OSM-ből (`url:miserend` tag) | `\ExternalApi\OverpassApi` |
+| **OSM Overpass** | `overpass-api.de` | 443 | Templom-elemek és határok lekérése OSM-ből (`url:miserend` tag) | `\ExternalApi\OverpassApi` |
 | **OSM opening_hours evaluator** | `openingh.openstreetmap.de` | 443 | `opening_hours` mező parse / evaluate | `\ExternalApi\OpeninghApi` |
 | **OSM OAuth** | fejlesztéshez `master.apis.dev.openstreetmap.org`, élesen:  `api.openstreetmap.org` | 443 | OSM adatok módosítása | `\ExternalApi\OpenStreetMapApi` |
 | **Mapquest Directions** | `open.mapquestapi.com` | 80 | Útvonal-távolság számítás templomok között (cron) | `\ExternalApi\MapquestApi` |

--- a/webapp/classes/externalapi/nominatimapi.php
+++ b/webapp/classes/externalapi/nominatimapi.php
@@ -8,7 +8,16 @@ class NominatimApi extends \ExternalApi\ExternalApi {
 
     public $name = 'nominatim';
     public $apiUrl = "https://nominatim.openstreetmap.org/" ;    
-    public $testQuery = 'search?q=Szent%20József%20jezsuita&format=json';
+    /*
+     * #706: a /health-en ez a lekérdezés pirosan bukott ("ResponseCode: 400"),
+     * miközben a Nominatim maga rendben volt. A hiba nálunk volt: az ékezetes
+     * betűk NYERSEN álltak az URL-ben, azokat a Nominatim 400-zal utasítja el.
+     * Kimérve, ugyanazzal a User-Agenttel:
+     *   ...q=Szent%20József%20jezsuita   -> 400
+     *   ...q=Szent%20J%C3%B3zsef%20...   -> 200
+     * Ezért teljesen url-kódolva tesszük be.
+     */
+    public $testQuery = 'search?q=Szent%20J%C3%B3zsef%20jezsuita&format=json';
 
     function OSM2GeoJson($osmtype, $osmid) {
         


### PR DESCRIPTION
Az élő /health-en a Nominatim pirosan bukik:

```
External API return data is not a valid JSON!
ResponseCode: 400
```

Ez úgy néz ki, mintha a szolgáltató lenne rossz. Nem az: a mi `testQuery`-nkben az ékezetes betűk **nyersen** álltak az URL-ben, azokat a Nominatim 400-zal utasítja el.

Kimérve, azonos User-Agenttel:

| lekérdezés | válasz |
|---|---|
| `q=Szent%20József%20jezsuita` (mostani) | **400** |
| `q=Szent%20J%C3%B3zsef%20jezsuita` | 200 |
| `q=Szeged` | 200 |
| `q=Szeged`, User-Agent nélkül | 403 |

Url-kódolva teszem be. Konténerben ellenőrizve: `NominatimApi::test()` -> `OK`.

## Mellékesen: a docs Overpass-portja rossz volt

A `docs/outgoing-connections.md` 80-as portot írt, a kód viszont `https://overpass-api.de/...`-t hív, vagyis **443**-at. Egyenként engedélyezős kimenő tűzfalnál ez pont azt a hibát adja, ami az élő /health-en látszik:

```
Failed to connect to overpass-api.de port 443 after 65 ms: Could not connect to server (curl)
```

A 65 ms azonnali elutasítás, nem időtúllépés. Nem tudom innen igazolni, hogy a szerveren tényleg allow-list van, de a dokumentáció mindenképp téves volt, javítom.

Tesztek zöldek: integration 213, api 133, simple 159, request 51.