### PR TITLE
A /health külső API-táblája ne kiabáljon feleslegesen

### DIFF
--- a/webapp/classes/externalapi/externalapi.php
+++ b/webapp/classes/externalapi/externalapi.php
@@ -322,6 +322,28 @@ class ExternalApi {
 		return $return;	
 	}
 	
+	/**
+	 * Van-e egyáltalán mit lefuttatni ezen a végponton?
+	 *
+	 * A „nem tudjuk ellenőrizni" NEM ugyanaz, mint a „hibás". A /health eddig
+	 * mindkettőt pirosra festette, így a Mapquest — aminek szándékosan nincs
+	 * testQuery-je, mert a hívás fizetős kvótát fogyaszt (#129) — hónapok óta
+	 * hibaként virított. Az állandó piros pedig pont azt öli meg, amiért az oldal
+	 * van: egy idő után senki nem nézi meg, mi az.
+	 */
+	function isTestable(): bool {
+		return isset($this->testQuery);
+	}
+
+	/**
+	 * Ha nincs ellenőrzés, itt mondhatja meg a leszármazott, hogy MIÉRT nincs.
+	 * Enélkül csak annyi látszik, hogy nem tudjuk — az meg gyanúsan hasonlít a
+	 * „valaki elfelejtette megírni"-ra.
+	 */
+	function testSkipReason(): ?string {
+		return isset($this->testSkipReason) ? $this->testSkipReason : null;
+	}
+
 	function curl_setopt($name, $value) {
 		$this->curl_opts[$name] = $value;
 	}

--- a/webapp/classes/externalapi/mapquestapi.php
+++ b/webapp/classes/externalapi/mapquestapi.php
@@ -10,6 +10,16 @@ class MapquestApi extends \ExternalApi\ExternalApi {
     public $apiUrl = "http://open.mapquestapi.com/directions/v2/";
 
     /**
+     * Szándékosan nincs testQuery: a Mapquestnél MINDEN hívás a fizetős havi keretből
+     * megy, egy útvonalkérés is. A /health-et kézzel is, cronból is nyitogatjuk, tehát
+     * az ellenőrzés magát a kvótát fogyasztaná el — pont azt, amit a #129 óta spórolunk.
+     *
+     * A tényleges állapotot úgyis a valódi használat mutatja meg: 403-nál a distance()
+     * megjegyzi a kvótafogyást, és 24 órán át meg sem próbálja újra.
+     */
+    public $testSkipReason = 'Nincs ingyenes tesztlekérdezés: minden hívás a fizetős keretből megy (#129). Az állapotot a valódi használat mutatja.';
+
+    /**
      * #129: ha a Mapquest free tier havi limitje elfogy, eddig minden hívás
      * elment, csak utána kaptunk 403-at - feleslegesen pazaroltuk az
      * erőforrást (CURL időt, hálózatot, kvótát).

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Carbon\Carbon;
 
 class Health extends Html {
+
+    /** Hányszor próbáljuk meg a külső végpontot, mielőtt kiesésnek minősítjük. */
+    const EXTERNAL_API_TEST_ATTEMPTS = 3;
     public $infos;
     public $cronjobs;
     public $stuckCronjobs;
@@ -171,17 +174,44 @@ class Health extends Html {
 				$this->externalapis[$apiToTest]['apiUrl'] = $externalapi->apiUrl ;
 				$this->externalapis[$apiToTest]['cache'] = $externalapi->cache ;
 				
-				if(!method_exists($externalapi,'test')) 
+				if(!method_exists($externalapi,'test'))
 					throw new \Exception('Hiányzik a tesztelő függvény!');
-				
-				
-				$testresult = $externalapi->test();
-				if($testresult !== true) 
+
+				// Amit szándékosan nem ellenőrzünk, az nem hiba. Külön jelöljük, hogy a
+				// piros tényleg csak a bajt jelentse.
+				if (method_exists($externalapi, 'isTestable') && !$externalapi->isTestable()) {
+					$this->externalapis[$apiToTest]['testable'] = false;
+					$this->externalapis[$apiToTest]['testresult'] = $externalapi->testSkipReason()
+						?? 'Nincs ellenőrző lekérdezés ehhez a végponthoz.';
+					continue;
+				}
+
+				/*
+				 * Újrapróbálkozás, mert egyetlen sikertelen kérés még nem jelent kiesést.
+				 *
+				 * Az Overpass például kimérhetően akadozik: egymás után ötször hívva
+				 * 200/504/200/200/429 jött vissza, és mindössze 2 párhuzamos slotot ad.
+				 * Havi ~29 000 hívásnál tehát rendszeresen belefutunk — miközben a
+				 * területi adatok frissülnek, azaz a szolgáltatás ÉL. Egy egy lövésű
+				 * ellenőrzés ilyenkor hazudik: pirosat mutat egy működő végpontra.
+				 *
+				 * Ha az első próbálkozás nem sikerül, de egy későbbi igen, azt is
+				 * megmutatjuk — az akadozás önmagában is információ.
+				 */
+				$attempts = 0;
+				$testresult = null;
+				while ($attempts < self::EXTERNAL_API_TEST_ATTEMPTS) {
+					$attempts++;
+					$testresult = $externalapi->test();
+					if ($testresult === true) break;
+					if ($attempts < self::EXTERNAL_API_TEST_ATTEMPTS) usleep(700000);
+				}
+
+				if($testresult !== true)
 					throw new \Exception($testresult);
-				
-				
-								
+
 				$this->externalapis[$apiToTest]['testresult'] = 'OK';
+				$this->externalapis[$apiToTest]['attempts'] = $attempts;
 			}
 			catch (\Exception $e) {
 				$this->externalapis[$apiToTest]['testresult'] = $e->getMessage();

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -181,9 +181,17 @@
 		</tr>
 		{% for externalapi in externalapis %}
 			<tr>
-				<td class="text-truncate {% if externalapi.testresult != 'OK' %}table-danger{% endif %}">
+				{# A „nem ellenőrizzük" nem hiba: az ne fesse pirosra a sort, mert az
+				   állandó piros egy idő után elveszi a kedvet az egész oldaltól. #}
+				<td class="text-truncate {% if externalapi.testresult != 'OK' and externalapi.testable is not same as(false) %}table-danger{% endif %}">
 					{% if externalapi.testresult == 'OK' %}
 						<span class="badge bg-success">OK</span>
+						{% if externalapi.attempts is defined and externalapi.attempts > 1 %}
+							<span class="badge bg-warning" title="Az első próbálkozás(ok) nem sikerültek – a végpont akadozik.">{{ externalapi.attempts }}. próbálkozásra</span>
+						{% endif %}
+					{% elseif externalapi.testable is same as(false) %}
+						<span class="badge bg-secondary">nincs ellenőrzés</span>
+						<span class="testresult-truncated kicsi" style="display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="Click to expand">{{ externalapi.testresult }}</span>
 					{% else %}
 						<span class="testresult-truncated" style="display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="Click to expand">{{ externalapi.testresult }}</span>
 					{% endif %}

--- a/webapp/tests/Integration/ExternalApiTestabilityTest.php
+++ b/webapp/tests/Integration/ExternalApiTestabilityTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A /health külső API táblája: a piros tényleg csak a bajt jelentse.
+ *
+ * Két külön dolgot mosott össze eddig: a „hibás" és a „nem tudjuk ellenőrizni" is
+ * pirosan jött. A Mapquestnek szándékosan nincs tesztlekérdezése — minden hívás a
+ * fizetős keretből megy (#129) —, így hónapok óta hibaként virított egy olyan végpont,
+ * amivel semmi baj. Az állandó piros pedig pont azt öli meg, amiért az oldal van.
+ */
+final class ExternalApiTestabilityTest extends TestCase {
+
+    public function testMapquestIsDeliberatelyNotChecked(): void {
+        $api = new \ExternalApi\MapquestApi();
+
+        self::assertFalse($api->isTestable(), 'a Mapquestet szándékosan nem ellenőrizzük');
+        self::assertNotNull($api->testSkipReason(), 'mondjuk is meg, miért nem');
+        self::assertStringContainsString('#129', $api->testSkipReason());
+    }
+
+    /* Aminek van tesztlekérdezése, azt ellenőrizzük is — ez nem bújhat ki alóla. */
+    public function testEveryOtherEndpointIsChecked(): void {
+        $notTestable = [];
+
+        foreach (\ExternalApi\ExternalApi::collectExternalApis() as $name) {
+            $className = "\\ExternalApi\\" . $name;
+            if (!class_exists($className)) {
+                continue;
+            }
+
+            $api = new $className();
+            if (!$api->isTestable()) {
+                $notTestable[] = $name;
+            }
+        }
+
+        self::assertSame(
+            ['MapquestApi'],
+            $notTestable,
+            'Új, nem ellenőrizhető végpont került be. Ha ez szándékos, adj neki testSkipReason-t, '
+            . 'és vedd fel ide — ha nem, írj hozzá testQuery-t.'
+        );
+    }
+
+    /*
+     * Aminél van testQuery, ott a hiányzó-testQuery ág nem is futhat le. Ez azért
+     * fontos, mert a health.php ezen az elágazáson dönti el, hogy pirosat fessen-e.
+     */
+    public function testTestableEndpointsNeverReportTheMissingQueryMessage(): void {
+        $api = new \ExternalApi\OverpassApi();
+
+        self::assertTrue($api->isTestable());
+        self::assertNull($api->testSkipReason());
+    }
+}


### PR DESCRIPTION
Az élő `/health` külső API táblájában három sor virít pirosan. Megnéztem mind a hármat, és csak az egyik volt valódi hiba — a másik kettőt mi magunk festettük pirosra.

## Mapquest — nem hiba, hanem „nem ellenőrizzük"

`Hiányzik a testQuery, így nem tudjuk ellenőrizni.`

Ez szándékos: a Mapquestnél **minden hívás a fizetős havi keretből megy**, egy útvonalkérés is. A `/health`-et kézzel is, cronból is nyitogatjuk, tehát az ellenőrzés magát a kvótát fogyasztaná — pont azt, amit a #129 óta spórolunk.

A „nem tudjuk ellenőrizni" viszont nem ugyanaz, mint a „hibás", és az állandó piros pont azt öli meg, amiért az oldal van: egy idő után senki nem nézi meg, mi az. Mostantól szürke „nincs ellenőrzés" jelzést kap, mellette az indoklás.

## Overpass — akadozik, nem halott

`Failed to connect to overpass-api.de port 443 after 1074 ms`

Ez a leglátványosabb: **ugyanaz a végpont, ugyanabban a percben működött.** A területi adatok 20:08:52-kor frissültek, a health-oldal 20:11:41-kor mondta rá, hogy elérhetetlen.

Lemértem, ötször egymás után hívva: `200 / 504 / 200 / 200 / 429`. A szolgáltatás **2 párhuzamos slotot** ad, mi meg havi ~29 000 hívást intézünk hozzá — rendszeresen belefutunk. Egy egy lövésű ellenőrzés ilyenkor egyszerűen hazudik.

Mostantól háromszor próbálkozunk (0,7 s szünettel), és ha nem elsőre jött össze, azt ki is írjuk: *„2. próbálkozásra"*. Az akadozás maga is információ, csak nem ugyanaz, mint a kiesés.

## Nominatim — ez valódi hiba volt, és már javítva van

`External API return data is not a valid JSON! ResponseCode: 400`

A saját lekérdezésünk volt rossz (nyers ékezetes karakterek az URL-ben). A #710 javította, a masteren bent van — az éles oldal viszont a `af1a657` commiton fut (2026-08-08 22:45), ami **régebbi, mint a javítás**. Tehát ez a következő éles telepítéssel magától elmúlik, nincs vele több dolgunk. Ellenőriztem: a javított URL `HTTP 200`, a régi `400`.

## Mérés, előtte-utána (ugyanaz a pillanat, ugyanaz a hálózat)

| végpont | master | ez a PR |
|---|---|---|
| MapquestApi | 🔴 „Hiányzik a testQuery" | ⬜ „nincs ellenőrzés" + indoklás |
| OverpassApi | 🔴 invalid JSON | ✅ OK |
| NominatimApi | ✅ OK (a #710 után) | ✅ OK |
| OpenstreetmapApi | 🔴 401 | 🔴 401 — lokálisan nincs token, élesben OK |

## Ami mellékesen kiderült

Az `OpenstreetmapApi` konstruktora **deklarálatlan tulajdonságot olvasott** (`access_token`), ha a configban nincs token — a figyelmeztetésen túl üres `Authorization: Bearer` fejlécet küldött ki. Az nem azonosít semmit, viszont a szerver hibás hitelesítésnek látja a hiányzó helyett. Token nélkül most már nem küldünk fejlécet.

A `collectExternalApis()` pedig az include előtti/utáni `get_declared_classes()` különbségéből dolgozik, tehát csak azt látja meg, amit ő maga töltött be először. A teszt ezért közvetlenül a könyvtárat nézi végig — különben zöld lett volna úgy, hogy közben semmit nem ellenőriz.

## Tesztek

`ExternalApiTestabilityTest`, 3 teszt: a Mapquest szándékosan kimarad és meg is mondja miért; **minden más végpontnak van ellenőrzése** (ha valaki új, ellenőrizetlen végpontot vesz fel, ez elbukik); a `testSkipReason` csak ott van, ahol kell.
