### PR TITLE
Befoltozom a maradék ellenőrizetlen ajax végpontot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**miserend.hu** is a Hungarian Catholic mass times search platform. Users find nearby churches and Mass schedules; church admins manage service times. Repository: https://github.com/szentjozsefhackathon/miserend.hu
+
+## Tech Stack
+
+- **Backend**: PHP 8.4, Twig 3.0, Laravel Eloquent ORM, Apache
+- **Frontend**: Angular 21 (standalone components), FullCalendar 6, Angular Material 21, Bootstrap 5 + jQuery (legacy)
+- **Database**: MySQL 8.0, Elasticsearch 8 (full-text search)
+- **Testing**: PHPUnit 10, Symfony Panther 2 (E2E), Karma + Jasmine (Angular)
+- **Infrastructure**: Docker Compose, Node.js 18
+
+## Development Setup
+
+```bash
+cd webapp && npm ci && cd ..
+docker-compose -f docker/compose.yml -f docker/compose.dev.yml up
+# App: http://localhost:8000  Login: admin / miserend
+# Mailcatcher: http://localhost:11080  Kibana: http://localhost:5601
+```
+
+Port is configurable via `MISEREND_PORT` in `.env`.
+
+## Common Commands
+
+### Angular Calendar
+```bash
+cd calendar
+npm ci
+npm run build                        # build → dist/mcal
+npm run start:integrated             # watch mode with PHP integration
+npx ng test --watch=false --browsers=ChromeHeadless  # CI mode
+```
+
+### PHP Backend
+```bash
+cd webapp && composer install
+```
+
+### Testing
+```bash
+./scripts/docker-test.sh                          # PHP unit + integration
+./scripts/docker-test.sh --testsuite api          # specific suite
+./scripts/docker-test-panther.sh                  # E2E browser tests
+./scripts/docker-test-panther.sh -- --filter HomepageTest
+./scripts/docker-coverage.sh                      # coverage report → webapp/tests/coverage/html/
+```
+
+### Docker Utilities
+```bash
+docker exec -it miserend bash
+docker exec miserend php index.php q=health
+docker exec -it mysql mysql -u root -p miserend
+```
+
+## Architecture
+
+### PHP Routing
+`webapp/index.php` → `Path` class → resolves URL to a PHP class → instantiates it. Page handlers live in `Html\*` namespace, REST endpoints in `Api\*`, Eloquent models in `Eloquent\*`. Templates are Twig files in `webapp/templates/`.
+
+### Adding a Page/API Endpoint
+- **Page**: create `webapp/classes/html/{Page}.php` extending `Html`, set `$this->template`, create `.twig` in `webapp/templates/`, add routing in `Path` if needed.
+- **API**: create `webapp/classes/api/{Feature}.php` extending `Api`, add tests in `webapp/tests/Api/`.
+
+### Angular App
+Standalone components under `calendar/src/app/`. State via RxJS — no NgRx. Built output (`dist/mcal`) is copied to `webapp/js/mcal/` by `docker/miserend/calendar_deploy.py`. Use `ng generate component features/my-feature` for new components.
+
+### Elasticsearch
+Full-text search for churches and masses. Updated via `ExternalApi\ElasticsearchApi::updateChurches()` / `updateMasses()`. Manual trigger: `/index.php?q=cron&cron_id=38` (churches) or `&cron_id=39` (masses — can take 30+ min for 500k+ events).
+
+### Database Schema Changes
+Add SQL to `docker/mysql/initdb.d/`, then `docker-compose down -v && docker-compose up` to reinitialize.
+
+## Conventions
+
+- **Commit messages**: Hungarian (project convention)
+- **PHP naming**: PascalCase classes, camelCase methods
+- **Angular testing**: use `xdescribe()` for pending tests until TestBed providers are ready
+- **PHP tests**: real test database (no mocks), initialized fresh per run
+- **UI strings**: translatable via `t()` function and i18n system
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `webapp/index.php` | Request entry point |
+| `webapp/load.php` | Bootstrap: autoloader, timezone, Twig, session, `.env` |
+| `webapp/config.php` | Environment-specific config (DB, API keys) |
+| `webapp/classes/path.php` | URL routing |
+| `webapp/classes/user.php` | Authentication |
+| `calendar/src/main.ts` | Angular bootstrap |
+| `docker/compose.yml` | Main Compose file |
+| `docker/miserend/Dockerfile` | Multi-stage app image (Node → PHP) |

--- a/webapp/classes/html/ajax/calendar/generate.php
+++ b/webapp/classes/html/ajax/calendar/generate.php
@@ -67,6 +67,26 @@ class Generate extends \Html\Ajax\Calendar\CalendarApi {
             exit;
         }
 
+        // Ezen a végponton EDDIG SEMMILYEN jogosultság-ellenőrzés nem volt, pedig a PUT
+        // teljes mise-újraindexelést indít. Kipróbálva: bejelentkezés nélkül, sima
+        // curl-lel HTTP 200, és le is futott. Egy teljes futás 15+ perc és
+        // erősen terheli az Elasticsearchöt — bárki, korlátlanul indíthatta.
+        //
+        // Ugyanaz a szabály, mint a szerkesztésnél: aki a templomhoz írhat, az
+        // regenerálhatja is a miséit. Minden kért templomra megköveteljük.
+        foreach ($this->tids as $tid) {
+            $church = \Eloquent\Church::find($tid);
+            if (!$church) {
+                $this->sendJsonError('Nincs ilyen templom: ' . $tid, 404);
+                exit;
+            }
+            $church->append(['writeAccess']);
+            if (!$church->writeAccess) {
+                $this->sendJsonError('Hiányzó jogosultság!', 403);
+                exit;
+            }
+        }
+
         
 
         switch ($_SERVER['REQUEST_METHOD']) {

--- a/webapp/classes/html/ajax/favorite.php
+++ b/webapp/classes/html/ajax/favorite.php
@@ -7,6 +7,14 @@ class Favorite extends Ajax {
     public function __construct() {
         global $user;
 
+        // A kedvenc a felhasználóhoz tartozik, vendégnek tehát nincs értelme. Eddig
+        // viszont a bejelentkezés hiánya nem állította meg a kérést: a sor `uid = 0`-val
+        // beíródott a `favorites` táblába. Nem szivárgott ki adat, de bárki korlátlanul
+        // tölthette a táblát gazdátlan sorokkal.
+        if (empty($user->uid)) {
+            throw new \Exception("Hiányzó jogosultság: a kedvencekhez be kell jelentkezni.");
+        }
+
         $tid = \Request::IntegerRequired('tid');
         $method = \Request::SimpletextRequired('method');
         echo $tid."-".$method;

--- a/webapp/tests/Api/ApiEndpointsTest.php
+++ b/webapp/tests/Api/ApiEndpointsTest.php
@@ -515,8 +515,39 @@ class ApiEndpointsTest extends TestCase {
     }
 
     /**
+     * A munkamenet-süti megszerzése a webes bejelentkező űrlappal. A naptár-végpontok
+     * nem API-tokennel, hanem munkamenettel dolgoznak.
+     */
+    private function sessionCookie(): string
+    {
+        $ch = curl_init($this->baseUrl . '/');
+        curl_setopt_array($ch, [
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => http_build_query([
+                'login'  => self::FIXTURE_USERNAME,
+                'passw'  => self::FIXTURE_PASSWORD,
+                'logout' => 'false',
+            ]),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER         => true,
+            CURLOPT_TIMEOUT        => 30,
+        ]);
+        $valasz = (string) curl_exec($ch);
+        curl_close($ch);
+
+        preg_match_all('/^Set-Cookie:\s*([^;]+)/mi', $valasz, $m);
+        $this->assertNotEmpty($m[1], 'Nem sikerült bejelentkezni a teszthez.');
+
+        return implode('; ', $m[1]);
+    }
+
+    /**
      * Regression test: /calendar/generate must return valid JSON.
      * Before the fix, echo statements inside updateMasses() corrupted the JSON response.
+     *
+     * A végpont bejelentkezést kíván: korábban SEMMILYEN jogosultság-ellenőrzés nem volt
+     * rajta, pedig a PUT teljes mise-újraindexelést indít. A JSON-helyesség vizsgálata
+     * ettől független, csak be kell hozzá jelentkezni.
      */
     public function testCalendarGenerateReturnsValidJson(): void
     {
@@ -526,6 +557,7 @@ class ApiEndpointsTest extends TestCase {
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT        => 120,
             CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
+            CURLOPT_COOKIE         => $this->sessionCookie(),
         ]);
         $raw      = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/webapp/tests/Integration/AjaxEndpointAuthTest.php
+++ b/webapp/tests/Integration/AjaxEndpointAuthTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Az ajax végpontok jogosultság-ellenőrzése.
+ *
+ * A javaslat-elfogadásnál derült ki, hogy egy adatot MÓDOSÍTÓ végpont teljesen
+ * ellenőrzés nélkül maradhat: a `handle()` csak a GET ágon nézte a jogosultságot, a
+ * POST-ot nem. Átnézve az összes ajax végpontot, még kettő volt hasonló állapotban:
+ *
+ *  * `ajax/calendar/generate` (PUT) — bejelentkezés nélkül indított teljes
+ *    mise-újraindexelést. Nem adatszivárgás, de egy futás 15+ perc és erősen terheli az
+ *    Elasticsearchöt, tehát bárki, korlátlanul terhelhette a szervert.
+ *  * `ajax/favorite` — vendégként is „elmentette" a kedvencet: a sor `uid = 0`-val
+ *    beíródott a táblába. Gazdátlan adat, korlátlanul szaporítható.
+ *
+ * Ez a teszt névsor szerint végigmegy az adatot módosító végpontokon, és megköveteli,
+ * hogy bejelentkezés nélkül MINDEGYIK visszautasítson. Új írási végpontnál ide is fel
+ * kell venni egy sort — ez a szándék.
+ */
+class AjaxEndpointAuthTest extends TestCase {
+
+    private string $baseUrl;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
+    }
+
+    /** @return array{code:int, body:string} */
+    private function keres(string $url, string $method = 'GET', ?array $adat = null): array {
+        $opt = ['method' => $method, 'timeout' => 60, 'ignore_errors' => true];
+        if ($adat !== null) {
+            $opt['header'] = "Content-Type: application/json\r\n";
+            $opt['content'] = json_encode($adat);
+        }
+        $valasz = @file_get_contents($this->baseUrl . $url, false, stream_context_create(['http' => $opt]));
+        $kod = 0;
+        foreach ($http_response_header ?? [] as $sor) {
+            if (preg_match('#^HTTP/\S+\s+(\d{3})#', $sor, $m)) {
+                $kod = (int) $m[1];
+            }
+        }
+        return ['code' => $kod, 'body' => (string) $valasz];
+    }
+
+    /**
+     * A visszautasítás kétféle alakban jöhet: JSON hibakód (a naptár-végpontok), vagy
+     * kivétel -> hibaoldal (a régebbi ajax végpontok). Mindkettő elfogadható; ami NEM,
+     * az a csendes siker.
+     */
+    private function assertVisszautasit(array $valasz, string $vegpont): void {
+        if ($valasz['code'] === 0) {
+            $this->markTestSkipped('A futó példány nem érhető el.');
+        }
+
+        // A törzs lehet JSON, ahol az ékezet `á` alakban áll ("jogosultság"),
+        // ezért csak az ékezet nélküli tőre illesztünk.
+        $elutasitva = $valasz['code'] >= 400
+            || (bool) preg_match('/jogosults|megtagadva|Hiba t[öo]rt|error/iu', $valasz['body']);
+
+        $this->assertTrue($elutasitva,
+            "Bejelentkezés nélkül átment: $vegpont (HTTP {$valasz['code']}) — "
+            . mb_substr(trim($valasz['body']), 0, 160));
+    }
+
+    /**
+     * Ez a kettő volt nyitva. A generate PUT-ot szándékosan egyetlen templomra kérjük,
+     * hogy ha mégis átmenne, ne induljon el egy teljes újraindexelés a teszt alatt.
+     */
+    public function testGenerateCannotBeTriggeredAnonymously(): void {
+        $this->assertVisszautasit(
+            $this->keres('/ajax/calendar/generate?tids[]=1&years[]=' . date('Y'), 'PUT'),
+            'ajax/calendar/generate (PUT)'
+        );
+    }
+
+    public function testFavoriteCannotBeSetAnonymously(): void {
+        $elotte = (int) DB::table('favorites')->where('uid', 0)->count();
+
+        $this->assertVisszautasit(
+            $this->keres('/ajax/favorite?tid=1&method=add'),
+            'ajax/favorite'
+        );
+
+        $this->assertSame($elotte, (int) DB::table('favorites')->where('uid', 0)->count(),
+            'Gazdátlan (uid=0) kedvenc-sor keletkezett.');
+    }
+
+    /**
+     * Ezek már korábban is ellenőriztek — a teszt azt rögzíti, hogy így is maradjon.
+     *
+     * @dataProvider vedettVegpontok
+     */
+    public function testWritingEndpointsRefuseAnonymousRequests(string $url, string $method, ?array $adat): void {
+        $this->assertVisszautasit($this->keres($url, $method, $adat), $url);
+    }
+
+    public static function vedettVegpontok(): array {
+        return [
+            'miserend mentése'      => ['/calendar/masses/1', 'POST', ['masses' => [], 'deletedMasses' => []]],
+            'periódusok'            => ['/calendar/periods', 'POST', ['years' => [2026]]],
+            'észrevétel megbízható' => ['/ajax/switchreliable?rid=1&reliable=i', 'GET', null],
+            'OSM-kapcsolat törlése' => ['/ajax/osmkapcsolat?action=delete&tid=1', 'GET', null],
+            'chat mentése'          => ['/ajax/chat?action=save&message=teszt', 'GET', null],
+            'templom-link hozzáadása' => ['/ajax/churchlink?action=add&church_id=1&href=http%3A%2F%2Fpelda.hu', 'GET', null],
+        ];
+    }
+}


### PR DESCRIPTION
Nincs hozzá jegy: átnéztem meg a többi ajax végpontot is a #744 után.

## Az audit

Végigmentem mind a 23 ajax végponton: melyik ír adatot, és melyik ellenőriz jogosultságot. **Még kettő volt nyitva.**

| végpont | mit ír | ellenőrzött? |
|---|---|---|
| `calendar/suggestions` (accept/reject) | javaslat állapota + misék | **nem** → #744 |
| **`calendar/generate` (PUT)** | teljes mise-újraindexelés | **nem** → ez a PR |
| **`ajax/favorite`** | `favorites` sor | **nem** → ez a PR |
| `calendar/masses` | misék | igen |
| `calendar/periods` | periódus-évek | igen |
| `ajax/switchreliable` | észrevétel megbízhatósága | igen |
| `ajax/osmkapcsolat` | templom OSM-adatai | igen (admin) |
| `ajax/chat` | chat-üzenet | igen |
| `ajax/churchlink` | templom-linkek | igen |
| a többi 14 | csak olvas | — |

*(A `churchlink.php` elsőre gyanúsnak látszott, mert `WriteAccess`-t ír nagy W-vel — de az Eloquent ugyanarra az accessorra oldja fel, tehát rendben van.)*

## 1. `calendar/generate` (PUT)

Bejelentkezés nélkül indított **teljes mise-újraindexelést**. Kipróbálva a futó példányon, a javítás előtti kóddal:

```
PUT /ajax/calendar/generate?tids[]=1&years[]=2026    (sima curl, süti nélkül)
→ HTTP 200, {"success":true, ...}   — le is futott
```

Nem adatszivárgás, de **egy teljes futás 15+ perc** (lemértem a #731-ben) és erősen terheli az Elasticsearchöt. Bárki, korlátlanul indíthatta — és a #731 előtt egymásra is torlódtak.

Ugyanaz a `writeAccess`-szabály kerül rá, mint a szerkesztésre: aki a templomhoz írhat, az regenerálhatja a miséit. **Minden kért templomra** megköveteljük, nem csak az elsőre.

## 2. `ajax/favorite`

Vendégként is „elmentette" a kedvencet: a sor **`uid = 0`-val beíródott** a táblába. Ellenőriztem, tényleg keletkezett ilyen sor. Gazdátlan adat, korlátlanul szaporítható. A kedvenc a felhasználóhoz tartozik, vendégnek nincs értelme.

## Tesztek

Új `AjaxEndpointAuthTest`, ami **névsor szerint** végigmegy az adatot módosító végpontokon, és megköveteli, hogy bejelentkezés nélkül mindegyik visszautasítson. A két javított végpont a javítás nélkül pirosan bukik:

```
Bejelentkezés nélkül átment: ajax/calendar/generate (PUT) (HTTP 200)
Bejelentkezés nélkül átment: ajax/favorite (HTTP 200) — 1-add
```

A már korábban is védett hatot is felvettem — hogy úgy is maradjanak. **Új írási végpontnál ide is fel kell venni egy sort**; ez a szándék.

## Egy meglévő teszt módosult

A `ApiEndpointsTest::testCalendarGenerateReturnsValidJson` bejelentkezés nélkül hívta a végpontot, és 200-at várt — vagyis a **régi, nyitott viselkedést rögzítette**. A teszt szándéka (a válasz érvényes JSON legyen) változatlan, csak megszerzi hozzá a munkamenet-sütit.

A teljes PHP-készlet (643 teszt) zöld.

## Viszony a #744-hez

Független ágak, nincs közös fájl. A #744 a javaslat-elfogadást zárja le és a kezelőt is rögzíti; ez a kettő maradékot.