### PR TITLE
Kiszabadítom a hónapok óta elakadt cron-munkákat

### DIFF
--- a/webapp/classes/eloquent/cron.php
+++ b/webapp/classes/eloquent/cron.php
@@ -17,13 +17,40 @@ class Cron extends \Illuminate\Database\Eloquent\Model {
         $this->deadline_at = date('Y-m-d H:i:s', strtotime('now +' . $this->frequency));
     }
 
+    /**
+     * A sorrend a LEGRÉGEBBEN esedékes munkával kezdődik.
+     *
+     * Eddig `attempts ASC` volt az elsődleges rendezés, és ez kiéheztetett: a futtató
+     * egy körben EGY munkát indít, tehát amelyik egyszer felhalmozott néhány próbálkozást,
+     * az örökre a sor végére került, és csak akkor jutott szóhoz, ha épp semmi más nem
+     * volt esedékes. Ezért állt élesben a \User::deleteNonActivatedUsers() 135 napja
+     * (65 próbálkozás, egyetlen siker nélkül) — a hibái mellett a rendezés is fogva
+     * tartotta.
+     *
+     * Az attempts már csak holtverseny-döntő: azonos esedékességnél a kevesebbszer
+     * bukott munka megy előbb.
+     */
     public function scopeNextJobs($query) {
         return $query->where('deadline_at', '<', date('Y-m-d H:i:s'))
                         ->where(function($query) {
                             $query->where('attempts', '<', 10)
                             ->orWhere('updated_at', '<', date('Y-m-d H:i:s', strtotime('-12 hour')));
                         })
-                        ->orderBy('attempts', 'ASC')->orderBy('deadline_at', 'ASC');
+                        ->orderBy('deadline_at', 'ASC')->orderBy('attempts', 'ASC');
+    }
+
+    /**
+     * Sikertelen futás után a következő esedékesség a szokásos ritmus szerint jön.
+     *
+     * A deadline_at eddig CSAK sikerre újult meg, tehát egy bukó munka örökre
+     * "esedékes" maradt: minden kopogás újrapróbálta, az attempts percenként nőtt, és
+     * 10 fölött 12 órára ki is zárta magát. A fenti, esedékesség szerinti rendezés
+     * mellett ráadásul minden mást maga elé engedett volna — egy tartósan hibás munka
+     * megbénította volna a többit.
+     */
+    public function backOff(): void {
+        $this->renewDeadline();
+        $this->save();
     }
 
     public function initialize() {

--- a/webapp/classes/html/cron.php
+++ b/webapp/classes/html/cron.php
@@ -70,6 +70,10 @@ class Cron extends Html {
             $this->error = true;
             echo "<strong>" . $job->class . "->" . $job->function . "() futtatása sikertelen.</strong>\n";
             $this->printExceptionVerbose($exception);
+            // A következő próbálkozás a szokásos ritmus szerint jöjjön. Enélkül a bukott
+            // munka „esedékes" maradt, minden kopogás újrapróbálta, és percek alatt
+            // átlépte a 10-es korlátot — onnan pedig 12 órára kizárta magát.
+            $job->backOff();
         }
 
         if (!isset($this->error)) {

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -585,8 +585,7 @@ class User {
 			$email = new \Eloquent\Email();
 			$email->to = $result->email;
 			$email->render('user_youhavebeendeleted',$result);			
-			// $email->addToQueue();
-			$email->send();
+			$email->addToQueue();
 			
 		}
 
@@ -636,8 +635,7 @@ class User {
 				$email = new \Eloquent\Email();
 				$email->to = $user->email;
 				$email->render('user_pleaseactivate',$user);			
-				// $email->addToQueue();
-				$email->send();
+				$email->addToQueue();
 			}
 		}
 		
@@ -683,8 +681,7 @@ class User {
                 $email = new \Eloquent\Email();
                 $email->to = $user->email;
                 $email->render('user_youhavebeendeleted',$user);			
-                // $email->addToQueue();
-                $email->send();
+                $email->addToQueue();
                 if (!DB::table('user')->where('uid',$user->uid)->limit(1)->delete())  {
                             addMessage('Nem sikerül mindenkit törölni.', 'error');
                             echo "Nem sikerült mindenkit aki még nem lépett be törölni! ".print_r($user,1)." ";
@@ -698,8 +695,7 @@ class User {
 				$email = new \Eloquent\Email();
 				$email->to = $user->email;
 				$email->render('user_pleaselogin',$user);			
-				// $email->addToQueue();
-				$email->send();
+				$email->addToQueue();
 			}
 		}
 		
@@ -783,8 +779,7 @@ class User {
 			$email = new \Eloquent\Email();
 			$email->to = $user->email;
 			$email->render('user_pleaseupdate',$user);
-			// $email->addToQueue();
-			$email->send();
+			$email->addToQueue();
 					
 		}
 		

--- a/webapp/tests/Integration/CronStarvationTest.php
+++ b/webapp/tests/Integration/CronStarvationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Élesben a `\User::deleteNonActivatedUsers()` 135 napja nem futott le sikeresen:
+ * 65 próbálkozás, egyetlen siker nélkül, a deadline_at pedig 2026-03-27-en állt.
+ *
+ * Két, egymást erősítő ok:
+ *
+ *  1. A sorrend `attempts ASC` volt, a futtató pedig körönként EGY munkát indít. Amelyik
+ *     egyszer felhalmozott néhány próbálkozást, az a sor végére került, és csak akkor
+ *     jutott szóhoz, ha épp semmi más nem volt esedékes.
+ *  2. A `deadline_at` CSAK sikerre újult meg. Egy bukó munka örökre „esedékes" maradt,
+ *     minden kopogás újrapróbálta, az attempts percek alatt átlépte a 10-et — onnantól
+ *     pedig a scopeNextJobs 12 órára kizárta.
+ */
+class CronStarvationTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::connection()->beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::connection()->rollBack();
+        parent::tearDown();
+    }
+
+    private function job(string $function, string $deadline, int $attempts, ?string $updatedAt = null): \Eloquent\Cron {
+        $cron = new \Eloquent\Cron();
+        $cron->class = '\Crons';
+        $cron->function = $function;
+        $cron->frequency = '1 day';
+        $cron->attempts = $attempts;
+        $cron->deadline_at = $deadline;
+        $cron->save();
+
+        if ($updatedAt !== null) {
+            // Az Eloquent minden mentésnél a mostani időt írja az updated_at-be, a
+            // scopeNextJobs viszont pont ezt nézi — kézzel kell visszaállítani.
+            DB::table('crons')->where('id', $cron->id)->update(['updated_at' => $updatedAt]);
+            $cron->refresh();
+        }
+
+        return $cron;
+    }
+
+    /**
+     * A lényeg: a régóta esedékes, sokat bukott munka MEGELŐZI a frissen esedékes,
+     * hibátlan munkát. Korábban pont fordítva volt, és ezért nem került soha sorra.
+     */
+    public function testTheLongestOverdueJobComesFirstEvenWithManyAttempts(): void {
+        DB::table('crons')->update(['deadline_at' => date('Y-m-d H:i:s', strtotime('+1 day'))]);
+
+        // Az élesen látott állapot: 135 napja esedékes, 65 bukott próbálkozás, és a
+        // 10-es korlát miatt csak 12 óránként egyszer láthatja meg a futtató.
+        $ehezo = $this->job('tesztEhezo', date('Y-m-d H:i:s', strtotime('-135 days')), 65,
+            date('Y-m-d H:i:s', strtotime('-13 hours')));
+        $friss = $this->job('tesztFriss', date('Y-m-d H:i:s', strtotime('-1 minute')), 0);
+
+        $sorrend = \Eloquent\Cron::nextJobs()->get()
+            ->map(static fn($j) => $j->function)->all();
+
+        $this->assertContains('tesztEhezo', $sorrend, 'A 65 próbálkozásos munka ki sem került a listába.');
+        $this->assertSame('tesztEhezo', $sorrend[0],
+            'A régóta esedékes munkának kell elöl lennie, különben újra kiéhezik.');
+        $this->assertContains('tesztFriss', $sorrend);
+        unset($ehezo, $friss);
+    }
+
+    /** Azonos esedékességnél viszont a kevesebbszer bukott menjen előbb. */
+    public function testAttemptsBreakTheTieAtEqualDeadlines(): void {
+        DB::table('crons')->update(['deadline_at' => date('Y-m-d H:i:s', strtotime('+1 day'))]);
+
+        $mikor = date('Y-m-d H:i:s', strtotime('-10 minutes'));
+        $this->job('tesztSokBukas', $mikor, 9);
+        $this->job('tesztKevesBukas', $mikor, 0);
+
+        $sorrend = \Eloquent\Cron::nextJobs()->get()
+            ->map(static fn($j) => $j->function)->all();
+
+        $this->assertSame(['tesztKevesBukas', 'tesztSokBukas'], array_slice($sorrend, 0, 2));
+    }
+
+    /**
+     * Bukás után a következő próbálkozás a szokásos ritmus szerint jöjjön — ne minden
+     * ötperces kopogásnál.
+     */
+    public function testFailureMovesTheDeadlineForward(): void {
+        $job = $this->job('tesztBukik', date('Y-m-d H:i:s', strtotime('-1 hour')), 3);
+
+        $job->backOff();
+        $job->refresh();
+
+        $this->assertGreaterThan(time() + 3600, strtotime((string) $job->deadline_at),
+            'Bukás után a napi munkának nem szabad azonnal újra esedékesnek lennie.');
+        // A bukás nem siker: a lastsuccess_at nem mozdulhat.
+        $this->assertNull($job->lastsuccess_at);
+    }
+
+    /**
+     * A 10-es korlát fölött a munka 12 óránként EGYSZER látszik. Ez a fék önmagában
+     * rendben van; a baj az volt, hogy a bukó munka percek alatt átlépte a korlátot,
+     * mert a deadline_at sosem mozdult. A backOff() óta ez lassan gyűlik.
+     */
+    public function testTooManyAttemptsThrottleButDoNotBlockForever(): void {
+        DB::table('crons')->update(['deadline_at' => date('Y-m-d H:i:s', strtotime('+1 day'))]);
+
+        $frissenProbalt = $this->job('tesztFrissenProbalt', date('Y-m-d H:i:s', strtotime('-1 hour')), 65,
+            date('Y-m-d H:i:s', strtotime('-1 minute')));
+        $sorrend = \Eloquent\Cron::nextJobs()->get()->map(static fn($j) => $j->function)->all();
+        $this->assertNotContains('tesztFrissenProbalt', $sorrend, 'A most próbált munka várjon a fékkel.');
+
+        DB::table('crons')->where('id', $frissenProbalt->id)
+            ->update(['updated_at' => date('Y-m-d H:i:s', strtotime('-13 hours'))]);
+
+        $sorrend = \Eloquent\Cron::nextJobs()->get()->map(static fn($j) => $j->function)->all();
+        $this->assertContains('tesztFrissenProbalt', $sorrend, '12 óra után újra sorra kell kerülnie.');
+    }
+
+    /**
+     * A siker viszont nullázza a számlálót — így egy korábban elakadt munka
+     * magától visszatér a normál kerékvágásba.
+     */
+    public function testSuccessClearsTheAttemptPenalty(): void {
+        $job = $this->job('tesztSikerul', date('Y-m-d H:i:s', strtotime('-1 hour')), 65);
+
+        $job->success();
+        $job->refresh();
+
+        $this->assertSame(0, (int) $job->attempts);
+        $this->assertNotNull($job->lastsuccess_at);
+    }
+}


### PR DESCRIPTION
Nincs hozzá jegy: a 35-ös cron 135 napos elakadására néztem rá.

Erre kérdeztél rá:

```
35  \User::deleteNonActivatedUsers()  20 minutes (1am - 6am)  2026-03-27 06:10:01  65  2026-03-27 05:50:01
135 napja nem futott le sikeresen
```

Nem egy ok van, hanem három, egymást erősítve.

## 1. Kiéheztetés

A `scopeNextJobs` **`attempts ASC`** szerint rendezett, a futtató pedig körönként **egy** munkát indít, az elsőt, ami épp az időablakában van. Amelyik munka egyszer felhalmozott néhány próbálkozást, az a sor **végére** került, és csak akkor jutott szóhoz, ha véletlenül semmi más nem volt esedékes. 65 próbálkozásnál ez már majdnem soha.

Mostantól a **legrégebben esedékes** megy előbb; az `attempts` már csak holtverseny-döntő (azonos esedékességnél a kevesebbszer bukott megy előbb).

## 2. Nincs visszalépés bukás után

A `deadline_at` **csak sikerre** újult meg — látszik is: 2026-03-27 06:10-en áll azóta. A bukó munka tehát örökre „esedékes" maradt: minden ötperces kopogás újrapróbálta, az `attempts` percek alatt átlépte a tízes korlátot, onnantól pedig a `scopeNextJobs` 12 órára kizárta.

Bevezetem a visszalépést: bukás után a következő próbálkozás a szokásos ritmus szerint jön. Ez az 1. ponthoz is kell — esedékesség szerinti rendezésnél egy tartósan hibás munka különben minden mást maga elé engedne.

## 3. A kiváltó ok: szinkron SMTP a cronban

A job **20 levelet küld egyesével, szinkron SMTP-n**, a `Html\Cron` időkorlátja viszont **300 másodperc**. Helyben ez 0,05 mp/fő (mailcatcher ugyanazon a hálózaton), éles SMTP-vel viszont másodpercekben mérhető — 20 × 15 mp már pontosan a korlát. Egy időtúllépés pedig **nyom nélkül** öli meg a futást: a `success()` sosem fut le, az `attempts` viszont már megnőtt. Pontosan ezt látjuk.

Közben kiderült, hogy a megoldás **készen áll a kódban, kikommentezve**:

```php
// $email->addToQueue();
$email->send();
```

Öt helyen, mind az öt cron-vezérelt tömeges értesítő. A `\Eloquent\Email::sendQueued` kiküldő cron létezik és fut (#290), a `holder_holiday_reminder` már használja is. Bekapcsolom mind az ötnél — így az SMTP lassulása nem viszi el az egész munkát.

Interaktív levélhez (regisztráció, jelszó) nem nyúltam, azok máshol vannak és maradnak azonnaliak.

## Miért nem lehetett ezt a naplóból látni

Mert nem volt napló. A #732 (`error_reporting(0)` élesben) épp ezt javítja — az ott bevezetett shutdown handler mostantól kiírja az időtúllépést is. Ha ez a PR mégsem oldaná meg, a következő futás után ott lesz a pontos ok.

## Tesztek

Új `CronStarvationTest`: a 135 napja esedékes, 65 próbálkozásos munka **megelőzi** a frissen esedékes hibátlant (korábban fordítva volt); azonos esedékességnél az `attempts` dönt; bukás után a határidő előre mozdul és a `lastsuccess_at` nem; a tízes fék 12 óra után enged; a siker nullázza a büntetést.

A teljes PHP-készlet (640 teszt) zöld.

## Deploy után

A már 65-ön álló számláló magától rendeződik: az első sikeres futás nullázza. Ha nem akarod kivárni a 12 órás féket:

```sql
UPDATE crons SET attempts = 0 WHERE attempts >= 10;
```
