### PR TITLE
Nem engedem be a NaN időpontot a naptárszerkesztőből

### DIFF
--- a/webapp/classes/eloquent/calmass.php
+++ b/webapp/classes/eloquent/calmass.php
@@ -692,6 +692,77 @@ echo "Period nélküli RRULE-os mise: ".$mass->id." - ".$mass->title." in year "
         return $massPeriods;
     }
 
+    /**
+     * Értelmezhető-e a mise kezdete? Tiszta függvény (se DB, se HTTP), hogy tesztelhető
+     * legyen, és hogy a mentés meg az import ugyanazt a határt húzza meg.
+     *
+     * A kiváltó eset: a naptárszerkesztőből `2026-01-01TNaN:NaN:NaN` érkezett — üresen
+     * hagyott időpontból —, és a mentés ellenőrzés nélkül kiírta. Az ilyen mise némán
+     * eltűnik: a generátor kihagyja ("Invalid RRULE dtstart, skipping mass ID …"), tehát
+     * a keresőbe soha nem kerül be, a szerkesztőben viszont ott van.
+     *
+     * @param array $massData snake_case kulcsokkal, ahogy a mentés kapja
+     * @return string|null a hiba oka, vagy null ha rendben van
+     */
+    public static function invalidDateTimeReason(array $massData): ?string {
+        $start = $massData['start_date'] ?? null;
+        if ($start !== null && $start !== '' && !self::isParsableDateTime($start)) {
+            return 'A kezdés nem értelmezhető: ' . $start;
+        }
+
+        $rrule = $massData['rrule'] ?? null;
+        if (is_string($rrule) && $rrule !== '') {
+            $rrule = json_decode($rrule, true);
+        }
+        if (!is_array($rrule)) {
+            return null;
+        }
+
+        foreach (['dtstart', 'until'] as $mezo) {
+            $ertek = $rrule[$mezo] ?? null;
+            if ($ertek !== null && $ertek !== '' && !self::isParsableDateTime($ertek)) {
+                return 'Az ismétlődés ' . $mezo . ' értéke nem értelmezhető: ' . $ertek;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * A Carbon a "2026-01-01TNaN:NaN:NaN"-t is elfogadná (a NaN-t szemétként eldobva,
+     * éjfélre kerekítve), ezért nem elég ráhagyni: a nyilvánvalóan hibás alakot külön
+     * kizárjuk. Így a hibás időpont a mentésnél derül ki, nem hónapokkal később a
+     * keresőben.
+     */
+    private static function isParsableDateTime($value): bool {
+        if ($value instanceof \DateTimeInterface) {
+            return true;
+        }
+        if (!is_string($value)) {
+            return false;
+        }
+        $value = trim($value);
+        if ($value === '') {
+            return false;
+        }
+
+        // Csak a ténylegesen használt alakokat fogadjuk el. Szabad formátumnál a Carbon
+        // nagyvonalú: a "2026-01-01TNaN:NaN:NaN"-ból is éjfelet csinál, tehát önmagában
+        // ráhagyva a hibás időpont csendben átcsúszna.
+        $alak = preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) === 1
+            || preg_match('/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+\-]\d{2}:?\d{2})?$/', $value) === 1;
+        if (!$alak) {
+            return false;
+        }
+
+        try {
+            Carbon::parse($value);
+            return true;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
     static private function applyCollisionAvoidance(array $masses): array
     {
         // Kevés CalPeriod van, és minden misénél kell, ezért inkább előre egyszer töltjük be mindet.

--- a/webapp/classes/html/ajax/calendar/masses.php
+++ b/webapp/classes/html/ajax/calendar/masses.php
@@ -107,6 +107,29 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
 
     public function save(ChangeRequest $changeRequest): void
     {
+        // A mentés eddig ELLENŐRZÉS NÉLKÜL írta ki, amit a frontend küldött. Így került az
+        // adatbázisba `2026-01-01TNaN:NaN:NaN` kezdés (a szerkesztőben üresen maradt
+        // időpontból), és az ilyen mise NÉMÁN eltűnt: az újraindexelő kihagyja
+        // ("Invalid RRULE dtstart, skipping mass ID …"), tehát a keresőben soha nem
+        // jelenik meg, a szerkesztőben viszont ott van — a gondnok jogosan hiszi, hogy
+        // felvitte. A /health "elastic-misék nélküli misézőhelyek" listáján bukkant elő.
+        //
+        // Előbb MINDENT ellenőrzünk, és csak utána írunk: fél-mentett miserendet ne
+        // hagyjunk magunk után.
+        foreach ($changeRequest->masses as $mass) {
+            $ellenorzendo = CalModel::arrayKeysToSnakeCase(is_array($mass) ? $mass : (array) $mass);
+            $hiba = CalMass::invalidDateTimeReason($ellenorzendo);
+            if ($hiba !== null) {
+                $cim = trim((string) ($ellenorzendo['title'] ?? ''));
+                $this->sendJsonError(
+                    'Hiányzó vagy értelmezhetetlen időpont'
+                    . ($cim !== '' ? ' ennél: „' . $cim . '”' : '')
+                    . '. ' . $hiba,
+                    400
+                );
+            }
+        }
+
         // Törlendő misék
         if (!empty($changeRequest->deletedMasses)) {
             CalMass::whereIn('id', $changeRequest->deletedMasses)->delete();

--- a/webapp/tests/Unit/MassDateTimeValidationTest.php
+++ b/webapp/tests/Unit/MassDateTimeValidationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A /health „elastic-misék nélküli misézőhelyek" listáján bukkant elő: az
+ * Őrangyalok-kápolna (Nagyatád, #4553) két miséje `2026-01-01TNaN:NaN:NaN` kezdéssel
+ * ült az adatbázisban.
+ *
+ * A naptárszerkesztő mentése ELLENŐRZÉS NÉLKÜL írta ki, amit a frontend küldött, az
+ * üresen hagyott időpontból pedig `NaN` lett. Az ilyen mise **némán eltűnik**: az
+ * újraindexelő kihagyja („Invalid RRULE dtstart, skipping mass ID …"), tehát a keresőbe
+ * soha nem kerül be — a szerkesztőben viszont ott van, a gondnok jogosan hiszi, hogy
+ * felvitte.
+ */
+class MassDateTimeValidationTest extends TestCase {
+
+    /** @dataProvider ervenyesIdopontok */
+    public function testValidStartDatesAreAccepted(string $ertek): void {
+        $this->assertNull(\Eloquent\CalMass::invalidDateTimeReason(['start_date' => $ertek]));
+    }
+
+    public static function ervenyesIdopontok(): array {
+        return [
+            'dátum és idő' => ['2026-01-01T10:00:00'],
+            'szóközzel' => ['2026-01-01 10:00:00'],
+            'másodperc nélkül' => ['2026-12-31T23:59'],
+            'UTC jelöléssel' => ['2026-08-09T10:00:00Z'],
+            'időzóna-eltolással' => ['2026-08-09T12:00:00+02:00'],
+            'csak dátum' => ['2026-01-01'],
+        ];
+    }
+
+    /** @dataProvider ervenytelenIdopontok */
+    public function testInvalidStartDatesAreRejected(string $ertek): void {
+        $ok = \Eloquent\CalMass::invalidDateTimeReason(['start_date' => $ertek]);
+        $this->assertNotNull($ok, "Ezt el kellett volna utasítani: $ertek");
+        $this->assertStringContainsString($ertek, $ok, 'A hibaüzenet mondja meg, mi a rossz érték.');
+    }
+
+    public static function ervenytelenIdopontok(): array {
+        return [
+            // Az élesen talált érték.
+            'NaN idő' => ['2026-01-01TNaN:NaN:NaN'],
+            'NaN óra' => ['2026-01-01TNaN:00:00'],
+            'undefined' => ['undefined'],
+            'null szöveg' => ['null'],
+            'Invalid Date' => ['Invalid Date'],
+            'hiányos dátum' => ['2026-01'],
+            'fordított sorrend' => ['01/01/2026 10:00'],
+        ];
+    }
+
+    /** Az ismétlődés dátumai ugyanígy számítanak — a generátor ezeken hasal el. */
+    public function testInvalidRruleDtstartIsRejected(): void {
+        $ok = \Eloquent\CalMass::invalidDateTimeReason([
+            'start_date' => '2026-01-01T10:00:00',
+            'rrule' => ['freq' => 'monthly', 'dtstart' => '2026-01-01TNaN:NaN:NaN', 'until' => '2026-12-31T23:59'],
+        ]);
+        $this->assertNotNull($ok);
+        $this->assertStringContainsString('dtstart', $ok);
+    }
+
+    public function testInvalidRruleUntilIsRejected(): void {
+        $ok = \Eloquent\CalMass::invalidDateTimeReason([
+            'start_date' => '2026-01-01T10:00:00',
+            'rrule' => ['freq' => 'monthly', 'dtstart' => '2026-01-01T10:00:00', 'until' => 'NaN'],
+        ]);
+        $this->assertNotNull($ok);
+        $this->assertStringContainsString('until', $ok);
+    }
+
+    /** A frontend JSON-sztringként is küldheti az rrule-t. */
+    public function testRruleAsJsonStringIsAlsoChecked(): void {
+        $ok = \Eloquent\CalMass::invalidDateTimeReason([
+            'start_date' => '2026-01-01T10:00:00',
+            'rrule' => '{"freq":"monthly","dtstart":"2026-01-01TNaN:NaN:NaN"}',
+        ]);
+        $this->assertNotNull($ok);
+    }
+
+    /** Az élesen talált, teljes sor — pont ez nem mehet át többé. */
+    public function testTheRowFoundInProductionIsRejected(): void {
+        $this->assertNotNull(\Eloquent\CalMass::invalidDateTimeReason([
+            'start_date' => '2026-01-01TNaN:NaN:NaN',
+            'rrule' => ['freq' => 'monthly', 'until' => '2026-12-31T23:59',
+                        'dtstart' => '2026-01-01TNaN:NaN:NaN', 'bysetpos' => 1, 'byweekday' => ['SU']],
+            'title' => 'Szentmise',
+        ]));
+    }
+
+    /** Ismétlődés nélküli, hibátlan mise továbbra is átmegy. */
+    public function testAPlainValidMassPasses(): void {
+        $this->assertNull(\Eloquent\CalMass::invalidDateTimeReason([
+            'start_date' => '2026-03-02T10:00:00',
+            'rrule' => null,
+            'title' => 'Szentmise',
+        ]));
+    }
+}


### PR DESCRIPTION
Nincs hozzá jegy: a `/health` „elastic-misék nélküli misézőhelyek" listáját néztem meg és ez jött ki belőle.

## Mit mutat a /health

Helyben **1** misézőhely van misékkel, de elastic-misék nélkül: **Őrangyalok-kápolna (Nagyatád), #4553**.

⚠️ **Ez a dev-adatbázis száma**, nem az élesé — a `/health`-hez éles belépés kell. Ez helyileg nem látta az AI. Az éles számot neked kell megnézned; a lekérdezés a végén.

## Mi van azzal az egy templommal

Két miséje van, mindkettő így:

```
start_date: 2026-01-01TNaN:NaN:NaN
     rrule: {"freq":"monthly","until":"2026-12-31T23:59",
             "dtstart":"2026-01-01TNaN:NaN:NaN","bysetpos":1,"byweekday":["SU"]}
   comment: kéthetente
created_at: 2026-01-03 / 2026-01-12
```

A szabály maga értelmes — a hónap 1. és 3. vasárnapja, ahogy a „kéthetente" megjegyzés is mondja. **Csak az időpont hiányzik**, `NaN` alakban.

## Miért baj ez, és miért nem tűnt fel

Az ilyen mise **némán eltűnik**. A generátor kihagyja:

```
Invalid RRULE dtstart, skipping mass ID 107996: '2026-01-01TNaN:NaN:NaN'
```

Tehát a keresőbe soha nem kerül be — **a szerkesztőben viszont ott van**. A gondnok januárban felvitte a miserendet, látja is a naptárban, és fogalma sincs róla, hogy a látogatók számára nem létezik. Hét hónapja.

## Hol keletkezett

A mentés (`ajax/calendar/masses.php`) **ellenőrzés nélkül** írta ki, amit a frontend küld:

```php
CalMass::create($massData);   // se validáció, se szűrés
```

Az üresen hagyott időpontból a JS-ben `NaN` lesz, és ez így, változatlanul landolt az adatbázisban.

## Mit tettem

Ellenőrzöm a `start_date`-et és az ismétlődés `dtstart` / `until` értékét, és érthető hibaüzenettel visszautasítom a mentést:

> Hiányzó vagy értelmezhetetlen időpont ennél: „Szentmise". A kezdés nem értelmezhető: 2026-01-01TNaN:NaN:NaN

Előbb **mindent** megnézek, és csak utána írok — fél-mentett miserendet ne hagyjunk magunk után.

A `Carbon`-ra nem lehet ráhagyni: az a `NaN`-t szemétként eldobva **éjfelet csinál belőle**, tehát a hibás időpont csendben átcsúszna, és 00:00-s miseként jelenne meg. Ezért csak a ténylegesen használt alakokat fogadom el (dátum, dátum+idő másodperccel vagy anélkül, `Z` vagy `+02:00` végződéssel).

## Tesztek

18 eset: 6 érvényes alak átmegy, 7 hibás elbukik (köztük a pontos éles érték, `undefined`, `Invalid Date`, fordított dátumsorrend), plusz az `rrule.dtstart`, az `rrule.until`, és a JSON-sztringként küldött rrule.

A teljes PHP-készlet (653 teszt) zöld.

## Ami NEM ez a PR dolga

**A meglévő két sor időpontja elveszett** — a `duration` is `NULL`, tehát nincs miből visszafejteni. Ezeket a gondnoknak újra kell rögzítenie. Javaslom megkeresni; a `/health` listája amúgy is kiírja a templomot.

**A frontend oldali javítás külön téma.** A backend a végső védvonal, és most már fog; de jobb lenne, ha a szerkesztő be sem engedné elküldeni az üres időpontot. Ha akarod, ránézek az Angular oldalra is.

Az éles állapot lekérdezése:

```sql
SELECT id, church_id, title, start_date, rrule
FROM cal_masses
WHERE rrule LIKE '%NaN%' OR start_date LIKE '%NaN%';
```