### PR TITLE
Az image tartalmát szolgáljuk ki élesben, nem a hoszt checkoutját (#721, #720)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,6 +17,19 @@ Ez a fő Compose fájl, amely a legfontosabb szolgáltatásokat írja le:
 
 A szolgáltatások egy belső hálózaton kommunikálnak egymással. Ez a fájl az alapértelmezett, ha a teljes rendszert szeretnéd futtatni (pl. helyi teszteléshez vagy éles környezethez).
 
+### A `miserend` service tartalma futásidőben (#721, #720)
+
+Ez a fájl **nem** mountolja fölé a hoszt `webapp` könyvtárát: amit a konténer kiszolgál, az az image tartalma. Így a Dockerfile-ban lefutó `ng build --configuration=${NG_CONFIG}` és a `calendar_deploy.py` eredménye tényleg kimegy, és a `composer install` / `npm ci` friss függőségei is.
+
+Korábban ez nem így volt, és két hibát okozott:
+
+- a naptár minden környezetben a **beversenyzett, régi** `webapp/js/mcal/main-*.js`-t szolgálta ki, hiába épült friss az image-ben (#721);
+- a `vendor_data` / `node_modules_data` named volume csak az **első** létrehozáskor kapja meg az image tartalmát, a production deploy pedig `up -d`-t hív `down -v` nélkül — így új függőség (pl. a leaflet) sosem jutott ki (#720).
+
+Ami marad a hoszton: **`webapp/kepek`** (a feltöltött képek futásidőben keletkeznek, és a `.dockerignore` ki is hagyja őket az image-ből), valamint a `tmp` és `sqlite` named volume.
+
+**Következmény üzemeltetőnek:** a szerveren a `webapp/` alatti kézi fájlmódosítás többé nem érvényesül. A beállítás az `.env`-ből jön — a `config.php` minden értéke `env()`-en át olvas. Ha valamit tényleg felül kell írni, az `.env` a helye, nem a fájl.
+
 ## compose.kibana.yml – Kibana (opcionális)
 Ez a fájl egy opcionális Kibana szolgáltatást ad a stack-hez:
 

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -22,6 +22,10 @@ services:
     build:
       context: ..
       dockerfile: docker/miserend/Dockerfile
+      args:
+        # A Dockerfile alapértéke `production`, ami a naptárnak a
+        # https://miserend.hu/calendar/ apiUrl-t égeti be. Helyben a localProd kell.
+        NG_CONFIG: localProd
     depends_on:
       npm-init:
         condition: service_completed_successfully
@@ -29,6 +33,8 @@ services:
       - SMTP_HOST=mailcatcher
       - SMTP_PORT=1025
       - MISEREND_WEBAPP_ENVIRONMENT=development
+    # #721: a forrás-mount és a függőség-volume-ok CSAK fejlesztéshez kellenek (szerkesztek
+    # egy PHP fájlt, és azonnal látszik). Élesben pont ez takarta el az image tartalmát.
     volumes:
       - ../webapp:/miserend/webapp
       - vendor_data:/miserend/webapp/vendor

--- a/docker/compose.staging.yml
+++ b/docker/compose.staging.yml
@@ -2,9 +2,13 @@
 #   docker compose --env-file .env.staging -f docker/compose.yml -f docker/compose.staging.yml ...
 #
 # Miért nem a compose.dev.yml: az a host `../webapp`-ját mountolja a konténer kódja FÖLÉ,
-# így a hostion kellene `npm build`-elni a naptárt (borazslo által jelzett gubanc). Itt a
+# így a hoszton kellene `npm build`-elni a naptárt (borazslo által jelzett gubanc). Itt a
 # staging a MEGÉPÍTETT image-et futtatja (a Dockerfile multi-stage buildje a calendar-t is
 # legyártja), ezért nincs host-oldali build és nincs git-pull-ütközés.
+#
+# #721: ez a komment sokáig téves volt — a bind mount valójában a compose.yml-ben volt,
+# tehát a staging is örökölte, és ugyanúgy a beversenyzett csomagot szolgálta ki. A mount
+# azóta átkerült a compose.dev.yml-be, így a fenti állítás mostantól igaz is.
 #
 # Az env `staging` (nem `production`) → a layout.twig kiteszi a
 # <meta name="robots" content="noindex,nofollow"> tag-et (#547).

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -88,10 +88,22 @@ services:
       start_period: 40s
   miserend:
     image: ${MISEREND_IMAGE:-localhost/miserend:latest}
+    # #721/#720: itt NINCS `../webapp:/miserend/webapp` bind mount. Korábban volt, és
+    # eltakarta az image tartalmát: a Dockerfile hiába futtatta le az `ng build`-et a
+    # megfelelő NG_CONFIG-gal (és a calendar_deploy.py-t), futásidőben a hoszt git-
+    # checkoutja került a helyére. Így minden környezet a beversenyzett, régi naptár-
+    # csomagot szolgálta ki. Ugyanezért ragadt be a `vendor_data`/`node_modules_data`:
+    # a named volume csak az ELSŐ létrehozáskor kapja meg az image tartalmát, a
+    # production deploy pedig `up -d`-t hív `down -v` nélkül — így egy új composer/npm
+    # függőség (pl. a leaflet) soha nem jutott ki élesbe.
+    #
+    # A fejlesztői mountok a compose.dev.yml-be kerültek. Következmény: a szerveren
+    # a `webapp/` alatti kézi fájlmódosítás többé NEM érvényesül — a beállítás az
+    # `.env`-ből jön (a config.php minden értéke env()-en át olvas).
     volumes:
-       - ../webapp:/miserend/webapp
-       - vendor_data:/miserend/webapp/vendor
-       - node_modules_data:/miserend/webapp/node_modules    
+       # A feltöltött képek futásidőben keletkeznek és a hoszton élnek (a .dockerignore
+       # ki is hagyja őket az image-ből), ezért ez az egy könyvtár marad bind mount.
+       - ../webapp/kepek:/miserend/webapp/kepek
        - tmp:/miserend/webapp/fajlok/tmp
        - sqlite:/miserend/webapp/fajlok/sqlite
        - ./miserend/apache/ports.conf:/etc/apache2/ports.conf


### PR DESCRIPTION
Closes #721
Closes #720

Egy PR, mert egyetlen sor okozza mindkettőt.

## A gyökér

`docker/compose.yml` a `miserend` service-en:

```yaml
- ../webapp:/miserend/webapp
```

Ez **minden környezetben** ott volt (nem csak devben, ahogy a `compose.staging.yml` kommentje hitte), és a konténer kódja fölé mountolta a hoszt git-checkoutját. Ezért:

**#721** — a Dockerfile hiába futtatta le az `ng build --configuration=${NG_CONFIG}`-ot és a `calendar_deploy.py`-t: futásidőben a beversenyzett, régi `webapp/js/mcal/main-*.js` került a helyére. A `--build-arg NG_CONFIG=production` munkája sosem látszott.

**#720** — a `vendor_data` / `node_modules_data` named volume csak az **első** létrehozáskor kapja meg az image tartalmát. A production deploy `up -d`-t hív `down -v` nélkül, tehát a volume örökre az első deploy állapotában ragadt — innen a hiányzó leaflet. (A stagingen `down -v` fut, ezért ott nem látszott.)

## Mit tettem

A forrás-mountot és a két függőség-volume-ot áttettem a `compose.dev.yml`-be, ahol tényleg kell. Élesben a konténer az image tartalmát szolgálja ki.

A hoszton **`webapp/kepek`** marad bind mountként: a feltöltött képek futásidőben keletkeznek és a hoszton élnek, a `.dockerignore` ki is hagyja őket az image-ből. Enélkül a meglévő képek eltűnnének, az újak pedig minden `up -d`-nél elvesznének.

Mellékesen: a dev image mostantól `localProd` konfigurációval épül. Eddig a Dockerfile `production` alapértéke ment, ami a naptárba a `https://miserend.hu/calendar/` apiUrl-t égette — devben ez eddig azért nem fájt, mert a bind mount úgyis eltakarta.

## Amit leellenőriztem

Éles-szerű stacket húztam fel (`compose.yml` önmagában, `--build-arg NG_CONFIG=production`):

| | eredmény |
|---|---|
| kiszolgált csomag | `main-VPLSEGWD.js` (frissen épült), **nem** a beversenyzett `main-W5BRT6OR.js` |
| `Content-Type` | `text/javascript`, 1 864 890 bájt |
| apiUrl a csomagban | `https://miserend.hu/calendar/` |
| a templomoldal hivatkozása | a friss fájlnévre |
| leaflet a `node_modules`-ban | megvan |
| `webapp/kepek/templomok` | létezik, `www-data` írja |
| `fajlok/tmp`, `fajlok/sqlite` | írható |
| `fajlok/git_hash` | az image-ben (a deploy a build ELŐTT írja) |

Mellékes megerősítés: a régi fájlnév (`main-W5BRT6OR.js`) most **HTTP 200-at ad `text/html`-lel** — pontosan ez a néma hibamód, amiről a #716-ban írtam.

## ⚠️ Üzemeltetői következmény — ezt fontos

**A szerveren a `webapp/` alatti kézi fájlmódosítás többé nem érvényesül.** Ez borazslo javaslatának a „leghelyesebb" ága: staging és production környezetben ne nyúlkáljunk a fájlokhoz.

A `config.php` ezt már ma is támogatja — minden értéke `env()`-en át olvas (DB, SMTP, OSM, Overpass, MapQuest). Tehát ami eddig fájlmódosítás volt, az mostantól `.env` sor.

Ha van jelenleg kézzel módosított fájl a szerveren a `webapp/` alatt, azt **merge előtt** nézzétek meg — bár a `deploy-production.yml` `git pull`-ja piszkos munkakönyvtárnál amúgy is megállna, tehát valószínűleg nincs ilyen.

Az első deploy után a régi `*_vendor_data` és `*_node_modules_data` volume-ok használatlanul ott maradnak; nem zavarnak, de nyugodtan törölhetők.
