### PR TITLE
Láthatóvá teszem az éles hibákat (#725)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,10 @@ cd webapp && composer install
 docker exec -it miserend bash
 docker exec miserend php index.php q=health
 docker exec -it mysql mysql -u root -p miserend
+docker logs miserend-miserend-1 2>&1 | grep '\[miserend\]'   # alkalmazás-hibák stack trace-szel
 ```
+
+Logolás: nincs külön logfájl, minden a `docker logs`-ban van — részletek: `docs/logok.md`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ De szinte biztos, hogy a végén valami extra masszírozás kell.
 docker exec -it [mysql|mailcatcher|miserend] bash
 ```
 
+### 🪵 Logok
+
+Nincs külön logfájl, minden a `docker logs`-ban van. Az alkalmazás hibái `[miserend]` előtaggal mennek ki, stack trace-szel:
+
+```sh
+docker logs miserend-miserend-1 2>&1 | grep '\[miserend\]'
+```
+
+Részletek, éles példák és további szűrők: [docs/logok.md](docs/logok.md).
+
 ### 📦 Composer használata (interaktív módban):
 
 ```sh

--- a/docs/logok.md
+++ b/docs/logok.md
@@ -1,0 +1,84 @@
+# Hol vannak a logok?
+
+Rövid válasz: **minden a `docker logs`-ban van**, az alkalmazás nem ír külön logfájlt.
+
+A `php:8.4-apache` image az Apache naplóit a konténer kimenetére szimlinkeli:
+
+| fájl a konténerben | hova megy |
+|---|---|
+| `/var/log/apache2/access.log` | stdout |
+| `/var/log/apache2/error.log` | stderr |
+
+A PHP-nek nincs saját `error_log` beállítása, ezért az is az Apache error logjába, vagyis a stderr-re megy. A `docker logs` mindkettőt mutatja.
+
+## A leggyakoribb parancsok
+
+```bash
+# Élesben (a konténer neve környezetenként más, ellenőrizd: docker ps)
+docker logs -f miserend-prod-miserend-1
+
+# Csak az alkalmazás hibái, az access-log zaja nélkül
+docker logs miserend-prod-miserend-1 2>&1 | grep '\[miserend\]'
+
+# Az utolsó óra
+docker logs --since 1h miserend-prod-miserend-1 2>&1 | grep '\[miserend\]'
+
+# Egy konkrét oldal hibái
+docker logs miserend-prod-miserend-1 2>&1 | grep 'URI: /templom/5444/edit'
+
+# Élő követés, amíg reprodukálod a hibát egy másik ablakban
+docker logs -f --tail 0 miserend-prod-miserend-1 2>&1 | grep '\[miserend\]'
+
+# Az 500-as válaszok az access-logból
+docker logs miserend-prod-miserend-1 2>&1 | grep '" 500 '
+
+# Cron-futások
+docker logs miserend-prod-miserend-1 2>&1 | grep '\[cron\]'
+```
+
+Helyben ugyanez, csak `miserend-miserend-1` néven.
+
+## Hogyan néz ki egy alkalmazás-hiba
+
+Minden alkalmazás-hiba `[miserend]` előtaggal megy ki, két sorban — a második a stack trace:
+
+```
+[miserend] Render failed: TypeError: Cannot access offset of type string @ /miserend/webapp/classes/eloquent/church.php:1355 | URI: /templom/5444/edit
+[miserend] trace: #0 /miserend/webapp/index.php(61): Html\Church\Edit->render() …
+```
+
+Az előtag utáni szó a hiba helyét jelzi:
+
+| előtag | mikor |
+|---|---|
+| `Unhandled exception` | az oldal felépítése közben |
+| `Render failed` | a Twig-renderelés közben (a lusta Eloquent-accessorok itt futnak) |
+| `Uncaught` | bárhol máshol, elkapatlanul |
+| `Fatal error` | memória- vagy időtúllépés, parse error — ezek nem dobnak kivételt |
+
+## Amit tudni érdemes (#725)
+
+Ez a naplózás **2026 augusztusa előtt nem működött**. Három dolog volt együtt:
+
+1. Élesben `error_reporting(0)` futott (`config.php` `default` ág, amit a `production` örököl). Ez nem csak a kijelzést kapcsolja ki, hanem a **naplózást is** — a PHP saját `Fatal error: Uncaught …` üzenete sehova nem került ki.
+2. Az `index.php` csak `\Exception`-t fogott. A PHP 8-as `\Error` és `TypeError` nem `\Exception`, tehát átment rajta.
+3. A `render()` a `try`/`catch`-en kívül volt — márpedig a Twig-sablonok a lusta Eloquent-accessorokat (`church.location`, `church.holders`) csak ott hívják meg.
+
+Együtt ez azt jelentette, hogy egy hibás oldalról **pontosan annyi látszott, amennyit a jegy panaszolt**:
+
+```
+"GET /templom/5446/edit HTTP/1.1" 500 236
+```
+
+…és semmi több. Mindhármat javítottuk.
+
+## Mit NEM naplózunk
+
+A warning és a notice szint élesben szándékosan kimarad (`error_reporting` maszk), hogy a napló ne fulladjon zajba. Ha egy hibakereséshez kellenek, `.env`-ben át lehet állítani a környezetet `staging`-re, vagy ideiglenesen bővíteni a maszkot a `config.php`-ban.
+
+A napló **nem tartós**: alapértelmezett `json-file` driverrel megy, és `docker compose down` után elvész. Ha egy ritka hibát kell elkapni, érdemes a fenti `docker logs -f … | grep` sort egy fájlba irányítani.
+
+## Kapcsolódó
+
+- [`/health`](https://miserend.hu/index.php?q=health) — cron-elakadások, ES-index frissesség, séma-eltérések (belépés kell hozzá)
+- `docs/outgoing-connections.md` — kimenő hálózati kapcsolatok

--- a/webapp/config.php
+++ b/webapp/config.php
@@ -49,7 +49,14 @@ $environment['default'] = [
         'debugger' => 'eleklaszlosj@gmail.com'
     ],
     'debug' => 0,
-    'error_reporting' => false
+    // #725: eddig `false` volt, amiből a load.php `error_reporting(0)`-t csinált — és az
+    // nem csak a kijelzést, a NAPLÓZÁST is elnémítja. Élesben (a `production` ág ezt az
+    // alapértéket örökli) ezért egyetlen fatal errorról sem maradt nyom: a `docker logs`
+    // csak az access-log 500-as sorát mutatta, hibaüzenetet nem.
+    //
+    // A látogató ettől semmit nem lát: a php.ini-ben `display_errors = Off`. A warning és
+    // notice szint szándékosan marad kint, hogy a napló ne fulladjon zajba.
+    'error_reporting' => E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR
 ];
 
 $environment['testing'] = [

--- a/webapp/functions.php
+++ b/webapp/functions.php
@@ -277,3 +277,81 @@ function overrideArray(&$orig, $new) {
         }
     }
 }
+
+/**
+ * #725: egységes hibanaplózás, stack trace-szel.
+ *
+ * A jegy kiindulópontja az volt, hogy a /templom/5444/edit 500-at ad, a
+ * `docker logs` viszont csak az access-log sorát mutatja, hibaüzenetet nem. Ennek
+ * három oka volt együtt:
+ *
+ *  1. élesben `error_reporting(0)` futott (config.php `default`), ami nem csak a
+ *     kijelzést, a NAPLÓZÁST is kikapcsolja — a PHP saját "Fatal error: Uncaught …"
+ *     üzenete sehova nem került ki;
+ *  2. az index.php csak `\Exception`-t fogott, a PHP 8-as `\Error`/`TypeError` nem az;
+ *  3. a `render()` a try/catch-en kívül volt.
+ *
+ * Az `error_log()` hívást az `error_reporting` maszk NEM szűri, ezért ez akkor is
+ * megbízhatóan ír, ha a maszk szűk. A cél a `docker logs` — a php:8.4-apache image
+ * az Apache error logját a stderr-re szimlinkeli.
+ */
+function logThrowable(string $context, \Throwable $e): void {
+    $uri = $_SERVER['REQUEST_URI'] ?? (PHP_SAPI === 'cli' ? 'cli' : '?');
+    error_log(sprintf(
+        '[miserend] %s: %s: %s @ %s:%d | URI: %s',
+        $context, get_class($e), $e->getMessage(), $e->getFile(), $e->getLine(), $uri
+    ));
+    // A trace külön sorban: a stack nélkül egy Twig-hiba üzenete önmagában
+    // ("An exception has been thrown during the rendering of a template") használhatatlan.
+    error_log('[miserend] trace: ' . $e->getTraceAsString());
+
+    if ($previous = $e->getPrevious()) {
+        error_log(sprintf('[miserend] %s (previous): %s: %s @ %s:%d',
+            $context, get_class($previous), $previous->getMessage(),
+            $previous->getFile(), $previous->getLine()));
+    }
+}
+
+/**
+ * #725: a hibaoldal összeállítása. Két helyről kell (oldal-építés és renderelés),
+ * ezért került külön.
+ */
+function buildExceptionPage(\Throwable $e, bool $showDetails, $arguments = false): \Html\Html {
+    $html = new \Html\Html($arguments);
+    $html->template = 'Exception.twig';
+    $html->errorTrace = '';
+
+    if ($showDetails) {
+        $html->errorMessage = $e->getMessage();
+        foreach ($e->getTrace() as $trace) {
+            if (isset($trace['class'])) {
+                $html->errorTrace .= $trace['class'] . "::" . $trace['function'] . "()";
+            }
+            if (isset($trace['file'])) {
+                $html->errorTrace .= $trace['file'] . ":" . $trace['line'] . " -> " . $trace['function'] . "()";
+            }
+            $html->errorTrace .= "<br>";
+        }
+    } else {
+        $html->errorMessage = 'Váratlan hiba történt. Kérjük, próbáld újra később.';
+    }
+
+    return $html;
+}
+
+/**
+ * #725: a végzetes hibák (memória, max_execution_time, parse error) nem dobnak
+ * kivételt, tehát semmilyen catch nem fogja meg őket — csak a shutdown handler.
+ * Éppen ezek adják a néma 500-akat.
+ */
+function registerFatalErrorLogger(): void {
+    register_shutdown_function(static function (): void {
+        $error = error_get_last();
+        if ($error === null || !in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR], true)) {
+            return;
+        }
+        $uri = $_SERVER['REQUEST_URI'] ?? (PHP_SAPI === 'cli' ? 'cli' : '?');
+        error_log(sprintf('[miserend] Fatal error: %s @ %s:%d | URI: %s',
+            $error['message'], $error['file'], $error['line'], $uri));
+    });
+}

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -33,44 +33,38 @@ try {
     } else {
         $html = new $class($path->arguments);
     }
-} catch (\Exception $e) {
+} catch (\Throwable $e) {
     // #182: a nyers hibaüzenet (QueryException esetén a TELJES SQL) és a stack
     // trace eddig környezet-ellenőrzés NÉLKÜL kiment a frontendre — pl. egy emoji
     // beküldésekor a "SQLSTATE... Incorrect string value ... insert into `remarks`
     // ..." + fájlútvonalak/sorszámok. Csak debug módban (dev/testing/staging)
     // mutatjuk a részleteket; prod-ban ($config['debug']=0) generikus üzenet.
     // A részletek MINDIG a szerver-logba kerülnek, hogy debug=0 mellett se vesszenek el.
+    //
+    // #725: \Throwable, nem \Exception. A TypeError/Error a PHP 8-ban NEM \Exception,
+    // ezért az eddig átment ezen az ágon: 500 lett belőle, napló nélkül.
     $showDetails = !empty($config['debug']);
-    error_log('[miserend] Unhandled exception: ' . $e->getMessage()
-        . ' @ ' . $e->getFile() . ':' . $e->getLine());
+    logThrowable('Unhandled exception', $e);
 
     if (isset($html)) {
         addMessage($showDetails ? $e->getMessage() : 'Váratlan hiba történt. Kérjük, próbáld újra később.', 'danger');
     } else {
-
 		// Mi lenne, ha a hibaüzenetünket szeben írnánk ki?
-		$html = new \Html\Html($path->arguments);
-
-		$html->template = 'Exception.twig';
-		$html->errorTrace = '';
-
-        if ($showDetails) {
-            $html->errorMessage = $e->getMessage();
-            foreach ($e->getTrace() as $trace) {
-                if (isset($trace['class']))
-                    $html->errorTrace .= $trace['class'] . "::" . $trace['function'] . "()";
-                if (isset($trace['file']))
-                    $html->errorTrace .= $trace['file'] . ":" . $trace['line'] . " -> " . $trace['function'] . "()";
-                $html->errorTrace .= "<br>";
-            }
-        } else {
-            $html->errorMessage = 'Váratlan hiba történt. Kérjük, próbáld újra később.';
-        }
+		$html = buildExceptionPage($e, $showDetails, $path->arguments ?? false);
     }
 }
 if (isset($html)) {
-    $html->render();
-    if (trim($html->html) != '') {  
+    // #725: a renderelés eddig védtelen volt. Márpedig a Twig-sablonok a lusta Eloquent-
+    // accessorokat (church.location, church.holders, …) csak itt hívják meg — ha ott szállt
+    // el valami, abból 500 lett, a hibáról pedig SEMMI nem került a naplóba.
+    try {
+        $html->render();
+    } catch (\Throwable $e) {
+        logThrowable('Render failed', $e);
+        $html = buildExceptionPage($e, !empty($config['debug']), $path->arguments ?? false);
+        $html->render();
+    }
+    if (trim($html->html) != '') {
 		//Az API esetén a CORS policy megengedő kell legyen.
 		if(isset($html->api)) {			
 			header("Access-Control-Allow-Origin: *");

--- a/webapp/load.php
+++ b/webapp/load.php
@@ -30,6 +30,14 @@ if ($env !== 'production' && PHP_SAPI !== 'cli' && !headers_sent()) {
 }
 
 error_reporting($config['error_reporting'] ? $config['error_reporting'] : 0);
+
+// #725: a végzetes hibák és az elkapatlan kivételek naplózása. A php.ini-ben
+// `display_errors = Off`, tehát a látogató ettől semmit nem lát többet — csak a
+// `docker logs` lesz használható. Enélkül egy 500-as oldalról semmi nyom nem maradt.
+registerFatalErrorLogger();
+set_exception_handler(static function (\Throwable $e): void {
+    logThrowable('Uncaught', $e);
+});
 define('DOMAIN', $config['path']['domain']);
 
 Translator::init('hu'); // vagy autodetect

--- a/webapp/tests/Unit/ErrorLoggingTest.php
+++ b/webapp/tests/Unit/ErrorLoggingTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #725: „Hogyan lehet hatékonyan megtalálni a hibaüzeneteket most?"
+ *
+ * A válasz addig az volt, hogy sehogy: élesben `error_reporting(0)` futott, ami nem
+ * csak a kijelzést, a naplózást is elnémítja, az index.php pedig csak `\Exception`-t
+ * fogott — a PHP 8-as `\Error`/`TypeError` átment rajta. Egy 500-as oldalról ennyi
+ * látszott a naplóban: `"GET /templom/5446/edit HTTP/1.1" 500 236`.
+ */
+class ErrorLoggingTest extends TestCase {
+
+    private string $logFile;
+    private string $eredetiLog;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->logFile = sys_get_temp_dir() . '/miserend-error-log-test.log';
+        @unlink($this->logFile);
+        $this->eredetiLog = (string) ini_get('error_log');
+        ini_set('error_log', $this->logFile);
+    }
+
+    protected function tearDown(): void {
+        ini_set('error_log', $this->eredetiLog);
+        @unlink($this->logFile);
+        parent::tearDown();
+    }
+
+    public function testThrowableIsLoggedWithLocationUriAndTrace(): void {
+        $_SERVER['REQUEST_URI'] = '/templom/5444/edit';
+
+        logThrowable('Render failed', new \TypeError('valami elszállt'));
+
+        $log = (string) @file_get_contents($this->logFile);
+        $this->assertStringContainsString('[miserend] Render failed', $log);
+        $this->assertStringContainsString('TypeError', $log);
+        $this->assertStringContainsString('valami elszállt', $log);
+        $this->assertStringContainsString('URI: /templom/5444/edit', $log);
+        $this->assertStringContainsString('[miserend] trace:', $log);
+    }
+
+    /** A Twig-hibák üzenete a becsomagolt kivétel nélkül használhatatlan. */
+    public function testPreviousExceptionIsLoggedToo(): void {
+        $belso = new \RuntimeException('az igazi ok');
+        $kulso = new \Exception('An exception has been thrown during the rendering of a template', 0, $belso);
+
+        logThrowable('Render failed', $kulso);
+
+        $log = (string) @file_get_contents($this->logFile);
+        $this->assertStringContainsString('(previous)', $log);
+        $this->assertStringContainsString('az igazi ok', $log);
+    }
+
+    /**
+     * Az `error_log()` hívást az error_reporting maszk nem szűri — épp ezért használjuk.
+     * Ez a teszt azt őrzi, hogy a naplózás a legszűkebb maszk mellett is működjön.
+     */
+    public function testLoggingWorksEvenWithATightErrorReportingMask(): void {
+        $eredeti = error_reporting();
+        error_reporting(0);
+        try {
+            logThrowable('Uncaught', new \Exception('néma környezetben is látszik'));
+        } finally {
+            error_reporting($eredeti);
+        }
+
+        $log = (string) @file_get_contents($this->logFile);
+        $this->assertStringContainsString('néma környezetben is látszik', $log);
+    }
+
+    /**
+     * Élesben (production) a maszk fogja a végzetes hibákat. Korábban `false` volt,
+     * amiből a load.php `error_reporting(0)`-t csinált.
+     */
+    public function testProductionMaskCoversFatalErrors(): void {
+        // A config.php-t a configurationSetEnvironment() függvény-scope-ban include-olja,
+        // tehát az $environment nem globális — itt magunknak kell beolvasnunk.
+        $environment = [];
+        include PATH . 'config.php';
+
+        $this->assertArrayHasKey('default', $environment);
+
+        // A `production` ág üres, tehát a `default` értékét örökli.
+        $this->assertSame([], $environment['production']);
+
+        $mask = $environment['default']['error_reporting'];
+        $this->assertNotFalse($mask, 'Élesben megint elnémulna a naplózás.');
+        foreach ([E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR] as $level) {
+            $this->assertSame($level, $mask & $level);
+        }
+    }
+}


### PR DESCRIPTION
Closes #725

A jegy két kérdést tett fel. A „hogyan lehet hatékonyan megtalálni a hibaüzeneteket" felét ez a PR megoldja, és a doksit is megírja hozzá.

A konkrét Kölni 500-as **külön jegyet kapott: #738** — azt ez a PR nem javítja, de mostantól a napló megmondja, hol keressük.

## Miért nem láttál semmit a logban

Nem véletlen volt, hogy csak ennyi látszott:

```
"GET /templom/5446/edit HTTP/1.1" 500 236
```

Három dolog volt együtt:

1. **Élesben `error_reporting(0)` futott.** A `config.php` `default` ágában `'error_reporting' => false`, a `production` ág pedig üres, tehát ezt örökli. A `load.php` ebből `error_reporting(0)`-t csinál — és ez nem csak a kijelzést kapcsolja ki, hanem a **naplózást is**. A PHP saját `Fatal error: Uncaught …` üzenete sehova nem került ki, hiába `log_errors = On`.
2. **Az `index.php` csak `\Exception`-t fogott.** A PHP 8-as `\Error` és `TypeError` nem `\Exception`, tehát átment rajta — abból lett a néma 500.
3. **A `render()` a `try`/`catch`-en kívül volt.** Márpedig a Twig-sablonok a lusta Eloquent-accessorokat (`church.location`, `church.holders`, `church.names`) **csak ott** hívják meg. Az edit oldal hibái tipikusan pont ide esnek.

## Mit tettem

- A `default` (és így a `production`) maszkja `E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR`. A warning és notice szándékosan marad kint, hogy a napló ne fulladjon zajba. A látogató ettől **semmit nem lát többet**: a `php.ini`-ben `display_errors = Off`.
- `catch (\Throwable)` a `\Exception` helyett.
- A `render()` védett szakaszba került; ha ott száll el valami, hibaoldal megy ki 500 helyett, és a hiba a naplóba kerül.
- `set_exception_handler` + shutdown handler: a memória- és időtúllépés nem dob kivételt, azt csak így lehet elkapni — pedig épp ezek a néma 500-ak.
- Minden sor `[miserend]` előtaggal, fájllal, sorral, **URI-val** és **stack trace-szel** megy ki. A becsomagolt (`previous`) kivételt is naplózzuk: egy Twig-hiba üzenete önmagában (*„An exception has been thrown during the rendering of a template"*) használhatatlan.

## Végigmérve, valódi kéréssel

Beraktam egy oldalt, ami a renderelés közben `TypeError`-t dob, és lekértem HTTP-n:

**Előtte:** HTTP 500, a naplóban semmi.

**Utána:** HTTP 200 a hibaoldallal, a naplóban:

```
[miserend] Render failed: TypeError: szimulált render-hiba @ /miserend/webapp/classes/html/rendercrashprobe.php:6 | URI: /index.php?q=rendercrashprobe
[miserend] trace: #0 /miserend/webapp/index.php(61): Html\RenderCrashProbe->render() #1 {main}
```

## Dokumentáció

Új `docs/logok.md` a konkrét parancsokkal (ez volt a jegy tényleges kérdése), hivatkozva a `README.md`-ből és a `CLAUDE.md`-ből. A lényeg:

```sh
docker logs miserend-prod-miserend-1 2>&1 | grep '\[miserend\]'
docker logs miserend-prod-miserend-1 2>&1 | grep 'URI: /templom/5444/edit'
docker logs -f --tail 0 miserend-prod-miserend-1 2>&1 | grep '\[miserend\]'
```

## ⚠️ A konkrét 500-ast NEM javítja

Ezt előre szólom: **a Kölni templomok hibáját nem reprodukáltam.** Végigpróbáltam helyben a külföldi templomokat (Bécs, Alvinc, Topolya, és egy német tesztsor Kölnnel) — **mind 200**, 0,13 másodperc alatt. A hiba tehát az éles 5444/5446 adatára vagy a környezetre specifikus, nem arra, hogy „külföldi".

Amit kizártam: az `orszag`/`megye`/`egyhazmegye` nem lehet NULL (`NOT NULL DEFAULT 0`), tehát a null-dereferencia elesik.

Ami gyanús maradt, de bizonyíték nélkül:
- `pickAdministrativeBoundaries()` nem ismeri a német admin_level-eket (a német `level=5` „Regierungsbezirk" nincs a `whereIn`-ben);
- `edit.php:441-449` az összes aktív templomot memóriába húzza (~4400 modell) 128M limit mellett;
- `edit.php:402-414` nyers `ST_distance_sphere` SQL — MySQL 8 (éles) validálja az SRID 4326 tartományt, a MariaDB (dev) nem, tehát egyetlen hibás koordináta megbuktathatja.

**Merge után** kérlek futtasd ezt, és nyisd meg közben az oldalt — utána már ott lesz a pontos hely:

```sh
docker logs -f --tail 0 miserend-prod-miserend-1 2>&1 | grep '\[miserend\]'
```

Küldd át a kiírást, és megcsinálom a javítást.

## Tesztek

Új `ErrorLoggingTest`: a hiba helye/URI-ja/trace-e bekerül a naplóba, a becsomagolt kivétel is, a naplózás a legszűkebb maszk mellett is működik, és a production maszkja tényleg fedi a végzetes hibákat — ez utóbbi őrzi, hogy ne tudjon némán visszaromlani.

A teljes PHP-készlet (639 teszt) zöld.

