### PR TITLE
Jelentem a hibás url:miserend értékeket, nem dobom el őket

### DIFF
--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -246,6 +246,32 @@ class OSM {
      *
      * @throws Exception Ha az Overpass API lekérdezésből hiányoznak az elemek
      */
+    /** Egy futásban ennyi elemnél többet nem dolgozunk fel. */
+    const URL_MISEREND_LIMIT = 10000;
+
+    /**
+     * #658: az `url:miserend` értékéből a templom azonosítója.
+     *
+     * #410: a mintát nem horgonyozzuk, így a http/https/www prefix nem számít; kezeli
+     * az opcionális `?`-et és a path-suffixeket (pl. /templom/5/calendar). Mindkét
+     * útvonal-formát elfogadja: `templom/N` és `(?)templom=N`.
+     *
+     * #510: az `uj.miserend.hu`-t szándékosan NEM fogadjuk el (negatív lookbehind):
+     * hibás adat, essen a „van url:miserend, de nem használható" ágba.
+     *
+     * Külön metódus, hogy tesztelhető legyen, MELYIK alakot fogadjuk el — a jegy épp
+     * arról szól, hogy az OSM-ben sokféle alak van forgalomban.
+     */
+    public static function churchIdFromMiserendUrl(?string $url): ?int {
+        if ($url === null || trim($url) === '') {
+            return null;
+        }
+        if (preg_match('#(?<!uj\.)miserend\.hu/?\??templom(?:=|/)(\d+)#i', $url, $match) !== 1) {
+            return null;
+        }
+        return (int) $match[1];
+    }
+
     function syncUrlMiserendFromOSM() {
         
         $overpass = new \ExternalApi\OverpassApi();
@@ -254,29 +280,74 @@ class OSM {
          if (!$overpass->jsonData->elements) {
             throw new Exception("Missing Json Elements from OverpassApi Query");
         }
+
+        /*
+         * #658: a hibás értékeket JELENTJÜK, nem dobjuk el némán.
+         *
+         * Az OSM-ben sokféle alak van forgalomban (http nélkül, `?templom=345`,
+         * `uj.miserend.hu`, elgépelt hoszt), és borazslo egyetlen nagy changesetben
+         * akarja rendbe tenni. Ahhoz viszont tudnia kell, MELYIK elemről van szó —
+         * eddig ezek nyom nélkül elvesztek (a kódban ottfelejtett TODO helyén).
+         */
+        $hibasErtek = [];
+        $ismeretlenTemplom = [];
+        $sikeres = 0;
+
         $c = 0;
         foreach ($overpass->jsonData->elements as $element) {
             $c++;
-            if($c > 10000) exit;
-            // #410: robusztusabb match. A mintát nem horgonyozzuk, így a
-            // http/https/www prefix nem számít; kezeli az opcionális `?`-et és
-            // a path-suffixeket (pl. /templom/5/calendar). Mindkét útvonal-
-            // formát elfogadja: templom/N és (?)templom=N. A korábbi {1,5}
-            // helyett \d+ (nincs 5-jegyű felső korlát az ID-n).
-            // #510: az uj.miserend.hu-t szándékosan NEM matcheljük (negatív
-            // lookbehind) - hibás adat, így a "van url:miserend, de nem
-            // használható" ágba esik, amit borazslo kézzel javít.
-            preg_match('#(?<!uj\.)miserend\.hu/?\??templom(?:=|/)(\d+)#i', $element->tags->{'url:miserend'} ?? '', $match);
-            if(!isset($match[1])) {
-                /*
-                 * TODO: Van url:miserend, de az értéke vacak.
-                 */
-                //printr($element);
+            if ($c > self::URL_MISEREND_LIMIT) {
+                // Itt korábban `exit` állt: az a cron-futtatót is megölte, tehát a munka
+                // SOHA nem került sikeres állapotba, és a többi cron sem futott le utána.
+                echo "OSM url:miserend: elértem a(z) " . self::URL_MISEREND_LIMIT
+                    . " elemes korlátot, a többit ebben a körben kihagyom.\n";
+                break;
+            }
 
-            } else {
-                $church = \Eloquent\Church::find($match[1]);
-                if($church)
-                    $this->saveOSM2Church($church,$element);
+            $ertek = $element->tags->{'url:miserend'} ?? '';
+            $tid = self::churchIdFromMiserendUrl($ertek);
+
+            if ($tid === null) {
+                $hibasErtek[] = $this->osmElementLabel($element) . ' → ' . $ertek;
+                continue;
+            }
+
+            $church = \Eloquent\Church::find($tid);
+            if (!$church) {
+                $ismeretlenTemplom[] = $this->osmElementLabel($element) . ' → ' . $ertek;
+                continue;
+            }
+
+            $this->saveOSM2Church($church, $element);
+            $sikeres++;
+        }
+
+        $this->reportUrlMiserendIssues($sikeres, $hibasErtek, $ismeretlenTemplom);
+    }
+
+    /** Az OSM-elem emberi azonosítója, hogy a jelentésből meg lehessen találni. */
+    private function osmElementLabel($element): string {
+        return ($element->type ?? '?') . '/' . ($element->id ?? '?');
+    }
+
+    /**
+     * #658: a futás összegzése. A cron-oldalon és a `docker logs`-ban is látszik,
+     * tehát egyetlen futásból megvan a javítandó elemek listája.
+     */
+    private function reportUrlMiserendIssues(int $sikeres, array $hibasErtek, array $ismeretlenTemplom): void {
+        printf("OSM url:miserend: %d elem átkötve, %d hibás értékű, %d ismeretlen templomra mutat.\n",
+            $sikeres, count($hibasErtek), count($ismeretlenTemplom));
+
+        foreach ([
+            'Nem értelmezhető url:miserend érték' => $hibasErtek,
+            'Nem létező templomra mutat'          => $ismeretlenTemplom,
+        ] as $cim => $lista) {
+            if (!$lista) {
+                continue;
+            }
+            echo '  ' . $cim . ":\n";
+            foreach ($lista as $sor) {
+                echo '    ' . $sor . "\n";
             }
         }
     }

--- a/webapp/tests/Unit/UrlMiserendParsingTest.php
+++ b/webapp/tests/Unit/UrlMiserendParsingTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #658: az OSM-ben az `url:miserend` címke sokféle alakban van forgalomban — van, ahol
+ * `https` nélkül, máshol `miserend.hu/?templom=345` formában, és állítólag olyan is,
+ * hogy `miserend:/?templom=456`.
+ *
+ * Két külön kérdés, és a jegy szempontjából mindkettő fontos:
+ *
+ *  1. Melyik alakot ISMERJÜK FEL? Amit felismerünk, azt az OSM-ben nem is muszáj
+ *     javítani — a takarítás úgyis egyetlen nagy changesetben megy majd.
+ *  2. Melyiket NEM? Azok kerülnek a futás végi jelentésbe, és pont azok a javítandók.
+ *
+ * A felismerés eddig a szinkronizáló ciklus közepén, névtelenül állt; ezért került ki
+ * külön metódusba.
+ */
+class UrlMiserendParsingTest extends TestCase
+{
+    /** @dataProvider elfogadottAlakok */
+    public function testTheseFormsAreRecognised(string $url, int $vart): void
+    {
+        self::assertSame($vart, \OSM::churchIdFromMiserendUrl($url), $url);
+    }
+
+    public static function elfogadottAlakok(): array
+    {
+        return [
+            'kanonikus'            => ['https://miserend.hu/templom/452', 452],
+            'https nélkül'         => ['http://miserend.hu/templom/452', 452],
+            'séma nélkül'          => ['miserend.hu/templom/452', 452],
+            'www-vel'              => ['https://www.miserend.hu/templom/452', 452],
+            'régi kérdőjeles'      => ['miserend.hu/?templom=345', 345],
+            'kérdőjel nélkül'      => ['miserend.hu/templom=345', 345],
+            'aloldallal'           => ['https://miserend.hu/templom/5/calendar', 5],
+            'záró perjellel'       => ['https://miserend.hu/templom/452/', 452],
+            'nagybetűs hoszt'      => ['HTTPS://MISEREND.HU/templom/452', 452],
+            'hosszú azonosító'     => ['https://miserend.hu/templom/123456', 123456],
+            'szöveg közepén'       => ['lásd itt: https://miserend.hu/templom/99 (miserend)', 99],
+        ];
+    }
+
+    /** @dataProvider elutasitottAlakok */
+    public function testTheseFormsAreReported(?string $url): void
+    {
+        self::assertNull(\OSM::churchIdFromMiserendUrl($url), (string) $url);
+    }
+
+    public static function elutasitottAlakok(): array
+    {
+        return [
+            'null'                 => [null],
+            'üres'                 => [''],
+            'csak szóköz'          => ['   '],
+            // #510: szándékosan nem fogadjuk el — hibás adat, kézzel javítandó.
+            'uj.miserend.hu'       => ['https://uj.miserend.hu/templom/452'],
+            // A jegyben említett, elrontott séma: essen a jelentésbe, ne áldjuk meg.
+            'hoszt nélküli séma'   => ['miserend:/?templom=456'],
+            'azonosító nélkül'     => ['https://miserend.hu/templom/'],
+            'nem szám azonosító'   => ['https://miserend.hu/templom/abc'],
+            'más oldal'            => ['https://example.com/templom/452'],
+            'főoldal'              => ['https://miserend.hu'],
+            'kereső link'          => ['https://miserend.hu/kereses?kulcsszo=Budapest'],
+        ];
+    }
+
+    /**
+     * A jegy egyik konkrét példája: ugyanaz a templom háromféle alakban. Amit fel tudunk
+     * ismerni, az ugyanazt az azonosítót kell adja — különben az OSM-takarítás előtt
+     * ugyanaz a templom többféleképpen viselkedne.
+     */
+    public function testTheRecognisedFormsAgreeOnTheChurch(): void
+    {
+        $alakok = [
+            'https://miserend.hu/templom/452',
+            'http://miserend.hu/templom/452',
+            'miserend.hu/?templom=452',
+            'https://www.miserend.hu/templom/452/',
+        ];
+
+        foreach ($alakok as $alak) {
+            self::assertSame(452, \OSM::churchIdFromMiserendUrl($alak), $alak);
+        }
+    }
+}


### PR DESCRIPTION
Closes #658

Írtad, hogy az OSM-oldali takarítást egyetlen nagy changesetben csinálnád meg egyszer. Ahhoz viszont tudni kell, **melyik elemekről van szó** — és pont ezt nem mondja meg semmi.

## Amit eddig csináltunk a hibás értékekkel: semmit

A szinkronizálás némán eldobta őket, a kódban ottfelejtett TODO helyén:

```php
if(!isset($match[1])) {
    /*
     * TODO: Van url:miserend, de az értéke vacak.
     */
    //printr($element);
} else {
    $church = \Eloquent\Church::find($match[1]);
    if($church)                      // ← ha nincs ilyen templom, az is elveszett
        $this->saveOSM2Church($church,$element);
}
```

Mostantól a futás végén kiírom mindkét listát, az OSM-elem azonosítójával (`node/123456`), tehát **egyetlen futásból megvan a javítandók listája**:

```
OSM url:miserend: 4521 elem átkötve, 87 hibás értékű, 31 ismeretlen templomra mutat.
  Nem értelmezhető url:miserend érték:
    node/123456 → https://uj.miserend.hu/templom/452
    way/98765 → miserend:/?templom=456
  Nem létező templomra mutat:
    node/24680 → https://miserend.hu/templom/99999
```

## Mellékesen: egy `exit` a ciklus közepén

```php
if($c > 10000) exit;
```

Ez nem csak a feldolgozást állította le a tízezredik elemnél, hanem **az egész cron-futtatót**: a munka soha nem került sikeres állapotba (`lastsuccess_at` nem frissült), és a sorban mögötte álló többi cron sem futott le. Ugyanaz a hibaosztály, ami a #239-et hónapokra megállította. Most jelzem a korlát elérését és kilépek a ciklusból.

## Amit felismerünk, azt nem kell javítani

Az azonosító-kinyerés külön, tesztelhető metódusba került, és 22 teszt rögzíti a határt. **Felismerjük** (tehát az OSM-ben maradhat így): `https` nélkül, séma nélkül, `www`-vel, `miserend.hu/?templom=345`, aloldallal (`/templom/5/calendar`), záró perjellel, nagybetűs hoszttal.

**Nem ismerjük fel** (tehát ezek kerülnek a jelentésbe): `uj.miserend.hu` (#510 szerint szándékosan), a jegyben említett elrontott `miserend:/?templom=456`, más oldal, azonosító nélküli vagy nem szám azonosítójú link.

Ez a lista maga is válasz a jegy kérdésére: a felsorolt formák közül a `miserend.hu/?templom=345` **már ma is működik**, tehát nem kell miatta hozzányúlni az OSM-hez.

## Teszt

904 unit teszt zöld.