### PR TITLE
Megjavítom az újraindexelés null-dátumra futását

### DIFF
--- a/webapp/classes/eloquent/calmass.php
+++ b/webapp/classes/eloquent/calmass.php
@@ -397,6 +397,15 @@ class CalMass extends CalModel
             $massesFromImport = [];
 
             foreach ($masses as $mass) {
+                // Körönként nullázni kell, különben átszivárog az előző miséről.
+                // A period nélküli, importált sorozatok ága ugyanis NEM állítja be
+                // ($massesFromImport-ba teszi a misét, és külön, lentebb dolgozza fel) —
+                // a lenti `foreach ($periods ...)` viszont utána is lefut. Így az ilyen
+                // mise az ELŐZŐ mise periódusaival is legenerálódott, rossz dátumokkal.
+                // (Az első ilyennél `$periods` egyszerűen null volt: "foreach() argument
+                // must be of type array|object, null given".)
+                $periods = collect([]);
+
                 /*
                 $this->logDebug("Mise feldolgozás indul", [
                     'mass_id' => $mass->id,
@@ -646,25 +655,40 @@ class CalMass extends CalModel
             foreach($massesFromImport as $mass) {
 echo "Period nélküli RRULE-os mise: ".$mass->id." - ".$mass->title." in year ".$year."<br>\n";
 
-                $endsBeforeGlobalEnd = false;
+                // A ciklusváltozókat KÖRÖNKÉNT nullázni kell. Korábban az `if` blokkokon
+                // belül keletkeztek, tehát az előző mise értéke átszivárgott a következőre:
+                // egy `until` nélküli szabály némán az előző mise záródátumát kapta meg,
+                // az első ilyennél pedig — amikor még semmi nem volt beállítva — a
+                // `$until->toIso8601String()` nullra futott:
+                //   "Call to a member function toIso8601String() on null"
+                // Élesben ez két darabot buktatott az újraindexelésből (~200 templom).
+                $until = null;
+                $dtstart = null;
+
+                // A nevek korábban félrevezetők voltak: itt az a kérdés, hogy a szabály
+                // teljes egészében kívül esik-e az indexelt éven.
+                $endsBeforeWindow = false;
                 if(isset($mass->rrule['until'])) {
                     $until = Carbon::parse($mass->rrule['until']);
                     if($until->lt($globalStart)) {
-                        $endsBeforeGlobalEnd = true;
+                        $endsBeforeWindow = true;
                     }
                 }
-                $startsBeforeGlobalStart = false;
+                $startsAfterWindow = false;
                 if(isset($mass->rrule['dtstart'])) {
                     $dtstart = Carbon::parse($mass->rrule['dtstart']);
                     if($dtstart->gt($globalEnd)) {
-                        $startsBeforeGlobalStart = true;
+                        $startsAfterWindow = true;
                     }
                 }
 
-                if(!$endsBeforeGlobalEnd and !$startsBeforeGlobalStart) {
-                    
+                if(!$endsBeforeWindow and !$startsAfterWindow) {
+
                 $newRrule = $mass->rrule;  // Az aktuális tömb lekérése
-                $newRrule['until'] = $until->toIso8601String();  // Módosítás
+                // Nyitott végű szabálynál (nincs UNTIL — pl. "minden vasárnap", ami a
+                // Google-naptárakban a leggyakoribb) az indexelt év vége a záródátum.
+                // Az évet úgyis évenként külön generáljuk, tehát ez nem vág le semmit.
+                $newRrule['until'] = ($until ?? $globalEnd)->toIso8601String();
                 $mass->rrule = $newRrule;  // Explicit reasszignálás az Eloquentnek
                
                 $newMassPeriod = [

--- a/webapp/tests/Unit/MassPeriodOpenEndedRruleTest.php
+++ b/webapp/tests/Unit/MassPeriodOpenEndedRruleTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Élesben az újraindexelés két darabja bukott el ezzel:
+ *
+ *   2 darab újraindexelése hibázott:
+ *   3. darab (templomok: 233, 234, …): Call to a member function toIso8601String() on null
+ *   16. darab (templomok: 1629, 1630, …): Call to a member function toIso8601String() on null
+ *
+ * A hiba a period nélküli, RRULE-os misék ágán volt (ezek a külső naptárból importált
+ * sorozatok). A `$until` az `if (isset($mass->rrule['until']))` blokkON BELÜL keletkezett,
+ * a `foreach` viszont nem nullázta körönként:
+ *
+ *   - az ELSŐ olyan misénél, aminek nincs UNTIL-je, a `$until` nem létezett → null →
+ *     `toIso8601String()` on null → az egész darab elszállt;
+ *   - a további ilyen miséknél az ELŐZŐ mise záródátumát kapta meg — némán, rossz adattal.
+ *
+ * A nyitott végű szabály (`FREQ=WEEKLY;BYDAY=SU` UNTIL nélkül) a Google-naptárakban a
+ * leggyakoribb alak, tehát ez nem szélsőséges eset.
+ */
+class MassPeriodOpenEndedRruleTest extends TestCase {
+
+    private const EV = 2025;
+
+    private function mise(int $id, array $rrule): \Eloquent\CalMass {
+        $mass = new \Eloquent\CalMass();
+        $mass->id = $id;
+        $mass->church_id = 1;
+        $mass->title = 'Szentmise';
+        $mass->start_date = self::EV . '-03-02T10:00:00';
+        $mass->rite = 'ROMAN_CATHOLIC';
+        $mass->lang = 'hu';
+        $mass->period_id = null;
+        $mass->comment = ExternalCalendarImporter::IMPORT_MARKER;
+        $mass->rrule = $rrule;
+        return $mass;
+    }
+
+    /** @return array<int, array> a period nélküli (import) ágon keletkezett sorok */
+    private function generate(array $masses): array {
+        $eredmeny = \Eloquent\CalMass::generateMassPeriodInstancesForYears(
+            $masses,
+            [1 => 'Europe/Budapest'],
+            [self::EV]
+        );
+        return array_values(array_filter($eredmeny, static fn($sor) => $sor['period_id'] === null));
+    }
+
+    /**
+     * A reprodukció: UNTIL nélküli, period nélküli mise. Javítás előtt itt szállt el
+     * a teljes darab.
+     */
+    public function testOpenEndedRuleDoesNotCrashTheWholeChunk(): void {
+        $sorok = $this->generate([
+            $this->mise(135166, ['freq' => 'weekly', 'byweekday' => ['SU'], 'dtstart' => self::EV . '-03-02T10:00:00']),
+        ]);
+
+        $this->assertCount(1, $sorok, 'A nyitott végű szabálynak be kell kerülnie az indexbe.');
+        // Nyitott vég → az indexelt év vége a záródátum.
+        $this->assertSame(
+            Carbon::create(self::EV, 12, 31)->endOfDay()->toIso8601String(),
+            $sorok[0]['rrule']['until']
+        );
+    }
+
+    /**
+     * A csendesebb, de rosszabb fele: az UNTIL nélküli mise NE az előző mise
+     * záródátumát örökölje.
+     */
+    public function testOpenEndedRuleDoesNotInheritThePreviousMassUntil(): void {
+        $sorok = $this->generate([
+            $this->mise(1, ['freq' => 'weekly', 'byweekday' => ['SU'],
+                            'dtstart' => self::EV . '-01-05T10:00:00',
+                            'until' => self::EV . '-04-30T10:00:00']),
+            $this->mise(2, ['freq' => 'weekly', 'byweekday' => ['SU'],
+                            'dtstart' => self::EV . '-01-05T18:00:00']),
+        ]);
+
+        $this->assertCount(2, $sorok);
+        $szerint = [];
+        foreach ($sorok as $sor) {
+            $szerint[$sor['mass_id']] = $sor['rrule']['until'];
+        }
+
+        $this->assertStringStartsWith(self::EV . '-04-30', $szerint[1], 'A megadott UNTIL maradjon.');
+        $this->assertStringStartsWith(self::EV . '-12-31', $szerint[2],
+            'A nyitott végű szabály nem örökölheti az előző mise záródátumát.');
+    }
+
+    /**
+     * A `$periods` ugyanúgy átszivárgott a cikluson, mint az `$until`: az import-ág nem
+     * állítja be (a misét a `$massesFromImport`-ba teszi, és külön dolgozza fel lentebb),
+     * a rá következő `foreach ($periods ...)` viszont utána is lefut.
+     *
+     * Következmény: az importált mise az ELŐZŐ mise generált időszakaival is legenerálódott,
+     * tehát **kétszer** került az indexbe — duplikált miseidőpontokat adva a keresésben.
+     * Mérve: javítás nélkül a 11-es mise két sort kap, egyet a sajátjából, egyet a 10-eséből.
+     *
+     * Itt az importált misének szándékosan VAN `until`-je: enélkül a fenti null-hiba
+     * előbb elszállna, és ez az ág el sem érhető.
+     */
+    public function testImportedMassDoesNotInheritThePreviousMassPeriods(): void {
+        // Olyan periódus kell, aminek TÉNYLEG van generált időszaka az indexelt évben —
+        // különben a `$periods` üresen szivárogna át, és a teszt vakon menne át.
+        $periodId = \Eloquent\CalGeneratedPeriod::where('start_date', '<=', self::EV . '-12-31')
+            ->where('end_date', '>', self::EV . '-01-01')
+            ->value('period_id');
+        if ($periodId === null) {
+            $this->markTestSkipped('Nincs generált időszak ' . self::EV . '-re a teszt-adatbázisban.');
+        }
+
+        $periodusos = $this->mise(10, ['freq' => 'weekly', 'byweekday' => ['SU'],
+                                       'dtstart' => self::EV . '-01-05T08:00:00']);
+        $periodusos->period_id = $periodId;
+
+        $importalt = $this->mise(11, ['freq' => 'weekly', 'byweekday' => ['SU'],
+                                      'dtstart' => self::EV . '-01-05T18:00:00',
+                                      'until' => self::EV . '-06-30T18:00:00']);
+
+        $mind = \Eloquent\CalMass::generateMassPeriodInstancesForYears(
+            [$periodusos, $importalt], [1 => 'Europe/Budapest'], [self::EV]
+        );
+
+        $importaltSorok = array_values(array_filter($mind, static fn($s) => $s['mass_id'] === 11));
+        $this->assertCount(1, $importaltSorok,
+            'Az importált misének pontosan egy sora lehet — a sajátja, nem a szomszédjáé.');
+        $this->assertNull($importaltSorok[0]['period_id']);
+    }
+
+    /** Az éven kívülre eső szabályok továbbra sem kerülnek be. */
+    public function testRulesOutsideTheIndexedYearAreStillSkipped(): void {
+        $sorok = $this->generate([
+            // Már véget ért az év előtt.
+            $this->mise(3, ['freq' => 'weekly', 'byweekday' => ['SU'],
+                            'dtstart' => (self::EV - 3) . '-01-05T10:00:00',
+                            'until' => (self::EV - 2) . '-04-30T10:00:00']),
+            // Csak az év után kezdődik.
+            $this->mise(4, ['freq' => 'weekly', 'byweekday' => ['SU'],
+                            'dtstart' => (self::EV + 2) . '-01-05T10:00:00']),
+        ]);
+
+        $this->assertSame([], $sorok);
+    }
+}


### PR DESCRIPTION
Nincs hozzá jegy: az élesből küldött `updateMasses` hibanapló alapján.

Kezelve **nem volt.** A #731 az átfedést javítja, a #736 az ütemezést; ez egy harmadik, önálló hiba.

## A hiba

```
2 darab újraindexelése hibázott:
3. darab (templomok: 233, 234, 235, 236, 237, …): Call to a member function toIso8601String() on null
16. darab (templomok: 1629, 1630, 1631, 1632, 1633, …): Call to a member function toIso8601String() on null
```

A közvetlenül előtte álló sorok megmondják, hol keressük:

```
Period nélküli RRULE-os mise: 135166 - Szentmise in year 2025
```

Ez a period nélküli, RRULE-os misék ága — a külső naptárból importált sorozatok.

## Miért

```php
if (isset($mass->rrule['until'])) {
    $until = Carbon::parse($mass->rrule['until']);   // csak ITT keletkezik
    ...
}
...
$newRrule['until'] = $until->toIso8601String();       // de MINDIG használjuk
```

A `$until` az `isset` blokkon **belül** jön létre, a `foreach` viszont nem nullázza körönként:

- az **első** olyan misénél, aminek nincs `UNTIL`-je, a változó nem létezik → `null` → az egész darab elszáll;
- a **további** ilyen miséknél az **előző mise záródátumát** kapja meg — némán, rossz adattal.

A nyitott végű szabály (`FREQ=WEEKLY;BYDAY=SU`, `UNTIL` nélkül) a Google-naptárakban a leggyakoribb alak, tehát ez nem szélsőséges eset. Mostantól ilyenkor az indexelt év vége a záródátum — az évet úgyis évenként külön generáljuk, tehát nem vág le semmit.

## És egy csendes testvére, amit közben találtam

Ugyanez a hibacsalád a **`$periods`** változóval is fennállt. Az import-ág nem állítja be (a misét a `$massesFromImport`-ba teszi, és külön dolgozza fel lentebb), a rá következő `foreach ($periods ...)` viszont utána is lefut — így az importált mise az **előző mise generált időszakaival is** legenerálódott.

Ez nem elmélet, megmértem. Egy periódusos mise után egy importált (aminek van `UNTIL`-je, tehát nem száll el a fenti hibán):

| | mass_id=10 | mass_id=11 |
|---|---|---|
| javítás nélkül | 1 sor | **2 sor** |
| javítással | 1 sor | 1 sor |

Vagyis az importált misék **duplikálva** kerültek a mise-indexbe — duplikált miseidőpontokat adva a keresésben. Ez eddig azért nem tűnt fel, mert a hangosabb testvére elvitte a figyelmet.

Az első ilyen misénél amúgy a `$periods` egyszerűen `null` volt, és minden futás hagyott maga után egy `foreach() argument must be of type array|object, null given` figyelmeztetést.

## Mellékesen

Átneveztem két félrevezető változót: az `$endsBeforeGlobalEnd` valójában „az év kezdete ELŐTT véget ért", az `$startsBeforeGlobalStart` pedig „az év vége UTÁN kezdődik". A logika jó volt, csak a nevek hazudtak.

## Tesztek

Új `MassPeriodOpenEndedRruleTest`, 4 eset. Javítás nélkül **3 bukik**, pontosan az éles hibaüzenettel:

```
Error: Call to a member function toIso8601String() on null
Failed asserting that '2025-04-30T10:00:00+02:00' starts with "2025-12-31".
Failed asserting that actual size 2 matches expected size 1.
```

A teljes PHP-készlet (639 teszt) zöld.

## Amit érdemes tudni

A hiba a darabokat buktatta, nem az egész futást (#306 óta), tehát az érintett ~200 templom miséi **kimaradtak az indexből**. Ezt a `reindexMissingMasses` cron amúgy is foltozza, de a merge utáni első teljes futás után érdemes ránézni a `/health` „hiányzó misék" blokkjára.

A 34 perc 42 másodperces futásidő külön téma — a #731 leírásában írtam róla.