### PR TITLE
Egyszerre csak egy cron-munka fusson

### DIFF
--- a/webapp/classes/html/cron.php
+++ b/webapp/classes/html/cron.php
@@ -32,6 +32,54 @@ class Cron extends Html {
             return;
         }
 
+        // Az updateMasses fél óráig is futhat (500 ezer liturgikus esemény), a hoszt
+        // crontabja viszont 5 percenként kopogtat. Zár nélkül tehát 6-8 futás indult
+        // egymásra: mindegyik megnövelte az attempts-et, egyik sem ért véget, és 10
+        // fölött a scopeNextJobs 12 órára kizárta a munkát. A konténerbeli cron-loop
+        // sorosan fut, ezért ott ez nem látszott — élesben viszont a hosztról ütemezünk.
+        //
+        // Az adatbázis-szintű zár azért jó ide, mert a hoszt-cron, a konténer-loop és a
+        // böngészőből indított kézi futás mind ugyanahhoz a MySQL-hez megy, és a zár a
+        // kapcsolat megszakadásakor magától elenged (nincs beragadó lockfile).
+        if (!self::acquireLock()) {
+            echo "Már fut egy cron-munka, ezt a kört kihagyom.<br>\n";
+            return;
+        }
+
+        try {
+            $this->run();
+        } finally {
+            self::releaseLock();
+        }
+    }
+
+    private const LOCK_NAME = 'miserend_cron';
+
+    private static function acquireLock(): bool {
+        try {
+            $row = \Illuminate\Database\Capsule\Manager::selectOne(
+                'SELECT GET_LOCK(?, 0) AS acquired', [self::LOCK_NAME]
+            );
+        } catch (\Throwable $e) {
+            // Ha a zár nem kérhető, inkább fussunk le, mint hogy a cron néma legyen.
+            error_log('[cron] a zár nem kérhető: ' . $e->getMessage());
+            return true;
+        }
+
+        return (int) ($row->acquired ?? 0) === 1;
+    }
+
+    private static function releaseLock(): void {
+        try {
+            \Illuminate\Database\Capsule\Manager::selectOne(
+                'SELECT RELEASE_LOCK(?)', [self::LOCK_NAME]
+            );
+        } catch (\Throwable $e) {
+            error_log('[cron] a zár elengedése nem sikerült: ' . $e->getMessage());
+        }
+    }
+
+    private function run(): void {
         if($jobId = \Request::Integer('cron_id')) {
             $nextjob = \Eloquent\Cron::find($jobId);
 			if (!$nextjob) return;

--- a/webapp/tests/Integration/CronOverlapTest.php
+++ b/webapp/tests/Integration/CronOverlapTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Az élesen látott tünet: a `\ExternalApi\ElasticsearchApi->updateMasses()` sora
+ * attempts = 10-en állt, miközben egy nappal korábban még sikeresen lefutott.
+ *
+ * Az ok nem hiba, hanem átfedés: az updateMasses fél óráig is futhat (500 ezer+
+ * liturgikus esemény; helyben, 5051 templommal 15 perc volt), a hoszt crontabja
+ * viszont 5 percenként kopogtat. Minden kopogás megnövelte az attempts-et és
+ * elindított egy újabb futást a még dolgozó mellé; 10 fölött pedig a scopeNextJobs
+ * 12 órára kizárta a munkát.
+ *
+ * A konténerbeli cron-loop.sh sorosan fut, ezért ott ez sosem látszott.
+ */
+class CronOverlapTest extends TestCase {
+
+    /** Külön kapcsolat, hogy a zárat tényleg MÁSIK futásként tartsuk. */
+    private static function masikKapcsolat(): \Illuminate\Database\Connection {
+        global $config;
+        $c = $config['connection'];
+        $capsule = new \Illuminate\Database\Capsule\Manager();
+        $capsule->addConnection([
+            'driver' => 'mysql',
+            'host' => $c['host'],
+            'database' => $c['database'],
+            'username' => $c['user'],
+            'password' => $c['password'],
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+        ], 'masik');
+
+        return $capsule->getConnection('masik');
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::connection()->beginTransaction();
+        // Biztonsági háló: ha az őr egyszer kikerülne a kódból, ez a teszt akkor se
+        // indítson el egy valódi, félórás újraindexelést — csak bukjon el.
+        DB::table('crons')->update(['deadline_at' => date('Y-m-d H:i:s', strtotime('+1 day'))]);
+    }
+
+    protected function tearDown(): void {
+        DB::connection()->rollBack();
+        parent::tearDown();
+    }
+
+    public function testRunningJobIsNotStartedAgainByTheNextTick(): void {
+        $masik = self::masikKapcsolat();
+
+        // Egy "épp futó" cron a másik kapcsolaton.
+        $fogott = $masik->selectOne('SELECT GET_LOCK(?, 0) AS acquired', ['miserend_cron']);
+        $this->assertSame(1, (int) $fogott->acquired, 'A tesztzárat nem sikerült megszerezni.');
+
+        try {
+            $job = \Eloquent\Cron::where('function', 'updateMasses')->firstOrFail();
+            $elotte = (int) $job->attempts;
+
+            // Most kopog a következő kör.
+            ob_start();
+            new \Html\Cron();
+            $kimenet = ob_get_clean();
+
+            $this->assertStringContainsString('Már fut egy cron-munka', $kimenet);
+
+            // A lényeg: a párhuzamos kopogás nem égeti el az attempts-et.
+            $job->refresh();
+            $this->assertSame($elotte, (int) $job->attempts);
+        } finally {
+            $masik->selectOne('SELECT RELEASE_LOCK(?)', ['miserend_cron']);
+            $masik->disconnect();
+        }
+    }
+
+    /** Ha senki nem tartja a zárat, a cron a szokásos módon dolgozik. */
+    public function testFreeLockLetsTheCronRun(): void {
+        $masik = self::masikKapcsolat();
+        try {
+            $szabad = $masik->selectOne('SELECT IS_FREE_LOCK(?) AS free', ['miserend_cron']);
+            $this->assertSame(1, (int) $szabad->free, 'A zár nem szabadult fel egy korábbi futás után.');
+        } finally {
+            $masik->disconnect();
+        }
+    }
+}


### PR DESCRIPTION
A „40 `\ExternalApi\ElasticsearchApi::updateMasses()` 1 day … attempts 10 … ez egyáltalán nem fut? vagy csak lassú?"* Ez volt az alapkérdésem.

## Mit találtam: lassú, és emiatt torlódik

Lemértem helyben. **15 perc 6,77 másodperc** — 5051 templommal és 1,39 millió indexelt eseménnyel. Élesen több az adat, tehát a README-ben szereplő „eltarthat fél óráig is" reális.

Mellette:

- élesben a `CRON_ENABLED` alapból `0`, tehát a **hoszt crontabja** ütemez, **5 percenként**;
- a `Html\Cron` **először megnöveli az `attempts`-et, aztán indítja a munkát**;
- a `renewDeadline()` csak sikerre fut, tehát a még dolgozó munka végig „esedékes" marad;
- így minden kopogás elindít egy újabb `updateMasses`-t a még futó mellé. Fél óra alatt ez 6-8 párhuzamos futás, az `attempts` pedig 10-re szalad;
- 10 fölött a `scopeNextJobs` (`attempts < 10`) **12 órára kizárja** a munkát.

Ezért látszik a sor `attempts = 10`-en úgy, hogy közben egy nappal korábban még sikeresen lefutott. Nem elakadt — torlódott.

A konténerbeli `cron-loop.sh` **sorosan** fut, ezért ott ez sosem jelentkezett. Élesben viszont a hosztról ütemezünk.

## Mit tettem

Adatbázis-szintű zár (`GET_LOCK`) a futás köré. Ha egy munka még dolgozik, a következő kopogás kiírja, hogy kihagyja, és **nem növeli az `attempts`-et**.

Miért DB-zár és nem lockfile: a hoszt-cron, a konténer-loop és a böngészőből indított kézi futás mind ugyanahhoz a MySQL-hez megy, és a zár a kapcsolat megszakadásakor magától elenged — nem tud beragadni egy elhalt futás után.

A kézi (`?q=cron&cron_id=N`) futás is a zár alá kerül. Ez szándékos: eddig egy kézzel indított újraindexelés simán ráindulhatott a cronéra.

## Tesztek

Új `CronOverlapTest`, ami **külön DB-kapcsolaton** tartja a zárat, tehát tényleg másik futást szimulál. Az őr nélkül pirosan bukik.

A teszt biztonsági hálót is kapott: minden cron határidejét a jövőbe tolja, így ha az őr egyszer kikerülne a kódból, a teszt akkor sem indít el egy valódi, félórás újraindexelést — csak elbukik.

## Ami ettől még nyitva marad

Az `updateMasses` **magától lassú**. A #306/#627 őre már kihagyja a felesleges teljes újragenerálást, de amikor tényleg kell, az fél óra. Ha zavaró, azt külön jegyben érdemes nézni (pl. évenkénti bontás, vagy csak a változott templomok). Ez a PR csak azt intézi el, hogy közben ne torlódjon önmagára.

Élesben a merge után érdemes egyszer nullázni a beragadt számlálót:
`UPDATE crons SET attempts = 0 WHERE function = 'updateMasses';`
