### PR TITLE
Nem veszek fel betűre azonos észrevételt kétszer

### DIFF
--- a/webapp/classes/api/report.php
+++ b/webapp/classes/api/report.php
@@ -110,6 +110,21 @@ class Report extends Api {
 
         $this->prepareRemark();
 
+        // #755: ugyanaz az észrevétel néha két-háromszor futott be. A mobilkliens
+        // ismételt küldése (rossz hálózaton a felhasználó újra nyom, vagy a kérés
+        // magától fut le kétszer) ugyanúgy termeli a duplikátumot, mint a webes űrlap,
+        // ezért itt is szűrünk. A válasz változatlan: a beküldő ne higgye, hogy nem
+        // ment el, mert akkor megint próbálkozna.
+        $duplicate = \Eloquent\Remark::findRecentDuplicate(
+            $this->remark->church_id,
+            $this->remark->email,
+            $this->remark->leiras
+        );
+        if ($duplicate) {
+            $this->return['text'] = 'Köszönjük. Elmentettük.';
+            return;
+        }
+
         try {
             $this->remark->save();
             $this->remark->emails();

--- a/webapp/classes/eloquent/remark.php
+++ b/webapp/classes/eloquent/remark.php
@@ -34,6 +34,41 @@ class Remark extends \Illuminate\Database\Eloquent\Model {
         return \Eloquent\Church::find($this->church_id);
         
     }    
+
+    /**
+     * #755: mennyi ideig számít ismétlésnek a betűre azonos észrevétel.
+     *
+     * Bőven a „kétszer kattintottam" fölött: a /remark/add POST-ra nincs
+     * átirányítás, tehát egy F5 percekkel később is újraküldi ugyanazt. Téves
+     * elnyomásból nincs kár — a szöveg azonos, tehát nem vész el információ; egy
+     * valóban új mondanivaló pedig már nem betűre ugyanaz.
+     */
+    public const DUPLICATE_WINDOW_SECONDS = 600;
+
+    /**
+     * #755: van-e friss, betűre azonos észrevétel ugyanattól, ugyanahhoz a templomhoz?
+     *
+     * Ugyanaz az észrevétel néha két-háromszor futott be, pár másodperc különbséggel.
+     * Kiszolgáló oldalon szűrjük, mert az mindhárom okot lefedi: dupla kattintás,
+     * újraküldés (F5), hálózati ismétlés. A hívó a meglévő sorral tér vissza, hogy a
+     * beküldő ugyanazt a visszajelzést kapja — különben azt hinné, nem ment el, és
+     * megint próbálkozna.
+     *
+     * @return static|null
+     */
+    public static function findRecentDuplicate($churchId, ?string $email, ?string $leiras)
+    {
+        if (empty($churchId) || empty($email) || empty($leiras)) {
+            return null;
+        }
+
+        return static::where('church_id', $churchId)
+            ->where('email', $email)
+            ->where('leiras', $leiras)
+            ->where('created_at', '>=', date('Y-m-d H:i:s', time() - static::DUPLICATE_WINDOW_SECONDS))
+            ->orderBy('created_at', 'desc')
+            ->first();
+    }
     
     /* 
      * custom functions 

--- a/webapp/classes/html/remark.php
+++ b/webapp/classes/html/remark.php
@@ -107,7 +107,7 @@ class Remark extends Html {
        
    
     function pageAdded() {
-                
+
         $remark = new \Eloquent\Remark;
 
         $remark->church_id = $this->church->id;
@@ -125,15 +125,30 @@ class Remark extends Html {
             $remark->email = $user->email;
         }
         
+        // #755: ugyanaz az észrevétel néha két-háromszor futott be, pár másodperc
+        // különbséggel — a beküldő türelmetlenül többször nyomta a gombot, illetve a
+        // /remark/add POST-ra nincs átirányítás, tehát egy frissítés is újraküldi.
+        //
+        // Kiszolgáló oldalon fogjuk meg, mert az fedi le mindhárom okot (dupla
+        // kattintás, újraküldés, hálózati ismétlés). Azonos templom + azonos email +
+        // BETŰRE azonos szöveg rövid időn belül nem lehet szándékos második
+        // észrevétel. A beküldő ugyanazt a visszajelzést kapja, különben azt hinné,
+        // hogy nem ment el, és megint próbálkozna.
+        if (\Eloquent\Remark::findRecentDuplicate($remark->church_id, $remark->email, $remark->leiras)) {
+            global $config;
+            $this->debug = $config['debug'];
+            return;
+        }
+
         $megbizhato = \Eloquent\Remark::select('megbizhato')->where('email',$remark->email)->orderBy('created_at','desc')->limit(1)->first();
         if($megbizhato)
             $remark->megbizhato = $megbizhato->megbizhato;
         else
             $remark->megbizhato = '?';
-                                
+
         if (!$remark->save())
             addMessage("Nem sikerült elmenteni az észrevételt. Sajánljuk.", "danger");
-                
+
         if (!$remark->emails())
             addMessage("Nem sikerült elküldeni az értesítő emaileket.", "warning");
                 

--- a/webapp/templates/remark_form.twig
+++ b/webapp/templates/remark_form.twig
@@ -15,7 +15,16 @@
         az egészet beküldheted javaslatcsomagként a karbantartóknak – és nem kell sem bejelentkezésed sem a szöveges forma.
     </div>
 
-    <form method=post action="/remark/add/{{ church.id }}">
+    {# #755: a türelmetlen második-harmadik kattintás miatt ugyanaz az észrevétel
+       többször futott be. A kiszolgáló is szűri (Remark::findRecentDuplicate), ez
+       csak azért van itt, hogy a beküldő LÁSSA, hogy elindult — enélkül nem tudja,
+       történt-e valami, és megint nyom. JS nélküli böngészőben a form változatlanul
+       működik, csak ez a visszajelzés marad el. #}
+    <form method=post action="/remark/add/{{ church.id }}" onsubmit="
+        var b = this.querySelector('button[type=submit]');
+        if (b) { b.disabled = true; b.textContent = 'Küldés…'; }
+        return true;
+    ">
         <input type=hidden name=tid value='{{ church.id }}'>
         {% if not user.loggedin %}
             <span class=alap>Nevem: </span>

--- a/webapp/tests/Integration/RemarkDuplicateTest.php
+++ b/webapp/tests/Integration/RemarkDuplicateTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #755: „Dupla (tripla) észrevétel".
+ *
+ * Ugyanaz az észrevétel néha két-háromszor futott be, pár másodperc különbséggel.
+ * Három ok vezet ide, és mind ugyanoda: a beküldő többször nyomja a gombot, a
+ * /remark/add POST-ra nincs átirányítás (tehát az F5 újraküldi), illetve a
+ * mobilkliens is ismételhet. Ezért kiszolgáló oldalon szűrünk.
+ */
+class RemarkDuplicateTest extends TestCase
+{
+    private int $churchId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $this->churchId = DB::table('templomok')->insertGetId([
+            'nev'        => '755 Teszt templom',
+            'varos'      => 'Budapest',
+            'frissites'  => '2020-01-01',
+            'ok'         => 'i',
+            'plebania'   => '',
+            'leiras'     => '',
+            'megjegyzes' => '',
+            'misemegj'   => '',
+            'bucsu'      => '',
+            'adminmegj'  => '',
+            'log'        => '',
+            'lat'        => 47.5,
+            'lon'        => 19.0,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function addRemark(string $email, string $leiras, ?string $createdAt = null): int
+    {
+        return DB::table('remarks')->insertGetId([
+            'church_id'  => $this->churchId,
+            'allapot'    => 'u',
+            'nev'        => 'Teszt Elek',
+            'email'      => $email,
+            'leiras'     => $leiras,
+            'created_at' => $createdAt ?? date('Y-m-d H:i:s'),
+        ]);
+    }
+
+    public function testAnIdenticalRemarkSecondsLaterIsRecognisedAsDuplicate(): void
+    {
+        $this->addRemark('teszt@example.invalid', 'A vasárnapi mise 10 órakor van, nem 9-kor.');
+
+        $found = \Eloquent\Remark::findRecentDuplicate(
+            $this->churchId,
+            'teszt@example.invalid',
+            'A vasárnapi mise 10 órakor van, nem 9-kor.'
+        );
+
+        self::assertNotNull($found);
+    }
+
+    public function testDifferentTextIsNotADuplicate(): void
+    {
+        $this->addRemark('teszt@example.invalid', 'A vasárnapi mise 10 órakor van.');
+
+        $found = \Eloquent\Remark::findRecentDuplicate(
+            $this->churchId,
+            'teszt@example.invalid',
+            'A szombati mise is elmarad.'
+        );
+
+        self::assertNull($found, 'Más mondanivalót nem szabad elnyomni.');
+    }
+
+    public function testDifferentSenderIsNotADuplicate(): void
+    {
+        $this->addRemark('elso@example.invalid', 'Ugyanaz a hiba a miserendben.');
+
+        $found = \Eloquent\Remark::findRecentDuplicate(
+            $this->churchId,
+            'masodik@example.invalid',
+            'Ugyanaz a hiba a miserendben.'
+        );
+
+        self::assertNull($found, 'Két különböző ember ugyanazt is jelezheti.');
+    }
+
+    public function testDifferentChurchIsNotADuplicate(): void
+    {
+        $this->addRemark('teszt@example.invalid', 'Rossz a miserend.');
+
+        $found = \Eloquent\Remark::findRecentDuplicate(
+            $this->churchId + 100000,
+            'teszt@example.invalid',
+            'Rossz a miserend.'
+        );
+
+        self::assertNull($found);
+    }
+
+    /** Az ablakon kívül már valódi, új észrevétel — nem nyomjuk el. */
+    public function testAnOldIdenticalRemarkIsNotADuplicate(): void
+    {
+        $old = date('Y-m-d H:i:s', time() - \Eloquent\Remark::DUPLICATE_WINDOW_SECONDS - 60);
+        $this->addRemark('teszt@example.invalid', 'Megint rossz a miserend.', $old);
+
+        $found = \Eloquent\Remark::findRecentDuplicate(
+            $this->churchId,
+            'teszt@example.invalid',
+            'Megint rossz a miserend.'
+        );
+
+        self::assertNull($found);
+    }
+
+    /** Hiányos adatnál ne szűrjünk vakon — ott a mentés validációja dönt. */
+    public function testIncompleteInputIsNeverTreatedAsDuplicate(): void
+    {
+        $this->addRemark('teszt@example.invalid', 'Valami.');
+
+        self::assertNull(\Eloquent\Remark::findRecentDuplicate(null, 'teszt@example.invalid', 'Valami.'));
+        self::assertNull(\Eloquent\Remark::findRecentDuplicate($this->churchId, '', 'Valami.'));
+        self::assertNull(\Eloquent\Remark::findRecentDuplicate($this->churchId, 'teszt@example.invalid', ''));
+    }
+}


### PR DESCRIPTION
Closes #755

## Ok

Három út vezet ugyanoda, és mind valós:

1. A beküldő türelmetlenül többször nyomja az „Elküld" gombot.
2. A `/remark/add` POST-ra **nincs átirányítás** — a válasz maga a köszönő oldal. Egy F5 tehát percekkel később is újraküldi ugyanazt.
3. Az `api/report` végponton a mobilkliens is ismételhet (rossz hálózaton a felhasználó újra nyom).

## Megoldás

Kiszolgáló oldalon szűrök, mert az mindhármat lefedi — a kliensoldali gombtiltás a (2)-t és a (3)-at nem fogja meg.

`Remark::findRecentDuplicate()`: azonos templom + azonos email + **betűre** azonos szöveg tíz percen belül. Ez nem lehet szándékos második észrevétel, egy valóban új mondanivaló pedig már nem betűre ugyanaz. Ha téved, sincs kár: a szöveg azonos, tehát nem vész el információ.

Fontos részlet: a beküldő **ugyanazt a visszajelzést kapja**. Ha hibát látna, azt hinné, nem ment el, és megint próbálkozna — pont amit el akarunk kerülni.

Mindkét belépő használja: a webes űrlap (`Html\Remark::pageAdded`) és az `Api\Report`.

Az űrlapra beteszem a gomb letiltását is. Az nem véd — csak látszik tőle, hogy elindult a küldés, és ettől nem nyom megint. JS nélkül a form változatlanul működik.

## Amit szándékosan NEM csinálok

Nem vezetek be POST-redirect-GET-et a `/remark/add`-ra. Az lenne a tankönyvi javítás a (2)-re, de átírná az oldal működését (üzenetek átvitele, `remark.twig` renderelése), és a dedup enélkül is lefedi. Ha egyszer hozzányúlunk a lapfolyamathoz, ott a helye.

## Teszt

`RemarkDuplicateTest`, 6 eset: azonos szöveg elnyomva; más szöveg, más beküldő, más templom **nem**; az ablakon kívüli azonos szöveg **nem**; hiányos adatnál nem szűrünk vakon. PHP: 764 zöld.
