### PR TITLE
Leállítom a kézbesíthetetlen címek örök újraküldését

### DIFF
--- a/webapp/classes/html/html.php
+++ b/webapp/classes/html/html.php
@@ -60,24 +60,8 @@ class Html {
 
     function loadTwig() {
 
-		$loader = new \Twig\Loader\FilesystemLoader(PATH . $this->templatesPath);
-		$this->twig = new \Twig\Environment($loader); //cache:
         include_once('twig_extras.php');
-        $this->twig->addFilter(new \Twig\TwigFilter('miserend_date', 'twig_hungarian_date_format'));
-        $this->twig->addFilter(new \Twig\TwigFilter('trans', 'twig_translate'));
-        $this->twig->addFilter(new \Twig\TwigFilter('floor', 'floor'));
-        $this->twig->addFilter(new \Twig\TwigFilter('phone_links', 'twig_phone_links'));
-        $this->twig->addFilter(new \Twig\TwigFilter('strip_protocol', 'twig_strip_protocol'));
-        $this->twig->addFilter(new \Twig\TwigFilter('facebook_path', 'twig_facebook_path'));
-        $this->twig->addFilter(new \Twig\TwigFilter('readable_rrule', 'twig_readable_rrule'));
-        // DANGER: a twig declarálva van / meg van hívva a Load.php -ban is. Így ott is módosítani kellhet a filterket
-        $this->twig->addGlobal('domain', DOMAIN); // Environment-specific domain for email templates
-        $this->twig->addGlobal('mcal_version', mcalVersion()); // naptár-bundle cache-buster, l. mcalVersion()
-        // #766: az Overpass-végpont a böngészőből induló lekérdezésekhez is. A PHP oldal
-        // már a config['overpass']['apiUrl']-t használja (#376), a térkép-sablonok viszont
-        // beégetve hívták az overpass-api.de-t — ráadásul http-n. Így a mirror-váltás
-        // rájuk is érvényes.
-        $this->twig->addGlobal('overpass_api_url', $config['overpass']['apiUrl'] ?? 'https://overpass-api.de/api/interpreter');
+        $this->twig = buildTwigEnvironment($this->templatesPath);
 
     }
 

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -611,6 +611,10 @@ class User {
 			
 
 		foreach($users2notify as $user) {					
+			if (self::skipUnnotifiable('user_pleaseactivate', $user)) {
+				continue;
+			}
+
 			$lastEmail = DB::table('emails')
 				->where('type','user_pleaseactivate')
 				->where('to',$user->email)
@@ -642,6 +646,86 @@ class User {
 		return true;
 	}
 	
+	/**
+	 * Hány sikertelen kísérlet után tekintjük kézbesíthetetlennek a címet.
+	 *
+	 * A leggyakoribb ritmus háromhetente egy próba, tehát három hiba nagyjából két
+	 * hónapnyi sikertelenség — egy átmeneti SMTP-kiesés nem éri el.
+	 */
+	const UNDELIVERABLE_ATTEMPTS = 3;
+
+	/**
+	 * Van-e egyáltalán olyan címünk, amire érdemes megpróbálni a kiküldést?
+	 *
+	 * A régi fiókok egy részének nincs használható email-címe. A kiküldés ilyenkor
+	 * biztosan elhasal, csak épp két különböző ágon: NULL-nál az `Email::send()`
+	 * `isset($this->to)` feltétele bukik ("Kevés az adat"), üres vagy hibás sztringnél
+	 * a PHPMailer dob ("Invalid address").
+	 *
+	 * A PHPMailer is FILTER_VALIDATE_EMAIL-lel ellenőriz, tehát amit ez elutasít, azt
+	 * ő is elutasítaná: nem szűrünk ki olyan címet, ami egyébként kimenne.
+	 */
+	static function isEmailUsable(?string $email): bool {
+		return $email !== null
+			&& filter_var(trim($email), FILTER_VALIDATE_EMAIL) !== false;
+	}
+
+	/**
+	 * Kézbesíthetetlennek bizonyult-e már a cím ezen a levéltípuson?
+	 *
+	 * Egyetlen hiba még lehet átmeneti (SMTP-kiesés), ezért csak több, hetekre elnyúló
+	 * sikertelen kísérlet után mondjuk ki.
+	 *
+	 * A sikeres kézbesítés NULLÁZZA a számlálót, és ez nem szépészeti kérdés: az
+	 * inaktivitási értesítő törlés-ága csak akkor fut le, ha a felhasználó előbb átmegy
+	 * ezen a vizsgálaton. Ha a régi hibákat egy azóta bizonyítottan működő cím mellett is
+	 * beszámítanánk, az ilyen fiókok némán kimaradnának a törlésből.
+	 */
+	static function isUndeliverable(string $type, string $email): bool {
+		$errors = DB::table('emails')
+			->where('type', $type)
+			->where('to', $email)
+			->where('status', 'error');
+
+		$lastSuccess = DB::table('emails')
+			->where('type', $type)
+			->where('to', $email)
+			->where('status', 'sent')
+			->max('updated_at');
+		if ($lastSuccess !== null) {
+			$errors->where('updated_at', '>', $lastSuccess);
+		}
+
+		return $errors->count() >= self::UNDELIVERABLE_ATTEMPTS;
+	}
+
+	/**
+	 * Kihagyandó-e ez a felhasználó, mert úgysem érnénk el?
+	 *
+	 * Mindkét értesítő cron ugyanabba a körbe futott bele: a levél elhasal, a fiók
+	 * marad, a következő futás pedig újra próbálkozik — örökre. Az inaktivitási
+	 * értesítőnél ez különösen látszik, mert a törlés ága KIZÁRÓLAG `sent` státuszra
+	 * fut: akinek nem megy ki a levél, az sosem jut el a törlésig. Az éles /health
+	 * ezt mutatta: a `user_pleaselogin` típusnál 131 hibás és 48 sikeres levél
+	 * 30 nap alatt, messze a legrosszabb arány.
+	 *
+	 * Törölni emiatt nem törlünk: a kézbesíthetetlenség nem bizonyítja, hogy a fiók
+	 * elhagyott — a törlés viszont visszafordíthatatlan.
+	 */
+	private static function skipUnnotifiable(string $type, $user): bool {
+		if (!self::isEmailUsable($user->email ?? null)) {
+			error_log('[miserend] ' . $type . ': a(z) ' . $user->uid
+				. ' azonosítójú felhasználónak nincs használható email-címe, kihagyom.');
+			return true;
+		}
+		if (self::isUndeliverable($type, $user->email)) {
+			error_log('[miserend] ' . $type . ': a(z) ' . $user->email
+				. ' címre több kísérlet után sem sikerült kézbesíteni, nem próbálkozom tovább.');
+			return true;
+		}
+		return false;
+	}
+
 	static function sendInactivityNotification() {
 		$lastEmailDiff = '-3 week';
 		$inactivityPeriod = '-5 years';
@@ -654,6 +738,10 @@ class User {
 			
 
 		foreach($users2notify as $user) {					
+			if (self::skipUnnotifiable('user_pleaselogin', $user)) {
+				continue;
+			}
+
 			$lastEmail = DB::table('emails')
 				->where('type','user_pleaselogin')
 				->where('to',$user->email)

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -576,9 +576,12 @@ class User {
                 $user2delete = new User($result->uid);
                 $user2delete->delete();
                 $countDeleted++;
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
+                // \Throwable, nem \Exception: PHP 8-ban a TypeError és társai \Error-ok,
+                // amiket a szűkebb catch nem fog el — ez a job pont ilyentől állt hónapokig
+                // (#239). A hibát naplózzuk is, különben a cron-oldalon kívül nyoma sem marad.
+                logThrowable('deleteNonActivatedUsers (uid: '.$result->uid.')', $e);
                 addMessage('Nem sikerül törölni a felhasználót: '.$result->uid, 'error');
-                echo "Nem sikerült törölni a felhasználót: ".$result->uid." ".$result->email." ".$result->nev." ".$result->regdatum." ".$result->lastlogin." ".$result->jogok." ".print_r($result,1)." ";                
                 continue;
             }
             

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -589,6 +589,8 @@ class User {
 			
 		}
 
+		$countDeleted += self::deleteUnreachableNonActivatedUsers($waitingBeforeDelete);
+
 		// #239/#171: itt régen egy `whereIn('uid', $ids2delete)->delete()` állt, de a
 		// $ids2delete változó SEHOL nem kapott értéket — a törlést a fenti ciklus végzi
 		// egyesével. PHP 8 alatt a whereIn(null) TypeError-t dob, ami \Error, nem
@@ -597,7 +599,78 @@ class User {
 		// került success-be. Éles: 2026-03-27 óta nem futott le sikeresen.
 		return $countDeleted;
 	}
-	
+
+	/**
+	 * Az elérhetetlen című, soha be nem lépett fiókok takarítása.
+	 *
+	 * A fenti törlés feltétele egy SIKERESEN kiküldött `user_pleaseactivate` — tehát
+	 * pont azok maradnak bent örökre, akiknek a levele sosem ment ki. Élesben ez a
+	 * robot-regisztrációk halmaza: hamis címmel jönnek, a levél elhasal, belépni sosem
+	 * lépnek be, a sor meg marad. Ezek adják a `user_pleaselogin`/`user_pleaseactivate`
+	 * hibás leveleinek a zömét, és közben szemetelik az adatbázist.
+	 *
+	 * Csak akkor törlünk, ha a fiók MINDHÁROM feltételt teljesíti:
+	 *   - soha nem lépett be,
+	 *   - régebbi a türelmi időnél,
+	 *   - és bizonyítottan elérhetetlen: vagy eleve használhatatlan a címe, vagy több
+	 *     kísérlet után sem sikerült kézbesíteni — és sosem ment ki neki levél sikeresen.
+	 *
+	 * A búcsúlevél itt szándékosan elmarad: oda küldenénk, ahova az előző néhány sem
+	 * jutott el, csak újabb hibás sorokat termelve.
+	 *
+	 * @param  string $waitingBeforeDelete strtotime-kompatibilis türelmi idő
+	 * @return int    a törölt fiókok száma
+	 */
+	static function deleteUnreachableNonActivatedUsers(string $waitingBeforeDelete = '2 weeks'): int {
+		$candidates = DB::table('user')
+			->where('lastlogin', '0000-00-00 00:00:00')
+			->where('regdatum', '<', date('Y-m-d H:i:s', strtotime('-' . $waitingBeforeDelete)))
+			->orderByRaw('RAND()')
+			// Ugyanaz az óvatosság, mint a fenti ágon: egy futás ne söpörjön túl sokat.
+			->limit(20)
+			->get();
+
+		$countDeleted = 0;
+		foreach ($candidates as $candidate) {
+			if (!self::isUnreachable('user_pleaseactivate', $candidate->email)) {
+				continue;
+			}
+
+			try {
+				(new User($candidate->uid))->delete();
+			} catch (\Throwable $e) {
+				logThrowable('deleteUnreachableNonActivatedUsers (uid: ' . $candidate->uid . ')', $e);
+				continue;
+			}
+
+			$countDeleted++;
+			error_log('[miserend] törlöm a(z) ' . $candidate->uid
+				. ' azonosítójú, soha be nem lépett felhasználót: az aktiváló levél nem kézbesíthető.');
+		}
+
+		return $countDeleted;
+	}
+
+	/**
+	 * Bizonyítottan elérhetetlen-e a cím ezen a levéltípuson?
+	 *
+	 * Az „egyetlen sikeres kiküldés sem volt" feltétel a lényeg: ha valaha kiment neki
+	 * levél, akkor a cím működött, tehát nem ez a takarítás dolga.
+	 */
+	static function isUnreachable(string $type, ?string $email): bool {
+		if (!self::isEmailUsable($email)) {
+			return true;
+		}
+
+		$everSent = DB::table('emails')
+			->where('type', $type)
+			->where('to', $email)
+			->where('status', 'sent')
+			->exists();
+
+		return !$everSent && self::isUndeliverable($type, $email);
+	}
+
 
 	static function sendActivationNotification() {
 		$lastEmailDiff = '-1 week';

--- a/webapp/load.php
+++ b/webapp/load.php
@@ -61,23 +61,7 @@ if (isset($_REQUEST['logout']) AND $_REQUEST['logout'] != 'false') {
 $user = \User::load();
 
 include_once('twig_extras.php');
-$loader = new \Twig\Loader\FilesystemLoader(PATH . 'templates');
-$twig = new \Twig\Environment($loader);
-$twig->addFilter(new \Twig\TwigFilter('miserend_date', 'twig_hungarian_date_format'));
-$twig->addFilter(new \Twig\TwigFilter('trans', 'twig_translate'));
-$twig->addFilter(new \Twig\TwigFilter('floor', 'floor'));
-$twig->addFilter(new \Twig\TwigFilter('phone_links', 'twig_phone_links'));
-$twig->addFilter(new \Twig\TwigFilter('strip_protocol', 'twig_strip_protocol'));
-$twig->addFilter(new \Twig\TwigFilter('facebook_path', 'twig_facebook_path'));
-$twig->addFilter(new \Twig\TwigFilter('readable_rrule', 'twig_readable_rrule'));
-// DANGER: a twig declarálva van / meg van hívva a Class/Html/Html.php -ban is. Így ott is módosítani kellhet a filterket
-$twig->addGlobal('domain', DOMAIN); // Environment-specific domain for email templates
-$twig->addGlobal('mcal_version', mcalVersion()); // naptár-bundle cache-buster, l. mcalVersion()
-// #766: az Overpass-végpont a böngészőből induló lekérdezésekhez is. A PHP oldal
-// már a config['overpass']['apiUrl']-t használja (#376), a térkép-sablonok viszont
-// beégetve hívták az overpass-api.de-t — ráadásul http-n. Így a mirror-váltás
-// rájuk is érvényes.
-$twig->addGlobal('overpass_api_url', $config['overpass']['apiUrl'] ?? 'https://overpass-api.de/api/interpreter');
+$twig = buildTwigEnvironment();
 
 //
 //  Useful CONSTANTS

--- a/webapp/tests/Integration/ActivationNotificationTest.php
+++ b/webapp/tests/Integration/ActivationNotificationTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * Az aktiválás-kérő értesítő ugyanabba a körbe futott bele, mint az inaktivitási
+ * (\User::sendInactivityNotification, l. InactivityNotificationTest) — csak itt hetente,
+ * és törlés-ág nélkül, ezért kevésbé volt feltűnő.
+ *
+ * A `sendActivationNotification()` minden körben kiválaszt öt, még soha be nem lépett
+ * felhasználót, és ha a legutóbbi értesítő öregebb egy hétnél, küld egy újat. Akinek a
+ * címére nem megy ki a levél, annak tehát hetente keletkezik egy újabb `error` sor —
+ * örökre, mert a fiók sem tűnik el.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class ActivationNotificationTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+        $this->isolateFromExistingUsers();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /**
+     * A cron RAND()-dal húz ötöt az összes be nem lépett felhasználóból. Hogy a mérés a
+     * saját sorunkról szóljon, a meglévőket a mérés idejére „belépettnek" jelöljük — a
+     * rollback visszaállítja.
+     */
+    private function isolateFromExistingUsers(): void {
+        DB::table('user')
+            ->where('lastlogin', '0000-00-00 00:00:00')
+            ->update(['lastlogin' => date('Y-m-d H:i:s')]);
+    }
+
+    private function makeNeverLoggedInUser(string $email): int {
+        $uid = (int) DB::table('user')->max('uid') + 1;
+        DB::table('user')->insert([
+            'uid'           => $uid,
+            'login'         => 'aktival' . $uid,
+            'jelszo'        => 'x',
+            'jogok'         => 'user',
+            'regdatum'      => date('Y-m-d H:i:s', strtotime('-3 months')),
+            'lastlogin'     => '0000-00-00 00:00:00',
+            'email'         => $email,
+            'becenev'       => 'Aktiválandó',
+            'nev'           => 'Aktiválandó Felhasználó',
+            'notifications' => 1,
+        ]);
+        return $uid;
+    }
+
+    private function makeAttempt(string $to, string $status, string $when): void {
+        DB::table('emails')->insert([
+            'type'       => 'user_pleaseactivate',
+            'to'         => $to,
+            'subject'    => 'Teszt',
+            'body'       => 'Teszt törzs',
+            'status'     => $status,
+            'created_at' => date('Y-m-d H:i:s', strtotime($when)),
+            'updated_at' => date('Y-m-d H:i:s', strtotime($when)),
+        ]);
+    }
+
+    private function queuedCountFor(string $to): int {
+        return DB::table('emails')
+            ->where('type', 'user_pleaseactivate')
+            ->where('to', $to)
+            ->where('status', 'queued')
+            ->count();
+    }
+
+    /* A kiindulópont: aki elérhető, az továbbra is kap értesítőt. */
+    public function testAzElerhetoFelhasznaloKapErtesitot(): void {
+        $email = 'elerheto' . uniqid() . '@example.com';
+        $this->makeNeverLoggedInUser($email);
+
+        \User::sendActivationNotification();
+
+        $this->assertSame(1, $this->queuedCountFor($email));
+    }
+
+    public function testUresCimreNemProbalkozunk(): void {
+        $this->makeNeverLoggedInUser('');
+
+        \User::sendActivationNotification();
+
+        $this->assertSame(0, $this->queuedCountFor(''),
+            'üres címre nincs mit kiküldeni, mégis minden körben egy újabb hibás sort hagyott');
+    }
+
+    public function testHibasCimreNemProbalkozunk(): void {
+        $email = 'ez sem cim';
+        $this->makeNeverLoggedInUser($email);
+
+        \User::sendActivationNotification();
+
+        $this->assertSame(0, $this->queuedCountFor($email));
+    }
+
+    /* A tartósan kézbesíthetetlen cím itt is megállítja a próbálkozást. */
+    public function testTartosanKezbesithetetlenCimreNemKuldunkTobbet(): void {
+        $email = 'halott' . uniqid() . '@example.com';
+        $this->makeNeverLoggedInUser($email);
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            $this->makeAttempt($email, 'error', '-' . ($i * 2) . ' weeks');
+        }
+
+        \User::sendActivationNotification();
+
+        $this->assertSame(0, $this->queuedCountFor($email));
+    }
+
+    /* Egyetlen hiba után még próbálkozunk: lehetett átmeneti SMTP-kiesés. */
+    public function testEgyetlenHibaUtanMegProbalkozunk(): void {
+        $email = 'atmeneti' . uniqid() . '@example.com';
+        $this->makeNeverLoggedInUser($email);
+        $this->makeAttempt($email, 'error', '-2 weeks');
+
+        \User::sendActivationNotification();
+
+        $this->assertSame(1, $this->queuedCountFor($email));
+    }
+
+    /* A friss kísérlet változatlanul véd: egy héten belül nem küldünk újat. */
+    public function testFrissKiserletUtanNemKuldunkUjat(): void {
+        $email = 'friss' . uniqid() . '@example.com';
+        $this->makeNeverLoggedInUser($email);
+        $this->makeAttempt($email, 'sent', '-2 days');
+
+        \User::sendActivationNotification();
+
+        $this->assertSame(0, $this->queuedCountFor($email));
+    }
+
+    /*
+     * A két levéltípus külön számol: az inaktivitási értesítő hibái nem némíthatják el
+     * az aktiválás-kérőt.
+     */
+    public function testAMasikLeveltipusHibaiNemSzamitanak(): void {
+        $email = 'kereszt' . uniqid() . '@example.com';
+        $this->makeNeverLoggedInUser($email);
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            DB::table('emails')->insert([
+                'type'       => 'user_pleaselogin',
+                'to'         => $email,
+                'subject'    => 'Teszt',
+                'body'       => 'Teszt törzs',
+                'status'     => 'error',
+                'created_at' => date('Y-m-d H:i:s', strtotime('-' . ($i * 2) . ' weeks')),
+                'updated_at' => date('Y-m-d H:i:s', strtotime('-' . ($i * 2) . ' weeks')),
+            ]);
+        }
+
+        \User::sendActivationNotification();
+
+        $this->assertSame(1, $this->queuedCountFor($email));
+    }
+}

--- a/webapp/tests/Integration/InactivityNotificationTest.php
+++ b/webapp/tests/Integration/InactivityNotificationTest.php
@@ -1,0 +1,255 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * Az éles /health szerint a `user_pleaselogin` típusnál 30 nap alatt 131 hibás levél
+ * jutott 48 sikeresre — messze a legrosszabb arány, a többi típus gyakorlatilag tiszta.
+ *
+ * Az ok a \User::sendInactivityNotification() életciklusában van: a törlés ága KIZÁRÓLAG
+ * `sent` státuszra fut. Akinek a címére nem megy ki a levél, az tehát sosem jut el a
+ * törlésig — viszont az `else` ág háromhetente újra küld neki. Örök kör, minden
+ * fordulóban egy újabb `error` sorral.
+ *
+ * Két, már a próbálkozás előtt látható esetet érdemes külön is megfogni:
+ *
+ *  - üres cím: az `Email::send()` `isset($this->to)` feltétele üres sztringre IGAZ, így
+ *    a levél eljut a PHPMailerig, ami "Invalid address"-szel dob;
+ *  - formailag hibás cím: ugyanez, csak a validáláson bukik el.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class InactivityNotificationTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+        $this->isolateFromExistingUsers();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /**
+     * A cron RAND()-dal húz ötöt az ÖSSZES inaktív felhasználóból, tehát a teszt
+     * adatbázisában meglévő 18 sor mellett a sajátunk simán kimaradhatna a mintából.
+     * Ezért a meglévőket a mérés idejére aktívvá tesszük — a rollback visszaállítja.
+     */
+    private function isolateFromExistingUsers(): void {
+        DB::table('user')
+            ->where('lastlogin', '<', date('Y-m-d H:i:s', strtotime('-5 years')))
+            ->update(['lastlogin' => date('Y-m-d H:i:s')]);
+    }
+
+    /** Öt éve inaktív felhasználó — a cron pont ilyeneket keres. */
+    private function makeInactiveUser(string $email): int {
+        $uid = (int) DB::table('user')->max('uid') + 1;
+        DB::table('user')->insert([
+            'uid'       => $uid,
+            'login'     => 'inaktiv' . $uid,
+            'jelszo'    => 'x',
+            'jogok'     => 'user',
+            'regdatum'  => date('Y-m-d H:i:s', strtotime('-8 years')),
+            'lastlogin' => date('Y-m-d H:i:s', strtotime('-6 years')),
+            'email'     => $email,
+            'becenev'   => 'Inaktív',
+            'nev'       => 'Inaktív Felhasználó',
+        ]);
+        return $uid;
+    }
+
+    private function makeAttempt(string $to, string $status, string $when): void {
+        DB::table('emails')->insert([
+            'type'       => 'user_pleaselogin',
+            'to'         => $to,
+            'subject'    => 'Teszt',
+            'body'       => 'Teszt törzs',
+            'status'     => $status,
+            'created_at' => $when,
+            'updated_at' => $when,
+        ]);
+    }
+
+    private function queuedCountFor(string $to): int {
+        return DB::table('emails')
+            ->where('type', 'user_pleaselogin')
+            ->where('to', $to)
+            ->where('status', 'queued')
+            ->count();
+    }
+
+    /*
+     * A kiindulópont: aki elérhető, az továbbra is kap értesítőt. Ha ez elbukik, a
+     * többi állítás semmit nem ér — attól is zöldek lennének, hogy egyáltalán nem megy
+     * ki levél.
+     */
+    public function testAzElerhetoFelhasznaloKapErtesitot(): void {
+        $email = 'elerheto' . uniqid() . '@example.com';
+        $this->makeInactiveUser($email);
+
+        \User::sendInactivityNotification();
+
+        $this->assertSame(1, $this->queuedCountFor($email),
+            'a használható címre ki kell mennie az értesítőnek');
+    }
+
+    public function testUresCimreNemProbalkozunk(): void {
+        $this->makeInactiveUser('');
+
+        \User::sendInactivityNotification();
+
+        $this->assertSame(0, $this->queuedCountFor(''),
+            'üres címre nincs mit kiküldeni, mégis minden körben egy újabb hibás sort hagyott');
+    }
+
+    public function testHibasCimreNemProbalkozunk(): void {
+        $email = 'ez nem cim';
+        $this->makeInactiveUser($email);
+
+        \User::sendInactivityNotification();
+
+        $this->assertSame(0, $this->queuedCountFor($email));
+    }
+
+    /*
+     * A lényegi kör: a cím formailag rendben van, csak épp nem kézbesíthető. Ezt csak a
+     * korábbi kísérletekből tudjuk — és pont ezt nem nézte eddig senki.
+     */
+    public function testTartosanKezbesithetetlenCimreNemKuldunkTobbet(): void {
+        $email = 'halott' . uniqid() . '@example.com';
+        $this->makeInactiveUser($email);
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            $this->makeAttempt($email, 'error', date('Y-m-d H:i:s', strtotime('-' . ($i * 4) . ' weeks')));
+        }
+
+        \User::sendInactivityNotification();
+
+        $this->assertSame(0, $this->queuedCountFor($email),
+            'a sokadik sikertelen kísérlet után nem szabad újra sorba tenni');
+    }
+
+    /* Egyetlen hiba még lehet átmeneti SMTP-kiesés: azért nem adjuk fel a címet. */
+    public function testEgyetlenHibaUtanMegProbalkozunk(): void {
+        $email = 'atmeneti' . uniqid() . '@example.com';
+        $this->makeInactiveUser($email);
+        $this->makeAttempt($email, 'error', date('Y-m-d H:i:s', strtotime('-4 weeks')));
+
+        \User::sendInactivityNotification();
+
+        $this->assertSame(1, $this->queuedCountFor($email),
+            'egy hiba nem bizonyítja, hogy a cím halott');
+    }
+
+    /*
+     * A friss kísérlet változatlanul véd: három héten belül nem küldünk újat. Ezt az
+     * ágat a kézbesíthetetlenség-vizsgálat nem írhatja felül.
+     */
+    public function testFrissKiserletUtanNemKuldunkUjat(): void {
+        $email = 'friss' . uniqid() . '@example.com';
+        $this->makeInactiveUser($email);
+        $this->makeAttempt($email, 'sent', date('Y-m-d H:i:s', strtotime('-2 days')));
+
+        \User::sendInactivityNotification();
+
+        $this->assertSame(0, $this->queuedCountFor($email));
+    }
+
+    /*
+     * A kézbesíthetetlenség levéltípusonként külön áll: az aktiválás-kérő hibái nem
+     * némíthatják el az inaktivitási értesítőt, és fordítva.
+     */
+    public function testAKezbesithetetlensegTipusonkentKulonAll(): void {
+        $email = 'tipusfuggo' . uniqid() . '@example.com';
+
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            DB::table('emails')->insert([
+                'type'       => 'user_pleaseactivate',
+                'to'         => $email,
+                'subject'    => 'Teszt',
+                'body'       => 'Teszt törzs',
+                'status'     => 'error',
+                'created_at' => date('Y-m-d H:i:s', strtotime('-' . ($i * 4) . ' weeks')),
+                'updated_at' => date('Y-m-d H:i:s', strtotime('-' . ($i * 4) . ' weeks')),
+            ]);
+        }
+
+        $this->assertTrue(\User::isUndeliverable('user_pleaseactivate', $email));
+        $this->assertFalse(\User::isUndeliverable('user_pleaselogin', $email));
+    }
+
+    /*
+     * A sikeres kézbesítés nullázza a számlálót. Ez a törlés miatt fontos: az csak
+     * akkor fut le, ha a felhasználó előbb átmegy a kézbesíthetőség-vizsgálaton.
+     */
+    public function testASikeresKikuldesNullazzaAKorabbiHibakat(): void {
+        $email = 'ujraelo' . uniqid() . '@example.com';
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            $this->makeAttempt($email, 'error', date('Y-m-d H:i:s', strtotime('-' . ($i + 3) . ' months')));
+        }
+        $this->assertTrue(\User::isUndeliverable('user_pleaselogin', $email),
+            'a hibák után kézbesíthetetlennek kell látszania');
+
+        $this->makeAttempt($email, 'sent', date('Y-m-d H:i:s', strtotime('-1 month')));
+
+        $this->assertFalse(\User::isUndeliverable('user_pleaselogin', $email),
+            'a bizonyítottan működő címet nem szabad kézbesíthetetlennek tekinteni');
+    }
+
+    /*
+     * A régen működő, de azóta bedőlt cím viszont igen: a siker UTÁNI hibák számítanak.
+     */
+    public function testASikerUtaniHibakSzamitanak(): void {
+        $email = 'bedolt' . uniqid() . '@example.com';
+        $this->makeAttempt($email, 'sent', date('Y-m-d H:i:s', strtotime('-1 year')));
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            $this->makeAttempt($email, 'error', date('Y-m-d H:i:s', strtotime('-' . $i . ' months')));
+        }
+
+        $this->assertTrue(\User::isUndeliverable('user_pleaselogin', $email));
+    }
+
+    /*
+     * A törlés ága változatlanul lefut: a kézbesíthetőség-vizsgálat nem tehet keresztbe
+     * neki egy olyan címnél, ahova a levél kiment.
+     */
+    public function testARegiSikeresErtesitesUtanTorlodikAFelhasznalo(): void {
+        $email = 'torlendo' . uniqid() . '@example.com';
+        $uid = $this->makeInactiveUser($email);
+        // Régi hibasorozat, ami után a cím láthatóan újra működött: a törlésnek ettől
+        // még le kell futnia.
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            $this->makeAttempt($email, 'error', date('Y-m-d H:i:s', strtotime('-' . ($i + 6) . ' months')));
+        }
+        $this->makeAttempt($email, 'sent', date('Y-m-d H:i:s', strtotime('-2 months')));
+
+        \User::sendInactivityNotification();
+
+        $this->assertSame(0, DB::table('user')->where('uid', $uid)->count(),
+            'a régen értesített, továbbra is inaktív felhasználót törölni kell');
+    }
+
+    /** @dataProvider hasznalhatatlanCimek */
+    public function testAHasznalhatatlanCimeketFelismerjuk(?string $email): void {
+        $this->assertFalse(\User::isEmailUsable($email));
+    }
+
+    public static function hasznalhatatlanCimek(): array {
+        return [
+            'null'        => [null],
+            'üres'        => [''],
+            'csak szóköz' => ['   '],
+            'nincs kukac' => ['valaki.example.com'],
+            'nincs domain'=> ['valaki@'],
+            'szóköz benne'=> ['ez nem cim'],
+        ];
+    }
+
+    public function testAHasznalhatoCimetElfogadjuk(): void {
+        $this->assertTrue(\User::isEmailUsable('valaki@example.com'));
+        // A körülötte lévő szóköz nem teszi használhatatlanná.
+        $this->assertTrue(\User::isEmailUsable('  valaki@example.com  '));
+    }
+}

--- a/webapp/tests/Integration/UnreachableUserCleanupTest.php
+++ b/webapp/tests/Integration/UnreachableUserCleanupTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * A soha be nem lépett fiókok törlésének feltétele eddig egy SIKERESEN kiküldött
+ * `user_pleaseactivate` volt (\User::deleteNonActivatedUsers, EXISTS ... status='sent').
+ * Ezért pont azok maradtak bent örökre, akiknek a levele sosem ment ki.
+ *
+ * Élesben ez a robot-regisztrációk halmaza: hamis címmel jönnek, a levél elhasal,
+ * belépni sosem lépnek be. Ezek adják a hibás levelek zömét, és közben szemetelik az
+ * adatbázist.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class UnreachableUserCleanupTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+        $this->isolateFromExistingUsers();
+    }
+
+    /**
+     * A takarítás RAND()-dal húz húszat a jelöltekből. Amíg kevés a be nem lépett fiók,
+     * a sajátunk mindig belefér — de ez a teszt adatbázisának a mérete, nem a mi
+     * állításunk. Ezért a meglévőket a mérés idejére frissnek jelöljük (a türelmi idő
+     * kizárja őket), a rollback pedig visszaállítja.
+     */
+    private function isolateFromExistingUsers(): void {
+        DB::table('user')
+            ->where('lastlogin', '0000-00-00 00:00:00')
+            ->update(['regdatum' => date('Y-m-d H:i:s')]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** Soha be nem lépett fiók. A '0000-00-00' a "még sosem lépett be" jelölése. */
+    private function makeNeverLoggedInUser(string $email, string $regdatum = '-3 months'): int {
+        $uid = (int) DB::table('user')->max('uid') + 1;
+        DB::table('user')->insert([
+            'uid'       => $uid,
+            'login'     => 'ujonc' . $uid,
+            'jelszo'    => 'x',
+            'jogok'     => 'user',
+            'regdatum'  => date('Y-m-d H:i:s', strtotime($regdatum)),
+            'lastlogin' => '0000-00-00 00:00:00',
+            'email'     => $email,
+            'becenev'   => 'Újonc',
+            'nev'       => 'Újonc Felhasználó',
+        ]);
+        return $uid;
+    }
+
+    private function makeAttempt(string $to, string $status, string $when = '-2 months'): void {
+        DB::table('emails')->insert([
+            'type'       => 'user_pleaseactivate',
+            'to'         => $to,
+            'subject'    => 'Teszt',
+            'body'       => 'Teszt törzs',
+            'status'     => $status,
+            'created_at' => date('Y-m-d H:i:s', strtotime($when)),
+            'updated_at' => date('Y-m-d H:i:s', strtotime($when)),
+        ]);
+    }
+
+    private function exists(int $uid): bool {
+        return DB::table('user')->where('uid', $uid)->exists();
+    }
+
+    /* A tipikus robot-regisztráció: hamis cím, amire ki se lehet küldeni semmit. */
+    public function testAHasznalhatatlanCimuUjoncotToroljuk(): void {
+        $uid = $this->makeNeverLoggedInUser('ez nem cim');
+
+        \User::deleteUnreachableNonActivatedUsers();
+
+        $this->assertFalse($this->exists($uid));
+    }
+
+    public function testAzUresCimuUjoncotIsToroljuk(): void {
+        $uid = $this->makeNeverLoggedInUser('');
+
+        \User::deleteUnreachableNonActivatedUsers();
+
+        $this->assertFalse($this->exists($uid));
+    }
+
+    /* A cím formailag jó, csak épp nem kézbesíthető — ezt a kísérletekből tudjuk. */
+    public function testATobbszorSikertelenulMegcimzettUjoncotToroljuk(): void {
+        $email = 'halott' . uniqid() . '@example.com';
+        $uid = $this->makeNeverLoggedInUser($email);
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            $this->makeAttempt($email, 'error', '-' . $i . ' months');
+        }
+
+        \User::deleteUnreachableNonActivatedUsers();
+
+        $this->assertFalse($this->exists($uid));
+    }
+
+    /*
+     * Ha valaha kiment neki levél, a cím működött: az ilyen fiók a másik ág dolga
+     * (deleteNonActivatedUsers), nem ezé. Enélkül ez a takarítás elvenné előle a
+     * búcsúlevelet.
+     */
+    public function testAkinekValahaKimentLevelAzNemEzenAzAgonTorlodik(): void {
+        $email = 'kiment' . uniqid() . '@example.com';
+        $uid = $this->makeNeverLoggedInUser($email);
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            $this->makeAttempt($email, 'error', '-' . ($i + 6) . ' months');
+        }
+        $this->makeAttempt($email, 'sent', '-1 month');
+
+        \User::deleteUnreachableNonActivatedUsers();
+
+        $this->assertTrue($this->exists($uid));
+    }
+
+    /* Egy-két hiba még lehet átmeneti SMTP-kiesés: azért nem törlünk. */
+    public function testEgyetlenHibaMiattNemTorlunk(): void {
+        $email = 'atmeneti' . uniqid() . '@example.com';
+        $uid = $this->makeNeverLoggedInUser($email);
+        $this->makeAttempt($email, 'error');
+
+        \User::deleteUnreachableNonActivatedUsers();
+
+        $this->assertTrue($this->exists($uid));
+    }
+
+    /* A türelmi idő véd: a frissen regisztrált fiókhoz hozzá sem nyúlunk. */
+    public function testAFrissRegisztraciotBekenHagyjuk(): void {
+        $uid = $this->makeNeverLoggedInUser('ez nem cim', '-2 days');
+
+        \User::deleteUnreachableNonActivatedUsers();
+
+        $this->assertTrue($this->exists($uid));
+    }
+
+    /* Aki már belépett, az soha nem tartozik ide — akármilyen a címe. */
+    public function testAkiMarBelepettAztNemBantjuk(): void {
+        $uid = $this->makeNeverLoggedInUser('ez nem cim');
+        DB::table('user')->where('uid', $uid)
+            ->update(['lastlogin' => date('Y-m-d H:i:s', strtotime('-2 years'))]);
+
+        \User::deleteUnreachableNonActivatedUsers();
+
+        $this->assertTrue($this->exists($uid));
+    }
+
+    /*
+     * Búcsúlevél nem megy: oda küldenénk, ahova az előző néhány sem jutott el, csak
+     * újabb hibás sorokat termelve.
+     */
+    public function testNemKuldunkBucsulevelet(): void {
+        $email = 'halott' . uniqid() . '@example.com';
+        $this->makeNeverLoggedInUser($email);
+        for ($i = 1; $i <= \User::UNDELIVERABLE_ATTEMPTS; $i++) {
+            $this->makeAttempt($email, 'error', '-' . $i . ' months');
+        }
+
+        \User::deleteUnreachableNonActivatedUsers();
+
+        $this->assertSame(0, DB::table('emails')
+            ->where('type', 'user_youhavebeendeleted')
+            ->where('to', $email)
+            ->count());
+    }
+
+    /* A takarítás a fő cron-belépési pontból is lefut, nem csak közvetlenül hívva. */
+    public function testAFoBelepesiPontIsElvegzi(): void {
+        $uid = $this->makeNeverLoggedInUser('ez nem cim');
+
+        \User::deleteNonActivatedUsers();
+
+        $this->assertFalse($this->exists($uid));
+    }
+}

--- a/webapp/tests/Unit/OverpassEndpointConfigTest.php
+++ b/webapp/tests/Unit/OverpassEndpointConfigTest.php
@@ -48,15 +48,35 @@ class OverpassEndpointConfigTest extends TestCase
         }
     }
 
-    /** A globálist mindkét Twig-környezetnek regisztrálnia kell (l. a DANGER-kommentet). */
-    public function testBothTwigEnvironmentsRegisterTheGlobal(): void
+    /**
+     * A globálisnak tényleg ott kell lennie a felépített környezetben.
+     *
+     * Ez eddig a két fájl FORRÁSSZÖVEGÉBEN kereste az `addGlobal` hívást, mert a
+     * Twig-környezet két teljes másolatban élt (load.php és Html::loadTwig), mindkettőn
+     * a DANGER-figyelmeztetéssel. Azóta egyetlen gyár építi mindkettőt, tehát a szöveges
+     * keresés a lényeget vesztette — a lényeg viszont maradt: a globális legyen ott.
+     */
+    public function testTheBuiltEnvironmentRegistersTheGlobal(): void
+    {
+        $globals = buildTwigEnvironment()->getGlobals();
+
+        self::assertArrayHasKey('overpass_api_url', $globals,
+            'hiányzik az overpass_api_url globális');
+        self::assertNotSame('', (string) $globals['overpass_api_url']);
+    }
+
+    /**
+     * És egyik hívó se építsen sajátot: pont a másolatok szétcsúszása volt a baj.
+     */
+    public function testNoCallSiteBuildsItsOwnEnvironment(): void
     {
         foreach ([__DIR__ . '/../../load.php', __DIR__ . '/../../classes/html/html.php'] as $utvonal) {
-            self::assertStringContainsString(
-                "addGlobal('overpass_api_url'",
-                file_get_contents($utvonal),
-                basename($utvonal) . ': hiányzik az overpass_api_url globális.'
-            );
+            $tartalom = file_get_contents($utvonal);
+
+            self::assertStringNotContainsString('new \\Twig\\Environment', $tartalom,
+                basename($utvonal) . ': saját Twig-környezetet épít — használd a buildTwigEnvironment()-et.');
+            self::assertStringContainsString('buildTwigEnvironment(', $tartalom,
+                basename($utvonal) . ': nem a közös gyárból veszi a Twig-környezetet.');
         }
     }
 

--- a/webapp/tests/Unit/OverpassEndpointConfigTest.php
+++ b/webapp/tests/Unit/OverpassEndpointConfigTest.php
@@ -58,11 +58,27 @@ class OverpassEndpointConfigTest extends TestCase
      */
     public function testTheBuiltEnvironmentRegistersTheGlobal(): void
     {
-        $globals = buildTwigEnvironment()->getGlobals();
+        global $config;
+        $eredeti = $config['overpass']['apiUrl'] ?? null;
+        // Kifejezett érték, mert a beállítás környezetenként más — kikapcsolt külső
+        // API-knál (#695) üres is lehet, és akkor az üresség a HELYES kimenet.
+        $config['overpass']['apiUrl'] = 'https://teszt.example.com/api/interpreter';
 
-        self::assertArrayHasKey('overpass_api_url', $globals,
-            'hiányzik az overpass_api_url globális');
-        self::assertNotSame('', (string) $globals['overpass_api_url']);
+        try {
+            $globals = buildTwigEnvironment()->getGlobals();
+
+            self::assertArrayHasKey('overpass_api_url', $globals,
+                'hiányzik az overpass_api_url globális');
+            self::assertSame('https://teszt.example.com/api/interpreter',
+                $globals['overpass_api_url'],
+                'a globálisnak a beállított végpontot kell hoznia');
+        } finally {
+            if ($eredeti === null) {
+                unset($config['overpass']['apiUrl']);
+            } else {
+                $config['overpass']['apiUrl'] = $eredeti;
+            }
+        }
     }
 
     /**

--- a/webapp/tests/bootstrap.php
+++ b/webapp/tests/bootstrap.php
@@ -41,3 +41,11 @@ dbconnect();
 
 date_default_timezone_set('Europe/Budapest');
 
+// A levélküldés Twig-sablonból áll elő (\Eloquent\Email::render()), így $twig nélkül
+// egyetlen email-út sem tesztelhető. Ugyanaz a környezet, mint amit a load.php épít.
+//
+// A $GLOBALS azért kell, mert a PHPUnit ezt a fájlt FÜGGVÉNYEN BELÜLRŐL tölti be: a
+// sima $twig értékadás ott lokális változó lenne, a render() `global $twig`-je pedig
+// továbbra is null-t kapna.
+$GLOBALS['twig'] = buildTwigEnvironment();
+

--- a/webapp/twig_extras.php
+++ b/webapp/twig_extras.php
@@ -242,3 +242,40 @@ function mcalVersion(): string {
     $version = $mtime ? (string) $mtime : '0';
     return $version;
 }
+
+/**
+ * A Twig-környezet összeállítása — EGY helyen.
+ *
+ * Eddig két teljes másolat élt belőle (load.php és Html\Html::loadTwig), mindkettőn
+ * ott a figyelmeztetés, hogy a másikat is módosítani kell. A tesztek bootstrapja lett
+ * volna a harmadik, ezért inkább összevontam: egy szűrő felvétele így nem tud
+ * félbemaradni.
+ *
+ * A DOMAIN-t azért nem közvetlenül a konstansból veszem, mert azt a load.php
+ * definiálja — CLI-ből (teszt, cron) a környezet enélkül is használható kell legyen.
+ */
+function buildTwigEnvironment(?string $templatesPath = null): \Twig\Environment {
+    global $config;
+
+    $loader = new \Twig\Loader\FilesystemLoader(PATH . ($templatesPath ?? 'templates'));
+    $twig = new \Twig\Environment($loader);
+
+    $twig->addFilter(new \Twig\TwigFilter('miserend_date', 'twig_hungarian_date_format'));
+    $twig->addFilter(new \Twig\TwigFilter('trans', 'twig_translate'));
+    $twig->addFilter(new \Twig\TwigFilter('floor', 'floor'));
+    $twig->addFilter(new \Twig\TwigFilter('phone_links', 'twig_phone_links'));
+    $twig->addFilter(new \Twig\TwigFilter('strip_protocol', 'twig_strip_protocol'));
+    $twig->addFilter(new \Twig\TwigFilter('facebook_path', 'twig_facebook_path'));
+    $twig->addFilter(new \Twig\TwigFilter('readable_rrule', 'twig_readable_rrule'));
+
+    // Az email-sablonok abszolút hivatkozásaihoz kell.
+    $twig->addGlobal('domain', defined('DOMAIN') ? DOMAIN : ($config['path']['domain'] ?? ''));
+    $twig->addGlobal('mcal_version', mcalVersion()); // naptár-bundle cache-buster, l. mcalVersion()
+    // #766: az Overpass-végpont a böngészőből induló lekérdezésekhez is. A PHP oldal
+    // már a config['overpass']['apiUrl']-t használja (#376), a térkép-sablonok viszont
+    // beégetve hívták az overpass-api.de-t — ráadásul http-n. Így a mirror-váltás
+    // rájuk is érvényes.
+    $twig->addGlobal('overpass_api_url', $config['overpass']['apiUrl'] ?? 'https://overpass-api.de/api/interpreter');
+
+    return $twig;
+}


### PR DESCRIPTION
Az éles /health-en a `user_pleaselogin` a legrosszabb arányú levéltípus: 30 nap alatt **131 hibás, 48 sikeres**. A többi típus gyakorlatilag tiszta.

## Ok

A `\User::sendInactivityNotification()` életciklusa körbeér. A törlés ága **kizárólag `sent` státuszra fut**:

```php
elseif ($lastEmail->status == 'sent' AND $lastEmail->updated_at < '-3 week') { /* törlés */ }
else { /* új user_pleaselogin */ }
```

Akinek a levele elhasal, az sosem esik a törlés ágába — az `else` viszont háromhetente újra küld neki. Minden fordulóban egy újabb `error` sor, a felhasználó marad, a következő körben megint sorra kerül. Örökre.

Két eset már a próbálkozás előtt látszik:

- **üres cím**: az `Email::send()` `isset($this->to)` feltétele üres sztringre igaz, így a levél eljut a PHPMailerig, ami `Invalid address`-szel dob;
- **formailag hibás cím**: ugyanez, csak a validáláson bukik el.

Ugyanez a kör megvan a `sendActivationNotification()`-nél is, ott hetente — csak ott nincs törlés-ág, tehát kevésbé feltűnő.

## Megoldás

A hurok elején kimarad, akinek nincs használható címe (`FILTER_VALIDATE_EMAIL` — ugyanaz, amivel a PHPMailer is ellenőriz, tehát nem szűrök ki olyat, ami egyébként kimenne), és az is, akinek a címére `UNDELIVERABLE_ATTEMPTS` (3) kísérlet után sem sikerült kézbesíteni. Egy hiba még lehet átmeneti SMTP-kiesés, három hiba háromhetes ritmus mellett nagyjából két hónapnyi sikertelenség.

A sikeres kiküldés **nullázza** a számlálót. Ez nem szépészeti kérdés: a törlés csak akkor fut le, ha a felhasználó előbb átmegy ezen a vizsgálaton, tehát a régi hibák egy azóta bizonyítottan működő cím mellett némán kizárnák a fiókot a törlésből.

**Törölni a kézbesíthetetlenség miatt nem törlök.** Az nem bizonyítja, hogy a fiók elhagyott, a törlés viszont visszafordíthatatlan.

## Figyelmeztetés

A már beragadt fiókok deploy után **nem tűnnek el**: nem kapnak több levelet, de törölve sem lesznek, mert sosem jutottak el egy sikeres értesítésig. Ezek kézi átnézést kívánnak — hogy mi legyen velük, az nem kódkérdés. A hibás sorok szaporodása viszont megáll.

## Mellékesen: Twig a tesztekben

A levél Twig-sablonból áll elő (`Email::render()`), a teszt-bootstrap viszont nem hozott létre `$twig`-et — emiatt eddig **egyetlen email-út sem volt tesztelhető**. Pótoltam.

A Twig-környezet felépítése eddig két teljes másolatban élt (`load.php` és `Html\Html::loadTwig()`), mindkettőn ott a `DANGER` megjegyzés, hogy a másikat is módosítani kell. Harmadik másolat helyett `buildTwigEnvironment()`-be vontam össze; egy szűrő felvétele így nem tud félbemaradni.

## Teszt

17 új teszt (`webapp/tests/Integration/InactivityNotificationTest.php`). Ellenőriztem, hogy a javítás nélkül buknak: az őrszem kiiktatásával 3, a nullázás kiiktatásával további 2. Teljes csomag: 814 zöld.