### PR TITLE
A BYDAY sorszámos alakja ne ölje meg az importot

### DIFF
--- a/webapp/classes/externalcalendarimporter.php
+++ b/webapp/classes/externalcalendarimporter.php
@@ -453,6 +453,54 @@ class ExternalCalendarImporter {
     }
 
     /**
+     * #765: az RRULE `BYDAY` értékének feldolgozása (RFC 5545).
+     *
+     * Alakja vesszős lista, elemenként opcionális előjeles sorszámmal:
+     *   `SU,MO`      → minden vasárnap és hétfő
+     *   `2SU`        → minden hónap 2. vasárnapja
+     *   `-1FR`       → a hónap utolsó péntekje
+     *
+     * A `byweekday` MINDIG tömb — ez volt a hiba forrása: a sorszámos ág korábban
+     * stringet adott, és a SimpleRRule típus-kikötése elhasalt rajta.
+     *
+     * A sorszám a `bysetpos`-ba megy. Több, KÜLÖNBÖZŐ sorszámot (pl. `1SU,3SU`) nem
+     * tudunk leképezni erre az egy mezőre, ezért azt inkább elutasítjuk — a néma,
+     * fél-jó ismétlődés rosszabb, mint a kihagyott szabály.
+     *
+     * @return array{byweekday: string[], bysetpos: int|null}|null null: nem értelmezhető
+     */
+    public static function parseByDay(string $value): ?array
+    {
+        $napok = [];
+        $sorszamok = [];
+
+        foreach (explode(',', $value) as $elem) {
+            $elem = trim($elem);
+            if ($elem === '' || !preg_match('/^([+-]?\d{1,2})?(SU|MO|TU|WE|TH|FR|SA)$/i', $elem, $m)) {
+                return null;
+            }
+            $napok[] = strtoupper($m[2]);
+            if (($m[1] ?? '') !== '') {
+                $sorszamok[] = (int) $m[1];
+            }
+        }
+
+        if ($napok === []) {
+            return null;
+        }
+
+        $sorszamok = array_values(array_unique($sorszamok));
+        if (count($sorszamok) > 1) {
+            return null;
+        }
+
+        return [
+            'byweekday' => $napok,
+            'bysetpos' => $sorszamok === [] ? null : $sorszamok[0],
+        ];
+    }
+
+    /**
      * #756: a `cal_masses.title` varchar(255) — a hosszabb SUMMARY-tól az import
      * elhasalt („Data too long"). Élő eset a templom/282 gyászmise-bejegyzése, ami a
      * teljes gyászjelentést beleírta a címbe (~430 karakter).
@@ -660,18 +708,32 @@ class ExternalCalendarImporter {
                 if ($value) {
                     if($key == 'FREQ') $value = strtolower($value);
                     
-                    if($key == 'BYDAY' AND preg_match('/^(SU|MO|TU|WE|TH|FR|SA)(,(SU|MO|TU|WE|TH|FR|SA))*$/', $value)) {
-                        // Convert BYDAY=SU,MO to ["SU", "MO"]                        
-                        $ruleArray["byweekday"] = explode(',', $value);
-                    }
-
-                    else if($key === 'BYDAY' AND preg_match('/^(1|2|3|4|5|-1)(SU|MO|TU|WE|TH|FR|SA)*$/', $value, $match)) {
-                        $ruleArray["bysetpos"] = (int)$match[1];
-                        $ruleArray["byweekday"] = $match[2];                        
+                    if ($key === 'BYDAY') {
+                        /*
+                         * #765: a BYDAY kétféle alakja eddig KÉTFÉLE TÍPUST adott:
+                         * a `SU,MO` tömböt, a `2SU` viszont sima stringet. A SimpleRRule
+                         * tömböt vár, ezért a második alak TypeError-ral megölte az egész
+                         * import futását (templom/281).
+                         *
+                         * A régi minta ráadásul némán veszített adatot: a
+                         * `(SU|MO|…)*` ismétlődő csoportból csak az UTOLSÓ találat
+                         * maradt meg, tehát egy `2SU,2MO` alakból a vasárnap eltűnt.
+                         *
+                         * Most az RFC 5545 szerint bontunk: vesszős lista, elemenként
+                         * opcionális előjeles sorszámmal.
+                         */
+                        $parsed = self::parseByDay($value);
+                        if ($parsed === null) {
+                            throw new \Exception("Unsupported RRULE parameter: $key - skipping RRULE: ". $rrule);
+                        }
+                        $ruleArray['byweekday'] = $parsed['byweekday'];
+                        if ($parsed['bysetpos'] !== null) {
+                            $ruleArray['bysetpos'] = $parsed['bysetpos'];
+                        }
                     }
                     else {
                         
-                        if($key == "BYDAY" OR $key == "BYMONTHDAY") {
+                        if($key == "BYMONTHDAY") {
                         throw new \Exception("Unsupported RRULE parameter: $key - skipping RRULE: ". $rrule);
                         }
 

--- a/webapp/classes/simplerrule.php
+++ b/webapp/classes/simplerrule.php
@@ -44,13 +44,41 @@ class SimpleRRule
         }
     }
 
-    private function normalizeByWeekday(array $days): array
+    /**
+     * #765: a `byweekday` STRINGKÉNT is érkezhet, nem csak tömbként.
+     *
+     * A külső naptár importálója a `BYDAY=2SU` alakot (minden hónap 2. vasárnapja)
+     * egyetlen stringgel adta vissza, míg a `BYDAY=SU,MO` alakot tömbbel — a típus-
+     * kikötés miatt az előbbi TypeError-ral megölte az egész import futását.
+     *
+     * Az importálót külön javítom, de itt is elfogadjuk: az adatbázisban MÁR ott vannak
+     * a korábbi futások stringes sorai, és azok különben minden generáláskor újra
+     * elhasalnának.
+     *
+     * @param array|string|null $days
+     */
+    private function normalizeByWeekday($days): array
     {
+        if ($days === null || $days === '') {
+            return [];
+        }
+        if (!is_array($days)) {
+            $days = [$days];
+        }
+
         $map = [
             'MO' => 1, 'TU' => 2, 'WE' => 3, 'TH' => 4,
             'FR' => 5, 'SA' => 6, 'SU' => 7,
         ];
-        return array_map(fn($d) => $map[strtoupper($d)] ?? $d, $days);
+
+        $out = [];
+        foreach ($days as $d) {
+            if ($d === null || $d === '') {
+                continue;
+            }
+            $out[] = $map[strtoupper((string) $d)] ?? $d;
+        }
+        return $out;
     }
 
     public function getOccurrences(): array

--- a/webapp/tests/Unit/ByDayParsingTest.php
+++ b/webapp/tests/Unit/ByDayParsingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #765: az RRULE `BYDAY` feldolgozása.
+ *
+ * A hiba: a `SU,MO` alak tömböt adott, a `2SU` viszont sima stringet, a SimpleRRule
+ * pedig tömböt vár — a sorszámos alak ezért TypeError-ral megölte az EGÉSZ import
+ * futását (templom/281). Ráadásul a régi minta némán veszített adatot: az ismétlődő
+ * `(SU|MO|…)*` csoportból csak az utolsó találat maradt meg.
+ */
+class ByDayParsingTest extends TestCase
+{
+    private static function parse(string $ertek): ?array
+    {
+        return \ExternalCalendarImporter::parseByDay($ertek);
+    }
+
+    public function testPlainWeekdayList(): void
+    {
+        self::assertSame(
+            ['byweekday' => ['SU', 'MO'], 'bysetpos' => null],
+            self::parse('SU,MO')
+        );
+    }
+
+    public function testSingleWeekday(): void
+    {
+        self::assertSame(['byweekday' => ['FR'], 'bysetpos' => null], self::parse('FR'));
+    }
+
+    /** A jegyben szereplő eset: minden hónap 2. vasárnapja. */
+    public function testOrdinalWeekdayYieldsAnArray(): void
+    {
+        $eredmeny = self::parse('2SU');
+
+        self::assertIsArray($eredmeny['byweekday'], 'a byweekday MINDIG tömb — ezen hasalt el az import');
+        self::assertSame(['SU'], $eredmeny['byweekday']);
+        self::assertSame(2, $eredmeny['bysetpos']);
+    }
+
+    public function testNegativeOrdinal(): void
+    {
+        self::assertSame(['byweekday' => ['FR'], 'bysetpos' => -1], self::parse('-1FR'));
+    }
+
+    public function testExplicitPlusSign(): void
+    {
+        self::assertSame(['byweekday' => ['WE'], 'bysetpos' => 3], self::parse('+3WE'));
+    }
+
+    /** Több nap AZONOS sorszámmal: a napok egyike sem veszhet el. */
+    public function testSameOrdinalOnSeveralWeekdaysKeepsEveryDay(): void
+    {
+        $eredmeny = self::parse('2SU,2MO');
+
+        self::assertSame(['SU', 'MO'], $eredmeny['byweekday'], 'a régi minta a vasárnapot elnyelte');
+        self::assertSame(2, $eredmeny['bysetpos']);
+    }
+
+    /** Különböző sorszámokat nem tudunk egyetlen bysetpos-ra leképezni — inkább kihagyjuk. */
+    public function testDifferentOrdinalsAreRejected(): void
+    {
+        self::assertNull(self::parse('1SU,3SU'));
+    }
+
+    public function testGarbageIsRejected(): void
+    {
+        self::assertNull(self::parse(''));
+        self::assertNull(self::parse('XX'));
+        self::assertNull(self::parse('2'));
+        self::assertNull(self::parse('SU,,MO'));
+        self::assertNull(self::parse('2SUMO'));
+    }
+
+    public function testLowercaseIsAccepted(): void
+    {
+        self::assertSame(['byweekday' => ['SU'], 'bysetpos' => 2], self::parse('2su'));
+    }
+
+    /* ---------- a SimpleRRule oldala ---------- */
+
+    /**
+     * A már adatbázisban lévő, STRINGES byweekday se hasaljon el: a korábbi futások
+     * ilyen sorokat írtak be, és azok különben minden generáláskor újra elszállnának.
+     */
+    public function testSimpleRRuleAcceptsAStringByWeekday(): void
+    {
+        $rrule = new \SimpleRRule([
+            'freq' => 'monthly',
+            'dtstart' => '2026-01-01T09:00:00',
+            'until' => '2026-06-30T09:00:00',
+            'byweekday' => 'SU',
+            'bysetpos' => 2,
+        ]);
+
+        self::assertNotEmpty($rrule->getOccurrences(), 'stringes byweekday mellett is kell időpont');
+    }
+
+    public function testSimpleRRuleAcceptsAnEmptyByWeekday(): void
+    {
+        $rrule = new \SimpleRRule([
+            'freq' => 'daily',
+            'dtstart' => '2026-01-01T09:00:00',
+            'count' => 3,
+            'byweekday' => '',
+        ]);
+
+        self::assertCount(3, $rrule->getOccurrences());
+    }
+}


### PR DESCRIPTION
Closes #765

Haladunk: a cím-levágás működik (azok a ⚠ sorok a szándék szerintiek), és most már a következő akadály látszik.

## Az ok

A `BYDAY` kétféle alakja **kétféle típust** adott:

```php
// BYDAY=SU,MO  ->  tömb
$ruleArray["byweekday"] = explode(',', $value);

// BYDAY=2SU    ->  STRING
$ruleArray["byweekday"] = $match[2];
```

A `SimpleRRule::normalizeByWeekday()` tömböt vár, ezért a sorszámos alak `TypeError`-ral megölte az **egész** import futását — nem csak azt az egy misét.

## Egy másik, csendesebb hiba ugyanott

A régi minta `(SU|MO|TU|WE|TH|FR|SA)*` — ismétlődő csoport. Abból a `$match[2]` csak az **utolsó** találatot tartja meg, tehát egy `BYDAY=2SU,2MO` alakból a vasárnap **némán eltűnt**. Ez nem hasalt el, csak rossz miserendet generált.

## A javítás

Az RFC 5545 szerint bontom: vesszős lista, elemenként opcionális előjeles sorszámmal (`SU,MO`, `2SU`, `-1FR`, `+3WE`). A `byweekday` **mindig tömb**.

Több, KÜLÖNBÖZŐ sorszámot (`1SU,3SU`) nem tudunk egyetlen `bysetpos`-ra leképezni, ezért azt elutasítom — a néma, fél-jó ismétlődés rosszabb, mint a kihagyott szabály.

A `SimpleRRule` is elfogadja a stringes `byweekday`-t. Ez azért kell, mert az adatbázisban **már ott vannak** a korábbi futások ilyen sorai: enélkül azok minden generáláskor újra elhasalnának, akkor is, ha az importáló már jól ír.

## Ellenőrizve

A jegyben szereplő pontos eset, végponttól végpontig:

```
parseByDay("2SU")  ->  {"byweekday":["SU"],"bysetpos":2}
SimpleRRule        ->  12 időpont, első: 2026-01-11 09:00:00
```

2026-01-11 valóban január 2. vasárnapja, és havonta egy előfordulás van. A stringes alak sem dob többé.

`ByDayParsingTest`, 11 eset. PHP: 792 zöld.
