### PR TITLE
Nyomtatható miserend a templom ajtajára

### DIFF
--- a/webapp/classes/html/church/nyomtat.php
+++ b/webapp/classes/html/church/nyomtat.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Html\Church;
+
+use Carbon\Carbon;
+
+/**
+ * #36: nyomtatható miserend egy templomhoz.
+ *
+ * A jegyben a tartalom kérdése nyitva maradt („nem egészen értem, hogyan lehetne
+ * praktikus a végtelen miseidőszakok nyomtatása"), ezért a döntéseket itt írom le —
+ * mindegyik abból indul ki, KI olvassa a papírt: a templom ajtajára kitett lapot idős
+ * hívek nézik, a plébánián pedig titkárok sokszorosítják.
+ *
+ * 1. NEM nyomtatjuk ki az összes időszakot. Az „egész évben / nyári / téli / adventi"
+ *    rétegek egymást írják felül; papíron egymás mellett állva félrevezetők, mert a
+ *    lapról nem derül ki, melyik érvényes MA. Ezért csak az érvényben lévő rend kerül
+ *    ki, heti bontásban.
+ *
+ * 2. A lap MEGMONDJA, meddig érvényes. Ez a válasz a jegy nyitott kérdésére: a
+ *    „végtelen időszak" nem attól kezelhető, hogy mindent kiírunk, hanem attól, hogy a
+ *    lap maga jelzi, mikor jár le. Előre végignézzük a következő évet, és megkeressük
+ *    az első napot, amikor a heti rend megváltozik — az a lejárat.
+ *
+ * 3. Nem időszaknév, hanem NAP szerint csoportosítunk. A „Nyári időszámítás" belső
+ *    szakszó; a hívő azt kérdezi, vasárnap hánykor van mise.
+ *
+ * 4. Az alkalmi (nem heti) alkalmak — ünnepek, búcsú — külön szakaszban, dátummal,
+ *    a következő három hónapra. Ennyi ideig marad reálisan a falon egy lap.
+ *
+ * 5. A miséket ugyanaz a motor állítja elő, mint a naptárat és a keresőt
+ *    (`CalMass::generateMassPeriodInstancesForYears`), tehát a papír nem mondhat mást,
+ *    mint a weboldal. Az időszakok közti elsőbbséget sem itt számoljuk újra: a
+ *    kizárt napok (`exdate`) már benne vannak a szabályban.
+ */
+class Nyomtat extends \Html\Html {
+
+    /** Meddig soroljuk előre az alkalmi miséket. */
+    private const ALKALMI_NAPOK = 90;
+
+    /** Meddig keressük előre a rend megváltozását. */
+    private const ELORETEKINTES_NAPOK = 400;
+
+    private const HONAPOK = [
+        1 => 'január', 2 => 'február', 3 => 'március', 4 => 'április',
+        5 => 'május', 6 => 'június', 7 => 'július', 8 => 'augusztus',
+        9 => 'szeptember', 10 => 'október', 11 => 'november', 12 => 'december',
+    ];
+
+    /** Vasárnappal kezdünk: a miserendet is így olvassák. */
+    private const NAPOK = [
+        0 => 'Vasárnap',
+        1 => 'Hétfő',
+        2 => 'Kedd',
+        3 => 'Szerda',
+        4 => 'Csütörtök',
+        5 => 'Péntek',
+        6 => 'Szombat',
+    ];
+
+    /*
+     * A property-ket kiírjuk. PHP 8.2 óta a dinamikus property elavult, és bár a régebbi
+     * oldalosztályok még így csinálják, új kód ne termeljen újabb figyelmeztetést.
+     */
+    public $church;
+    public $nyomtatasNapja;
+    public $hetiRend = [];
+    public $alkalmak = [];
+    public $ervenyesigSzoveg;
+    public $nyomtatasSzoveg;
+    public $ellenorzesSzoveg;
+    public $plebaniaSzoveg = '';
+    public $megjegyzesSzoveg = '';
+    public $bucsuSzoveg = '';
+
+    public function __construct($path) {
+        parent::__construct();
+
+        $id = $this->churchIdFromPath($path);
+        if (!$id) {
+            throw new \Exception('Nem található templom azonosító a nyomtatási nézethez.');
+        }
+
+        $church = \Eloquent\Church::find($id);
+        if (!$church) {
+            throw new \Exception('Nincs ilyen templom.');
+        }
+
+        /*
+         * Ugyanaz a jogosultság-ellenőrzés, mint a templomoldalon (Html\Church\Church):
+         * a nem publikus templom adata ezen az úton sem szivároghat ki. Külön útvonal,
+         * külön belépési pont — a védelmet is külön kell kimondani.
+         */
+        $church = $church->append(['readAccess']);
+        if (!$church->readAccess) {
+            throw new \Exception('Ehhez a templomhoz nincs hozzáférésed.');
+        }
+
+        $this->template = 'church/nyomtat.twig';
+        $this->church = $church;
+        $this->nyomtatasNapja = Carbon::now()->startOfDay();
+
+        $naptar = $this->occurrencesByDate($church, $this->nyomtatasNapja);
+
+        $this->hetiRend   = $this->weeklySchedule($naptar, $this->nyomtatasNapja);
+        $this->alkalmak   = $this->upcomingOneOffs($naptar, $this->nyomtatasNapja);
+
+        /*
+         * A dátumokat itt formázzuk, nem a sablonban. A `miserend_date` szűrő
+         * RELATÍV alakot ad („ma", „holnap", „szerda"), ami képernyőn hasznos, papíron
+         * viszont értelmetlen: a lap hetekig ott lóg, és a „holnap" nem tudni, mikorra
+         * vonatkozik. Nyomtatáshoz csak abszolút dátum jó.
+         */
+        $ervenyesig = $this->validUntil($naptar, $this->nyomtatasNapja, $this->hetiRend);
+        $this->ervenyesigSzoveg = $ervenyesig
+            ? self::magyarDatum(Carbon::parse($ervenyesig), false) . '-ig'
+            : null;
+        $this->nyomtatasSzoveg = self::magyarDatum($this->nyomtatasNapja);
+        $this->ellenorzesSzoveg = $church->frissites
+            ? self::magyarDatum(Carbon::parse($church->frissites))
+            : null;
+
+        // A szabad szöveges mezők HTML-t tartalmaznak (<strong>, <br />, entitások).
+        // Papírra sima szöveg való, és így nem is kell nyers HTML-t kiengedni a sablonba.
+        $this->plebaniaSzoveg = self::plainText($church->plebania ?? '');
+        $this->megjegyzesSzoveg = self::plainText($church->misemegj ?? '');
+        $this->bucsuSzoveg = self::plainText($church->bucsu ?? '');
+    }
+
+    /** „2026. október 24." — ponttal a végén, kivéve ha rag jön utána. */
+    private static function magyarDatum(Carbon $nap, bool $zaroPont = true): string {
+        return $nap->year . '. ' . self::HONAPOK[(int) $nap->month] . ' ' . $nap->day . ($zaroPont ? '.' : '');
+    }
+
+    /** A HTML-t tartalmazó szabad szöveges mezőkből olvasható, sima szöveg. */
+    private static function plainText(string $ertek): string {
+        $ertek = preg_replace('#<br\s*/?>#i', "\n", $ertek);
+        $ertek = html_entity_decode(strip_tags($ertek), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        // A nyers mezőkben gyakori a többszörös szóköz és a sorvégi szemét.
+        $ertek = preg_replace('/[ \t]+/', ' ', $ertek);
+        return trim(preg_replace('/\n{2,}/', "\n", $ertek));
+    }
+
+    private function churchIdFromPath($path): ?int {
+        if (is_array($path) && isset($path[0]) && is_numeric($path[0])) {
+            return (int) $path[0];
+        }
+        $value = \Request::get('id');
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * Nap → alkalmak. A szabályokat ugyanazzal a motorral bontjuk ki, amivel a naptár;
+     * a `SimpleRRule` a kizárt napokat (`exdate`) is figyelembe veszi, tehát ami itt
+     * megjelenik, az tényleg meg is történik.
+     *
+     * @return array<string, array<int, array{ido:string, cim:string, heti:bool}>>
+     */
+    private function occurrencesByDate(\Eloquent\Church $church, Carbon $mostantol): array {
+        $masses = \Eloquent\CalMass::where('church_id', $church->id)->get()->all();
+        if (!$masses) {
+            return [];
+        }
+
+        $evek = [(int) $mostantol->year, (int) $mostantol->year + 1];
+        $sorok = \Eloquent\CalMass::generateMassPeriodInstancesForYears($masses, [], $evek);
+
+        $hatar = $mostantol->copy()->addDays(self::ELORETEKINTES_NAPOK);
+        $naptar = [];
+
+        foreach ($sorok as $sor) {
+            if (empty($sor['rrule'])) {
+                continue;
+            }
+            $heti = ($sor['rrule']['freq'] ?? '') === 'weekly';
+
+            foreach ((new \SimpleRRule($sor['rrule']))->getOccurrences() as $alkalom) {
+                $nap = Carbon::instance($alkalom);
+                if ($nap->lt($mostantol) || $nap->gt($hatar)) {
+                    continue;
+                }
+                $naptar[$nap->toDateString()][] = [
+                    'ido'  => $nap->format('H:i'),
+                    'cim'  => (string) ($sor['title'] ?? 'Szentmise'),
+                    'heti' => $heti,
+                ];
+            }
+        }
+
+        foreach ($naptar as $nap => $alkalmak) {
+            usort($alkalmak, static fn($a, $b) => strcmp($a['ido'], $b['ido']));
+            $naptar[$nap] = $alkalmak;
+        }
+
+        return $naptar;
+    }
+
+    /**
+     * A most érvényes heti rend: a következő hét napból olvassuk ki, mert az adja azt,
+     * amit a hívő MA tapasztal.
+     *
+     * @return array<int, array{nap:string, alkalmak:array<int,array{ido:string,cim:string}>}>
+     */
+    private function weeklySchedule(array $naptar, Carbon $mostantol): array {
+        $rend = [];
+        for ($i = 0; $i < 7; $i++) {
+            $nap = $mostantol->copy()->addDays($i);
+            $alkalmak = array_values(array_filter(
+                $naptar[$nap->toDateString()] ?? [],
+                static fn($a) => $a['heti']
+            ));
+            if ($alkalmak) {
+                $rend[(int) $nap->dayOfWeek] = $alkalmak;
+            }
+        }
+
+        // Vasárnappal kezdve, a hét sorrendjében.
+        $rendezett = [];
+        foreach (self::NAPOK as $sorszam => $nev) {
+            if (isset($rend[$sorszam])) {
+                $rendezett[] = [
+                    'nap'      => $nev,
+                    'alkalmak' => array_map(
+                        static fn($a) => ['ido' => $a['ido'], 'cim' => $a['cim']],
+                        $rend[$sorszam]
+                    ),
+                ];
+            }
+        }
+        return $rendezett;
+    }
+
+    /**
+     * Meddig érvényes a fenti rend? Az első olyan napig, amelyen a heti rend eltér a
+     * mostanitól.
+     *
+     * Ez a jegy nyitott kérdésére a válasz: a „végtelen időszak" nem attól kezelhető,
+     * hogy mindent kiírunk, hanem attól, hogy a lap megmondja, mikor avul el. Az
+     * alkalmi (ünnepi) miséket szándékosan kihagyjuk a vizsgálatból: egy búcsú nem
+     * rendváltozás, csak egyszeri alkalom.
+     *
+     * @return string|null ISO-dátum, vagy null ha a belátható időn belül nem változik
+     */
+    private function validUntil(array $naptar, Carbon $mostantol, array $hetiRend): ?string {
+        if (!$hetiRend) {
+            return null;
+        }
+
+        $minta = [];
+        for ($i = 0; $i < 7; $i++) {
+            $nap = $mostantol->copy()->addDays($i);
+            $minta[(int) $nap->dayOfWeek] = $this->weeklySignature($naptar, $nap);
+        }
+
+        for ($i = 7; $i <= self::ELORETEKINTES_NAPOK; $i++) {
+            $nap = $mostantol->copy()->addDays($i);
+            if ($this->weeklySignature($naptar, $nap) !== ($minta[(int) $nap->dayOfWeek] ?? '')) {
+                return $nap->copy()->subDay()->toDateString();
+            }
+        }
+
+        return null;
+    }
+
+    /** Egy nap heti alkalmainak ujjlenyomata — ebből látszik, ha megváltozik a rend. */
+    private function weeklySignature(array $naptar, Carbon $nap): string {
+        $alkalmak = array_filter($naptar[$nap->toDateString()] ?? [], static fn($a) => $a['heti']);
+        $jegyek = array_map(static fn($a) => $a['ido'] . ' ' . $a['cim'], $alkalmak);
+        sort($jegyek);
+        return implode('|', $jegyek);
+    }
+
+    /**
+     * Alkalmi (nem heti) misék a következő három hónapra, dátummal.
+     *
+     * @return array<int, array{datum:string, alkalmak:array<int,array{ido:string,cim:string}>}>
+     */
+    private function upcomingOneOffs(array $naptar, Carbon $mostantol): array {
+        $hatar = $mostantol->copy()->addDays(self::ALKALMI_NAPOK);
+        $lista = [];
+
+        foreach ($naptar as $nap => $alkalmak) {
+            $datum = Carbon::parse($nap);
+            if ($datum->gt($hatar)) {
+                continue;
+            }
+            $alkalmi = array_values(array_filter($alkalmak, static fn($a) => !$a['heti']));
+            if (!$alkalmi) {
+                continue;
+            }
+            $lista[] = [
+                'datum'    => $nap,
+                // A hétköznap nevét is kiírjuk: papíron a puszta dátumból nehéz
+                // fejben kiszámolni, milyen nap lesz.
+                'nap'      => self::NAPOK[(int) $datum->dayOfWeek],
+                'datumSzoveg' => self::magyarDatum($datum, false) . ', ' . mb_strtolower(self::NAPOK[(int) $datum->dayOfWeek]),
+                'alkalmak' => array_map(
+                    static fn($a) => ['ido' => $a['ido'], 'cim' => $a['cim']],
+                    $alkalmi
+                ),
+            ];
+        }
+
+        usort($lista, static fn($a, $b) => strcmp($a['datum'], $b['datum']));
+        return $lista;
+    }
+}

--- a/webapp/classes/path.php
+++ b/webapp/classes/path.php
@@ -41,6 +41,8 @@ class Path {
             // hogy a kliens-oldali kód ne törjön a refactor után.
             ["^calendar\/(.+)$", "ajax/calendar/$1"],
             ["^templom\/([0-9]{1,5})\/widget$", "church/widget/$1"],
+            // #36: nyomtatható miserend a templom ajtajára / plébániai sokszorosításra.
+            ["^templom\/([0-9]{1,5})\/nyomtat$", "church/nyomtat/$1"],
             ["^templom\/([0-9]{1,5})\/javaslatok$", "church/suggestionpackages/$1"],
             ["^templom\/([0-9]{1,5})\/eszrevetelek$", "remark/list/$1"],
             ["^templom\/([0-9]{1,5})\/ujeszrevetel$", "remark/addform/$1"],

--- a/webapp/templates/church/church.twig
+++ b/webapp/templates/church/church.twig
@@ -171,6 +171,14 @@
             &nbsp;<a href="#" onclick="document.getElementById('cal-full-{{ id }}').style.display='none'; document.getElementById('cal-preview-{{ id }}').style.display='inline'; return false;" title="Bezárás">bezár</a>
         </span>
     </small>
+    {# #36: nyomtatható miserend. Szándékosan NEM a naptár-legördülőben: a plébániai
+       titkárok és az idős atyák nem legördülőkben keresgélnek, és pont ez a funkció
+       készült nekik. Külön gomb, ikon MELLETT szöveggel. #}
+    <a class="btn btn-default btn-sm" style="margin-left:10px;"
+       href="{{ constant('DOMAIN') }}/templom/{{ id }}/nyomtat"
+       title="Nyomtatható miserend (A4)">
+        <i class="fa fa-print" aria-hidden="true"></i> Nyomtatás
+    </a>
     <div class="btn-group btn-group-sm" style="margin-left:10px;">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Naptár">
             <i class="fa fa-calendar" aria-hidden="true"></i> Naptár <span class="caret"></span>

--- a/webapp/templates/church/nyomtat.twig
+++ b/webapp/templates/church/nyomtat.twig
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="hu">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>{{ church.nev }} — miserend</title>
+<style>
+/*
+ * #36: nyomtatásra tervezve, idős szemnek.
+ *
+ * A lap a templom ajtajára kerül vagy kézbe. Ezért: nagy betű, tiszta fekete-fehér
+ * (szürke szöveg fénymásolat után olvashatatlan), semmi ikon, semmi kép, semmi
+ * színkód — amit nem lehet felolvasni, az papíron nem információ.
+ *
+ * A4 álló, 15 mm margóval: ez fér be a plébániák nyomtatóiba, és A3-ra is felnagyítható
+ * torzulás nélkül. Ha a tartalom hosszabb, a második oldalra folyik — jobb, mint
+ * kicsire zsugorítani.
+ */
+:root { --alap: 12.5pt; }
+
+* { box-sizing: border-box; }
+
+body {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: var(--alap);
+    line-height: 1.5;
+    color: #000;
+    background: #fff;
+    margin: 0;
+    padding: 15mm;
+    max-width: 210mm;
+}
+
+h1 {
+    font-size: 22pt;
+    line-height: 1.2;
+    margin: 0 0 2mm;
+}
+
+.patrocinium { font-size: 14pt; margin: 0 0 3mm; }
+.hely { font-size: 12.5pt; margin: 0 0 6mm; }
+
+.ervenyesseg {
+    border: 1.5pt solid #000;
+    padding: 3mm 4mm;
+    margin: 0 0 7mm;
+    font-size: 12.5pt;
+}
+.ervenyesseg strong { font-size: 13.5pt; }
+
+h2 {
+    font-size: 15pt;
+    margin: 7mm 0 3mm;
+    padding-bottom: 1mm;
+    border-bottom: 1pt solid #000;
+}
+
+table { border-collapse: collapse; width: 100%; }
+td { padding: 2mm 3mm 2mm 0; vertical-align: baseline; }
+
+/* A nap neve kapja a hangsúlyt: a szem ezt keresi először. */
+.nap {
+    font-weight: bold;
+    font-size: 14pt;
+    white-space: nowrap;
+    width: 32mm;
+}
+/* Az időpont a második legfontosabb — ezért nagyobb, mint a cím. */
+.ido {
+    font-weight: bold;
+    font-size: 14pt;
+    white-space: nowrap;
+    width: 20mm;
+}
+.cim { font-size: 12.5pt; }
+.datum { white-space: nowrap; width: 46mm; font-weight: bold; }
+
+tr + tr .nap, tr + tr .datum { border-top: 0.5pt solid #999; }
+tbody tr td { border-top: 0.5pt solid #ccc; }
+tbody tr:first-child td { border-top: 0; }
+
+.megjegyzes { margin: 5mm 0 0; }
+
+footer {
+    margin-top: 9mm;
+    padding-top: 3mm;
+    border-top: 1pt solid #000;
+    font-size: 10.5pt;
+}
+
+.nincs { font-style: italic; }
+
+/* Képernyőn: egy gomb, ami papíron nem jelenik meg. */
+.nyomtatas-gomb {
+    display: inline-block;
+    margin-bottom: 6mm;
+    padding: 2mm 5mm;
+    font: inherit;
+    font-size: 12pt;
+    border: 1.5pt solid #000;
+    background: #fff;
+    cursor: pointer;
+}
+
+@media print {
+    body { padding: 0; }
+    .nyomtatas-gomb { display: none; }
+    /* A napok sorai ne törjenek ketté oldalhatáron. */
+    tr { page-break-inside: avoid; }
+    h2 { page-break-after: avoid; }
+}
+
+@page { size: A4 portrait; margin: 15mm; }
+</style>
+</head>
+<body>
+
+<button class="nyomtatas-gomb" onclick="window.print()">Nyomtatás</button>
+
+<h1>{{ church.nev }}</h1>
+{% if church.ismertnev %}<p class="patrocinium">{{ church.ismertnev }}</p>{% endif %}
+<p class="hely">
+    {{ church.varos }}{% if church.cim %}, {{ church.cim }}{% endif %}
+    {% if plebaniaSzoveg %}<br>{{ plebaniaSzoveg|nl2br }}{% endif %}
+</p>
+
+<div class="ervenyesseg">
+    {% if ervenyesigSzoveg %}
+        <strong>Ez a rend {{ ervenyesigSzoveg }} érvényes.</strong><br>
+        Utána a miserend változik, kérjük, nyomtasson újat.
+    {% else %}
+        <strong>Ez a rend a nyomtatás napján érvényes.</strong><br>
+        A belátható időn belül nincs bejegyzett változás.
+    {% endif %}
+</div>
+
+<h2>Rendszeres miserend</h2>
+{% if hetiRend %}
+    <table>
+        <tbody>
+        {% for nap in hetiRend %}
+            {% for alkalom in nap.alkalmak %}
+                <tr>
+                    <td class="nap">{% if loop.first %}{{ nap.nap }}{% endif %}</td>
+                    <td class="ido">{{ alkalom.ido }}</td>
+                    <td class="cim">{{ alkalom.cim }}</td>
+                </tr>
+            {% endfor %}
+        {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <p class="nincs">Erre a templomra nincs rendszeres miserend rögzítve.</p>
+{% endif %}
+
+{% if alkalmak %}
+    <h2>Ünnepek, alkalmi szentmisék</h2>
+    <table>
+        <tbody>
+        {% for nap in alkalmak %}
+            {% for alkalom in nap.alkalmak %}
+                <tr>
+                    <td class="datum">{% if loop.first %}{{ nap.datumSzoveg }}{% endif %}</td>
+                    <td class="ido">{{ alkalom.ido }}</td>
+                    <td class="cim">{{ alkalom.cim }}</td>
+                </tr>
+            {% endfor %}
+        {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if megjegyzesSzoveg or bucsuSzoveg %}
+    <h2>Megjegyzés</h2>
+    {% if bucsuSzoveg %}<p class="megjegyzes"><strong>Búcsú:</strong> {{ bucsuSzoveg|nl2br }}</p>{% endif %}
+    {% if megjegyzesSzoveg %}<p class="megjegyzes">{{ megjegyzesSzoveg|nl2br }}</p>{% endif %}
+{% endif %}
+
+<footer>
+    Forrás: {{ domain }}/templom/{{ church.id }}<br>
+    Nyomtatva: {{ nyomtatasSzoveg }}
+    {% if ellenorzesSzoveg %}Az adatok utolsó ellenőrzése: {{ ellenorzesSzoveg }}{% endif %}
+</footer>
+
+</body>
+</html>

--- a/webapp/tests/Integration/ChurchPrintableScheduleTest.php
+++ b/webapp/tests/Integration/ChurchPrintableScheduleTest.php
@@ -1,0 +1,198 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #36: nyomtatható miserend.
+ *
+ * A jegyben a TARTALOM kérdése maradt nyitva („nem egészen értem, hogyan lehetne
+ * praktikus a végtelen miseidőszakok nyomtatása"). A tesztek ezért nem csak azt mérik,
+ * hogy a lap előáll, hanem a meghozott döntéseket is rögzítik — hogy később látszódjon,
+ * mit MIÉRT így csinálunk:
+ *
+ *  - csak az ÉRVÉNYBEN LÉVŐ rend kerül papírra, nem az összes időszak;
+ *  - a lap megmondja, meddig érvényes (ez a válasz a „végtelen időszak" kérdésre);
+ *  - nap szerint csoportosítunk, nem időszaknév szerint;
+ *  - a dátum abszolút, sosem relatív („ma", „holnap") — a lap hetekig ott lóg;
+ *  - a szabad szöveges mezőkből sima szöveg lesz, nem nyers HTML.
+ *
+ * A lapot ugyanaz a motor tölti fel, mint a naptárat és a keresőt, tehát a papír nem
+ * mondhat mást, mint a weboldal.
+ */
+class ChurchPrintableScheduleTest extends TestCase
+{
+    /** Szentendre, Péter-Pál: teljes heti rend, nyári/téli időszakkal. */
+    private const TESZT_TEMPLOM = 1;
+
+    private function lap(int $tid = self::TESZT_TEMPLOM): \Html\Church\Nyomtat
+    {
+        return new \Html\Church\Nyomtat([$tid]);
+    }
+
+    public function testAlapadatokRakerulnekALapra(): void
+    {
+        $lap = $this->lap();
+
+        self::assertSame(self::TESZT_TEMPLOM, (int) $lap->church->id);
+        self::assertNotSame('', (string) $lap->church->nev);
+        self::assertSame('church/nyomtat.twig', $lap->template);
+    }
+
+    /** A heti rend napokra bontva áll elő, nem időszaknév szerint. */
+    public function testAHetiRendNapokRaBontvaAllElo(): void
+    {
+        $lap = $this->lap();
+
+        self::assertNotEmpty($lap->hetiRend, 'ennek a templomnak van rendszeres miserendje');
+
+        $napnevek = array_column($lap->hetiRend, 'nap');
+        foreach ($napnevek as $nev) {
+            self::assertContains($nev,
+                ['Vasárnap', 'Hétfő', 'Kedd', 'Szerda', 'Csütörtök', 'Péntek', 'Szombat'],
+                'a csoportosítás nem nap szerint történt: ' . $nev);
+        }
+        self::assertSame(count($napnevek), count(array_unique($napnevek)),
+            'ugyanaz a nap többször szerepel');
+    }
+
+    /** Vasárnappal kezdünk: a miserendet így olvassák. */
+    public function testAHetVasarnappalKezdodik(): void
+    {
+        $lap = $this->lap();
+        $napnevek = array_column($lap->hetiRend, 'nap');
+
+        if (!in_array('Vasárnap', $napnevek, true)) {
+            self::markTestSkipped('ezen a templomon nincs vasárnapi mise');
+        }
+        self::assertSame('Vasárnap', $napnevek[0]);
+    }
+
+    /** Minden alkalomnak van időpontja és megnevezése — üres cella papíron használhatatlan. */
+    public function testMindenAlkalomnakVanIdopontjaEsMegnevezese(): void
+    {
+        $lap = $this->lap();
+
+        foreach ($lap->hetiRend as $nap) {
+            self::assertNotEmpty($nap['alkalmak']);
+            foreach ($nap['alkalmak'] as $alkalom) {
+                self::assertMatchesRegularExpression('/^\d{2}:\d{2}$/', $alkalom['ido']);
+                self::assertNotSame('', trim($alkalom['cim']));
+            }
+        }
+    }
+
+    /**
+     * A napon belül időrendben — a szem fentről lefelé olvassa.
+     */
+    public function testAzAlkalmakIdorendbenAllnak(): void
+    {
+        $lap = $this->lap();
+
+        foreach ($lap->hetiRend as $nap) {
+            $idok = array_column($nap['alkalmak'], 'ido');
+            $rendezett = $idok;
+            sort($rendezett);
+            self::assertSame($rendezett, $idok, $nap['nap'] . ': nem időrendben');
+        }
+    }
+
+    /**
+     * A lényeg: a lap megmondja, meddig érvényes.
+     *
+     * Ez a válasz a jegy nyitott kérdésére. Nem az összes időszakot nyomtatjuk ki
+     * egymás mellé (papíron nem derülne ki, melyik él MA), hanem a mostanit — és
+     * mellé azt, mikor avul el.
+     */
+    public function testALapMegmondjaMeddigErvenyes(): void
+    {
+        $lap = $this->lap();
+
+        self::assertNotNull($lap->ervenyesigSzoveg,
+            'ennek a templomnak van évszakos rendje, tehát van lejárat');
+        self::assertMatchesRegularExpression('/^\d{4}\. [a-záéíóöőúüű]+ \d{1,2}-ig$/u',
+            $lap->ervenyesigSzoveg);
+    }
+
+    /**
+     * A dátum SOSEM lehet relatív. A `miserend_date` szűrő „ma"/„holnap"/„szerda"
+     * alakot ad, ami képernyőn hasznos — papíron viszont értelmetlen, mert a lap
+     * hetekig ott lóg a falon.
+     */
+    public function testADatumokAbszolutak(): void
+    {
+        $lap = $this->lap();
+
+        foreach ([$lap->nyomtatasSzoveg, $lap->ervenyesigSzoveg, $lap->ellenorzesSzoveg] as $szoveg) {
+            if ($szoveg === null) {
+                continue;
+            }
+            self::assertMatchesRegularExpression('/^\d{4}\./', (string) $szoveg,
+                'relatív dátum került a nyomtatott lapra: ' . $szoveg);
+        }
+    }
+
+    /**
+     * A szabad szöveges mezők HTML-t tartalmaznak (`<strong>`, `<br />`, entitások).
+     * Papírra sima szöveg való — és így nyers HTML-t sem kell kiengedni a sablonba.
+     */
+    public function testASzabadSzovegesMezokbolSimaSzovegLesz(): void
+    {
+        $lap = $this->lap();
+
+        foreach (['plebaniaSzoveg', 'megjegyzesSzoveg', 'bucsuSzoveg'] as $mezo) {
+            $ertek = (string) $lap->{$mezo};
+            self::assertStringNotContainsString('<', $ertek, $mezo . ': maradt benne HTML');
+            self::assertStringNotContainsString('&amp;', $ertek, $mezo . ': maradt benne entitás');
+            self::assertStringNotContainsString('&oacute;', $ertek, $mezo . ': maradt benne entitás');
+        }
+    }
+
+    /** Az alkalmi (ünnepi) miséket dátummal és a nap nevével írjuk ki. */
+    public function testAzAlkalmiMisekDatummalSzerepelnek(): void
+    {
+        $lap = $this->lap();
+
+        self::assertIsArray($lap->alkalmak);
+
+        foreach ($lap->alkalmak as $nap) {
+            self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $nap['datum']);
+            self::assertMatchesRegularExpression(
+                '/^\d{4}\. [a-záéíóöőúüű]+ \d{1,2}, [a-záéíóöőúüű]+$/u',
+                $nap['datumSzoveg'],
+                'az alkalmi dátum nem olvasható alakban van'
+            );
+        }
+    }
+
+    /**
+     * Nem publikus templom adata ezen az úton sem szivároghat ki.
+     *
+     * Külön útvonal, külön belépési pont — a templomoldal `readAccess`-ellenőrzését
+     * itt is ki kell mondani, nem elég, hogy amott megvan.
+     */
+    public function testNemPublikusTemplomotNemAdunkKi(): void
+    {
+        $rejtett = \Illuminate\Database\Capsule\Manager::table('templomok')
+            ->where('ok', '<>', 'i')->value('id');
+
+        if (!$rejtett) {
+            self::markTestSkipped('nincs nem publikus templom a teszt-adatbázisban');
+        }
+
+        $this->expectException(\Exception::class);
+        new \Html\Church\Nyomtat([(int) $rejtett]);
+    }
+
+    /** Ismeretlen templomra nem adunk üres lapot. */
+    public function testIsmeretlenTemplomraHibatDobunk(): void
+    {
+        $this->expectException(\Exception::class);
+        new \Html\Church\Nyomtat([999999999]);
+    }
+
+    public function testAzonositoNelkulHibatDobunk(): void
+    {
+        $this->expectException(\Exception::class);
+        new \Html\Church\Nyomtat([]);
+    }
+}


### PR DESCRIPTION
Closes #36

A jegyben a **tartalom** kérdése maradt nyitva: *„nem egészen értem/látom át, hogyan lehetne praktikus a végtelen miseidőszakok nyomtatása."* Meghoztam a döntéseket, és leírom, miért így.

Kiindulópont: **ki olvassa a papírt.** Idős hívek a templom ajtaján, plébániai titkárok a fénymásolóban. Ebből minden más következik.

## 1. Nem nyomtatom ki az összes időszakot

Az „egész évben / nyári / téli / adventi" rétegek egymást írják felül. Papíron egymás mellett félrevezetők, mert a lapról nem derül ki, melyik él **ma**. Csak az érvényben lévő rend kerül ki.

## 2. Helyette a lap megmondja, meddig érvényes

Ez a válasz a nyitott kérdésre. A „végtelen időszak" nem attól kezelhető, hogy mindent kiírunk, hanem attól, hogy **a lap maga jelzi, mikor avul el**. Előre végignézem a következő évet, és megkeresem az első napot, amikor a heti rend megváltozik:

> **Ez a rend 2026. október 24-ig érvényes.**
> Utána a miserend változik, kérjük, nyomtasson újat.

Élő adaton ellenőrizve: Újfehértó, Örömhírvétel-templom → október 24. (a téli időszámítás előtti nap). Szentendre, Péter-Pál → augusztus 30. (a nyári szünet vége).

Az ünnepeket szándékosan kihagyom ebből a vizsgálatból: egy búcsú nem rendváltozás, csak egyszeri alkalom.

## 3. Nap szerint csoportosítok, nem időszaknév szerint

A „Nyári időszámítás" belső szakszó. A hívő azt kérdezi, vasárnap hánykor van mise. A hét **vasárnappal kezd** — a miserendet így olvassák.

```
Vasárnap   07:00  Szent Liturgia
           08:15  Utrenye
           09:00  Szent Liturgia
           17:30  Szent Liturgia
Hétfő      07:00  Szent Liturgia
Szerda     17:30  Szent Liturgia
```

Az ünnepi, alkalmi misék külön szakaszban, dátummal és a nap nevével, a következő **három hónapra** — ennyi ideig marad reálisan a falon egy lap.

## 4. Tipográfia idős szemnek

12,5 pt alap, **14 pt a nap neve és az időpont**, tiszta fekete-fehér. Semmi ikon, semmi szín, semmi kép: a szürke szöveg fénymásolat után olvashatatlan, a színkód pedig fekete-fehér nyomtatón eltűnik. A4 álló, 15 mm margó — ez fér be a plébániák nyomtatóiba, és A3-ra torzulás nélkül nagyítható. Ha hosszabb, a második oldalra folyik; jobb, mint kicsire zsugorítani.

A dátum **sosem relatív**: a `miserend_date` szűrő „ma"/„holnap"/„szerda" alakot ad, ami képernyőn hasznos, papíron viszont értelmetlen — a lap hetekig ott lóg.

## 5. Nem mondhat mást, mint a weboldal

A miséket ugyanaz a motor állítja elő, mint a naptárat és a keresőt (`CalMass::generateMassPeriodInstancesForYears`), és az időszakok elsőbbségét sem számolom itt újra: a kizárt napok már benne vannak a szabályban.

A szabad szöveges mezők (plébánia, megjegyzés, búcsú) HTML-t tartalmaznak (`<strong>`, `<br />`, `&oacute;`) — ezekből sima szöveg lesz, így nyers HTML-t sem kell kiengedni a sablonba.

A templomoldal `readAccess`-ellenőrzését itt is kimondom: külön útvonal, külön belépési pont, a nem publikus templom ezen az úton sem szivároghat ki.

## Elérés

`/templom/{id}/nyomtat`, és a templomoldalon **külön, látható gomb** — szándékosan nem a naptár-legördülőben, mert a célközönség nem legördülőkben keresgél.

## Amit NEM tartalmaz

A plébánia-szintű összefoglalót (a hozzá tartozó misézőhelyekkel) nem: az a #506-ra vár, a plébánia–fília összekötés még nem létezik. A keresési találatok exportját sem — ahhoz a jegyben nincs használati eset.

## Teszt

12 teszt, ami a döntéseket is rögzíti (nap szerinti csoportosítás, vasárnapi kezdés, időrend, abszolút dátum, sima szöveg, jogosultság). Teljes csomag: 894 zöld.