### PR TITLE
Kiderül, ha elavul a keresőindex; a sikertelen határ-lekérdezés nem számít ellenőrzésnek

### DIFF
--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -871,6 +871,46 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return $byChurch;
 	}
 
+	/**
+	 * Hány indexelt templomnak HIÁNYZIK a `location` geo_point mezője?
+	 *
+	 * A távolság szerinti templomkeresés kizárólag erre a mezőre szűr. A mapping
+	 * régóta tartalmazza, a dokumentumot építő kód is kiírja — de a meglévő
+	 * indexbe csak azoknál került be, amelyeket a javítás ÓTA újraindexeltünk.
+	 * Élesben ez azt jelentette, hogy a „X km-en belül" keresés a templomok
+	 * túlnyomó részét egyszerűen nem találta meg, és NÉMÁN: nem hiba, csak nulla
+	 * találat, amit a felhasználó „nincs ilyen templom"-nak olvas.
+	 *
+	 * Ezt csak egy teljes újraindexelés javítja (`updateChurches()` tid nélkül).
+	 * A /health ezért mutatja a számot: a mapping-változás önmagában nem elég,
+	 * és enélkül semmi nem szólt volna.
+	 *
+	 * @return array{indexed:int,missing:int}|null null, ha az index nem kérdezhető
+	 */
+	function churchesMissingLocation(): ?array {
+		$count = function (?array $query): ?int {
+			$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
+			$this->buildQuery('churches/_count', $query === null ? null : json_encode($query));
+			$this->run();
+			if ($this->responseCode != 200 || !isset($this->jsonData->count)) {
+				return null;
+			}
+			return (int) $this->jsonData->count;
+		};
+
+		$indexed = $count(null);
+		if ($indexed === null) {
+			return null;
+		}
+
+		$withLocation = $count(['query' => ['exists' => ['field' => 'location']]]);
+		if ($withLocation === null) {
+			return null;
+		}
+
+		return ['indexed' => $indexed, 'missing' => max(0, $indexed - $withLocation)];
+	}
+
 	function churchIdsWithMassesInPeriod($startDate, $endDate) {
 		$this->curl_setopt(CURLOPT_CUSTOMREQUEST, "GET");
 		$this->buildQuery('mass_index/_search', json_encode([

--- a/webapp/classes/externalapi/externalapi.php
+++ b/webapp/classes/externalapi/externalapi.php
@@ -33,6 +33,22 @@ class ExternalApi {
      * ilyenkor is elérhető marad a $this->error / hasError() felől.
      */
     public $quiet = false;
+
+    /**
+     * A most kiszolgált kérés JSON-t ad-e vissza?
+     *
+     * Az ajax/api végpontok a törzsükbe semmilyen HTML-t nem tűrnek el, tehát a
+     * hibakereső üzemmód kiírásait sem. A `Path` a kérés elején beállítja.
+     */
+    private static $jsonResponse = false;
+
+    public static function markJsonResponse(bool $isJson = true): void {
+        self::$jsonResponse = $isJson;
+    }
+
+    public static function isJsonResponse(): bool {
+        return self::$jsonResponse;
+    }
 	
     function __construct() {
         
@@ -107,7 +123,11 @@ class ExternalApi {
             // Ha a cache be van kapcsolva, akkor szeretnénk elmenteni a letöltött adatokat.
             // De pl. az overpass API-nál gyakori az 503, ha túlterhelt, és ilyenkor nem szeretnénk elmenteni a cache-be a hibás választ.
             // Viszont pl. a kozossegek.hu talán 404-et ad vissza sokszor, ha nem találja a keresett adatot, és ezeket a cache-be menteni szeretnénk, hogy ne kelljen újra lekérdezni az API-t.
-            if ($this->cache AND ( isset($this->responseCode) && !in_array($this->responseCode, [503, 504]) ) ) {
+            // #429: a rate-limit (429) ugyanolyan MÚLÓ hiba, mint az 503/504 — ha
+            // elmentenénk, egyetlen kvótatúllépés a teljes cache-élettartamra
+            // beégetné a hibaszöveget a válasz helyére. Az Overpass épp ezt csinálja,
+            // ha sok kérés megy egy IP-ről.
+            if ($this->cache AND ( isset($this->responseCode) && !in_array($this->responseCode, [429, 503, 504]) ) ) {
                 $this->saveToCache();
             }
             
@@ -131,7 +151,23 @@ class ExternalApi {
              * A hibát ilyenkor is eltesszük ($this->error, hasError()), csak nem
              * tesszük ki a lapra.
              */
-            if(empty($this->quiet)) {
+            /*
+             * JSON-választ SOHA nem szennyezünk. A hibakereső üzemmód eddig
+             * feltétel nélkül kiechózta a teljes verem-kiírást — egy ajax végponton
+             * ez a JSON törzs elé került, tehát a válasz értelmezhetetlen lett, a
+             * látogató pedig fájlútvonalakat és belső hívásláncot látott. Élő eset:
+             * az Overpass 429-e a főoldal egyházmegye-rétegénél.
+             *
+             * A hibát ilyenkor is eltesszük ($this->error, hasError()), és a
+             * szerver-naplóba is kiírjuk — csak nem a válaszba.
+             */
+            if (!empty($this->quiet) || self::isJsonResponse()) {
+                if (function_exists('logThrowable')) {
+                    logThrowable('External API hiba (' . static::class . ')', $e);
+                } else {
+                    error_log('[miserend] External API hiba (' . static::class . '): ' . $e->getMessage());
+                }
+            } else {
                 if($config['debug'] > 1) echo $this->error;
                 elseif($config['debug'] > 0) addMessage($this->error,'warning');
             }

--- a/webapp/classes/html/ajax/ajax.php
+++ b/webapp/classes/html/ajax/ajax.php
@@ -6,6 +6,21 @@ class Ajax extends \Html\Html {
 
     public $template = "layout_empty.twig";
 
+    /*
+     * Az ajax végpontok JSON-t adnak vissza. A külső API-k hibakereső üzemmódban
+     * eddig a teljes verem-kiírást a válaszba echózták — az a JSON törzs elé
+     * került, tehát értelmezhetetlen lett, és a látogató fájlútvonalakat látott
+     * (élő eset: az Overpass 429-e a főoldal egyházmegye-rétegénél). Innentől ott
+     * csak a szerver-naplóba kerül.
+     *
+     * A leszármazottak konstruktora előtt kell megtörténnie, ezért van itt, és nem
+     * az egyes végpontokban — különben minden új ajax végponton újra elő tudna
+     * jönni ugyanez.
+     */
+    public static function markJson(): void {
+        \ExternalApi\ExternalApi::markJsonResponse(true);
+    }
+
     public function __construct($path) {
         // #391: eddig a teljes $_REQUEST-et visszaechóztuk JSON-ként. Ennek nincs hívója —
         // egyetlen leszármazott sem épít rá —, viszont az /ajax végpont így bármit

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -15,6 +15,7 @@ class Health extends Html {
     public $elasticsearch;
     public $churchesWithNoElasticMasses;
     public $churchesWithNoElasticMassesCount;
+    public $churchesMissingLocation;
     public $externalapis;
     public $boundariesStats;
     public $schemaCheck;
@@ -129,6 +130,21 @@ class Health extends Html {
 		$elastic->run();		
 		if(isset($elastic->jsonData))
 			$this->elasticsearch = $elastic->jsonData;
+
+		/*
+		 * A távolság szerinti templomkeresés a `location` geo_pointra szűr. Ha az
+		 * indexben nincs kitöltve, a keresés NÉMÁN nem talál semmit — nem hiba, csak
+		 * nulla találat, amit „nincs ilyen templom"-nak olvas a felhasználó. Pontosan
+		 * ez történt: a mapping és a dokumentum-építés is rendben volt, de az index
+		 * nagy része a javítás előtti teljes újraindexelésből maradt.
+		 *
+		 * A szám SOHA ne vigye le a /health-et — a többi ellenőrzés fontosabb.
+		 */
+		try {
+			$this->churchesMissingLocation = $elastic->churchesMissingLocation();
+		} catch (\Throwable $e) {
+			$this->churchesMissingLocation = null;
+		}
 
 		$ids = $elastic->churchIdsWithMassesInPeriod(date('Y-01-01'), date('Y-12-31'));
 		$this->churchesWithNoElasticMasses = \Eloquent\Church::whereNotIn('id', $ids)->has('massrules')->get()->toArray();

--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -36,22 +36,60 @@ class OSM {
         ];
 
         foreach ($churches as $church) {
-            $this->checkBoundariesForOne($church, $referenceData);
+            if (!$this->checkBoundariesForOne($church, $referenceData)) {
+                /*
+                 * #570/#700: ha az Overpass elhasalt, a köteg többi templomával
+                 * tovább kopogtatni értelmetlen — jellemzően rate-limit (429) az ok,
+                 * amit a további kérések csak mélyítenek. Megállunk; a következő
+                 * cron-futás ugyanezekkel a templomokkal folytatja, mert bélyeget
+                 * nem tettünk rájuk.
+                 */
+                error_log('[miserend] OSM: a határ-lekérdezés elhasalt (templom #'
+                    . $church->id . '), a köteget megszakítom.');
+                return;
+            }
         }
     }
 
-    function checkBoundariesForOne($church, array $referenceData = []) {
+    /**
+     * Egy templom határainak felderítése.
+     *
+     * #570/#700: eddig MINDEN esetben rákerült a `boundaries_checked_at` bélyeg,
+     * akkor is, ha az Overpass elhasalt (429/503/időtúllépés). A batch a legrégebben
+     * ellenőrzöttet veszi előre, tehát a sikertelen próbálkozás a templomot a sor
+     * VÉGÉRE tette — határok nélkül, örökre. Egyetlen rate-limitelt futás így
+     * tömegével tett templomot elérhetetlenné a települési keresés számára, és ez
+     * sehol nem látszott hibaként: a felhasználó csak annyit lát, hogy „Pécs" alatt
+     * nem jön ki a Szent Ferenc-templom.
+     *
+     * A sikertelenséget innentől megkülönböztetjük a „lekérdeztük, de nincs határ"
+     * esettől: hibánál NEM bélyegzünk, tehát a templom a sor elején marad, és a
+     * következő futás újra próbálja.
+     *
+     * @return bool sikerült-e a lekérdezés (false: a hívó állítsa le a köteget)
+     */
+    function checkBoundariesForOne($church, array $referenceData = []): bool {
         $boundaries = $this->downloadBoundaries($church->lat, $church->lon);
 
-        // Mindig jelöljük, hogy megpróbáltuk – akár sikeres volt, akár nem (pl. Overpass 503).
-        // Ez megakadályozza az örökös hurkot: a következő futásban más templomok kerülnek sorra.
+        // A `null` a régi jelzés volt mindenféle kudarcra; kezeljük ugyanúgy, hogy
+        // egy régebbi hívó vagy teszt-dublőr se okozzon hamis „ellenőrizve" bélyeget.
+        if ($boundaries === false || $boundaries === null) {
+            // Nem tudjuk, van-e határa — ne állítsuk azt, hogy ellenőriztük.
+            return false;
+        }
+
+        // Idáig eljutva a lekérdezés SIKERES volt. A bélyeg ilyenkor kell: enélkül a
+        // valóban határ nélküli templomok (pl. tengerpart, hiányos OSM-adat) minden
+        // futásban újra sorra kerülnének, és kiszorítanák a többit.
         \Eloquent\Church::where('id', $church->id)
             ->update(['boundaries_checked_at' => date('Y-m-d H:i:s')]);
 
-        if ($boundaries === null || count($boundaries) < 1) return;
+        if (count($boundaries) < 1) return true;
 
         $church->boundaries()->sync($boundaries);
         $church->MmigrateBoundaries($referenceData);
+
+        return true;
     }
     
     function deleteOrphanBoundaries() {
@@ -100,19 +138,32 @@ class OSM {
         // stagingen pontosan ez csúfította el egy templom oldalát.
         $overpass->quiet = true;
 
+        /*
+         * #570/#700: a visszatérés HÁROM különböző dolgot jelenthetett, mind `null`-t
+         * adott, és a hívó nem tudta megkülönböztetni őket:
+         *   - a lekérdezés elhasalt (429/503/időtúllépés)  -> most: false
+         *   - lefutott, de nincs itt határ                 -> most: []
+         *   - lefutott, van határ                          -> tömb
+         * A különbség azért számít, mert csak a második kettőnél szabad
+         * „ellenőrizve" bélyeget tenni a templomra.
+         */
         try {
             $overpass->downloadEnclosingBoundaries($lat, $lon);
         } catch (\Exception $e) {
             // ExternalApi::runQuery() should catch internally, but just in case
-            return null;
-        }
-        
-        if ($overpass->hasError()) {
-            return null;
+            return false;
         }
 
-        if (!isset($overpass->jsonData->elements) || empty($overpass->jsonData->elements)) {
-            return null;
+        if ($overpass->hasError()) {
+            return false;
+        }
+
+        if (!isset($overpass->jsonData->elements)) {
+            return false;
+        }
+
+        if (empty($overpass->jsonData->elements)) {
+            return [];
         }
          
         foreach($overpass->jsonData->elements as $element) {            

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -34,6 +34,15 @@ try {
 
     $class = $path->className;
 	if(!$class) throw new Exception('Az oldal nem található');
+
+    // A JSON-t adó végpontok (ajax/, api/) törzsébe semmilyen HTML nem kerülhet.
+    // A külső API-k hibakereső üzemmódban eddig a teljes verem-kiírást a válaszba
+    // echózták; ott csak a szerver-naplóba való. Itt jelöljük meg, még a végpont
+    // példányosítása ELŐTT — a konstruktorban már megtörténhet a külső hívás.
+    if (str_starts_with((string) $path->url, 'ajax') || str_starts_with((string) $path->url, 'api/')) {
+        \ExternalApi\ExternalApi::markJsonResponse(true);
+    }
+
 		
     if (method_exists($path->className, 'factory')) {
         $html = $class::factory($path->arguments);

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -111,6 +111,30 @@
 		{% endfor %}
 	</table>
 	
+	{# A távolság szerinti templomkeresés kizárólag a `location` geo_pointra szűr.
+	   Ha az indexben nincs kitöltve, a keresés némán nem talál semmit — nem hiba,
+	   csak nulla találat. Egyedül teljes újraindexelés javítja. #}
+	<p style="margin-top: 15px;">
+		<h4>Indexelt templomok <code>location</code> nélkül (távolság-keresés):</h4>
+		{% if churchesMissingLocation is null %}
+			<span class="badge bg-secondary" style="font-size: 1.1em; padding: 0.5em 0.8em;">nem kérdezhető</span>
+		{% elseif churchesMissingLocation.missing == 0 %}
+			<span class="badge bg-success" style="font-size: 1.3em; padding: 0.6em 0.9em;">0</span>
+			<small class="text-muted">/ {{ churchesMissingLocation.indexed }} indexelt</small>
+		{% else %}
+			{% set arany = churchesMissingLocation.indexed > 0
+				? (churchesMissingLocation.missing * 100 / churchesMissingLocation.indexed)|round
+				: 0 %}
+			<span class="badge {{ arany > 10 ? 'bg-danger' : 'bg-warning' }}" style="font-size: 1.3em; padding: 0.6em 0.9em;">{{ churchesMissingLocation.missing }}</span>
+			<small class="text-muted">/ {{ churchesMissingLocation.indexed }} indexelt ({{ arany }}%)</small>
+			<div class="alert alert-warning" style="margin-top: 8px;">
+				Ezeket a templomokat a „X km-en belül" keresés <strong>nem találja meg</strong>.
+				Teljes újraindexelés kell: <code>/index.php?q=cron&amp;cron_id=38</code>
+				(vagy <code>\ExternalApi\ElasticsearchApi::updateChurches()</code> templom-azonosítók nélkül).
+			</div>
+		{% endif %}
+	</p>
+
 	<p style="margin-top: 15px;">
 		<h4>Misézőhelyek misékkel, de elastic-misék nélkül:</h4>
 		{% if churchesWithNoElasticMassesCount < 10 %}

--- a/webapp/tests/Functional/ChurchDetailPageTest.php
+++ b/webapp/tests/Functional/ChurchDetailPageTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Functional;
 
 use Facebook\WebDriver\WebDriverDimension;
-use Symfony\Component\Panther\PantherTestCase;
 
 /**
  * Test 5: Church Detail Page Test
@@ -11,21 +10,13 @@ use Symfony\Component\Panther\PantherTestCase;
  * Tests individual church pages to verify data is rendered correctly,
  * the schedule (miserend) is displayed, and no PHP errors occur.
  */
-final class ChurchDetailPageTest extends PantherTestCase
+final class ChurchDetailPageTest extends FunctionalTestCase
 {
     private $client;
 
     protected function setUp(): void
     {
-        $this->client = static::createPantherClient(
-            [
-                'external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000',
-            ],
-            [],
-            [
-                'browser' => static::CHROME,
-            ]
-        );
+        $this->client = static::pantherClient();
     }
 
     /**

--- a/webapp/tests/Functional/ChurchRemarkFormTest.php
+++ b/webapp/tests/Functional/ChurchRemarkFormTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Functional;
 
-use Symfony\Component\Panther\PantherTestCase;
 
 /**
  * Test 6: Church Remark Form Test
@@ -10,21 +9,13 @@ use Symfony\Component\Panther\PantherTestCase;
  * Tests the remark (észrevétel) form functionality on church pages.
  * Validates that the form elements are present and the form can be accessed.
  */
-final class ChurchRemarkFormTest extends PantherTestCase
+final class ChurchRemarkFormTest extends FunctionalTestCase
 {
     private $client;
 
     protected function setUp(): void
     {
-        $this->client = static::createPantherClient(
-            [
-                'external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000',
-            ],
-            [],
-            [
-                'browser' => static::CHROME,
-            ]
-        );
+        $this->client = static::pantherClient();
     }
 
     private function getFirstChurchId(): ?int

--- a/webapp/tests/Functional/ChurchSearchResultsTest.php
+++ b/webapp/tests/Functional/ChurchSearchResultsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Functional;
 
-use Symfony\Component\Panther\PantherTestCase;
 
 /**
  * Test 3: Church Search Results Test
@@ -10,21 +9,13 @@ use Symfony\Component\Panther\PantherTestCase;
  * Tests the church search functionality and validates that results are properly rendered.
  * Validates dynamic foreach loops for church listings and filter display.
  */
-final class ChurchSearchResultsTest extends PantherTestCase
+final class ChurchSearchResultsTest extends FunctionalTestCase
 {
     private $client;
 
     protected function setUp(): void
     {
-        $this->client = static::createPantherClient(
-            [
-                'external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000',
-            ],
-            [],
-            [
-                'browser' => static::CHROME,
-            ]
-        );
+        $this->client = static::pantherClient();
     }
 
     public function testChurchSearchWithKeyword(): void

--- a/webapp/tests/Functional/FormDynamicFilterTest.php
+++ b/webapp/tests/Functional/FormDynamicFilterTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Functional;
 
-use Symfony\Component\Panther\PantherTestCase;
 
 /**
  * Test 7: Form Dynamic Filter Test
@@ -10,22 +9,14 @@ use Symfony\Component\Panther\PantherTestCase;
  * Tests JavaScript-driven filter buttons on the homepage.
  * Validates that filter buttons change state and update hidden inputs correctly.
  */
-final class FormDynamicFilterTest extends PantherTestCase
+final class FormDynamicFilterTest extends FunctionalTestCase
 {
     private $client;
     private $crawler;
 
     protected function setUp(): void
     {
-        $this->client = static::createPantherClient(
-            [
-                'external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000',
-            ],
-            [],
-            [
-                'browser' => static::CHROME,
-            ]
-        );
+        $this->client = static::pantherClient();
         $this->crawler = $this->client->request('GET', '/');
         $this->client->waitFor('body', 10);
     }

--- a/webapp/tests/Functional/FunctionalTestCase.php
+++ b/webapp/tests/Functional/FunctionalTestCase.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Functional;
+
+use Symfony\Component\Panther\Client as PantherClient;
+use Symfony\Component\Panther\PantherTestCase;
+
+/**
+ * Közös ős a böngészős (Panther) tesztekhez.
+ *
+ * Azért kell, mert a kliens létrehozása mindenhol IDŐKORLÁT NÉLKÜL történt, és ettől
+ * a CI rendszeresen beragadt: a PHPUnit kiírta a bannert, aztán 12 percig semmi, majd
+ * a lépés időtúllépéssel elbukott — egyetlen teszteredmény és egyetlen használható
+ * hibaüzenet nélkül.
+ *
+ * Az ok a Pantherben van. A `ChromeManager::getDefaultOptions()` nem ad meg
+ * `request_timeout_in_ms`-t, a `start()` pedig így hívja a WebDrivert:
+ *
+ *     RemoteWebDriver::create($url, $capabilities,
+ *         $this->options['connection_timeout_in_ms'] ?? null,
+ *         $this->options['request_timeout_in_ms'] ?? null);
+ *
+ * A php-webdriver a `CURLOPT_TIMEOUT_MS`-t CSAK akkor állítja be, ha kapott értéket —
+ * null esetén tehát a kérésnek nincs időkorlátja. Ha a böngésző-munkamenet nyitása
+ * elakad, a curl a világ végéig vár.
+ *
+ * Itt ezért kifejezett korlátokat adunk. Beragadásnál a teszt másodperceken belül,
+ * valódi WebDriver-hibaüzenettel bukik el, nem a job felső korlátjánál némán.
+ *
+ * A `browser` kulcs egyúttal a HELYÉRE kerül: a Panther az ELSŐ paraméterből olvassa
+ * (`$options['browser']`), a tesztek viszont a harmadikba (manager-opciók) tették,
+ * ahol nem jelent semmit.
+ */
+abstract class FunctionalTestCase extends PantherTestCase
+{
+    /** A böngésző-munkamenet nyitása normálisan ezredmásodpercek kérdése. */
+    private const CONNECTION_TIMEOUT_MS = 30000;
+
+    /**
+     * Egyetlen WebDriver-kérés felső korlátja. Bőven a leglassabb oldalbetöltés fölött,
+     * de messze a CI 12 perces lépés-korlátja alatt — hogy a hiba a TESZTBŐL jöjjön,
+     * hibaüzenettel, ne a futtatóból.
+     */
+    private const REQUEST_TIMEOUT_MS = 120000;
+
+    protected static function pantherClient(array $options = []): PantherClient
+    {
+        return static::createPantherClient(
+            array_merge([
+                'external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000',
+                'browser' => static::CHROME,
+            ], $options),
+            [],
+            [
+                'connection_timeout_in_ms' => self::CONNECTION_TIMEOUT_MS,
+                'request_timeout_in_ms' => self::REQUEST_TIMEOUT_MS,
+            ]
+        );
+    }
+}

--- a/webapp/tests/Functional/HomepageFormElementsTest.php
+++ b/webapp/tests/Functional/HomepageFormElementsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Functional;
 
-use Symfony\Component\Panther\PantherTestCase;
 
 /**
  * Test 2: Homepage Form Elements Test
@@ -10,22 +9,14 @@ use Symfony\Component\Panther\PantherTestCase;
  * Validates that all critical form elements on the homepage are present and rendered correctly.
  * This includes search inputs, dropdowns, date pickers, and dynamic filter buttons.
  */
-final class HomepageFormElementsTest extends PantherTestCase
+final class HomepageFormElementsTest extends FunctionalTestCase
 {
     private static $client;
     private static $crawler;
 
     public static function setUpBeforeClass(): void
     {
-        self::$client = static::createPantherClient(
-            [
-                'external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000',
-            ],
-            [],
-            [
-                'browser' => static::CHROME,
-            ]
-        );
+        self::$client = static::pantherClient();
         self::$crawler = self::$client->request('GET', '/');
     }
 

--- a/webapp/tests/Functional/HomepageLogoTest.php
+++ b/webapp/tests/Functional/HomepageLogoTest.php
@@ -1,19 +1,12 @@
 <?php
 
-use Symfony\Component\Panther\PantherTestCase;
 
-final class HomepageLogoTest extends PantherTestCase {
+use Tests\Functional\FunctionalTestCase;
+
+final class HomepageLogoTest extends FunctionalTestCase {
 
     public function testLogoExistsAndImageIsLoaded(): void {
-        $client = static::createPantherClient(
-            array(
-                'external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000',
-            ),
-            array(),
-            array(
-                'browser' => static::CHROME,
-            )
-        );
+        $client = static::pantherClient();
 
         $crawler = $client->request('GET', '/');
 

--- a/webapp/tests/Functional/MapInitializationTest.php
+++ b/webapp/tests/Functional/MapInitializationTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Facebook\WebDriver\WebDriverDimension;
-use Symfony\Component\Panther\PantherTestCase;
 
 /**
  * #640: a /terkep elsőre hibára futott, ctrl+R-re viszont megjavult.
@@ -15,14 +14,12 @@ use Symfony\Component\Panther\PantherTestCase;
  *
  * Ez a teszt azt őrzi, hogy a térkép ELSŐ betöltésre is hibátlanul álljon fel.
  */
-final class MapInitializationTest extends PantherTestCase {
+use Tests\Functional\FunctionalTestCase;
+
+final class MapInitializationTest extends FunctionalTestCase {
 
     private function client() {
-        return static::createPantherClient(
-            ['external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000'],
-            [],
-            ['browser' => static::CHROME]
-        );
+        return static::pantherClient();
     }
 
     /*

--- a/webapp/tests/Functional/MassSearchResultsTest.php
+++ b/webapp/tests/Functional/MassSearchResultsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Functional;
 
-use Symfony\Component\Panther\PantherTestCase;
 
 /**
  * Test 4: Mass Search Results with Filters Test
@@ -10,21 +9,13 @@ use Symfony\Component\Panther\PantherTestCase;
  * Tests the mass (miserend) search functionality with various filters.
  * This is the most complex test validating foreach loops for results, filters, and liturgical days.
  */
-final class MassSearchResultsTest extends PantherTestCase
+final class MassSearchResultsTest extends FunctionalTestCase
 {
     private $client;
 
     protected function setUp(): void
     {
-        $this->client = static::createPantherClient(
-            [
-                'external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000',
-            ],
-            [],
-            [
-                'browser' => static::CHROME,
-            ]
-        );
+        $this->client = static::pantherClient();
     }
 
     public function testMassSearchPageLoads(): void

--- a/webapp/tests/Functional/UnifiedAutocompleteTest.php
+++ b/webapp/tests/Functional/UnifiedAutocompleteTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Functional;
 
-use Symfony\Component\Panther\PantherTestCase;
 
 /**
  * Functional (browser) tests for the Unified Autocomplete UX.
@@ -13,17 +12,13 @@ use Symfony\Component\Panther\PantherTestCase;
  * Requires a running local server at PANTHER_EXTERNAL_BASE_URI
  * (defaults to http://127.0.0.1:8000).
  */
-final class UnifiedAutocompleteTest extends PantherTestCase
+final class UnifiedAutocompleteTest extends FunctionalTestCase
 {
     private static $client;
 
     public static function setUpBeforeClass(): void
     {
-        self::$client = static::createPantherClient(
-            ['external_base_uri' => getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000'],
-            [],
-            ['browser' => static::CHROME]
-        );
+        self::$client = static::pantherClient();
     }
 
     private function loadHomepage(): \Symfony\Component\DomCrawler\Crawler

--- a/webapp/tests/Integration/ExternalApiQuietTest.php
+++ b/webapp/tests/Integration/ExternalApiQuietTest.php
@@ -95,8 +95,8 @@ final class ExternalApiQuietTest extends TestCase {
     }
 
     /*
-     * A területi adatok pótlása ilyen „várt kudarc" hely: null-lal tér vissza, a hívó
-     * ezt kezeli — közben semmit nem ír a lapra. Ez a templomoldal esete.
+     * A területi adatok pótlása ilyen „várt kudarc" hely: false-szal tér vissza, a
+     * hívó ezt kezeli — közben semmit nem ír a lapra. Ez a templomoldal esete.
      */
     public function testBoundaryDownloadStaysSilentOnFailure(): void {
         global $config;
@@ -109,7 +109,10 @@ final class ExternalApiQuietTest extends TestCase {
                 $result = (new \OSM())->downloadBoundaries(47.5, 19.05);
             });
 
-            self::assertNull($result, 'elérhetetlen Overpassnál null a helyes válasz');
+            // #570/#700: a kudarc jelzése `false` lett, hogy megkülönböztethető legyen
+            // a „lefutott, de nincs itt határ" ([]) esettől — csak az utóbbinál szabad
+            // a templomot ellenőrzöttnek bélyegezni.
+            self::assertFalse($result, 'elérhetetlen Overpassnál false a helyes válasz');
             self::assertSame('', $output, 'a templomoldal nem kaphat hibakiírást');
         } finally {
             if ($originalUrl === null) {

--- a/webapp/tests/Integration/OsmBoundariesTest.php
+++ b/webapp/tests/Integration/OsmBoundariesTest.php
@@ -77,7 +77,14 @@ class OsmBoundariesTest extends TestCase {
     }
 
     /** Create a partial mock of OSM that stubs downloadBoundaries() */
-    private function osmWithMockedDownload(?array $returnValue): OSM {
+    /**
+     * #570/#700: a `downloadBoundaries()` háromféle választ ad — `false` (a lekérdezés
+     * elhasalt), `[]` (lefutott, de nincs itt határ) és a határok tömbje. A dublőrnek
+     * mindhármat tudnia kell, mert épp a köztük lévő különbség a lényeg.
+     *
+     * @param array|false|null $returnValue
+     */
+    private function osmWithMockedDownload($returnValue): OSM {
         $osm = $this->getMockBuilder(OSM::class)
             ->onlyMethods(['downloadBoundaries'])
             ->getMock();
@@ -207,18 +214,50 @@ class OsmBoundariesTest extends TestCase {
     }
 
     /**
-     * Ha az API null-t ad vissza (Overpass hiba), boundaries_checked_at akkor is frissüljön.
-     * Ez akadályozza meg az örökös hurkot.
+     * #570/#700: API-hibánál NEM szabad „ellenőrizve" bélyeget tenni.
+     *
+     * Ez a teszt korábban az ellenkezőjét rögzítette (az örökös hurok elkerülésére),
+     * és pontosan ettől lett vak a települési keresés: a batch a legrégebben
+     * ellenőrzöttet veszi előre, tehát egy rate-limitelt futás a templomot határok
+     * NÉLKÜL tette a sor végére — véglegesen. A hurok elleni védelem most máshol van:
+     * hibánál megszakítjuk a köteget, tehát nem pörgünk ugyanazon.
      */
-    public function testCheckBoundariesForOneUpdatesBoundariesCheckedAtOnApiFailure(): void {
-        $osm = $this->osmWithMockedDownload(null);
+    public function testCheckBoundariesForOneDoesNotStampOnApiFailure(): void {
+        foreach ([false, null] as $kudarc) {
+            DB::table('templomok')->where('id', $this->testChurchId)
+                ->update(['boundaries_checked_at' => null]);
 
-        $church = \Eloquent\Church::find($this->testChurchId);
-        $osm->checkBoundariesForOne($church);
+            $osm = $this->osmWithMockedDownload($kudarc);
+            $church = \Eloquent\Church::find($this->testChurchId);
 
-        $updated = DB::table('templomok')->where('id', $this->testChurchId)->first();
-        $this->assertNotNull($updated->boundaries_checked_at,
-            'boundaries_checked_at kell, hogy frissüljön még API hiba/null esetén is - örökös hurok megelőzése.');
+            $sikeres = $osm->checkBoundariesForOne($church);
+
+            $updated = DB::table('templomok')->where('id', $this->testChurchId)->first();
+            $this->assertFalse($sikeres, 'A kudarcot jeleznie kell a hívó felé.');
+            $this->assertNull($updated->boundaries_checked_at,
+                'API-hibánál nem állíthatjuk, hogy ellenőriztük — különben a templom határok nélkül esik ki a sorból.');
+        }
+    }
+
+    /** Kudarc esetén a köteg álljon meg: a rate-limitet további kérésekkel csak mélyítenénk. */
+    public function testCheckBoundariesStopsTheBatchOnFailure(): void {
+        $this->insertChurch(['lat' => 47.6, 'lon' => 19.1, 'boundaries_checked_at' => null]);
+        $this->insertChurch(['lat' => 47.7, 'lon' => 19.2, 'boundaries_checked_at' => null]);
+
+        $hivasok = 0;
+        $osm = $this->getMockBuilder(OSM::class)
+            ->onlyMethods(['downloadBoundaries'])
+            ->getMock();
+        $osm->method('downloadBoundaries')
+            ->willReturnCallback(function () use (&$hivasok) {
+                $hivasok++;
+                return false;
+            });
+
+        $osm->checkBoundaries(10);
+
+        $this->assertSame(1, $hivasok,
+            'Az első kudarc után nem szabad tovább kopogtatni az Overpasson.');
     }
 
     /**

--- a/webapp/tests/Unit/ExternalApiJsonResponseTest.php
+++ b/webapp/tests/Unit/ExternalApiJsonResponseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A külső API hibája ne szennyezze a JSON-választ, és a rate-limit ne ragadjon a cache-be.
+ *
+ * Élő eset: a főoldal egyházmegye-rétege (`ajax/DiocesesInBBox`) Overpassra megy. Amikor
+ * az 429-cel felelt, a hibakereső üzemmód a TELJES verem-kiírást a válasz törzsébe
+ * echózta — a JSON értelmezhetetlen lett, a látogató pedig fájlútvonalakat és belső
+ * hívásláncot látott a főoldalon.
+ */
+class ExternalApiJsonResponseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        \ExternalApi\ExternalApi::markJsonResponse(false);
+        parent::tearDown();
+    }
+
+    public function testJsonResponseIsNotMarkedByDefault(): void
+    {
+        \ExternalApi\ExternalApi::markJsonResponse(false);
+        self::assertFalse(\ExternalApi\ExternalApi::isJsonResponse());
+    }
+
+    public function testJsonResponseCanBeMarked(): void
+    {
+        \ExternalApi\ExternalApi::markJsonResponse(true);
+        self::assertTrue(\ExternalApi\ExternalApi::isJsonResponse());
+    }
+
+    /** A jelölés globális: minden külső API-példány lássa. */
+    public function testTheMarkIsVisibleToEveryInstance(): void
+    {
+        \ExternalApi\ExternalApi::markJsonResponse(true);
+
+        $overpass = new \ExternalApi\OverpassApi();
+        self::assertTrue($overpass::isJsonResponse());
+    }
+
+    /**
+     * A múló hibák válaszát nem mentjük cache-be. A 429 ugyanolyan múló, mint az
+     * 503/504: ha elmentenénk, egyetlen kvótatúllépés a teljes cache-élettartamra
+     * beégetné a hibaszöveget a valódi válasz helyére.
+     */
+    public function testTransientErrorCodesAreNotCached(): void
+    {
+        $forrás = file_get_contents(__DIR__ . '/../../classes/externalapi/externalapi.php');
+
+        self::assertMatchesRegularExpression(
+            '/!in_array\(\$this->responseCode,\s*\[429,\s*503,\s*504\]\)/',
+            $forrás,
+            'A 429 kikerült a nem-cache-elendő kódok közül.'
+        );
+    }
+
+    /** Az ajax és az api útvonal jelölje meg magát — enélkül a védelem néma marad. */
+    public function testEntryPointMarksJsonRoutes(): void
+    {
+        $index = file_get_contents(__DIR__ . '/../../index.php');
+
+        self::assertStringContainsString('markJsonResponse(true)', $index);
+        self::assertStringContainsString("str_starts_with((string) \$path->url, 'ajax')", $index);
+        self::assertStringContainsString("str_starts_with((string) \$path->url, 'api/')", $index);
+    }
+}

--- a/webapp/tests/functional-bootstrap.php
+++ b/webapp/tests/functional-bootstrap.php
@@ -11,3 +11,11 @@ if (!is_file($autoloadPath)) {
 }
 
 require_once $autoloadPath;
+
+/*
+ * A böngészős tesztek közös őse. A PHPUnit a teszt-FÁJLOKAT tölti be közvetlenül, a
+ * projektnek pedig nincs PSR-4 leképezése a `Tests\` névtérre (a composer.json
+ * autoload/autoload-dev egyaránt üres), ezért az ősosztályt magunknak kell betölteni —
+ * enélkül a legelső teszt „Class not found"-dal áll meg.
+ */
+require_once __DIR__ . '/Functional/FunctionalTestCase.php';


### PR DESCRIPTION
## 1. A távolság szerinti templomkeresés némán nem talált semmit

**Reprodukáltam** (Pécs Kertváros, 46.0785 / 18.1880): koordinátás keresés → **nulla találat** bármilyen sugárral, miközben a kulcsszavas keresés ugyanazokat a templomokat kiadta.

Az ok nem a kódban volt. A `churches` index `location` mezője `geo_point`, a `Church::toAPIArray('elastic')` ki is írja — de az indexbe csak azoknál került be, amelyeket a javítás **óta** újraindexeltünk:

```
location-nel:  221 / 5266 dokumentum
```

A `geo_distance` szűrő így a templomok 96%-át egyszerűen nem látta. Nem hibázott, nem naplózott — csak nem talált. A felhasználó ezt „nincs ilyen templom"-nak olvassa.

Teljes újraindexelés után:

```
location-nel: 5252 / 5267      (a maradék 15 a 0,0 koordinátás, azok helyesen maradnak ki)
3 km Pécs Kertvárosból: /templom/2010, /templom/2012 és további 7
```

**A javítás nem kód, hanem újraindexelés** — de az, hogy ez némán romolhatott el, igen. A `/health` mostantól kiírja, hány indexelt templomnak hiányzik a `location`-je, és megmondja, mi javítja. Enélkül a következő mapping- vagy dokumentum-változásnál ugyanez megismétlődne.

## 2. A 429-es válasz bekerült a cache-be

A `run()` csak az 503-at és az 504-et hagyta ki a mentésből. A 429 (rate limit) ugyanolyan **múló** hiba — elmentve viszont egyetlen kvótatúllépés a teljes cache-élettartamra beégeti a hibaszöveget a valódi válasz helyére. Az Overpass épp ezt csinálja, ha sok kérés megy egy IP-ről.

## 3. A külső API hibája a JSON-válasz törzsébe echózódott

Hibakereső üzemmódban (`debug > 1`) a teljes verem-kiírás közvetlenül a válaszba ment. Ajax végponton ez a JSON **elé** került: a válasz értelmezhetetlen lett, a látogató pedig fájlútvonalakat és belső hívásláncot látott a főoldalon. Élő eset:

```
External API return data is not a valid JSON!  ResponseCode: 429
... Dispatcher_Client::request_read_and_idx::rate_limited ...
Html\Ajax\DiocesesInBBox::__construct()/miserend/webapp/index.php:41
```

Az `ajax/` és `api/` útvonalakon innentől csak a szerver-naplóba kerül. HTML-oldalon a hibakereső kiírás **változatlan** — leellenőriztem: ott továbbra is 1079 bájtot ír ki, JSON-végponton 0-t.

A jelölés az `index.php`-ban, a végpont példányosítása **előtt** történik, mert a konstruktorban már lefuthat a külső hívás.

## Teszt

`ExternalApiJsonResponseTest`, 5 eset. PHP: 753 zöld.

## Deploy

**Kézi lépés kell:** egyszer le kell futtatni a teljes templom-újraindexelést élesben — `/index.php?q=cron&cron_id=38`, vagy `\ExternalApi\ElasticsearchApi::updateChurches()` templom-azonosítók nélkül. Utána a `/health` új sora 0-t kell mutasson. Amíg ez nem fut le, a „X km-en belül" keresés élesben is hiányos.

---

## 4. A települési keresés vaksága — #570 és #700

Amíg a fentit néztem, kiderült, hogy a másik két régi keresési jegy is ide tartozik, és **kódhiba**, nem adathiány.

`OSM::checkBoundariesForOne()` minden esetben rátette a `boundaries_checked_at` bélyeget — akkor is, ha az Overpass elhasalt:

```php
// Mindig jelöljük, hogy megpróbáltuk – akár sikeres volt, akár nem (pl. Overpass 503).
\Eloquent\Church::where('id', $church->id)->update(['boundaries_checked_at' => ...]);
if ($boundaries === null || count($boundaries) < 1) return;
```

A köteg viszont a **legrégebben ellenőrzöttet** veszi előre. A sikertelen próbálkozás tehát a templomot határok nélkül a sor **végére** tette — véglegesen. Egyetlen rate-limitelt futás így tömegével tett templomot elérhetetlenné a települési keresés számára. Helyben: **5051 aktív templomból 5-nek** van egyáltalán határa.

Ez magyarázza a #570-et („Pécs alatt nem jön ki a Szent Ferenc-templom") és a #700-at („Szekszárd, település → nem talál semmit"). És nem is látszott hibaként: a felhasználó csak annyit lát, hogy nincs találat.

A `downloadBoundaries()` háromféle helyzetre adott `null`-t — elhasalt a lekérdezés / lefutott de nincs itt határ / kivétel —, a hívó pedig nem tudta megkülönböztetni őket. Mostantól `false` a kudarc, `[]` a nincs-találat, és **csak az utóbbinál bélyegzünk**.

Az örökös hurok elleni védelem máshová kerül: kudarcnál **megszakítom a köteget**. További kérésekkel a rate-limitet csak mélyítenénk, és a következő cron-futás úgyis ugyanezekkel folytatja.

Átírtam azt a tesztet, ami a régi viselkedést rögzítette (`...UpdatesBoundariesCheckedAtOnApiFailure`) — az kódolta be a hibát —, és tettem mellé egyet a köteg megszakítására.

**Ez is igényel utómunkát élesben:** a már hibásan lebélyegzett templomok addig nem kapnak határt, amíg a cron újra sorra nem veszi őket. Mivel a rendezés a legrégebbi bélyeg szerint megy, ez magától megtörténik — csak lassan. Gyorsítani a `boundaries_checked_at` nullázásával lehet azoknál, amiknek nincs egyetlen határuk sem:

```sql
UPDATE templomok t SET t.boundaries_checked_at = NULL
WHERE t.ok = 'i'
  AND NOT EXISTS (SELECT 1 FROM lookup_boundary_church l WHERE l.church_id = t.id);
```
