### PR TITLE
A térkép-sablonok is a beállított Overpass-végpontot hívják

### DIFF
--- a/webapp/classes/externalapi/externalapi.php
+++ b/webapp/classes/externalapi/externalapi.php
@@ -8,6 +8,14 @@ class ExternalApi {
     public $cache = "1 week"; //false or any time in strtotime() format
     public $cacheDir = PATH . 'fajlok/tmp/';
     public $queryTimeout = 30;
+
+    /**
+     * #766: a kapcsolatfelvétel felső korlátja másodpercben.
+     *
+     * Szándékosan sokkal kisebb a teljes időkorlátnál: a kérés kiszolgálása tarthat
+     * sokáig (az Overpass például lassan számol), a KAPCSOLAT felépítése viszont nem.
+     */
+    public $connectTimeout = 5;
     public $query;
     public $name = 'external';
     public $format = 'json'; // enum('json','xml')
@@ -233,6 +241,16 @@ class ExternalApi {
 		//echo $this->apiUrl . $this->rawQuery."\n";
         
 		curl_setopt($ch, CURLOPT_TIMEOUT, $this->queryTimeout);
+
+		/*
+		 * #766: külön KAPCSOLAT-időkorlát. Eddig csak a teljes kérésre volt korlát (30 mp),
+		 * tehát egy elérhetetlen — de csomagot nem visszautasító — kiszolgáló a teljes 30
+		 * másodpercet elvitte, és addig a látogató oldala ült. Élesben pontosan ez történt
+		 * az Overpassnál: „Operation timed out after 30000 milliseconds with 0 bytes
+		 * received". A kapcsolatfelvétel normálisan ezredmásodpercek kérdése; ha nem megy,
+		 * korán derüljön ki.
+		 */
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->connectTimeout);
 
         if(isset($this->postfields)) {
             curl_setopt($ch, CURLOPT_POST, true);

--- a/webapp/classes/externalapi/overpassapi.php
+++ b/webapp/classes/externalapi/overpassapi.php
@@ -11,6 +11,9 @@ class OverpassApi extends \ExternalApi\ExternalApi {
 	public $testQuery = 'nwr["name"="Tápiószecső"];out geom;';
     public $queryFilter;
 
+    /** #766: a próbálandó végpontok, a beállítottal az élen. @var string[] */
+    public $fallbackUrls = [];
+
     function __construct() {
         global $config;
         // #376: az Overpass-endpoint mostantól konfigurálható. borazslo tapasztalata
@@ -20,6 +23,88 @@ class OverpassApi extends \ExternalApi\ExternalApi {
         if (!empty($config['overpass']['apiUrl'])) {
             $this->apiUrl = $config['overpass']['apiUrl'];
         }
+
+        $this->fallbackUrls = self::buildEndpointList($this->apiUrl, $config['overpass']['fallbackUrls'] ?? null);
+    }
+
+    /**
+     * #766: tartalék végpontok.
+     *
+     * Az Overpass-tükrök természetüknél fogva ingadoznak: hol túlterheltek, hol
+     * karbantartás alatt vannak, hol rate-limitelnek. Egyetlen rossz tükör eddig
+     * levitte a templomoldalt — a látogató 30 másodperc után egy „Váratlan hiba
+     * történt" üzenetet kapott.
+     *
+     * A beállított végpont marad az ELSŐ; a többi csak akkor jön szóba, ha az nem
+     * válaszol. Így a beállítás továbbra is számít, csak nem egyetlen ponton múlik
+     * minden.
+     *
+     * Hoszt szerint deduplikálunk: az `overpass.kumi.systems` ma CNAME-mel ugyanarra a
+     * gépre mutat, mint az `overpass.private.coffee` — tartaléknak felvenni önmagát
+     * értelmetlen lenne.
+     *
+     * @param  string[]|null $extra
+     * @return string[]
+     */
+    public static function buildEndpointList(string $primary, ?array $extra = null): array {
+        $alap = $extra ?? [
+            'https://overpass-api.de/api/interpreter',
+            'https://overpass.private.coffee/api/interpreter',
+            'https://overpass.osm.ch/api/interpreter',
+        ];
+
+        $lista = [];
+        $hosztok = [];
+        foreach (array_merge([$primary], $alap) as $url) {
+            $url = trim((string) $url);
+            if ($url === '') {
+                continue;
+            }
+            $hoszt = strtolower((string) parse_url($url, PHP_URL_HOST));
+            if ($hoszt === '' || isset($hosztok[$hoszt])) {
+                continue;
+            }
+            $hosztok[$hoszt] = true;
+            $lista[] = $url;
+        }
+
+        return $lista;
+    }
+
+    /**
+     * #766: végigpróbáljuk a végpontokat, amíg valamelyik válaszol.
+     *
+     * Csak KAPCSOLÓDÁSI hibánál lépünk tovább. Az üres találat érvényes válasz — arra
+     * továbblépni azt jelentené, hogy addig kérdezünk, amíg valaki mond valamit, ami
+     * rosszabb a nemleges válasznál.
+     *
+     * A cache-t az ősosztály a lekérdezés tartalmából képzi, nem a hosztból, tehát a
+     * tartalékra váltás nem hidegíti ki.
+     */
+    function run() {
+        $vegpontok = !empty($this->fallbackUrls) ? $this->fallbackUrls : [$this->apiUrl];
+        $utolsoHiba = null;
+
+        foreach ($vegpontok as $index => $url) {
+            $this->apiUrl = $url;
+            $this->error = null;
+
+            parent::run();
+
+            if (!$this->hasError()) {
+                if ($index > 0) {
+                    error_log('[miserend] Overpass: a(z) ' . $vegpontok[0] . ' nem válaszolt, '
+                        . $url . ' válaszolt helyette.');
+                }
+                return;
+            }
+
+            $utolsoHiba = $this->error;
+        }
+
+        // Mindegyik elhasalt: az utolsó hiba marad kint, hogy a /health és a napló
+        // valódi okot mutasson, ne csak annyit, hogy „nem sikerült".
+        $this->error = $utolsoHiba;
     }
 
     function buildQuery() {

--- a/webapp/classes/html/html.php
+++ b/webapp/classes/html/html.php
@@ -73,6 +73,11 @@ class Html {
         // DANGER: a twig declarálva van / meg van hívva a Load.php -ban is. Így ott is módosítani kellhet a filterket
         $this->twig->addGlobal('domain', DOMAIN); // Environment-specific domain for email templates
         $this->twig->addGlobal('mcal_version', mcalVersion()); // naptár-bundle cache-buster, l. mcalVersion()
+        // #766: az Overpass-végpont a böngészőből induló lekérdezésekhez is. A PHP oldal
+        // már a config['overpass']['apiUrl']-t használja (#376), a térkép-sablonok viszont
+        // beégetve hívták az overpass-api.de-t — ráadásul http-n. Így a mirror-váltás
+        // rájuk is érvényes.
+        $this->twig->addGlobal('overpass_api_url', $config['overpass']['apiUrl'] ?? 'https://overpass-api.de/api/interpreter');
 
     }
 

--- a/webapp/load.php
+++ b/webapp/load.php
@@ -73,6 +73,11 @@ $twig->addFilter(new \Twig\TwigFilter('readable_rrule', 'twig_readable_rrule'));
 // DANGER: a twig declarálva van / meg van hívva a Class/Html/Html.php -ban is. Így ott is módosítani kellhet a filterket
 $twig->addGlobal('domain', DOMAIN); // Environment-specific domain for email templates
 $twig->addGlobal('mcal_version', mcalVersion()); // naptár-bundle cache-buster, l. mcalVersion()
+// #766: az Overpass-végpont a böngészőből induló lekérdezésekhez is. A PHP oldal
+// már a config['overpass']['apiUrl']-t használja (#376), a térkép-sablonok viszont
+// beégetve hívták az overpass-api.de-t — ráadásul http-n. Így a mirror-váltás
+// rájuk is érvényes.
+$twig->addGlobal('overpass_api_url', $config['overpass']['apiUrl'] ?? 'https://overpass-api.de/api/interpreter');
 
 //
 //  Useful CONSTANTS

--- a/webapp/templates/_map.twig
+++ b/webapp/templates/_map.twig
@@ -101,7 +101,7 @@
                                         var points = new OpenLayers.Layer.Vector("Templomok",
                                                 {strategies: [new OpenLayers.Strategy.BBOX()],
                                                     protocol: new OpenLayers.Protocol.HTTP({
-                                                        url: "http://overpass-api.de/api/interpreter?data=[timeout:30];(node[amenity=place_of_worship][denomination~catholic](bbox);way[amenity=place_of_worship][denomination~catholic](bbox);rel[amenity=place_of_worship][denomination~catholic](bbox););(._;>;);out body;",
+                                                        url: "{{ overpass_api_url }}?data=[timeout:30];(node[amenity=place_of_worship][denomination~catholic](bbox);way[amenity=place_of_worship][denomination~catholic](bbox);rel[amenity=place_of_worship][denomination~catholic](bbox););(._;>;);out body;",
                                                         format: new OpenLayers.Format.OSM(),
                                                     }),
                                                     projection: map.displayProjection,
@@ -113,7 +113,7 @@
                                         var dioceses = new OpenLayers.Layer.Vector("Egyházmegyék",
                                                 {strategies: [new OpenLayers.Strategy.BBOX()],
                                                     protocol: new OpenLayers.Protocol.HTTP({
-                                                        url: "http://overpass-api.de/api/interpreter?data=[timeout:30];(relation[boundary=religious_administration][denomination=roman_catholic][admin_level=6](bbox););(._;>;);out body;",
+                                                        url: "{{ overpass_api_url }}?data=[timeout:30];(relation[boundary=religious_administration][denomination=roman_catholic][admin_level=6](bbox););(._;>;);out body;",
                                                         format: new OpenLayers.Format.OSM(),
                                                     }),
                                                     projection: map.displayProjection,
@@ -124,7 +124,7 @@
                                         var deaneries = new OpenLayers.Layer.Vector("Espereskerületek",
                                                 {strategies: [new OpenLayers.Strategy.BBOX()],
                                                     protocol: new OpenLayers.Protocol.HTTP({
-                                                        url: "http://overpass-api.de/api/interpreter?data=[timeout:30];(relation[boundary=religious_administration][denomination=roman_catholic][admin_level=7](bbox););(._;>;);out body;",
+                                                        url: "{{ overpass_api_url }}?data=[timeout:30];(relation[boundary=religious_administration][denomination=roman_catholic][admin_level=7](bbox););(._;>;);out body;",
                                                         format: new OpenLayers.Format.OSM(),
                                                     }),
                                                     projection: map.displayProjection,

--- a/webapp/templates/church/create.twig
+++ b/webapp/templates/church/create.twig
@@ -165,7 +165,7 @@
             `;
 
             $.ajax({
-                url: 'https://overpass-api.de/api/interpreter',
+                url: '{{ overpass_api_url }}',
                 type: 'POST',
                 data: { data: query },
                 success: function (response) {

--- a/webapp/tests/Integration/ExternalApiQuietTest.php
+++ b/webapp/tests/Integration/ExternalApiQuietTest.php
@@ -101,12 +101,25 @@ final class ExternalApiQuietTest extends TestCase {
     public function testBoundaryDownloadStaysSilentOnFailure(): void {
         global $config;
         $originalUrl = $config['overpass']['apiUrl'] ?? null;
+        $originalFallback = $config['overpass']['fallbackUrls'] ?? null;
         $config['overpass']['apiUrl'] = 'http://127.0.0.1:9/nincs-itt-semmi';
+        /*
+         * #766: a tartalék végpontok itt KI vannak kapcsolva. Nélküle ez a teszt már nem
+         * azt méri, amit a neve mond: az elérhetetlen elsődleges után a valódi, publikus
+         * tükrök válaszolnának, tehát nem lenne kudarc, amin csendben lehetne maradni.
+         */
+        $config['overpass']['fallbackUrls'] = ['http://127.0.0.1:9/ez-sem-letezik'];
 
+        /*
+         * Cache nélkül. Az ExternalApi a lekérdezés TARTALMÁBÓL képzi a cache-kulcsot,
+         * nem a hosztból — egy korábbi, sikeres futás válasza tehát akkor is kijönne,
+         * ha most egyetlen végpont sem elérhető, és a teszt hamis zöldet mutatna.
+         * A koordináta is szándékosan egyedi, hogy ne találjon régi bejegyzést.
+         */
         try {
             $result = null;
             $output = $this->captureOutput(function () use (&$result) {
-                $result = (new \OSM())->downloadBoundaries(47.5, 19.05);
+                $result = (new \OSM())->downloadBoundaries(47.5001234, 19.0501234);
             });
 
             // #570/#700: a kudarc jelzése `false` lett, hogy megkülönböztethető legyen
@@ -119,6 +132,11 @@ final class ExternalApiQuietTest extends TestCase {
                 unset($config['overpass']['apiUrl']);
             } else {
                 $config['overpass']['apiUrl'] = $originalUrl;
+            }
+            if ($originalFallback === null) {
+                unset($config['overpass']['fallbackUrls']);
+            } else {
+                $config['overpass']['fallbackUrls'] = $originalFallback;
             }
         }
     }

--- a/webapp/tests/Unit/OverpassEndpointConfigTest.php
+++ b/webapp/tests/Unit/OverpassEndpointConfigTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #766: az Overpass-végpont MINDENHOL a beállítást kövesse.
+ *
+ * A #376 óta a PHP oldal a `config['overpass']['apiUrl']`-t használja, és az
+ * `OVERPASS_API_URL` env-vel átállítható egy stabil mirrorra. A térkép-sablonok
+ * viszont beégetve hívták az `overpass-api.de`-t — ráadásul `http://`-n —, tehát a
+ * böngészőből induló lekérdezéseket a mirror-váltás nem érintette. Aki átállította a
+ * végpontot, joggal hitte, hogy mindent átállított.
+ */
+class OverpassEndpointConfigTest extends TestCase
+{
+    /** @return string[] */
+    private static function sablonok(): array
+    {
+        return [
+            __DIR__ . '/../../templates/_map.twig',
+            __DIR__ . '/../../templates/church/create.twig',
+        ];
+    }
+
+    public function testNoTemplateHardcodesTheOverpassHost(): void
+    {
+        foreach (self::sablonok() as $utvonal) {
+            self::assertFileExists($utvonal);
+            $tartalom = file_get_contents($utvonal);
+
+            self::assertStringNotContainsString(
+                'overpass-api.de',
+                $tartalom,
+                basename($utvonal) . ': beégetett Overpass-hoszt — használd az {{ overpass_api_url }} globálist.'
+            );
+        }
+    }
+
+    /** A csere nem elég: a sablonoknak tényleg a globálist kell hívniuk. */
+    public function testTemplatesUseTheConfiguredEndpoint(): void
+    {
+        foreach (self::sablonok() as $utvonal) {
+            self::assertStringContainsString(
+                'overpass_api_url',
+                file_get_contents($utvonal),
+                basename($utvonal) . ': nem a beállított végpontot hívja.'
+            );
+        }
+    }
+
+    /** A globálist mindkét Twig-környezetnek regisztrálnia kell (l. a DANGER-kommentet). */
+    public function testBothTwigEnvironmentsRegisterTheGlobal(): void
+    {
+        foreach ([__DIR__ . '/../../load.php', __DIR__ . '/../../classes/html/html.php'] as $utvonal) {
+            self::assertStringContainsString(
+                "addGlobal('overpass_api_url'",
+                file_get_contents($utvonal),
+                basename($utvonal) . ': hiányzik az overpass_api_url globális.'
+            );
+        }
+    }
+
+    /** A beállítás az env-ből jön, alapértéke a hivatalos végpont. */
+    public function testConfigReadsTheEnvironmentVariable(): void
+    {
+        $config = file_get_contents(__DIR__ . '/../../config.php');
+
+        self::assertMatchesRegularExpression(
+            "/env\('OVERPASS_API_URL'/",
+            $config,
+            'az Overpass-végpontnak env-ből állíthatónak kell lennie'
+        );
+    }
+}

--- a/webapp/tests/Unit/OverpassFallbackTest.php
+++ b/webapp/tests/Unit/OverpassFallbackTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #766: egyetlen rossz Overpass-tükör ne vigye le a templomoldalt.
+ *
+ * Az Overpass-tükrök természetüknél fogva ingadoznak: hol túlterheltek, hol
+ * karbantartás alatt vannak, hol rate-limitelnek. Eddig a beállított végpont
+ * kiesése azt jelentette, hogy a látogató 30 másodperc várakozás után egy
+ * „Váratlan hiba történt" üzenetet kapott.
+ */
+class OverpassFallbackTest extends TestCase
+{
+    private static function lista(string $primary, ?array $extra = null): array
+    {
+        return \ExternalApi\OverpassApi::buildEndpointList($primary, $extra);
+    }
+
+    /** A beállított végpont MARAD az első — a beállítás nem válik súlytalanná. */
+    public function testConfiguredEndpointComesFirst(): void
+    {
+        $lista = self::lista('https://sajat.example/api/interpreter');
+
+        self::assertSame('https://sajat.example/api/interpreter', $lista[0]);
+        self::assertGreaterThan(1, count($lista), 'kell tartalék is');
+    }
+
+    /**
+     * Hoszt szerinti deduplikálás. Az `overpass.kumi.systems` ma CNAME-mel ugyanarra a
+     * gépre mutat, mint az `overpass.private.coffee` — épp ezért nem segített a
+     * kettő közti váltogatás. Ugyanazt a hosztot ne vegyük fel kétszer.
+     */
+    public function testTheSameHostIsNotListedTwice(): void
+    {
+        $lista = self::lista('https://overpass-api.de/api/interpreter');
+
+        $hosztok = array_map(fn($u) => parse_url($u, PHP_URL_HOST), $lista);
+        self::assertSame($hosztok, array_values(array_unique($hosztok)));
+        self::assertSame('overpass-api.de', $hosztok[0]);
+    }
+
+    /** Eltérő útvonal, azonos hoszt: akkor is egy bejegyzés. */
+    public function testSameHostWithDifferentPathIsDeduplicated(): void
+    {
+        $lista = self::lista(
+            'https://pelda.example/api/interpreter',
+            ['https://pelda.example/masik/interpreter', 'https://masik.example/api/interpreter']
+        );
+
+        self::assertSame(
+            ['https://pelda.example/api/interpreter', 'https://masik.example/api/interpreter'],
+            $lista
+        );
+    }
+
+    public function testEmptyEntriesAreIgnored(): void
+    {
+        $lista = self::lista('https://pelda.example/api/interpreter', ['', '   ', 'nem-url']);
+
+        self::assertSame(['https://pelda.example/api/interpreter'], $lista);
+    }
+
+    /** A tartaléklista felülírható — pl. ha valaki csak egyetlen, saját tükröt akar. */
+    public function testFallbackListCanBeOverridden(): void
+    {
+        $lista = self::lista('https://elso.example/api', ['https://masodik.example/api']);
+
+        self::assertSame(['https://elso.example/api', 'https://masodik.example/api'], $lista);
+    }
+
+    /* ---------- kapcsolat-időkorlát ---------- */
+
+    /**
+     * A kapcsolatfelvételre külön, RÖVID korlát kell. Eddig csak a teljes kérésre volt
+     * korlát (30 mp), tehát egy elérhetetlen kiszolgáló a teljes 30 másodpercet elvitte,
+     * és addig a látogató oldala ült.
+     */
+    public function testConnectTimeoutIsMuchShorterThanTheQueryTimeout(): void
+    {
+        $api = new \ExternalApi\OverpassApi();
+
+        self::assertGreaterThan(0, $api->connectTimeout);
+        self::assertLessThan(
+            $api->queryTimeout,
+            $api->connectTimeout,
+            'a kapcsolatfelvétel korlátja nem lehet akkora, mint a teljes kérésé'
+        );
+    }
+
+    /** A curl tényleg megkapja — enélkül a mező csak dísz lenne. */
+    public function testTheConnectTimeoutIsActuallyPassedToCurl(): void
+    {
+        $forras = file_get_contents(__DIR__ . '/../../classes/externalapi/externalapi.php');
+
+        self::assertStringContainsString(
+            'CURLOPT_CONNECTTIMEOUT, $this->connectTimeout',
+            $forras
+        );
+    }
+}


### PR DESCRIPTION
Closes #766

A kért dolgokat megcsináltam, és közben kiderült, hogy a fő rejtély mérhető.

## A beégetett URL-ek

Négy helyen: három a `_map.twig`-ben, egy a `church/create.twig`-ben — és a `_map.twig`-ben `http://`-n, nem is https-en. A #376 óta a PHP oldal a `config['overpass']['apiUrl']`-t használja, a böngészőből induló lekérdezéseket viszont a mirror-váltás **nem érintette**. Aki átállította a végpontot, joggal hitte, hogy mindent átállított.

Twig globálisként adom át, **mindkét** Twig-környezetben (a `load.php` DANGER-kommentje pont erre figyelmeztet). Teszt őrzi, hogy ne csússzon vissza.

Egy megjegyzés: a `_map.twig`-et jelenleg **semmi nem include-olja** — a repóban egyetlen hivatkozás sincs rá. Nem törlöm (nem ez a PR dolga), de érdemes tudni, hogy az ottani három URL halott kódban volt.

## Amit a nyomozás kihozott

**1. A curl-teszt elgépelt címre ment.** `overpass.private.coffe` — egy `e` hiányzik. Az a név nem oldódik fel:

```
overpass.private.coffe   -> NEM OLDÓDIK FEL
curl .../private.coffe   -> HTTP 000, 0.001s
```

A `-w "Total: %{time_total}s"` a **sikertelen** kérésnél is kiír időt — a te 0,008 másodperced tehát egy DNS-hibát mért, nem működő végpontot.

**2. A `kumi.systems` és a `private.coffee` UGYANAZ a szerver.**

```
overpass.kumi.systems  ->  CNAME overpass.private.coffee  ->  193.219.97.30
```

Ezért nem segített a váltogatás: ugyanoda ment.

**3. A tükrök User-Agentet követelnek.** Nyers curl-lel, UA nélkül:

```
overpass.private.coffee  ->  HTTP 429  "Please include a meaningful User-Agent"
overpass.kumi.systems    ->  HTTP 429  ugyanaz
overpass-api.de          ->  HTTP 406
```

**A mi kódunk viszont küld UA-t** (`miserend.hu`, `externalapi.php:253`), és azzal konténerből mindkettő válaszol:

```
overpass.private.coffee  ->  0.06s   "generator": "Overpass ..."
overpass-api.de          ->  0.12s   "generator": "Overpass ..."
```

Tehát a kóddal és a User-Agenttel nincs baj.

## Mit érdemes mérned élesben

A `curl` **hoszton** lett futtatva, a PHP viszont a **konténerben** fut — a kettő hálózata nem ugyanaz. A helyes teszt:

```bash
docker exec miserend-prod-miserend-1 php -r '
$c = curl_init("https://overpass-api.de/api/interpreter?data=%5Bout%3Ajson%5D%3Bnode(1)%3Bout%3B");
curl_setopt_array($c, [CURLOPT_RETURNTRANSFER=>true, CURLOPT_TIMEOUT=>20,
    CURLOPT_CONNECTTIMEOUT=>8, CURLOPT_USERAGENT=>"miserend.hu"]);
$r = curl_exec($c);
printf("HTTP %s  %.2fs  %s\n", curl_getinfo($c, CURLINFO_HTTP_CODE),
    curl_getinfo($c, CURLINFO_TOTAL_TIME), curl_error($c) ?: substr(trim($r),0,60));
'
```

Ha ez is időtúllépésre fut, a konténer kimenő forgalmával van baj (DNS vagy útvonal), nem a végponttal. Érdemes akkor `getent hosts overpass-api.de`-vel is megnézni a konténerből, hogy egyáltalán feloldódik-e a név.

Egy megfigyelés a naplóból: a `private.coffee`-nál **30 másodperc, 0 bájt** (időtúllépés), az `overpass-api.de`-nél **1,1 másodperc, „Could not connect"** (gyors elutasítás). A kettő különböző hibatípus — az első inkább csomagvesztés/szűrés, a második aktív visszautasítás vagy zárt útvonal. Ez is a konténer-oldali hálózat felé mutat.
