### PR TITLE
Leválasztom az OSRM-tesztet a környezeti változóról

### DIFF
--- a/webapp/classes/externalapi/osrmapi.php
+++ b/webapp/classes/externalapi/osrmapi.php
@@ -31,9 +31,18 @@ class OsrmApi extends \ExternalApi\ExternalApi {
     public $testQuery;
     public $testSkipReason;
 
-    function __construct()
+    /**
+     * @param string|null $apiUrl a végpont; null esetén az OSRM_URL env-ből
+     *
+     * A paraméter a TESZTELHETŐSÉG miatt van. Az `env()` implementációja
+     * környezetfüggő — a projekté csak akkor él, ha az Illuminate helpere még nem
+     * definiálta —, és a `putenv()` nem mindenhol látszik rajta keresztül. Emiatt egy
+     * env-et állítgató teszt helyben átment, a CI-ban viszont elbukott. Kifejezett
+     * paraméterrel a viselkedés mindenhol ugyanaz.
+     */
+    function __construct(?string $apiUrl = null)
     {
-        $this->apiUrl = rtrim((string) env('OSRM_URL', ''), '/');
+        $this->apiUrl = rtrim($apiUrl ?? (string) env('OSRM_URL', ''), '/');
 
         if ($this->apiUrl === '') {
             $this->testSkipReason = 'Nincs beállítva az OSRM_URL — az útvonaltervező '

--- a/webapp/tests/Integration/ExternalApiTestabilityTest.php
+++ b/webapp/tests/Integration/ExternalApiTestabilityTest.php
@@ -68,35 +68,27 @@ final class ExternalApiTestabilityTest extends TestCase {
         }
     }
 
-    /** #673: beállított OSRM_URL mellett az útvonaltervező is a figyelt végpontok közé kerül. */
+    /**
+     * #673: beállított végpont mellett az útvonaltervező is a figyelt végpontok közé kerül.
+     *
+     * A végpontot KIFEJEZETTEN adjuk át, nem env-en keresztül. Az `env()` viselkedése
+     * környezetfüggő (a projekté csak akkor él, ha az Illuminate helpere még nem
+     * definiálta, és a `putenv()` nem mindenhol látszik rajta keresztül) — egy
+     * env-et állítgató teszt helyben átment, a CI-ban viszont elbukott, és a master
+     * CI-ját is elvitte.
+     */
     public function testOsrmIsCheckedWhenConfigured(): void {
-        $eredeti = getenv('OSRM_URL');
-        putenv('OSRM_URL=http://osrm:5000');
-        $_ENV['OSRM_URL'] = 'http://osrm:5000';
+        $api = new \ExternalApi\OsrmApi('http://osrm:5000');
 
-        try {
-            $api = new \ExternalApi\OsrmApi();
-            self::assertTrue($api->isTestable(), 'beállított OSRM_URL mellett ellenőrizni kell');
-            self::assertNull($api->testSkipReason());
-        } finally {
-            if ($eredeti === false) {
-                putenv('OSRM_URL');
-                unset($_ENV['OSRM_URL']);
-            } else {
-                putenv('OSRM_URL=' . $eredeti);
-                $_ENV['OSRM_URL'] = $eredeti;
-            }
-        }
+        self::assertTrue($api->isTestable(), 'beállított végpont mellett ellenőrizni kell');
+        self::assertNull($api->testSkipReason());
     }
 
     /** Beállítás nélkül viszont mondja meg, MIÉRT nincs ellenőrzés. */
     public function testOsrmExplainsWhyItIsNotChecked(): void {
-        $api = new \ExternalApi\OsrmApi();
+        $api = new \ExternalApi\OsrmApi('');
 
-        if ($api->isTestable()) {
-            self::markTestSkipped('Ebben a környezetben be van állítva az OSRM_URL.');
-        }
-
+        self::assertFalse($api->isTestable());
         self::assertNotNull($api->testSkipReason());
         self::assertStringContainsString('OSRM_URL', $api->testSkipReason());
     }


### PR DESCRIPTION
A master CI-ja piros, és **az én tesztem** buktatja (a #704-ből):

```
1) ExternalApiTestabilityTest::testOsrmIsCheckedWhenConfigured
   beállított OSRM_URL mellett ellenőrizni kell
   Failed asserting that false is true.
```

## Az ok

A teszt `putenv('OSRM_URL=…')`-gyel állította a végpontot, és elvárta, hogy az `env()` lássa. Az `env()` viszont **nem a projekté**: a `functions.php` csak `if (!function_exists("env"))` mellett definiálja, és az Illuminate helpere korábban betöltődik —

```
env() innen jön: vendor/illuminate/support/helpers.php:136
```

A Laravel `Env::get()`-je adapter-veremből olvas, amiben a `putenv` láthatósága verzió- és környezetfüggő. Helyben átment, a CI-ban nem — és ezzel a mastert is elvitte.

## A javítás

Az `OsrmApi` konstruktora opcionálisan megkapja a végpontot; a teszt kifejezetten átadja. Nincs többé env-piszkálás, a viselkedés mindenhol ugyanaz. A `new OsrmApi()` alak változatlan, tehát a `collectExternalApis()` és a `/health` ugyanúgy működik.

PHP: 797 zöld.