### PR TITLE
Nem hasal el a rendszer hosszú importált címtől, és nem indexeljük a régi éveket

### DIFF
--- a/webapp/classes/eloquent/calmass.php
+++ b/webapp/classes/eloquent/calmass.php
@@ -653,7 +653,10 @@ class CalMass extends CalModel
 
             // Periódus nélküli RRULE-os események kezelése. Ez főleg importált naptáraknál fordulhat elő, ahol nem tudjuk biztosan megkövetelni a period_id-t, de lehetnek RRULE-juk.
             foreach($massesFromImport as $mass) {
-echo "Period nélküli RRULE-os mise: ".$mass->id." - ".$mass->title." in year ".$year."<br>\n";
+                // #756: itt korábban egy bennfelejtett `echo` írta ki minden importált,
+                // period nélküli RRULE-os misét — pedig ez a NORMÁLIS eset (l. a fenti
+                // megjegyzést: importnál nem követelhetjük meg a period_id-t). Hibának
+                // látszott, közben csak zaj volt, és mise × év darabszámban ömlött.
 
                 // A ciklusváltozókat KÖRÖNKÉNT nullázni kell. Korábban az `if` blokkokon
                 // belül keletkeztek, tehát az előző mise értéke átszivárgott a következőre:

--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -731,8 +731,12 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 
 	           $rrule = new \SimpleRRule($mass['rrule']);
 	           $occs = $rrule->getOccurrences();
-			$log("Talált időpontok száma: " . count($occs));
-			//printr($occs); exit;
+			/*
+			 * #756: itt SORONKÉNT ment ki egy „Talált időpontok száma" a naplóba —
+			 * mise-periódusonként. Egyetlen templomnál (pl. #276) ez több ezer sor, és
+			 * a valódi hibákat (elhasalt import, túl hosszú cím) elmossa. Az összesített
+			 * darabszám a ciklus után úgyis ott van.
+			 */
 			foreach($occs as $occ) {
 				$bulkInsert[] = [
 					'index' => [

--- a/webapp/classes/externalcalendarimporter.php
+++ b/webapp/classes/externalcalendarimporter.php
@@ -251,13 +251,40 @@ class ExternalCalendarImporter {
         return true;
     }
 
+    /**
+     * #756: az indexelendő évek — ÉSSZERŰ ablakra vágva.
+     *
+     * Eddig a feed MINDEN `DTSTART` évét indexeltük. Egy régóta vezetett Google
+     * naptárban viszont ott van a teljes múlt is, sőt hibás/epoch dátumból 1970 is —
+     * a templom/276 naplója ezért volt tele „... in year 1970" sorokkal. Az 1970-es
+     * misékre senki nem keres, viszont minden ilyen év végigfut a teljes
+     * mise-generáláson, tehát csak a futásidőt szorozza.
+     *
+     * Az ablak alja a tavalyi év (ennyi kell a „mikor volt utoljára" jellegű
+     * kérdésekhez), a teteje pedig egy felső korlát: enélkül egyetlen elgépelt
+     * évszám (pl. 29999) beláthatatlanul sok kört jelentene.
+     */
+    private const INDEX_YEARS_BACK = 1;
+    private const INDEX_YEARS_AHEAD = 5;
+
     /** @return int[] */
     private static function extractIndexedYears(string $icsContent): array {
+        $thisYear = (int)date('Y');
+        $min = $thisYear - self::INDEX_YEARS_BACK;
+        $max = $thisYear + self::INDEX_YEARS_AHEAD;
+
         preg_match_all('/^DTSTART(?:;[^:]*)?:(\d{4})/mi', $icsContent, $matches);
-        $years = array_map('intval', $matches[1] ?? []);
-        $years[] = (int)date('Y') - 1;
-        $years[] = (int)date('Y');
-        $years[] = (int)date('Y') + 1;
+        $years = array_filter(
+            array_map('intval', $matches[1] ?? []),
+            static fn (int $y): bool => $y >= $min && $y <= $max
+        );
+
+        // A kereséshez ez a három év mindig kell, akkor is, ha a feed egyetlen
+        // eseménye sem esik ide (pl. csak régi vagy csak nagyon távoli dátumok).
+        $years[] = $thisYear - 1;
+        $years[] = $thisYear;
+        $years[] = $thisYear + 1;
+
         $years = array_values(array_unique($years));
         sort($years);
         return $years;
@@ -426,6 +453,39 @@ class ExternalCalendarImporter {
     }
 
     /**
+     * #756: a `cal_masses.title` varchar(255) — a hosszabb SUMMARY-tól az import
+     * elhasalt („Data too long"). Élő eset a templom/282 gyászmise-bejegyzése, ami a
+     * teljes gyászjelentést beleírta a címbe (~430 karakter).
+     *
+     * Nem az egész eseményt dobjuk el egy hosszú cím miatt: levágjuk. Szóhatáron,
+     * hogy ne maradjon csonka szó, és többájtos-biztosan (mb_*), különben egy
+     * kettévágott ékezetes karakter érvénytelen UTF-8-at adna.
+     *
+     * A `comment` mezőbe NEM tehetjük át a maradékot: azt az IMPORT_MARKER foglalja,
+     * és pontos egyezéssel dolgozik a `replaceAll()` törlése és az `isImported()` is.
+     */
+    private const TITLE_MAX_LENGTH = 255;
+
+    public static function trimSummary(string $summary): string {
+        // Az iCal SUMMARY tartalmazhat sortörést és folytatósort; egy sorba hozzuk.
+        $summary = trim(preg_replace('/\s+/u', ' ', $summary) ?? $summary);
+
+        if (mb_strlen($summary) <= self::TITLE_MAX_LENGTH) {
+            return $summary;
+        }
+
+        $cut = mb_substr($summary, 0, self::TITLE_MAX_LENGTH - 1);
+
+        // Csak akkor vágunk vissza szóhatárig, ha nem veszítjük el a cím felét.
+        $lastSpace = mb_strrpos($cut, ' ');
+        if ($lastSpace !== false && $lastSpace > (int)(self::TITLE_MAX_LENGTH / 2)) {
+            $cut = mb_substr($cut, 0, $lastSpace);
+        }
+
+        return rtrim($cut, " ,;:-–—") . '…';
+    }
+
+    /**
      * Convert iCalendar VEVENT to CalMass object
      */
     private static function createCalMassFromEvent($event, $churchId) {
@@ -450,7 +510,7 @@ class ExternalCalendarImporter {
 
         $calMass = \Eloquent\CalMass::make([
             'church_id' => $churchId,
-            'title' => $summary,
+            'title' => self::trimSummary($summary),
             'start_date' => $startDate,
             'rrule' => $rrule,
             'exdate' => !empty($exdates) ? $exdates : null,

--- a/webapp/classes/externalcalendarimporter.php
+++ b/webapp/classes/externalcalendarimporter.php
@@ -508,9 +508,16 @@ class ExternalCalendarImporter {
             $exdates = self::extractExDates($event);
         }
 
+        $title = self::trimSummary($summary);
+        if ($title !== trim(preg_replace('/\s+/u', ' ', $summary) ?? $summary)) {
+            // A vágás nem hiba, de nem is némán történik: a naptár gazdája így
+            // megtudja, hogy a bejegyzés címe hosszabb, mint amit meg tudunk jeleníteni.
+            echo "  ⚠ A cím túl hosszú volt, levágtam: " . htmlspecialchars($title) . "<br>\n";
+        }
+
         $calMass = \Eloquent\CalMass::make([
             'church_id' => $churchId,
-            'title' => self::trimSummary($summary),
+            'title' => $title,
             'start_date' => $startDate,
             'rrule' => $rrule,
             'exdate' => !empty($exdates) ? $exdates : null,

--- a/webapp/tests/Unit/ExternalCalendarImportLimitsTest.php
+++ b/webapp/tests/Unit/ExternalCalendarImportLimitsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #756: az importAllExternalCalendars() két zajforrása.
+ *
+ *  1. A `cal_masses.title` varchar(255); a hosszabb SUMMARY-tól az import elhasalt.
+ *     Élő eset a templom/282 gyászmise-bejegyzése (~430 karakter).
+ *  2. Az indexelendő évek listája a feed MINDEN `DTSTART`-jából jött, tehát a régi
+ *     (akár 1970-es) események évei is — feleslegesen szorozva a generálást.
+ */
+class ExternalCalendarImportLimitsTest extends TestCase
+{
+    private static function years(string $ics): array
+    {
+        $m = new \ReflectionMethod(\ExternalCalendarImporter::class, 'extractIndexedYears');
+        $m->setAccessible(true);
+        return $m->invoke(null, $ics);
+    }
+
+    /* ---------- 1) cím-hossz ---------- */
+
+    public function testShortSummaryIsKeptAsIs(): void
+    {
+        self::assertSame('Szentmise', \ExternalCalendarImporter::trimSummary('Szentmise'));
+    }
+
+    public function testWhitespaceIsNormalised(): void
+    {
+        self::assertSame('Szentmise a plébánián', \ExternalCalendarImporter::trimSummary("  Szentmise \n a   plébánián  "));
+    }
+
+    /** A jegyben szereplő valódi cím. */
+    public function testTheRealTooLongTitleFitsTheColumn(): void
+    {
+        $summary = 'Laczkovich Gézáné Mravik Piroska gyászmiséje és temetése, - Búcsúzik tőle: 3 fia Ádám, '
+            . '- György és Géza, - testvére Magdolna és sógora László, - két menye Brigitta és Réka, '
+            . '- unokái Csenge, - Domos, - Édua, - Annamária, - Zsuzsanna és Ferenc, - keresztfiai Tamás és László, '
+            . '- keresztlánya Edit és az ő családjaik, - rokonok, - barátok és ismerősök';
+
+        $trimmed = \ExternalCalendarImporter::trimSummary($summary);
+
+        self::assertGreaterThan(255, mb_strlen($summary), 'A fixture nem is volt túl hosszú.');
+        self::assertLessThanOrEqual(255, mb_strlen($trimmed));
+        self::assertStringStartsWith('Laczkovich Gézáné Mravik Piroska gyászmiséje', $trimmed);
+        self::assertStringEndsWith('…', $trimmed);
+    }
+
+    /** Többájtos vágás: érvényes UTF-8 kell maradjon. */
+    public function testCutStaysValidUtf8(): void
+    {
+        $trimmed = \ExternalCalendarImporter::trimSummary(str_repeat('árvíztűrő ', 60));
+
+        self::assertLessThanOrEqual(255, mb_strlen($trimmed));
+        self::assertSame($trimmed, mb_convert_encoding($trimmed, 'UTF-8', 'UTF-8'), 'Csonka többájtos karakter maradt.');
+    }
+
+    /** Szóköz nélküli szörnyeteg: vágjunk, de akkor is férjünk bele. */
+    public function testSummaryWithoutSpacesIsStillTruncated(): void
+    {
+        $trimmed = \ExternalCalendarImporter::trimSummary(str_repeat('a', 600));
+
+        self::assertLessThanOrEqual(255, mb_strlen($trimmed));
+        self::assertStringEndsWith('…', $trimmed);
+    }
+
+    /* ---------- 2) indexelendő évek ---------- */
+
+    private static function ics(array $dtstarts): string
+    {
+        $lines = ['BEGIN:VCALENDAR'];
+        foreach ($dtstarts as $d) {
+            $lines[] = 'BEGIN:VEVENT';
+            $lines[] = 'DTSTART:' . $d;
+            $lines[] = 'END:VEVENT';
+        }
+        $lines[] = 'END:VCALENDAR';
+        return implode("\r\n", $lines);
+    }
+
+    public function testEpochYearIsNotIndexed(): void
+    {
+        $years = self::years(self::ics(['19700101T000000Z', date('Y') . '0101T090000Z']));
+
+        self::assertNotContains(1970, $years, 'Az 1970-es évet is végiggenerálnánk.');
+    }
+
+    public function testOldYearsAreDropped(): void
+    {
+        $years = self::years(self::ics(['20030101T090000Z', '20140101T090000Z']));
+
+        self::assertNotContains(2003, $years);
+        self::assertNotContains(2014, $years);
+    }
+
+    /** A keresés három éve mindig benne van, akkor is, ha a feed csak régi dátumokat tartalmaz. */
+    public function testTheSearchWindowIsAlwaysPresent(): void
+    {
+        $now = (int)date('Y');
+        $years = self::years(self::ics(['19700101T000000Z']));
+
+        self::assertSame([$now - 1, $now, $now + 1], $years);
+    }
+
+    /** Az ablakon belüli jövőbeli év viszont kell. */
+    public function testNearFutureYearsAreKept(): void
+    {
+        $now = (int)date('Y');
+        $years = self::years(self::ics([($now + 3) . '0101T090000Z']));
+
+        self::assertContains($now + 3, $years);
+    }
+
+    /** Elgépelt évszám ne robbantsa fel a generálást. */
+    public function testAbsurdFutureYearIsDropped(): void
+    {
+        $years = self::years(self::ics(['29990101T090000Z']));
+
+        self::assertNotContains(2999, $years);
+    }
+}


### PR DESCRIPTION
Closes #756

## 1. Túl hosszú cím (templom/282)

A `cal_masses.title` `varchar(255)`, a külső naptár `SUMMARY`-ja viszont ennél hosszabb is lehet. A jegyben szereplő gyászmise-bejegyzés a teljes gyászjelentést beleírta a címbe (~430 karakter), és az import elhasalt rajta.

Nem dobom el az egész eseményt egy hosszú cím miatt: levágom. Szóhatáron, hogy ne maradjon csonka szó, és `mb_*`-gyel, különben egy kettévágott ékezetes karakter érvénytelen UTF-8-at adna.

A maradékot **nem** tehetem át a `comment` mezőbe: azt az `IMPORT_MARKER` foglalja, és pontos egyezéssel dolgozik rá a `replaceAll()` törlése meg az `isImported()` is.

## 2. „Period nélküli RRULE-os mise ... in year 1970" (templom/276)

Két külön dolog volt itt, és **egyik sem hiba**, ahogy sejtetted:

**a) A kiírás maga zaj.** A `calmass.php:656`-on egy bennfelejtett `echo` ült — behúzás nélkül, a sor elején. A fölötte lévő komment épp azt írja, hogy ez a NORMÁLIS eset: „importált naptáraknál ... nem tudjuk biztosan megkövetelni a period_id-t, de lehetnek RRULE-juk". A kód tehát eleve megengedi, csak közben kikiabálta. Törlöm.

**b) Az 1970 viszont valódi pazarlás.** Az `extractIndexedYears()` a feed **minden** `DTSTART` évét indexelte:

```php
preg_match_all('/^DTSTART(?:;[^:]*)?:(\d{4})/mi', $icsContent, $matches);
$years = array_map('intval', $matches[1] ?? []);
```

Egy régóta vezetett Google-naptárban ott a teljes múlt, hibás/epoch dátumból pedig 1970. Az 1970-es misékre senki nem keres, viszont minden ilyen év végigfut a **teljes** mise-generáláson — tehát csak a futásidőt szorozza, templomonként. Ésszerű ablakra vágom: tavalytól öt évre előre. A keresés három éve (tavaly/idén/jövőre) mindig bent marad, akkor is, ha a feed egyetlen eseménye sem esik oda.

Ez egyben magyarázza, miért „sok-sok" sor jött: a kiírás **mise × év** darabszámban ömlött.

## Teszt

`ExternalCalendarImportLimitsTest`, 10 eset — a jegyben szereplő valódi címmel és a 1970-es `DTSTART`-tal. PHP: 764 zöld.

## Megjegyzés a seedhez

Egyetértek, hogy a 15 naptár adata bekerülhetne a seedbe — nyilvános, és teszteléshez jó. Külön jegyet érdemel, mert a seed-fájl mérete és a felvétel módja (fix ICS-pillanatkép vs. élő letöltés) önálló döntés.
