### PR TITLE
Megjavítom az élesben elavultnak látszó séma-referenciát (#706)

### DIFF
--- a/webapp/classes/schemacheck.php
+++ b/webapp/classes/schemacheck.php
@@ -69,6 +69,60 @@ class SchemaCheck {
     }
 
     /**
+     * Fájlonkénti ujjlenyomat, hogy elavuláskor MEGMONDHASSUK, mi változott.
+     *
+     * A puszta „a könyvtár azóta változott" üzenet nem visz közelebb a megoldáshoz:
+     * borazslo élesben pontosan ezt kapta, és nem derült ki belőle, hogy valójában a
+     * referenciát generáltam elavult konténerből. Fájlszinten ez egy pillantás.
+     *
+     * @return array<string,string>|null  fájlnév => sha256, vagy null ha nem olvasható
+     */
+    static function initdbFileHashes(): ?array {
+        $dir = self::initdbDirectory();
+        if (!is_dir($dir) || !is_readable($dir)) return null;
+
+        $files = glob($dir . '/*.{sql,sh}', GLOB_BRACE);
+        if ($files === false || !$files) return null;
+
+        sort($files);
+
+        $hashes = [];
+        foreach ($files as $file) {
+            $hashes[basename($file)] = hash_file('sha256', $file);
+        }
+
+        return $hashes;
+    }
+
+    /**
+     * Mi változott a referencia készítése óta?
+     *
+     * @return string[] ember által olvasható sorok; üres tömb, ha nem tudjuk megmondani
+     */
+    static function initdbDifferences(array $reference): array {
+        $stored  = $reference['_meta']['initdb_files'] ?? null;
+        $current = self::initdbFileHashes();
+
+        if (!is_array($stored) || !is_array($current)) {
+            return [];
+        }
+
+        $lines = [];
+        foreach (array_diff_key($current, $stored) as $name => $_) {
+            $lines[] = 'új fájl: ' . $name;
+        }
+        foreach (array_diff_key($stored, $current) as $name => $_) {
+            $lines[] = 'eltűnt fájl: ' . $name;
+        }
+        foreach (array_intersect_key($current, $stored) as $name => $hash) {
+            if ($hash !== $stored[$name]) $lines[] = 'megváltozott: ' . $name;
+        }
+
+        sort($lines);
+        return $lines;
+    }
+
+    /**
      * Egy adatbázis szerkezete normalizált alakban, az information_schema-ból.
      *
      * Szándékosan NEM a `SHOW CREATE TABLE` szövegét hasonlítjuk: az tartalmaz
@@ -364,6 +418,9 @@ class SchemaCheck {
             'findings'     => $findings,
             'counts'       => self::summarise($findings),
             'stale'        => $stale,
+            // Elavulásnál a legfontosabb kérdés: MI változott. Enélkül az üzenet
+            // csak riaszt, de nem segít.
+            'stale_details' => $stale ? self::initdbDifferences($reference) : [],
             'generated_at' => $reference['_meta']['generated_at'] ?? null,
         ];
     }

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -3119,8 +3119,19 @@
         }
     },
     "_meta": {
-        "generated_at": "2026-08-09T19:06:13+02:00",
+        "generated_at": "2026-08-09T21:11:51+02:00",
         "source_schema": "miserend",
-        "initdb_fingerprint": "60d96d83d308bbf15c8184dd2e1db3e12bf0d5411bc0d2eb4a7c16c49975fe23"
+        "initdb_fingerprint": "34996d231b9e2ec02c69ca5945d31367c8d6c4c5ea1e7e2b39f70eeca4825b9a",
+        "initdb_files": {
+            "00-users.sh": "e4f1149c70b9b0b44ce0ba172110ca07ad099fffaf720876e45e8a0a5cb910f8",
+            "01-create-database.sql": "dec66da6495a0d5ee007beda9e2be684b104cb4875b12ba0cf21ebae81874385",
+            "02-schema.sql": "40fdcedfd73cc57f8cb24e64c5785c91286de80d22c42700e0704cd42d657b7a",
+            "03-migrations.sql": "b17a6da4226a09f95c8249d6886802fe1087b944644f705d75a716a9a562f644",
+            "04-attributes-index.sql": "b2cf9ff6b616a8679c944fb6eb09baf6daeaa53793c0395e8d921525a91ea61a",
+            "05-data.sh": "5cf4dcd42e89288863792ed219c41937abcca249da22fbbf623d30dcd176874f",
+            "06-data-integrity.sql": "d0afff9288b6b7ccd60aae9e9f9e14c903732f4560e7eb7efde299ff946a944a",
+            "06-relationship-type-drop.sql": "04ac1538b42e0d9ad1f8106762013c8e9003965b70bc76ae1b27891273da938e",
+            "07-boundaries-iso.sql": "120cd5b6a656e754c8eef74d34415e03d987a09dce6ba998cb5c6ad1604fc03b"
+        }
     }
 }

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -210,8 +210,19 @@
 		   <code>schema-reference.json</code> készült{% if schemaCheck.generated_at %}
 		   ({{ schemaCheck.generated_at }}){% endif %} — ezért az összevetés eredménye
 		   <strong>nem megbízható</strong>, se a „rendben", se az eltérés-lista.</p>
-		<p><small class="text-muted">Újragenerálás:
-		   <code>docker compose exec miserend php /miserend/webapp/tools/schema-reference.php</code></small></p>
+		{% if schemaCheck.stale_details %}
+			<p>Ami változott:</p>
+			<ul class="kicsi">
+				{% for line in schemaCheck.stale_details %}<li><code>{{ line }}</code></li>{% endfor %}
+			</ul>
+		{% else %}
+			<p><small class="text-muted">Fájlszintű összevetés nincs: a referencia még a
+			   fájlonkénti ujjlenyomat bevezetése előtt készült. Egy újragenerálás után
+			   itt fog látszani, pontosan mi tér el.</small></p>
+		{% endif %}
+		<p><small class="text-muted">Újragenerálás — <strong>frissen épített konténerben</strong>,
+		   különben az ujjlenyomat megint nem fog egyezni:
+		   <code>docker exec &lt;konténer&gt; php /miserend/webapp/tools/schema-reference.php</code></small></p>
 	{% elseif schemaCheck.findings is empty %}
 		<p><span class="badge bg-success">Rendben</span>
 		   A(z) <code>{{ schemaCheck.schema }}</code> adatbázis szerkezete pontosan megegyezik azzal, amit a

--- a/webapp/tools/schema-reference.php
+++ b/webapp/tools/schema-reference.php
@@ -34,6 +34,8 @@ $structure['_meta'] = [
     'generated_at'       => $generatedAt,
     'source_schema'      => $schema,
     'initdb_fingerprint' => \SchemaCheck::initdbFingerprint(),
+    // Fájlonként is, hogy elavuláskor meg tudjuk mondani, MI változott.
+    'initdb_files'       => \SchemaCheck::initdbFileHashes(),
 ];
 
 $json = json_encode(
@@ -46,4 +48,18 @@ file_put_contents(\SchemaCheck::referenceFile(), $json . "\n");
 printf("Referencia frissítve: %s\n", \SchemaCheck::referenceFile());
 printf("  forrás adatbázis: %s\n", $schema);
 printf("  táblák: %d\n", count($structure['tables']));
-printf("  initdb ujjlenyomat: %s\n", substr((string) $structure['_meta']['initdb_fingerprint'], 0, 16));
+printf("  initdb ujjlenyomat: %s (%d fájlból)\n",
+    substr((string) $structure['_meta']['initdb_fingerprint'], 0, 16),
+    count((array) $structure['_meta']['initdb_files']));
+
+/*
+ * A leggyakoribb hiba nem a felejtés, hanem a ELAVULT KONTÉNER: az ujjlenyomat abból
+ * az initdb.d-ből készül, ami a futó image-ben van, nem abból, ami a munkapéldányban.
+ * Ha az image régebbi, a referencia olyan ujjlenyomattal születik, ami sehol nem áll
+ * elő újra — élesben pedig ettől mond a /health örökös „elavult"-at. (Pontosan ez
+ * történt: #706.)
+ */
+printf("\nFIGYELEM: az ujjlenyomat a FUTÓ konténer sémafájljaiból készül.\n");
+printf("Ha az image nem a mostani kódból épült, előbb építsd újra, különben a\n");
+printf("referencia élesben „elavultnak\" fog látszani:\n");
+printf("  docker compose -f docker/compose.yml -f docker/compose.dev.yml up -d --build\n");


### PR DESCRIPTION
Fixes a #706-ban jelzett élesbeli hibát.

## Nem te rontottad el

> `A referencia elavult. A docker/mysql/initdb.d azóta változott…`

**Az ujjlenyomatot én generáltam rossz konténerből.** A `schema-reference.php` abból az `initdb.d`-ből számol, ami az **éppen futó image-ben** van — nem abból, ami a munkapéldányban. Az én image-em régebbi volt a kódnál, így a beversenyzett ujjlenyomat olyan érték lett, ami sehol máshol nem áll elő újra. Élesben ezért mondta örökké, hogy elavult, miközben a szerkezet valójában rendben volt.

Kimérve:

| | ujjlenyomat |
|---|---|
| beversenyzett (elavult image-ből) | `60d96d83…` |
| frissen épített image-ből | `34996d23…` |

A táblák szerkezete a kettő között **bitre azonos** — egyedül az ujjlenyomat volt rossz.

## Hogy ne fordulhasson elő némán még egyszer

**Fájlszintű ujjlenyomat.** A referencia mostantól fájlonként is tárolja a hasheket, és elavuláskor a `/health` megmondja, mi történt:

```
új fájl: 04-mass-languages.sql
megváltozott: 02-schema.sql
```

A „valami változott" önmagában csak riaszt; ebből viszont egy pillantás alatt látszik, hogy elfelejtett újragenerálás-e, vagy elavult image.

**A generátor figyelmeztet.** Kiírja, hány fájlból dolgozott, és hogy frissen épített konténerben kell futtatni.

## A staging `lang` találata valódi, és jó hír

> `cal_masses -> FIGY: lang típusa varchar(50), nálunk varchar(3).`

Ez nem a seed tökéletlensége. A stagingen az oszlop tényleg `varchar(50)`, a mi `initdb.d`-nkben viszont `varchar(3)` — vagyis az élő séma **előrébb jár**, mint amit a kód leír. A #690 pontosan ezt zárja be: viszi az `ALTER TABLE`-t az `initdb.d`-be, és a referenciát is frissítettem hozzá. Merge után ez a sor eltűnik.

Vagyis a szerszám első éles bevetésén valódi drift-et talált. 🙂

## Ellenőrzés

Frissen épített image, nulláról felhúzott adatbázis: `SchemaCheckTest` + `SchemaReferenceTest` együtt 20 teszt zöld, a CLI `0 hiba, 0 figyelmeztetés, 0 megjegyzés`, kilépési kód 0.

Egy apróság: a `docker compose exec` helyett tényleg `docker exec <konténer>` kell nálad — a szövegekben javítottam.
