### PR TITLE
A napi ablakkal futó cron ne látszódjon elakadtnak az ablakon kívül

### DIFF
--- a/webapp/classes/eloquent/cron.php
+++ b/webapp/classes/eloquent/cron.php
@@ -79,7 +79,13 @@ class Cron extends \Illuminate\Database\Eloquent\Model {
      * @param  int|null    $now            időbélyeg (teszthez); null = most
      * @return string|null                 az elakadás oka, vagy null ha rendben van
      */
-    public static function stuckReason(?string $lastSuccessAt, string $frequency, ?int $now = null): ?string {
+    public static function stuckReason(
+        ?string $lastSuccessAt,
+        string $frequency,
+        ?int $now = null,
+        ?string $windowFrom = null,
+        ?string $windowUntil = null
+    ): ?string {
         $now = $now ?? time();
 
         // A régi sorokban a "soha" nem NULL-ként, hanem nulla-dátumként szerepel.
@@ -103,18 +109,76 @@ class Cron extends \Illuminate\Database\Eloquent\Model {
         }
         $periodSeconds = $period - $now;
 
-        // Háromszoros periódus a türelmi határ: egy-két kimaradt futás még belefér
-        // (ütközhetett másik jobbal, vagy kívül esett a from/until ablakon).
-        $elapsed = $now - $last;
+        /*
+         * Csak azt az időt számoljuk, amikor a munka egyáltalán FUTHATOTT VOLNA.
+         *
+         * Sok munkának napi ablaka van (`from`–`until`, tipikusan 1am–6am). Az eltelt
+         * nyers idő ilyennél félrevezet: egy 15 perces, 1–6 óra közti munkánál a
+         * háromszoros türelem 45 perc, az ablak viszont reggel 6-kor bezár — vagyis
+         * 6:45-től másnap hajnalig GARANTÁLTAN „elakadtnak" látszott, holott pontosan
+         * a beállítás szerint viselkedett. Élesben ez naponta három hamis riasztást
+         * jelentett, és pont az ilyen állandó piros teszi használhatatlanná a /health-et.
+         */
+        $elapsed = self::eligibleSecondsBetween($last, $now, $windowFrom, $windowUntil);
         if ($elapsed <= 3 * $periodSeconds) {
             return null;
         }
 
+        $ablakos = self::hasWindow($windowFrom, $windowUntil) ? ' (az ablakán belül számolva)' : '';
+
         $days = (int) floor($elapsed / 86400);
         if ($days >= 1) {
-            return $days . ' napja nem futott le sikeresen';
+            return $days . ' napja nem futott le sikeresen' . $ablakos;
         }
-        return (int) floor($elapsed / 3600) . ' órája nem futott le sikeresen';
+        return (int) floor($elapsed / 3600) . ' órája nem futott le sikeresen' . $ablakos;
+    }
+
+    private static function hasWindow(?string $from, ?string $until): bool {
+        return trim((string) $from) !== '' && trim((string) $until) !== '';
+    }
+
+    /**
+     * Mennyi FUTÁSRA ALKALMAS idő telt el két időpont között?
+     *
+     * Ablak nélkül a teljes eltelt idő. Napi ablaknál csak az átfedő szakaszok összege.
+     * Az éjfélen átnyúló ablakot (pl. 22:00–02:00) is kezeli.
+     *
+     * Tiszta függvény, hogy tesztelhető legyen.
+     */
+    public static function eligibleSecondsBetween(int $from, int $to, ?string $windowFrom, ?string $windowUntil): int {
+        if ($to <= $from) {
+            return 0;
+        }
+        if (!self::hasWindow($windowFrom, $windowUntil)) {
+            return $to - $from;
+        }
+
+        $osszeg = 0;
+        // Egy nappal korábbról indulunk az éjfélen átnyúló ablak miatt.
+        $nap = strtotime('-1 day', strtotime(date('Y-m-d', $from)));
+        // Felső korlát, hogy egy évekkel korábbi lastsuccess se pörgesse végtelenbe.
+        $maxNap = 400;
+
+        while ($nap <= $to && $maxNap-- > 0) {
+            $datum = date('Y-m-d', $nap);
+            $kezd = strtotime($datum . ' ' . $windowFrom);
+            $veg  = strtotime($datum . ' ' . $windowUntil);
+
+            if ($kezd !== false && $veg !== false) {
+                if ($veg <= $kezd) {
+                    $veg = strtotime('+1 day', $veg);   // éjfélen átnyúló ablak
+                }
+                $also = max($kezd, $from);
+                $felso = min($veg, $to);
+                if ($felso > $also) {
+                    $osszeg += $felso - $also;
+                }
+            }
+
+            $nap = strtotime('+1 day', $nap);
+        }
+
+        return $osszeg;
     }
 
     /**

--- a/webapp/classes/externalapi/osrmapi.php
+++ b/webapp/classes/externalapi/osrmapi.php
@@ -31,9 +31,18 @@ class OsrmApi extends \ExternalApi\ExternalApi {
     public $testQuery;
     public $testSkipReason;
 
-    function __construct()
+    /**
+     * @param string|null $apiUrl a végpont; null esetén az OSRM_URL env-ből
+     *
+     * A paraméter a TESZTELHETŐSÉG miatt van. Az `env()` implementációja
+     * környezetfüggő — a projekté csak akkor él, ha az Illuminate helpere még nem
+     * definiálta —, és a `putenv()` nem mindenhol látszik rajta keresztül. Emiatt egy
+     * env-et állítgató teszt helyben átment, a CI-ban viszont elbukott. Kifejezett
+     * paraméterrel a viselkedés mindenhol ugyanaz.
+     */
+    function __construct(?string $apiUrl = null)
     {
-        $this->apiUrl = rtrim((string) env('OSRM_URL', ''), '/');
+        $this->apiUrl = rtrim($apiUrl ?? (string) env('OSRM_URL', ''), '/');
 
         if ($this->apiUrl === '') {
             $this->testSkipReason = 'Nincs beállítva az OSRM_URL — az útvonaltervező '

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -111,7 +111,12 @@ class Health extends Html {
 		foreach ($this->cronjobs as $i => $cron) {
 			$reason = \Eloquent\Cron::stuckReason(
 				$cron['lastsuccess_at'] ?? null,
-				(string) ($cron['frequency'] ?? '')
+				(string) ($cron['frequency'] ?? ''),
+				null,
+				// A napi ablak nélkül a számolás félrevezet: az ablakon KÍVÜLI órák nem
+				// a munka hibái. L. Cron::eligibleSecondsBetween().
+				$cron['from'] ?? null,
+				$cron['until'] ?? null
 			);
 			$this->cronjobs[$i]['stuck_reason'] = $reason;
 			if ($reason !== null) {

--- a/webapp/tests/Integration/ExternalApiTestabilityTest.php
+++ b/webapp/tests/Integration/ExternalApiTestabilityTest.php
@@ -68,35 +68,27 @@ final class ExternalApiTestabilityTest extends TestCase {
         }
     }
 
-    /** #673: beállított OSRM_URL mellett az útvonaltervező is a figyelt végpontok közé kerül. */
+    /**
+     * #673: beállított végpont mellett az útvonaltervező is a figyelt végpontok közé kerül.
+     *
+     * A végpontot KIFEJEZETTEN adjuk át, nem env-en keresztül. Az `env()` viselkedése
+     * környezetfüggő (a projekté csak akkor él, ha az Illuminate helpere még nem
+     * definiálta, és a `putenv()` nem mindenhol látszik rajta keresztül) — egy
+     * env-et állítgató teszt helyben átment, a CI-ban viszont elbukott, és a master
+     * CI-ját is elvitte.
+     */
     public function testOsrmIsCheckedWhenConfigured(): void {
-        $eredeti = getenv('OSRM_URL');
-        putenv('OSRM_URL=http://osrm:5000');
-        $_ENV['OSRM_URL'] = 'http://osrm:5000';
+        $api = new \ExternalApi\OsrmApi('http://osrm:5000');
 
-        try {
-            $api = new \ExternalApi\OsrmApi();
-            self::assertTrue($api->isTestable(), 'beállított OSRM_URL mellett ellenőrizni kell');
-            self::assertNull($api->testSkipReason());
-        } finally {
-            if ($eredeti === false) {
-                putenv('OSRM_URL');
-                unset($_ENV['OSRM_URL']);
-            } else {
-                putenv('OSRM_URL=' . $eredeti);
-                $_ENV['OSRM_URL'] = $eredeti;
-            }
-        }
+        self::assertTrue($api->isTestable(), 'beállított végpont mellett ellenőrizni kell');
+        self::assertNull($api->testSkipReason());
     }
 
     /** Beállítás nélkül viszont mondja meg, MIÉRT nincs ellenőrzés. */
     public function testOsrmExplainsWhyItIsNotChecked(): void {
-        $api = new \ExternalApi\OsrmApi();
+        $api = new \ExternalApi\OsrmApi('');
 
-        if ($api->isTestable()) {
-            self::markTestSkipped('Ebben a környezetben be van állítva az OSRM_URL.');
-        }
-
+        self::assertFalse($api->isTestable());
         self::assertNotNull($api->testSkipReason());
         self::assertStringContainsString('OSRM_URL', $api->testSkipReason());
     }

--- a/webapp/tests/Unit/CronWindowStuckTest.php
+++ b/webapp/tests/Unit/CronWindowStuckTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A napi ablakkal futó cronok ne látszódjanak elakadtnak az ablakon KÍVÜL.
+ *
+ * Sok munka `from`–`until` ablakban fut (tipikusan 1am–6am). Az elakadás-vizsgálat
+ * viszont csak a nyers eltelt időt nézte, a `stuckReason()` meg sem kapta az ablakot.
+ * Egy 20 perces, 1–6 óra közti munkánál a háromszoros türelem egy óra, az ablak
+ * viszont reggel 6-kor bezár — vagyis reggel 7-től másnap hajnalig GARANTÁLTAN
+ * „elakadtnak" látszott, holott pontosan a beállítás szerint viselkedett.
+ *
+ * Az éles /health ezt naponta három hamis riasztásként mutatta
+ * (`Email::sendQueued`, `sendInactivityNotification`, `deleteNonActivatedUsers`) —
+ * és épp az ilyen állandó piros teszi használhatatlanná az egészség-oldalt.
+ */
+class CronWindowStuckTest extends TestCase
+{
+    private const ABLAK_TOL = '1am';
+    private const ABLAK_IG = '6am';
+
+    private static function ido(string $datetime): int
+    {
+        return strtotime($datetime);
+    }
+
+    /* ---------- a hamis riasztás esete ---------- */
+
+    /** Az élesben látott helyzet: 05:55-kor futott, 06:43-kor nézzük. */
+    public function testJobIsNotStuckJustBecauseItsWindowClosed(): void
+    {
+        $ok = \Eloquent\Cron::stuckReason(
+            '2026-08-15 05:55:01',
+            '15 minutes',
+            self::ido('2026-08-15 06:43:34'),
+            self::ABLAK_TOL,
+            self::ABLAK_IG
+        );
+
+        self::assertNull($ok, 'az ablak bezárása nem elakadás');
+    }
+
+    /** Késő délután sem — pedig nyers időben már 12 óra telt el. */
+    public function testStillNotStuckLateInTheDay(): void
+    {
+        self::assertNull(\Eloquent\Cron::stuckReason(
+            '2026-08-15 05:55:01',
+            '20 minutes',
+            self::ido('2026-08-15 18:00:00'),
+            self::ABLAK_TOL,
+            self::ABLAK_IG
+        ));
+    }
+
+    /** Ablak NÉLKÜL ugyanez viszont valódi elakadás — a régi viselkedés megmarad. */
+    public function testWithoutAWindowTheSameGapIsStuck(): void
+    {
+        self::assertNotNull(\Eloquent\Cron::stuckReason(
+            '2026-08-15 05:55:01',
+            '15 minutes',
+            self::ido('2026-08-15 06:43:34')
+        ));
+    }
+
+    /* ---------- a valódi elakadást továbbra is elkapjuk ---------- */
+
+    /** Két ablak (két hajnal) kihagyása után igenis szólni kell. */
+    public function testMissingSeveralWindowsIsStillReported(): void
+    {
+        $ok = \Eloquent\Cron::stuckReason(
+            '2026-08-12 05:00:00',
+            '20 minutes',
+            self::ido('2026-08-15 06:00:00'),
+            self::ABLAK_TOL,
+            self::ABLAK_IG
+        );
+
+        self::assertNotNull($ok);
+        self::assertStringContainsString('ablakán belül számolva', $ok);
+    }
+
+    public function testNeverSucceededIsAlwaysReported(): void
+    {
+        self::assertSame(
+            'soha nem futott le sikeresen',
+            \Eloquent\Cron::stuckReason('0000-00-00 00:00:00', '1 day', null, self::ABLAK_TOL, self::ABLAK_IG)
+        );
+    }
+
+    /* ---------- az alkalmas idő számolása ---------- */
+
+    private static function alkalmas(string $tol, string $ig, ?string $ablakTol = self::ABLAK_TOL, ?string $ablakIg = self::ABLAK_IG): int
+    {
+        return \Eloquent\Cron::eligibleSecondsBetween(self::ido($tol), self::ido($ig), $ablakTol, $ablakIg);
+    }
+
+    /** Ablakon kívüli szakasz nem számít bele. */
+    public function testTimeOutsideTheWindowDoesNotCount(): void
+    {
+        self::assertSame(0, self::alkalmas('2026-08-15 07:00:00', '2026-08-15 23:00:00'));
+    }
+
+    /** Az ablakon belüli rész igen — pontosan annyi, amennyi átfed. */
+    public function testOnlyTheOverlapCounts(): void
+    {
+        // 05:00–07:00 közül csak az 5-6 óra esik az ablakba.
+        self::assertSame(3600, self::alkalmas('2026-08-15 05:00:00', '2026-08-15 07:00:00'));
+    }
+
+    /** Több napon át összeadódik: napi 5 óra. */
+    public function testWindowsAccumulateAcrossDays(): void
+    {
+        // 08-13 07:00 → 08-15 07:00: két teljes ablak (14-én és 15-én).
+        self::assertSame(2 * 5 * 3600, self::alkalmas('2026-08-13 07:00:00', '2026-08-15 07:00:00'));
+    }
+
+    /** Ablak nélkül a teljes eltelt idő számít. */
+    public function testWithoutAWindowEverythingCounts(): void
+    {
+        self::assertSame(7200, self::alkalmas('2026-08-15 10:00:00', '2026-08-15 12:00:00', null, null));
+        self::assertSame(7200, self::alkalmas('2026-08-15 10:00:00', '2026-08-15 12:00:00', '', ''));
+    }
+
+    /** Éjfélen átnyúló ablak (22:00–02:00) is helyesen számol. */
+    public function testWindowCrossingMidnight(): void
+    {
+        // 23:00 → 01:00: végig az ablakban.
+        self::assertSame(7200, self::alkalmas('2026-08-15 23:00:00', '2026-08-16 01:00:00', '10pm', '2am'));
+        // 03:00 → 21:00: teljesen kívül.
+        self::assertSame(0, self::alkalmas('2026-08-15 03:00:00', '2026-08-15 21:00:00', '10pm', '2am'));
+    }
+
+    public function testReversedRangeIsZero(): void
+    {
+        self::assertSame(0, self::alkalmas('2026-08-15 06:00:00', '2026-08-15 05:00:00'));
+    }
+}


### PR DESCRIPTION
Az éles `/health` négy elakadt munkát jelez, de **háromnál hamis a riasztás** — és a hiba az enyém.

```
\Eloquent\Email::sendQueued()          — 0 órája nem futott le sikeresen (0 próbálkozás)
\User::sendInactivityNotification()   — 1 órája nem futott le sikeresen (0 próbálkozás)
\User::deleteNonActivatedUsers()      — 1 órája nem futott le sikeresen (0 próbálkozás)
```

Mindhárom **1am–6am ablakban** fut, 15–20 perces gyakorisággal, és mindháromnál `attempts = 0` — vagyis semmi nem hibázott. A lap 06:43-kor készült.

## Az ok

A `stuckReason()` a nyers eltelt időt nézte, és **meg sem kapta** a `from`/`until` ablakot. Egy 20 perces munkánál a háromszoros türelem egy óra, az ablak viszont reggel 6-kor bezár — tehát reggel 7-től másnap hajnalig **garantáltan** elakadtnak látszik, holott pontosan a beállítás szerint viselkedik. Naponta 18+ órán át piros.

A régi kód kommentje meg is említette az ablakot („ütközhetett másik jobbal, vagy kívül esett a from/until ablakon"), de a kezelését a 3× türelemre bízta. Az percekben mér, az ablak viszont órákban zár — így sosem fedezte le.

## A javítás

Csak azt az időt számolom, amikor a munka egyáltalán **futhatott volna**: ablak nélkül a teljes eltelt időt, napi ablaknál az átfedő szakaszok összegét. Az éjfélen átnyúló ablakot (pl. 22:00–02:00) is kezeli, és van felső korlát a napok számára, hogy egy évekkel korábbi `lastsuccess` se pörögjön végtelenbe.

A számolás tiszta függvény (`Cron::eligibleSecondsBetween()`), tehát önmagában tesztelhető.

## Ellenőrizve az ÉLES értékekkel

```
Email::sendQueued              régi: 0 órája nem futott le  ->  új: rendben
sendInactivityNotification     régi: 1 órája nem futott le  ->  új: rendben
deleteNonActivatedUsers        régi: 1 órája nem futott le  ->  új: rendben
importAllExternalCalendars     régi: soha nem futott le     ->  új: soha nem futott le
```

A negyedik — a **valódi** hiba — megmarad. Azt a #769 javítja (a `BYDAY=2SU` alak `TypeError`-ja).

Ablak nélkül a viselkedés változatlan, és több kihagyott ablak után továbbra is szól — ilyenkor a szöveg jelzi is, hogy „az ablakán belül számolva".

`CronWindowStuckTest`, 12 eset. A meglévő `CronStuckDetectionTest` változatlanul zöld. PHP: 808 zöld.
