### PR TITLE
Megjavítom az egész napos események importját

### DIFF
--- a/webapp/classes/externalcalendarimporter.php
+++ b/webapp/classes/externalcalendarimporter.php
@@ -551,9 +551,43 @@ class ExternalCalendarImporter {
     }
 
     /**
-     * Parse iCalendar datetime string with support for TZID parameter
+     * Szétválasztja egy iCalendar tulajdonság paramétereit az értékétől (RFC 5545 3.2).
+     *
+     * A hívók a `DTSTART`/`DTEND`/`EXDATE` sorok jobb oldalát adják át, ami bármennyi
+     * paramétert hordozhat, tetszőleges sorrendben:
+     *   TZID=Europe/Budapest:20221201T060000
+     *   VALUE=DATE:20260326
+     *   VALUE=DATE;TZID=Europe/Budapest:20260326
+     * A parser eddig csak a TZID-t ismerte fel, minden más paramétert az értékbe
+     * számolt bele — egyetlen egész napos esemény (`VALUE=DATE`) az egész naptár
+     * importját megbuktatta.
+     *
+     * Csak akkor eszik paramétert, ha a sor tényleg `NEV=` alakkal kezdődik, így a
+     * paraméter nélküli értékek (`20221201T060000`, `2026-12-23T23:59:00`) érintetlenek
+     * maradnak — utóbbiban a `:` az időhöz tartozik, nem elválasztó.
+     *
+     * @return array{0: array<string,string>, 1: string} [paraméterek nagybetűs kulccsal, érték]
+     */
+    private static function splitIcsParameters($raw) {
+        $params = [];
+        $rest = trim((string) $raw);
+
+        while (preg_match('/^([A-Za-z0-9-]+)=("[^"]*"|[^";:]*)([;:])(.*)$/s', $rest, $m)) {
+            $params[strtoupper($m[1])] = trim($m[2], '"');
+            $rest = $m[4];
+            if ($m[3] === ':') {
+                break;
+            }
+        }
+
+        return [$params, trim($rest)];
+    }
+
+    /**
+     * Parse iCalendar datetime string with support for property parameters
      * Handles formats like:
      * - TZID=Europe/Budapest:20221201T060000
+     * - VALUE=DATE:20260326
      * - 20221201T060000
      * - 20221201T060000Z
      * - YYYY-MM-DDTHH:MM:SS
@@ -561,17 +595,11 @@ class ExternalCalendarImporter {
      * Returns ISO 8601 datetime string in UTC (Y-m-d\TH:i:s format)
      */
     private static function parseIcsDateTime($dateStr) {
-        $dateStr = trim($dateStr);        
+        $dateStr = trim($dateStr);
 
-        $tzid = null;
-        $dtString = $dateStr;
-        
-        // Extract TZID parameter if present (e.g., TZID=Europe/Budapest:20221201T060000)
-        if (preg_match('/^TZID=([^:;]+):(.+)$/', $dateStr, $matches)) {
-            $tzid = $matches[1];
-            $dtString = $matches[2];
-        }
-        
+        [$params, $dtString] = self::splitIcsParameters($dateStr);
+        $tzid = $params['TZID'] ?? null;
+
         // Handle date-only format (YYYYMMDD)
         if (strlen($dtString) == 8 && ctype_digit($dtString)) {
             $year = substr($dtString, 0, 4);

--- a/webapp/tests/Integration/ExternalCalendarImporterTest.php
+++ b/webapp/tests/Integration/ExternalCalendarImporterTest.php
@@ -75,6 +75,64 @@ class ExternalCalendarImporterTest extends TestCase
         $this->assertSame(['hours' => 1, 'minutes' => 30], $mass->duration);
     }
 
+    /**
+     * Éles hiba: "Unable to parse datetime: VALUE=DATE:20260326". Az egész napos
+     * eseményekre a Google `DTSTART;VALUE=DATE:...`-ot ír, a parser viszont csak a
+     * TZID paramétert ismerte fel — egyetlen ilyen esemény az ADOTT TEMPLOM teljes
+     * importját megbuktatta, a cron pedig az egész futást hibásnak jelölte.
+     */
+    public function testAllDayEventsAreImportedInsteadOfBreakingTheWholeFeed(): void
+    {
+        $ics = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n"
+            . "UID:allday-1@example.test\r\n"
+            . "SUMMARY:Búcsú\r\n"
+            . "DTSTART;VALUE=DATE:20260326\r\n"
+            . "DTEND;VALUE=DATE:20260327\r\n"
+            . "END:VEVENT\r\nBEGIN:VEVENT\r\n"
+            . "UID:timed-1@example.test\r\n"
+            . "SUMMARY:Vasárnapi szentmise\r\n"
+            . "DTSTART;TZID=Europe/Budapest:20260329T100000\r\n"
+            . "DURATION:PT1H\r\n"
+            . "END:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        $created = ExternalCalendarImporter::replaceFromIcs($ics, 1);
+
+        $this->assertSame(2, $created);
+
+        $allDay = Eloquent\CalMass::where('church_id', 1)->where('title', 'Búcsú')->firstOrFail();
+        $this->assertSame('2026-03-26T00:00:00', $allDay->start_date);
+        $this->assertSame(['hours' => 24, 'minutes' => 0], $allDay->duration);
+
+        // A paraméterek sorrendje nem számíthat, és az időpontos esemény sem sérülhet.
+        $timed = Eloquent\CalMass::where('church_id', 1)->where('title', 'Vasárnapi szentmise')->firstOrFail();
+        $this->assertSame('2026-03-29T10:00:00', $timed->start_date);
+    }
+
+    /**
+     * Ugyanez a paraméterkezelés fordított sorrenddel és idézőjeles TZID-vel is álljon,
+     * és a paraméter nélküli értékeket ne bántsa (a `2026-12-23T23:59:00`-ban a `:`
+     * az időhöz tartozik, nem paraméter-elválasztó).
+     */
+    public function testPropertyParametersAreParsedRegardlessOfOrder(): void
+    {
+        $ics = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n"
+            . "UID:params-1@example.test\r\n"
+            . "SUMMARY:Esti szentmise\r\n"
+            . "DTSTART;VALUE=DATE-TIME;TZID=\"Europe/Budapest\":20260329T180000\r\n"
+            . "DURATION:PT1H\r\n"
+            . "RRULE:FREQ=WEEKLY;BYDAY=SU;UNTIL=20261223T235900Z\r\n"
+            . "END:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        ExternalCalendarImporter::replaceFromIcs($ics, 1);
+
+        $mass = Eloquent\CalMass::where('church_id', 1)
+            ->where('comment', ExternalCalendarImporter::IMPORT_MARKER)
+            ->firstOrFail();
+        $this->assertSame('2026-03-29T18:00:00', $mass->start_date);
+        $this->assertSame('2026-03-29T18:00:00', $mass->rrule['dtstart']);
+        $this->assertSame('2026-12-24T00:59:00', $mass->rrule['until']);
+    }
+
     public function testCronReportsFailedCalendarInsteadOfMarkingTheRunSuccessful(): void
     {
         $calendar = Eloquent\ExternalCalendar::create([


### PR DESCRIPTION
Nincs hozzá jegy: élesből küldött cron-hibaüzenet alapján.

## A hiba

A napi naptárimport minden érintett templomnál elszállt:

```
✗ Import failed for Church #281: Unable to parse datetime: VALUE=DATE:20260326
✗ Import failed for Church #4432: Unable to parse datetime: VALUE=DATE:20190617
✗ Import failed for Church #280: Unable to parse datetime: VALUE=DATE:20260717
✗ Import failed for Church #276: Unable to parse datetime: VALUE=DATE:20170924
✗ Import failed for Church #282: Unable to parse datetime: VALUE=DATE:20180722
```

## Miért

Az iCal-parser csak a `TZID` paramétert ismerte fel, minden más tulajdonság-paramétert (RFC 5545 3.2) beleszámolt az értékbe. A Google az egész napos eseményekre `DTSTART;VALUE=DATE:20260326`-ot ír — a Carbon ezen elhasal.

És mivel a `replaceFromIcs()` az első hibás eseménynél megszakítja a feed feldolgozását, **egyetlen egész napos bejegyzés az adott templom összes miséjét kivette az importból**. Öt templom naptára állt így.

## Mit tettem

Bevezetek egy paraméter-szétválasztót, ami tetszőleges sorrendű és számú paramétert lekezel (`VALUE=DATE`, `TZID`, idézőjeles érték, a kettő együtt), és a paraméter nélküli értékekhez nem nyúl — a `2026-12-23T23:59:00`-ban a `:` az időhöz tartozik, nem elválasztó.

Két teszt, amik a fenti éles hibaüzenetet reprodukálják; javítás nélkül mindkettő pirosan bukik.

## Amit érdemes tudni

Az egész napos események mostantól **00:00-s kezdéssel, a DTEND-ből számolt hosszal** (egy nap → 24 óra) kerülnek be. Ez a literális iCal-olvasat. Ha ezeket inkább ki akarjuk hagyni a miserendből — mert egy „Búcsú" nem 00:00-kor kezdődő mise —, az külön döntés, szóljatok és megcsinálom. Itt csak az importot állítom helyre, adat eldobása nélkül.
