### PR TITLE
Piros CI, ha a naptár forrása változik, a csomag nem

### DIFF
--- a/.github/workflows/calendar-bundle.yml
+++ b/.github/workflows/calendar-bundle.yml
@@ -1,0 +1,78 @@
+# A naptár lefordított csomagja (webapp/js/mcal/main-*.js) beversenyzett fájl, és a
+# hivatkozás kézzel kerül a templates/angularjs.twig-be. Emiatt a calendar/src módosítása
+# önmagában SEMMIT nem visz ki az oldalra — a #541 (heti nézet tömörítése) így állt
+# hónapokig mergelve, láthatatlanul.
+#
+# Ez nem hangos hiba: a régi csomag ugyanúgy betöltődik, csak az új funkció nincs benne.
+# Ezért kell CI-őr: ha a forrás változott, de a csomag nem, legyen piros.
+#
+# Ha egyszer a csomag megszűnik verziókövetett fájl lenni (l. #721), ez az ellenőrzés
+# magától kikapcsol — l. a "van-e egyáltalán beversenyzett csomag" lépést.
+name: Naptár csomag frissessége
+
+on:
+  pull_request:
+    paths:
+      - 'calendar/src/**'
+      - 'calendar/public/**'
+      - 'calendar/angular.json'
+      - 'calendar/package-lock.json'
+      - '.github/workflows/calendar-bundle.yml'
+
+jobs:
+  bundle-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Ellenőrzés
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # A csomag verziókövetett-e egyáltalán? Ha nem (mert a deploy építi), nincs mit őrizni.
+          if [ -z "$(git ls-files 'webapp/js/mcal/main-*.js')" ]; then
+            echo "A lefordított csomag nincs verziókövetve — az ellenőrzés tárgytalan."
+            exit 0
+          fi
+
+          MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          CHANGED="$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA")"
+
+          # A forrást nézzük, nem a `calendar/**` egészét: a package.json, a tesztek és a
+          # doksik módosítása nem változtatja meg a csomagot.
+          SOURCE_CHANGED="$(printf '%s\n' "$CHANGED" \
+            | grep -E '^calendar/(src/|public/|angular\.json$|package-lock\.json$)' \
+            | grep -vE '\.spec\.ts$' || true)"
+
+          if [ -z "$SOURCE_CHANGED" ]; then
+            echo "A naptár forrása nem változott (csak teszt/konfig) — nincs teendő."
+            exit 0
+          fi
+
+          BUNDLE_CHANGED="$(printf '%s\n' "$CHANGED" \
+            | grep -E '^webapp/(js/mcal/|css/styles-.*\.css$|i18n/|cal_images/|mass-definitions\.json$)|^webapp/templates/angularjs\.twig$' || true)"
+
+          if [ -n "$BUNDLE_CHANGED" ]; then
+            echo "A naptár forrása és a kiszállított csomag is változott — rendben."
+            printf '%s\n' "$BUNDLE_CHANGED" | sed 's/^/  /'
+            exit 0
+          fi
+
+          echo "::error::A calendar/src módosult, de a lefordított csomag nem — így a változás NEM jut ki az oldalra."
+          echo
+          echo "Változott források:"
+          printf '%s\n' "$SOURCE_CHANGED" | sed 's/^/  /'
+          echo
+          echo "Tedd hozzá a csomagot is:"
+          echo "  cd calendar && npm ci"
+          echo "  npx ng build --configuration=production"
+          echo "  python3 ../docker/miserend/calendar_deploy.py dist/mcal/browser ../webapp"
+          echo "  git add ../webapp/js/mcal ../webapp/css ../webapp/i18n ../webapp/cal_images \\"
+          echo "          ../webapp/mass-definitions.json ../webapp/templates/angularjs.twig ../webapp/templates/layout.twig"
+          exit 1


### PR DESCRIPTION
Nincs hozzá jegy: a #716 alatt ígért CI-ellenőrzés.

Ezt ígértem a #716 alatt. Külön PR, hogy a kettő ne csússzon össze.

## Miért

A lefordított csomag (`webapp/js/mcal/main-*.js`) beversenyzett fájl, a hivatkozás pedig kézzel kerül a `templates/angularjs.twig`-be. Emiatt a `calendar/src` módosítása önmagában **semmit nem visz ki az oldalra**.

És ez nem hangos hiba: a régi csomag ugyanúgy betöltődik, csak az új funkció nincs benne. A #541 (heti nézet tömörítése) így állt hónapokig mergelve, láthatatlanul. Az `ng-test` ezt nem foghatta meg — az csak Karma tesztet futtat.

## Mit csinál

Ha a PR-ben változott a naptár forrása (`calendar/src`, `public`, `angular.json`, `package-lock.json`), de nem változott a kiszállított csomag (`webapp/js/mcal`, `css/styles-*.css`, `i18n`, `cal_images`, `mass-definitions.json`, `angularjs.twig`), a futás piros, és kiírja a build-parancsokat.

Tesztfájlra (`*.spec.ts`) és `package.json`-ra szándékosan nem szól: azok nem változtatják meg a csomagot.

## Visszamérve a valódi történeten

| PR | mit tartalmazott | az őr |
|---|---|---|
| #541 (a kiváltó ok) | csak forrás | **piros** |
| #690 | forrás + csomag | zöld |
| #716 | csak csomag | zöld |

## Ha a #721 landol

A #721-ben azt javaslom, hogy a csomag ne legyen többé verziókövetett fájl, hanem a deploy építse. Ha az landol, ez az ellenőrzés **magától kikapcsol** (első lépésként megnézi, van-e egyáltalán verziókövetett `main-*.js`), tehát a kettő nem üti egymást, és nem kell külön visszavonni.
