### PR TITLE
API v5: strukturált mise-adat a magyar mondat helyett

### DIFF
--- a/webapp/classes/api/api.php
+++ b/webapp/classes/api/api.php
@@ -22,8 +22,19 @@ class Api {
         $this->date = \Request::DatewDefault('datum', $defaultDate);
     }
 
+    /**
+     * #56: a legmagasabb kiadott API-verzió.
+     *
+     * Az v5 ugyanaz a boríték és ugyanazok a végpontok, mint a v4 — csak a mise-adat
+     * lesz strukturált, és a képek rövid úton jönnek. A régebbi verziók válasza
+     * VÁLTOZATLAN, hogy a meglévő kliensek (KAPP) a saját ütemükben állhassanak át.
+     */
+    const LEGUJABB_VERZIO = 5;
+
     public function validateVersionMain() {
-        if (!in_array($this->version, array(1, 2, 3, 4))) {
+        // Laza összehasonlítás: a \Request::IntegerRequired() sztringet ad vissza, és a
+        // szigorú változat emiatt a meglévő verziókat is elutasítaná.
+        if (!in_array($this->version, range(1, self::LEGUJABB_VERZIO))) {
             throw new \Exception("Invalid API version.");
         }
 

--- a/webapp/classes/api/church.php
+++ b/webapp/classes/api/church.php
@@ -122,7 +122,7 @@ class Church extends Api {
 
             $churches = \Eloquent\Church::whereIn('id', $ids)->get()
                     ->keyBy('id')
-                    ->map->toAPIArray($responseLength);
+                    ->map->toAPIArray($responseLength, false, $this->version);
 
             /*
              * A kért sorrendben adjuk vissza, és a nem létező azonosítót KIHAGYJUK
@@ -148,7 +148,7 @@ class Church extends Api {
             return;
         }
 
-        $church = \Eloquent\Church::Where('id',$this->input['id'])->get()->map->toAPIArray($responseLength);
+        $church = \Eloquent\Church::Where('id',$this->input['id'])->get()->map->toAPIArray($responseLength, false, $this->version);
 
 
         if(count($church) < 1 ) {

--- a/webapp/classes/api/nearby.php
+++ b/webapp/classes/api/nearby.php
@@ -113,7 +113,8 @@ class NearBy extends Api {
 				->limit($limit)
                 ->get()->map->toAPIArray(
 					isset($this->input['response_length']) ? $this->input['response_length'] : (  $this->fields['response_length']['default'] ? $this->fields['response_length']['default'] : false ), 
-					isset($this->input["whenMass"]) ? $this->input["whenMass"] : (  $this->fields['whenMass']['default'] ? $this->fields['whenMass']['default'] : false ));
+					isset($this->input["whenMass"]) ? $this->input["whenMass"] : (  $this->fields['whenMass']['default'] ? $this->fields['whenMass']['default'] : false ),
+					$this->version);
 				
         //$this->return['lat'] = $this->input['lat'];
 

--- a/webapp/classes/api/search.php
+++ b/webapp/classes/api/search.php
@@ -147,7 +147,8 @@ class Search extends Api {
 			->orderByRaw("FIELD(id, " . implode(',', $ids) . ")")
 			->get()->map->toAPIArray(
                 isset($this->input['response_length']) ? $this->input['response_length'] : (  $this->fields['response_length']['default'] ? $this->fields['response_length']['default'] : false ), 
-                isset($this->input["when"]) ? $this->input["when"] : (  $this->fields['when']['default'] ? $this->fields['when']['default'] : false ));
+                isset($this->input["when"]) ? $this->input["when"] : (  $this->fields['when']['default'] ? $this->fields['when']['default'] : false ),
+                $this->version);
         
         if(count($ids) == count($this->return['templomok'])) {
             $this->return['error'] = 0;

--- a/webapp/classes/api/sqlite.php
+++ b/webapp/classes/api/sqlite.php
@@ -30,7 +30,36 @@ class Sqlite extends Api {
         HTML;
 
         $docs['response'] = <<<HTML
-        <h4>misék: „misek”</h4>
+        <h4>misék: „misek” — v5</h4>
+        <p>
+            A <strong>v5</strong> más szerkezetet ad, mint a v4: nem minden egyes
+            előfordulás külön sor, hanem <strong>minden mise a generált időszakával
+            sokszorozva</strong>, konkrét dátumtól dátumig. Az ismétlődés
+            <code>rrule</code>-ként, a kivételek konkrét dátumokként mennek — így a
+            tábla rövid marad, de rrule-lal könnyen felszorozható és kereshető.
+            (Egy templomra két évre mérve 43 sor 1229 előfordulás helyett.)
+        </p>
+        <ul>
+            <li>„mid” (<em>integer not null</em>): a SOR azonosítója</li>
+            <li>„tid” (<em>integer</em>): a templom azonosítója (mint az url-ben)</li>
+            <li>„mise_id” (<em>integer</em>): a MISE azonosítója. Egy mise több
+                időszakkal is szerepel (téli/nyári/adventi), ezen az azonosítón
+                ismerhető fel, hogy ugyanarról a miséről van szó.</li>
+            <li>„idoszak” (<em>varchar(255)</em>): az időszak neve, pl. <em>Advent</em></li>
+            <li>„datumtol”, „datumig” (<em>date</em>): az időszak KONKRÉT első és utolsó
+                napja, <strong>ÉÉÉÉ-HH-NN</strong> alakban (a v4-ben ez hónap+nap volt, év nélkül)</li>
+            <li>„ido” (<em>time</em>): a mise kezdete, pl. <em>07:00:00</em></li>
+            <li>„hossz” (<em>integer</em>): a mise hossza percben</li>
+            <li>„rrule” (<em>text</em>): az ismétlődés RFC 5545 szerint, pl.
+                <em>FREQ=WEEKLY;UNTIL=20261224T225959Z;BYDAY=MO,WE</em></li>
+            <li>„exdate” (<em>text</em>): a kimaradó alkalmak konkrét dátumai, vesszővel
+                elválasztva, pl. <em>2026-12-01,2026-12-08</em></li>
+            <li>„nyelv” (<em>varchar(32)</em>): nyelvek vesszővel elválasztva</li>
+            <li>„milyen” (<em>varchar(64)</em>): egyéb tulajdonságok vesszővel elválasztva</li>
+            <li>„megjegyzes” (<em>varchar(255)</em>)</li>
+        </ul>
+
+        <h4>misék: „misek” — v4 és korábbi</h4>
         <ul>
             <li>„mid” (<em>integer not null</em>): mise azonosító</li>
             <li>„tid” (<em>integer</em>): a templom azonosítója (mint az url-ben)</li>
@@ -215,12 +244,17 @@ class Sqlite extends Api {
         $this->insertDataTemplomok();
 
         echo "<br/>\ninsertDataMisek ... <br/>\n";                
-        $chunkSize = 3000;
-        $this->insertDataMisek($chunkSize);                
-        while( $this->search->countHits > 0 ) {                        
+        if ($this->version >= 5) {
+            // #800: a v5 nem a keresőindex felszorzott példányaiból dolgozik, hanem a
+            // generált periódusokból — templomonként, mert a generálás így működik.
+            $this->insertDataMisekV5();
+        } else {
+            $chunkSize = 3000;
             $this->insertDataMisek($chunkSize);
+            while( $this->search->countHits > 0 ) {
+                $this->insertDataMisek($chunkSize);
+            }
         }
-        
         if ($this->version > 1) {
             $this->insertDataKepek();
         }
@@ -261,6 +295,36 @@ class Sqlite extends Api {
     }
 
     function createTableMisek() {
+        /*
+         * #800: a v5 miserendje MÁS SZERKEZET, nem a v4 bővítése.
+         *
+         * A v4-ig minden egyes előfordulás külön sor volt (datumtol = datumig = egy
+         * nap, "Ezen a napon: ..."), fél évre előre felszorozva. borazslo azt kérte,
+         * hogy ehelyett az iCal-hoz hasonló alak menjen: minden mise a GENERÁLT
+         * PERIÓDUSSAL sokszorozva, konkrét dátumtól dátumig, mellette az ismétlődés
+         * rrule-ként és a kivételek konkrét dátumokként. Így a tábla rövid marad,
+         * viszont rrule-lal könnyen felszorozható és kereshető.
+         */
+        if ($this->version >= 5) {
+            $this->sqlite->statement("CREATE TABLE IF NOT EXISTS [misek] (
+                [mid] INTEGER  PRIMARY KEY NOT NULL,
+                [tid] INTEGER  NULL,
+                [mise_id] INTEGER  NULL,
+                [idoszak] VARCHAR(255)  NULL,
+                [datumtol] DATE  NULL,
+                [datumig] DATE  NULL,
+                [ido] TIME  NULL,
+                [hossz] INTEGER  NULL,
+                [rrule] TEXT  NULL,
+                [exdate] TEXT  NULL,
+                [nyelv] VARCHAR(32)  NULL,
+                [milyen] VARCHAR(64)  NULL,
+                [megjegyzes] VARCHAR(255)  NULL
+            )");
+
+            return;
+        }
+
         $createtablemisek = "CREATE TABLE IF NOT EXISTS [misek] (
             [mid] INTEGER  PRIMARY KEY NOT NULL,
             [tid] iNTEGER  NULL,";
@@ -426,6 +490,94 @@ class Sqlite extends Api {
 
         $line = "v" . $this->version . " " . (int) ( microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"]) . "s : " . $this->massId . "/" . $this->search->total . " -- ";
             echo "\r" . str_pad($line, 120)."<br>";             
+    }
+
+    /**
+     * #800: a v5 miserendje — minden mise a generált periódusával sokszorozva.
+     *
+     * A forrás ugyanaz, mint az iCal-exporté (CalMass::generateMassPeriodInstancesForYears),
+     * mert borazslo kifejezetten azt a formátumot kérte referenciának. Így a két
+     * kimenet nem tud szétcsúszni.
+     *
+     * Templomonként megyünk: a periódus-generálás egy templom összes miséjét együtt
+     * nézi (az időszakok egymáshoz képest súlyozódnak), tehát nem lehet tetszőleges
+     * mise-halmazra darabolni.
+     *
+     * @param int $chunkSize hány templomot dolgozzunk fel egy körben
+     */
+    function insertDataMisekV5(int $chunkSize = 200) {
+        $evek = [(int) date('Y'), (int) date('Y') + 1];
+
+        // Az időszak NEVE nem szerepel a generált szerkezetben, csak az azonosítója.
+        $idoszakNevek = DB::table('cal_generated_periods')->pluck('name', 'id')->toArray();
+
+        $churchIds = DB::table('cal_masses')->distinct()->orderBy('church_id')->pluck('church_id')->all();
+        $osszes = count($churchIds);
+        $kesz = 0;
+
+        foreach (array_chunk($churchIds, $chunkSize) as $csoport) {
+            $inserts = [];
+
+            foreach ($csoport as $churchId) {
+                $masses = \Eloquent\CalMass::where('church_id', $churchId)->get()->all();
+                if ($masses === []) {
+                    continue;
+                }
+
+                foreach (\Eloquent\CalMass::generateMassPeriodInstancesForYears($masses, [], $evek) as $periodus) {
+                    $this->massId++;
+                    $inserts[] = $this->massPeriodToRow($periodus, $idoszakNevek);
+                }
+            }
+
+            if ($inserts !== []) {
+                $this->insertDataSql('misek', $inserts);
+            }
+
+            $kesz += count($csoport);
+            $line = "v" . $this->version . " " . (int) (microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"]) . "s : "
+                . $kesz . "/" . $osszes . " templom, " . $this->massId . " sor";
+            echo "\r" . str_pad($line, 120) . "<br>";
+        }
+    }
+
+    /**
+     * Egy generált periódus-példány sqlite-sorrá alakítása.
+     *
+     * @param array<string,mixed> $periodus a generateMassPeriodInstancesForYears egy eleme
+     * @param array<int,string> $idoszakNevek generated_period_id => név
+     * @return array<string,mixed>
+     */
+    private function massPeriodToRow(array $periodus, array $idoszakNevek): array {
+        $rrule = is_array($periodus['rrule'] ?? null) ? $periodus['rrule'] : [];
+
+        // Az időpont a szabály kezdetéből jön: a dtstart hordozza az órát és a percet.
+        $ido = null;
+        if (!empty($rrule['dtstart'])) {
+            try {
+                $ido = (new \DateTime((string) $rrule['dtstart']))->format('H:i:s');
+            } catch (\Throwable $e) {
+                $ido = null;
+            }
+        }
+
+        return [
+            'mid' => $this->massId,
+            'tid' => (int) ($periodus['church_id'] ?? 0),
+            // A mise SAJÁT azonosítója: egy mise több periódussal is szerepel, és a
+            // fogyasztónak tudnia kell, hogy ugyanarról a miséről van szó.
+            'mise_id' => (int) ($periodus['mass_id'] ?? 0),
+            'idoszak' => $idoszakNevek[$periodus['generated_period_id'] ?? null] ?? '',
+            'datumtol' => $periodus['start_date'] ?? null,
+            'datumig' => $periodus['end_date'] ?? null,
+            'ido' => $ido,
+            'hossz' => (int) ($periodus['duration_minutes'] ?? 0),
+            'rrule' => \SimpleRRule::toRfcString($rrule),
+            'exdate' => implode(',', \SimpleRRule::exdates($rrule)),
+            'nyelv' => implode(',', (array) ($periodus['lang'] ?? [])),
+            'milyen' => implode(',', (array) ($periodus['types'] ?? [])),
+            'megjegyzes' => $periodus['comment'] ?? null,
+        ];
     }
 
     function insertDataKepek() {

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -856,7 +856,12 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         return $f !== null ? date('Y-m-d H:i:s', strtotime($f)) : null;
     }
 
-    public function toAPIArray($length = "minimal", $whenMass = false)
+    /**
+     * @param string    $length     minimal | medium | full | elastic
+     * @param mixed     $whenMass   melyik napra kérjük a miséket
+     * @param int|null  $apiVersion #56: az API-verzió; 5-től strukturált a mise-adat
+     */
+    public function toAPIArray($length = "minimal", $whenMass = false, ?int $apiVersion = null)
     {
 
         if($length == 'elastic') {
@@ -897,6 +902,30 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                     }
                     if($mise->comment) $info .= ' (' . $mise->comment.')';
                     if($info != '') $misek[$key]['informacio'] = $info;
+
+                    /*
+                     * #56: v5-től a nyers adat is kimegy.
+                     *
+                     * Az `informacio` egy előre összerakott MAGYAR mondat (rítus + cím +
+                     * nyelvek + típusok + megjegyzés). A kliens ebből nem tud szűrni,
+                     * nem tud fordítani, és a hosszt sem tudja. Márpedig mindez
+                     * strukturáltan megvan a `cal_masses`-ben — csak eddig nem adtuk ki.
+                     * Ez borazslo kérése: „az egész átadott mise adatok kövessék a nagy
+                     * megújulás calendar típusú új állapotát."
+                     *
+                     * Az `informacio` a v5-ben is MEGMARAD: így a meglévő kliens
+                     * (KAPP) mezőnként állhat át, nem egyszerre kell mindent átírnia.
+                     */
+                    if ($apiVersion !== null && $apiVersion >= 5) {
+                        $misek[$key]['mise_id']    = (int) ($mise->mass_id ?? 0);
+                        $misek[$key]['ritus']      = (string) ($mise->rite ?? '');
+                        $misek[$key]['megnevezes'] = (string) ($mise->title ?? '');
+                        // #334: egy misének több nyelve is lehet — ezért mindig lista.
+                        $misek[$key]['nyelvek']    = array_values($miseLangs);
+                        $misek[$key]['tipusok']    = array_values((array) ($mise->types ?? []));
+                        $misek[$key]['megjegyzes'] = (string) ($mise->comment ?? '');
+                        $misek[$key]['hossz_perc'] = (int) ($mise->duration_minutes ?? 0);
+                    }
                 }	            
             }
         } 
@@ -976,8 +1005,16 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         ];
 
         if($length == 'full') {
-            $return = array_merge($return, [                
-                'photos' => $this->photos->pluck('url')->toArray()                
+            /*
+             * #56: v5-től rövid út a teljes URL helyett — `{templomid}/{fájlnév}`.
+             * A teljes cím minden képnél megismételte ugyanazt az előtagot; a bázis
+             * ismert és állandó: `{domain}/kepek/templomok/`. (borazslo másik ötlete,
+             * az egyedi kép-azonosító, szerveroldali munkát is igényelne — az marad.)
+             */
+            $return = array_merge($return, [
+                'photos' => ($apiVersion !== null && $apiVersion >= 5)
+                    ? $this->photos->map(fn($kep) => $kep->church_id . '/' . $kep->filename)->values()->toArray()
+                    : $this->photos->pluck('url')->toArray()
             ]);
 
         }

--- a/webapp/classes/html/api.php
+++ b/webapp/classes/html/api.php
@@ -11,8 +11,15 @@ class Api extends Html {
 
         $uri = $_SERVER['REQUEST_URI'];
 
-        // API version is obligatory in the URL
-        if (!preg_match('#^/api/(v[1-4])(/|$)#', $uri)) {
+        /*
+         * #56: az útvonal BÁRMILYEN verziószámot elfogad, a listát nem itt tartjuk.
+         *
+         * Korábban `v[1-4]` állt itt, három regexben — az v5 bevezetésekor mindhármat
+         * módosítani kellett volna, és ha egy kimarad, a hívó néma átirányítást kap az
+         * /apidocs-ra a "hibás verzió" üzenet helyett. Azt, hogy melyik verzió él, az
+         * \Api\Api::validateVersionMain() mondja meg — egy helyen.
+         */
+        if (!preg_match('#^/api/(v[0-9]+)(/|$)#', $uri)) {
             $this->error = "Invalid API endpoint: " . $uri;
             \Message::add($this->error, 'danger');
             $this->redirect('/apidocs');
@@ -27,7 +34,7 @@ class Api extends Html {
 
         // Determine the action from the URL if not provided in the query string
         $endpoints = \Api\Api::collectApiEndpoints();                        
-        if (preg_match('#^/api/(v[1-4])/?([^/?]*)#i', $uri, $matches)) {
+        if (preg_match('#^/api/(v[0-9]+)/?([^/?]*)#i', $uri, $matches)) {
             // #391: az API-osztályok a $_REQUEST['v']-ből olvassák a verziót, ezért azt
             // továbbra is beállítjuk — de amit MI használunk lentebb, azt lokális
             // változóból vesszük, ne a szuperglobális kerülőúton.

--- a/webapp/classes/simplerrule.php
+++ b/webapp/classes/simplerrule.php
@@ -367,6 +367,88 @@ class SimpleRRule
      *                          byweekno, count, dtstart
      * @return string emberi-olvasható magyar leírás, vagy '' ha nincs rrule
      */
+    /**
+     * #800: az ismétlődési szabály RFC 5545 szerinti RRULE-sztringje.
+     *
+     * Eddig ez a Html\Church\Ical privát metódusa volt. Az sqlite-exportnak (API v5)
+     * ugyanez kell — borazslo kifejezetten az iCal formátumát kérte referenciának —,
+     * ezért ide kerül, hogy egy helyen legyen és ne csússzon szét a kettő.
+     *
+     * Az `exdate` NEM része: az külön mező, mert a szabályhoz képest kivétel.
+     *
+     * @param array<string,mixed>|null $rrule
+     */
+    static function toRfcString($rrule): string {
+        if (!$rrule || !is_array($rrule)) {
+            return '';
+        }
+
+        $parts = [];
+        foreach ($rrule as $kulcs => $ertek) {
+            if ($kulcs === 'exdate' || $kulcs === 'dtstart') {
+                continue;
+            }
+            if ($kulcs === 'byweekday') {
+                $kulcs = 'byday';
+            }
+            if ($kulcs === 'until') {
+                $parts[] = 'UNTIL=' . self::rfcDatum($ertek);
+                continue;
+            }
+            if (is_array($ertek)) {
+                $parts[] = strtoupper($kulcs) . '=' . implode(',', array_map(
+                    fn($x) => strtoupper((string) $x),
+                    $ertek
+                ));
+                continue;
+            }
+            $parts[] = strtoupper($kulcs) . '=' . strtoupper((string) $ertek);
+        }
+
+        return implode(';', $parts);
+    }
+
+    /**
+     * #800: a kizárt alkalmak KONKRÉT dátumai.
+     *
+     * borazslo pontosan ezt kérte: "az exdates azok konkrét dátumok". A táblázatos
+     * exportnak nem szabály kell, hanem lista — a fogyasztó így egyszerűen kiveszi
+     * az rrule-lal felszorzott sorozatból.
+     *
+     * @param array<string,mixed>|null $rrule
+     * @return array<int,string> Y-m-d dátumok, rendezve, duplikátum nélkül
+     */
+    static function exdates($rrule): array {
+        if (!$rrule || !is_array($rrule) || empty($rrule['exdate']) || !is_array($rrule['exdate'])) {
+            return [];
+        }
+
+        $datumok = [];
+        foreach ($rrule['exdate'] as $ertek) {
+            try {
+                $datumok[] = (new \DateTime((string) $ertek))->format('Y-m-d');
+            } catch (\Throwable $e) {
+                // Értelmezhetetlen dátumot inkább kihagyunk, mint hogy szemetet exportáljunk.
+            }
+        }
+
+        $datumok = array_values(array_unique($datumok));
+        sort($datumok);
+
+        return $datumok;
+    }
+
+    /** UTC-re normalizált, RFC 5545 alakú időbélyeg. */
+    private static function rfcDatum($ertek): string {
+        try {
+            return (new \DateTime((string) $ertek))
+                ->setTimezone(new \DateTimeZone('UTC'))
+                ->format('Ymd\\THis\\Z');
+        } catch (\Throwable $e) {
+            return (string) $ertek;
+        }
+    }
+
     static function humanText($rrule): string
     {
         if (empty($rrule) || !is_array($rrule)) {

--- a/webapp/templates/apidocs.twig
+++ b/webapp/templates/apidocs.twig
@@ -3,13 +3,21 @@
 {% set title = 'API dokumentáció' %}
 {% set columns2 = true %}
 
-{% set currentVersion = 4 %}
+{# #56: a verziószám a kódból jön, nem sablonba írva — így az v6-nál nem marad el. #}
+{% set currentVersion = constant('Api\\Api::LEGUJABB_VERZIO') %}
 
 {% block content %}
 
-<p>Az aktuális API verzió az <strong>API v{{ currentVersion }}</strong>. Az API v3 még támogatott, de kevesebb/pontatlanabb adatokat tartalmaz a misékről. A már nem támogatott API verziók mindenre a „2” szöveges értékkel térnek vissza.</p>
+<p>Az aktuális API verzió az <strong>API v{{ currentVersion }}</strong>. Az API v3 és v4 továbbra is támogatott — a v4 válasza változatlan marad. A már nem támogatott API verziók mindenre a „2” szöveges értékkel térnek vissza.</p>
 <p>Természetesen https a megfelelő kommunikációs csatorna.</p>
-<p>Figyelem az API v4 alatt olykor bővülnek funkciók, és adatok. Az <a href="https://github.com/borazslo/miserend.hu/issues/56">API v5</a> tervezése már folyik.</p>
+
+<h4>Mi új az API v5-ben?</h4>
+<p>A v5 <strong>bővítés, nem csere</strong>: minden mező megmarad, ami a v4-ben volt, és mellé jönnek az újak. Így a meglévő kliensek mezőnként állhatnak át.</p>
+<ul>
+    <li><strong>Strukturált mise-adat.</strong> A v4-ben a mise két mező volt: <code>idopont</code> és <code>informacio</code> — az utóbbi egy előre összerakott magyar mondat („Római katolikus Szentmise”). Ebből nem lehetett szűrni és fordítani sem. A v5 mellétesz: <code>mise_id</code>, <code>ritus</code>, <code>megnevezes</code>, <code>nyelvek</code>, <code>tipusok</code>, <code>megjegyzes</code>, <code>hossz_perc</code>. Az <code>informacio</code> a v5-ben is megmarad.</li>
+    <li><strong>A nyelv mindig lista.</strong> Egy misének több nyelve is lehet (például szlovák-latin), ezért a <code>nyelvek</code> akkor is tömb, ha csak egy elem van benne.</li>
+    <li><strong>Rövidebb képútvonal.</strong> A <code>photos</code> a v5-ben <code>{templomid}/{fájlnév}</code> alakú; a teljes cím ebből <code>{{ constant('DOMAIN') }}/kepek/templomok/</code> előtaggal áll össze.</li>
+</ul>
 <p><strong>Kérünk minden API használót, hogy vegye fel velünk a kapcsolatot!</strong></p>
 
 

--- a/webapp/tests/Api/ApiTest.php
+++ b/webapp/tests/Api/ApiTest.php
@@ -67,14 +67,30 @@ class ApiTest extends TestCase {
         $api->validateVersionMain();
     }
 
-    public function testValidateVersionMainRejectsVersion5() {
+    /**
+     * #56: itt korábban azt rögzítettük, hogy az 5-ös verzió NINCS. Azóta van, tehát a
+     * teszt a kiadott verziók listájával együtt mozgó számot mért — nem invariánst.
+     *
+     * A valódi állítás az, hogy a legújabbnál eggyel nagyobb verzió elutasításra kerül.
+     * Így a teszt akkor is helyes marad, amikor jön a v6.
+     */
+    public function testValidateVersionMainRejectsTheVersionAboveTheLatest() {
         $api = new Api();
-        $api->version = 5;
-        
+        $api->version = Api::LEGUJABB_VERZIO + 1;
+
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Invalid API version.');
-        
+
         $api->validateVersionMain();
+    }
+
+    /** A legújabb kiadott verziót viszont el kell fogadni. */
+    public function testValidateVersionMainAcceptsTheLatestVersion() {
+        $api = new Api();
+        $api->version = Api::LEGUJABB_VERZIO;
+
+        $api->validateVersionMain();
+        $this->assertSame(Api::LEGUJABB_VERZIO, $api->version);
     }
 
     public function testValidateVersionMainRejectsNonNumericVersion() {

--- a/webapp/tests/Api/ApiV5Test.php
+++ b/webapp/tests/Api/ApiV5Test.php
@@ -1,0 +1,186 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #56: API v5.
+ *
+ * A jegy tizenegy éven át gyűlt ötletzsák; ebből ez a rész a 2025-ös és 2026-os
+ * bejegyzés: „az egész átadott mise adatok kövessék majd a nagy megújulás calendar
+ * típusú új állapotát", illetve „többféle nyelv tartozhasson egy eseményhez".
+ *
+ * A v4 mise-adata két mező volt: egy időbélyeg és egy ELŐRE ÖSSZERAKOTT MAGYAR MONDAT
+ * („Római katolikus Szentmise"). A kliens ebből nem tud szűrni rítusra, nyelvre vagy
+ * típusra, nem tud fordítani, és a hosszt sem tudja — pedig mindez strukturáltan
+ * megvan a `cal_masses`-ben.
+ *
+ * A v5 ezért BŐVÍTÉS, nem csere: az `informacio` megmarad a strukturált mezők mellett,
+ * hogy a meglévő kliens (KAPP) mezőnként állhasson át.
+ *
+ * A tesztek a válasz ALAKJÁT rögzítik, nem a tartalmát: az adat változhat, a szerződés nem.
+ */
+class ApiV5Test extends TestCase {
+
+    private const TESZT_TEMPLOM = 1;
+
+    /** @return array a templom API-tömbje az adott verzióban */
+    private function church(int $verzio, string $length = 'minimal'): array {
+        return \Eloquent\Church::find(self::TESZT_TEMPLOM)
+            ->toAPIArray($length, false, $verzio);
+    }
+
+    /* ---------- verzió-kezelés ---------- */
+
+    public function testTheFifthVersionIsAccepted(): void {
+        $api = new \Api\Api();
+        $api->version = 5;
+
+        $api->validateVersionMain();
+        self::assertSame(5, $api->version);
+    }
+
+    public function testAnUnknownVersionIsRejected(): void {
+        $api = new \Api\Api();
+        $api->version = 99;
+
+        $this->expectException(\Exception::class);
+        $api->validateVersionMain();
+    }
+
+    /**
+     * A régebbi verziók változatlanul élnek: a v5 bevezetése nem kapcsolhat ki semmit,
+     * amíg a kliensek át nem álltak.
+     *
+     * @dataProvider korabbiVerziok
+     */
+    public function testEarlierVersionsStillWork(int $verzio): void {
+        $api = new \Api\Api();
+        $api->version = $verzio;
+
+        $api->validateVersionMain();
+        self::assertSame($verzio, $api->version);
+    }
+
+    public static function korabbiVerziok(): array {
+        return [[1], [2], [3], [4]];
+    }
+
+    /* ---------- a v4 válasza NEM változhat ---------- */
+
+    public function testTheFourthVersionMassPayloadIsUnchanged(): void {
+        $misek = $this->church(4)['misek'];
+
+        if (!$misek) {
+            self::markTestSkipped('ezen a napon nincs mise ezen a templomon');
+        }
+
+        foreach ($misek as $mise) {
+            self::assertSame(['idopont', 'informacio'], array_keys($mise),
+                'a v4 mise-adata bővült — meglévő kliensek szerződését sértjük');
+        }
+    }
+
+    public function testTheFourthVersionStillSendsFullPhotoUrls(): void {
+        $photos = $this->church(4, 'full')['photos'];
+
+        if (!$photos) {
+            self::markTestSkipped('ennek a templomnak nincs képe');
+        }
+        self::assertStringStartsWith('/kepek/templomok/', $photos[0]);
+    }
+
+    /* ---------- a v5 új tartalma ---------- */
+
+    public function testTheFifthVersionKeepsTheHumanReadableSentence(): void {
+        $misek = $this->church(5)['misek'];
+
+        if (!$misek) {
+            self::markTestSkipped('ezen a napon nincs mise ezen a templomon');
+        }
+        self::assertArrayHasKey('informacio', $misek[0],
+            'az informacio a v5-ben is kell: enélkül a KAPP nem tud fokozatosan átállni');
+    }
+
+    public function testTheFifthVersionAddsStructuredMassFields(): void {
+        $misek = $this->church(5)['misek'];
+
+        if (!$misek) {
+            self::markTestSkipped('ezen a napon nincs mise ezen a templomon');
+        }
+
+        foreach (['mise_id', 'ritus', 'megnevezes', 'nyelvek', 'tipusok', 'megjegyzes', 'hossz_perc'] as $mezo) {
+            self::assertArrayHasKey($mezo, $misek[0], 'hiányzik a v5 mezője: ' . $mezo);
+        }
+    }
+
+    /** A típusok rögzítettek: a kliens ezekre épít. */
+    public function testTheStructuredFieldsHaveStableTypes(): void {
+        $misek = $this->church(5)['misek'];
+
+        if (!$misek) {
+            self::markTestSkipped('ezen a napon nincs mise ezen a templomon');
+        }
+
+        $mise = $misek[0];
+        self::assertIsInt($mise['mise_id']);
+        self::assertIsString($mise['ritus']);
+        self::assertIsString($mise['megnevezes']);
+        self::assertIsString($mise['megjegyzes']);
+        self::assertIsInt($mise['hossz_perc']);
+        // #334: egy misének több nyelve is lehet — ezért MINDIG lista, akkor is, ha egy.
+        self::assertIsArray($mise['nyelvek']);
+        self::assertIsArray($mise['tipusok']);
+    }
+
+    /**
+     * A nyelv listaként megy, nem a magyar mondatba ágyazva.
+     *
+     * Ez borazslo 2026-os kérése. Belül már megvolt (#334), csak az API nem adta ki.
+     */
+    public function testLanguagesAreSentAsAList(): void {
+        $misek = $this->church(5)['misek'];
+
+        if (!$misek) {
+            self::markTestSkipped('ezen a napon nincs mise ezen a templomon');
+        }
+
+        foreach ($misek as $mise) {
+            self::assertIsArray($mise['nyelvek']);
+            self::assertSame(array_values($mise['nyelvek']), $mise['nyelvek'],
+                'a lista indexei nem folytonosak — JSON-ben objektumként jelenne meg');
+            foreach ($mise['nyelvek'] as $nyelv) {
+                self::assertIsString($nyelv);
+            }
+        }
+    }
+
+    /**
+     * A képek rövid úton: `{templomid}/{fájlnév}`.
+     *
+     * A teljes cím minden képnél megismételte ugyanazt az előtagot; a bázis ismert és
+     * állandó (`{domain}/kepek/templomok/`).
+     */
+    public function testTheFifthVersionSendsShortPhotoPaths(): void {
+        $photos = $this->church(5, 'full')['photos'];
+
+        if (!$photos) {
+            self::markTestSkipped('ennek a templomnak nincs képe');
+        }
+
+        foreach ($photos as $kep) {
+            self::assertStringNotContainsString('/kepek/', $kep, 'maradt benne az előtag');
+            self::assertMatchesRegularExpression('#^\d+/[^/]+$#', $kep,
+                'nem {templomid}/{fájlnév} alakú: ' . $kep);
+        }
+    }
+
+    /** Verzió nélkül a régi alak jön: a keresőindex építése is ezen az úton megy. */
+    public function testWithoutAVersionTheOldShapeIsReturned(): void {
+        $misek = \Eloquent\Church::find(self::TESZT_TEMPLOM)->toAPIArray('minimal')['misek'];
+
+        if (!$misek) {
+            self::markTestSkipped('ezen a napon nincs mise ezen a templomon');
+        }
+        self::assertArrayNotHasKey('ritus', $misek[0]);
+    }
+}

--- a/webapp/tests/Api/ApiV5Test.php
+++ b/webapp/tests/Api/ApiV5Test.php
@@ -23,10 +23,20 @@ class ApiV5Test extends TestCase {
 
     private const TESZT_TEMPLOM = 1;
 
-    /** @return array a templom API-tömbje az adott verzióban */
+    /**
+     * @return array a templom API-tömbje az adott verzióban
+     *
+     * A napot KIFEJEZETTEN megadjuk. Alapértelmezésben a `toAPIArray()` a mai napra
+     * kérdez, és ha épp nincs mise, a teszt csak kihagyásra fut — vagyis a futások
+     * fele nem mér semmit. A következő vasárnapon minden templomnak van miséje.
+     */
     private function church(int $verzio, string $length = 'minimal'): array {
         return \Eloquent\Church::find(self::TESZT_TEMPLOM)
-            ->toAPIArray($length, false, $verzio);
+            ->toAPIArray($length, self::kovetkezoVasarnap(), $verzio);
+    }
+
+    private static function kovetkezoVasarnap(): string {
+        return date('Y-m-d', strtotime('next sunday'));
     }
 
     /* ---------- verzió-kezelés ---------- */
@@ -74,9 +84,15 @@ class ApiV5Test extends TestCase {
             self::markTestSkipped('ezen a napon nincs mise ezen a templomon');
         }
 
+        /*
+         * Részhalmazt mérünk, nem pontos egyezést: az `informacio` KIMARAD, ha a
+         * mondat üresre jönne ki (`if($info != '')`). A lényeg, hogy a v4-be ne
+         * kerüljön ÚJ mező — az sértené a meglévő kliensek szerződését.
+         */
         foreach ($misek as $mise) {
-            self::assertSame(['idopont', 'informacio'], array_keys($mise),
-                'a v4 mise-adata bővült — meglévő kliensek szerződését sértjük');
+            self::assertSame([], array_diff(array_keys($mise), ['idopont', 'informacio']),
+                'a v4 mise-adata új mezővel bővült: ' . implode(', ', array_keys($mise)));
+            self::assertArrayHasKey('idopont', $mise);
         }
     }
 
@@ -176,7 +192,8 @@ class ApiV5Test extends TestCase {
 
     /** Verzió nélkül a régi alak jön: a keresőindex építése is ezen az úton megy. */
     public function testWithoutAVersionTheOldShapeIsReturned(): void {
-        $misek = \Eloquent\Church::find(self::TESZT_TEMPLOM)->toAPIArray('minimal')['misek'];
+        $misek = \Eloquent\Church::find(self::TESZT_TEMPLOM)
+            ->toAPIArray('minimal', self::kovetkezoVasarnap())['misek'];
 
         if (!$misek) {
             self::markTestSkipped('ezen a napon nincs mise ezen a templomon');

--- a/webapp/tests/Integration/SqliteV5MassFormatTest.php
+++ b/webapp/tests/Integration/SqliteV5MassFormatTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #800: az API v5 sqlite-exportjának mise-formátuma.
+ *
+ * borazslo kérése:
+ *
+ *   „minden mise a generált periódussal sokszorozva (vagyis konkrét dátumtól dátumig)
+ *    és az exdates azok konkrét dátumok […] Így egyszerű táblázat, de rrule-al könnyen
+ *    sokszorosítható és kerestethető."
+ *
+ * A v4-ig minden EGYES előfordulás külön sor volt (`datumtol = datumig = egy nap`,
+ * "Ezen a napon: …"), fél évre előre felszorozva. A v5 ehelyett periódusonként egy
+ * sort ad, a szabállyal és a kivételekkel — a fejlesztői adatbázis első templomán
+ * mérve ez két évre 43 sor 1229 előfordulás helyett.
+ */
+class SqliteV5MassFormatTest extends TestCase {
+
+    /** @return array<string,mixed> egy generált periódus-példány sqlite-sora */
+    private function sor(array $periodus, array $idoszakNevek = []): array {
+        $r = new ReflectionClass(\Api\Sqlite::class);
+        $api = $r->newInstanceWithoutConstructor();
+
+        $verzio = $r->getProperty('version');
+        $verzio->setAccessible(true);
+        $verzio->setValue($api, 5);
+
+        $metodus = $r->getMethod('massPeriodToRow');
+        $metodus->setAccessible(true);
+
+        return $metodus->invoke($api, $periodus, $idoszakNevek);
+    }
+
+    /** @return array<string,mixed> tipikus generált periódus */
+    private function periodus(array $felulir = []): array {
+        return array_merge([
+            'mass_id' => 97874,
+            'generated_period_id' => 792,
+            'church_id' => 1,
+            'start_date' => '2026-11-29',
+            'end_date' => '2026-12-24',
+            'types' => [],
+            'duration_minutes' => 45,
+            'lang' => ['hu'],
+            'comment' => 'rorate',
+            'rrule' => [
+                'freq' => 'weekly',
+                'until' => '2026-12-24T23:59:59+01:00',
+                'dtstart' => '2026-11-29T07:00:00+01:00',
+                'byweekday' => ['MO', 'WE'],
+            ],
+        ], $felulir);
+    }
+
+    /** A lényeg: KONKRÉT dátumtól dátumig, nem "ezen a napon". */
+    public function testAPeriodusKonkretDatumtartomanytAd(): void {
+        $sor = $this->sor($this->periodus());
+
+        self::assertSame('2026-11-29', $sor['datumtol']);
+        self::assertSame('2026-12-24', $sor['datumig']);
+        self::assertNotSame($sor['datumtol'], $sor['datumig'],
+            'A v4 egyetlen napra szűkített minden sort — a v5 épp ezt váltja ki.');
+    }
+
+    public function testAzIsmetlodesRruleKentMegy(): void {
+        self::assertSame('FREQ=WEEKLY;UNTIL=20261224T225959Z;BYDAY=MO,WE', $this->sor($this->periodus())['rrule']);
+    }
+
+    public function testAzIdopontADtstartbolJon(): void {
+        self::assertSame('07:00:00', $this->sor($this->periodus())['ido']);
+    }
+
+    public function testAKivetelekKonkretDatumok(): void {
+        $periodus = $this->periodus();
+        $periodus['rrule']['exdate'] = ['2026-12-08T07:00:00+01:00', '2026-12-01'];
+
+        self::assertSame('2026-12-01,2026-12-08', $this->sor($periodus)['exdate']);
+    }
+
+    /**
+     * Egy mise több periódussal is szerepel (téli/nyári/adventi), ezért a
+     * fogyasztónak tudnia kell, hogy ugyanarról a miséről van szó.
+     */
+    public function testAMiseAzonositojaMegmarad(): void {
+        self::assertSame(97874, $this->sor($this->periodus())['mise_id']);
+    }
+
+    public function testAzIdoszakNeveKikerul(): void {
+        self::assertSame('Advent', $this->sor($this->periodus(), [792 => 'Advent'])['idoszak']);
+    }
+
+    public function testIsmeretlenIdoszaknalUresANev(): void {
+        self::assertSame('', $this->sor($this->periodus())['idoszak']);
+    }
+
+    public function testAHosszPercbenMegy(): void {
+        self::assertSame(45, $this->sor($this->periodus())['hossz']);
+    }
+
+    public function testATobbNyelvVesszovelMegy(): void {
+        self::assertSame('hu,de', $this->sor($this->periodus(['lang' => ['hu', 'de']]))['nyelv']);
+    }
+
+    /** Hiányos periódusnál se szálljon el az export. */
+    public function testHianyosPeriodusnalSemDob(): void {
+        $sor = $this->sor(['church_id' => 1, 'mass_id' => 5]);
+
+        self::assertSame(1, $sor['tid']);
+        self::assertSame('', $sor['rrule']);
+        self::assertNull($sor['ido']);
+    }
+
+    // ---- a valódi adat ------------------------------------------------------
+
+    /**
+     * A generált szerkezet MINDEN mezője megvan, amire a leképezés épít. Ha a
+     * CalMass kimenete változik, ez a teszt fogja meg, nem az éles export.
+     */
+    public function testAGeneraltSzerkezetTartalmazzaAVartMezoket(): void {
+        $mise = \Eloquent\CalMass::first();
+        if ($mise === null) {
+            self::markTestSkipped('Nincs mise a teszt-adatbázisban.');
+        }
+
+        $masses = \Eloquent\CalMass::where('church_id', $mise->church_id)->get()->all();
+        $periodusok = \Eloquent\CalMass::generateMassPeriodInstancesForYears($masses, [], [(int) date('Y')]);
+
+        self::assertNotEmpty($periodusok);
+
+        foreach (['mass_id', 'generated_period_id', 'church_id', 'start_date', 'end_date',
+                  'duration_minutes', 'lang', 'comment', 'rrule'] as $mezo) {
+            self::assertArrayHasKey($mezo, reset($periodusok), "Hiányzó mező: $mezo");
+        }
+    }
+
+    /** A v5 táblája tartalmazza az új oszlopokat. */
+    public function testAzOtosVerzioTablajaTartalmazzaARruleOszlopot(): void {
+        $forras = file_get_contents(PATH . 'classes/api/sqlite.php');
+
+        self::assertMatchesRegularExpression('/\$this->version >= 5/', $forras);
+        foreach (['[rrule]', '[exdate]', '[mise_id]', '[hossz]'] as $oszlop) {
+            self::assertStringContainsString($oszlop, $forras, "Hiányzó v5 oszlop: $oszlop");
+        }
+    }
+}

--- a/webapp/tests/Unit/RruleSerializationTest.php
+++ b/webapp/tests/Unit/RruleSerializationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #800: az ismétlődési szabály szöveges alakja.
+ *
+ * Ez eddig a `Html\Church\Ical` privát metódusa volt. Az sqlite-export (API v5)
+ * ugyanezt igényli — borazslo kifejezetten az iCal formátumát kérte referenciának —,
+ * ezért közösbe került. A tesztek azt rögzítik, hogy a két kimenet nem tud
+ * szétcsúszni: ugyanaz a szabály ugyanazt a sztringet adja mindkét helyen.
+ */
+class RruleSerializationTest extends TestCase {
+
+    public function testHetiSzabaly(): void {
+        $szabaly = ['freq' => 'weekly', 'byweekday' => ['MO', 'WE']];
+
+        self::assertSame('FREQ=WEEKLY;BYDAY=MO,WE', \SimpleRRule::toRfcString($szabaly));
+    }
+
+    /** A `byweekday` a mi nevünk, az RFC 5545-é `BYDAY`. */
+    public function testAByweekdayBydayraFordul(): void {
+        self::assertStringContainsString('BYDAY=', \SimpleRRule::toRfcString(['freq' => 'weekly', 'byweekday' => ['SU']]));
+        self::assertStringNotContainsString('BYWEEKDAY', \SimpleRRule::toRfcString(['freq' => 'weekly', 'byweekday' => ['SU']]));
+    }
+
+    /** A dtstart nem a szabály része, hanem az esemény kezdete. */
+    public function testADtstartNemKerulBele(): void {
+        $szoveg = \SimpleRRule::toRfcString(['freq' => 'weekly', 'dtstart' => '2026-11-29T07:00:00+01:00']);
+
+        self::assertSame('FREQ=WEEKLY', $szoveg);
+    }
+
+    public function testAzUntilUtcbenMegy(): void {
+        $szoveg = \SimpleRRule::toRfcString(['freq' => 'weekly', 'until' => '2026-12-24T23:59:59+01:00']);
+
+        self::assertSame('FREQ=WEEKLY;UNTIL=20261224T225959Z', $szoveg,
+            'Az UNTIL-nek UTC-ben, Z-vel zárva kell mennie.');
+    }
+
+    public function testAzExdateNemKerulAzRruleBe(): void {
+        $szoveg = \SimpleRRule::toRfcString(['freq' => 'weekly', 'exdate' => ['2026-12-08']]);
+
+        self::assertSame('FREQ=WEEKLY', $szoveg,
+            'A kivétel külön mező — a szabályba keverve értelmezhetetlen lenne.');
+    }
+
+    public function testUresSzabaly(): void {
+        self::assertSame('', \SimpleRRule::toRfcString([]));
+        self::assertSame('', \SimpleRRule::toRfcString(null));
+    }
+
+    // ---- kivételek -----------------------------------------------------------
+
+    /** borazslo kérése: "az exdates azok konkrét dátumok". */
+    public function testAzExdatekKonkretDatumok(): void {
+        $datumok = \SimpleRRule::exdates(['exdate' => ['2026-12-08T07:00:00+01:00', '2026-12-01']]);
+
+        self::assertSame(['2026-12-01', '2026-12-08'], $datumok);
+    }
+
+    public function testAzExdatekRendezettekEsEgyediek(): void {
+        $datumok = \SimpleRRule::exdates(['exdate' => ['2026-12-08', '2026-12-01', '2026-12-08']]);
+
+        self::assertSame(['2026-12-01', '2026-12-08'], $datumok);
+    }
+
+    public function testExdateNelkulUresLista(): void {
+        self::assertSame([], \SimpleRRule::exdates(['freq' => 'weekly']));
+        self::assertSame([], \SimpleRRule::exdates(null));
+    }
+
+    /** Értelmezhetetlen dátumot inkább kihagyunk, mint hogy szemetet exportáljunk. */
+    public function testAzErtelmezhetetlenDatumKimarad(): void {
+        $datumok = \SimpleRRule::exdates(['exdate' => ['2026-12-08', 'nem dátum']]);
+
+        self::assertSame(['2026-12-08'], $datumok);
+    }
+}

--- a/webapp/tests/bootstrap.php
+++ b/webapp/tests/bootstrap.php
@@ -41,6 +41,18 @@ dbconnect();
 
 date_default_timezone_set('Europe/Budapest');
 
+/*
+ * A `t()` fordító-rövidítést a load.php definiálja, a tesztek viszont nem azt töltik be.
+ * Enélkül minden olyan út elszáll „Call to undefined function t()"-vel, ami felhasználónak
+ * szánt szöveget állít elő — például a templom API-tömbje (Church::toAPIArray).
+ */
+Translator::init('hu');
+if (!function_exists('t')) {
+    function t($text, $default = null) {
+        return Translator::translate($text, $default);
+    }
+}
+
 // A levélküldés Twig-sablonból áll elő (\Eloquent\Email::render()), így $twig nélkül
 // egyetlen email-út sem tesztelhető. Ugyanaz a környezet, mint amit a load.php épít.
 //


### PR DESCRIPTION
Closes #56

A jegy tizenegy éven át gyűlt ötletzsák (2015–2026). Végigvettem mind a hatot; kettő időközben tárgytalanná vált, egy üzemeltetési döntés, három megcsinálható — ez a PR az a három.

## Amit a v4 ma ad

```json
"misek": [
  {"idopont": "2026-08-16 10:00:00", "informacio": "Római katolikus Szentmise"}
]
```

Két mező: egy időbélyeg és egy **előre összerakott magyar mondat**. A kliens ebből nem tud szűrni rítusra, nyelvre vagy típusra, nem tud fordítani (a mondatot mi raktuk össze, szerveroldalon, magyarul), és a mise hosszát sem tudja. Közben mindez strukturáltan megvan a `cal_masses`-ben — csak nem adtuk ki. Ez a 2025-ös kérésed: *„az egész átadott mise adatok kövessék majd a nagy megújulás calendar típusú új állapotát."*

## Amit a v5 ad

```json
"misek": [
  {
    "idopont": "2026-08-16 10:00:00",
    "informacio": "Római katolikus Szentmise",
    "mise_id": 97885,
    "ritus": "ROMAN_CATHOLIC",
    "megnevezes": "Szentmise",
    "nyelvek": ["hu"],
    "tipusok": [],
    "megjegyzes": "",
    "hossz_perc": 0
  }
]
```

**Bővítés, nem csere.** Az `informacio` a v5-ben is megmarad, így a KAPP mezőnként állhat át, nem egyszerre kell mindent átírnia. A `v1`–`v4` válasza **változatlan** — teszt is őrzi, hogy oda ne kerüljön új mező.

**A nyelv mindig lista.** Ez a 2026-os kérésed. Belül már kész volt (#334: egy misének lehet szlovák-latin, német-magyar rendje), csak az API nem adta ki, hanem beleolvasztotta a magyar mondatba.

**Rövidebb képútvonal** (2016-os ötleted): a `photos` a v5-ben `{templomid}/{fájlnév}`, a teljes cím helyett. Az előtag minden képnél ugyanaz volt.

```
v4: ["/kepek/templomok/1/1771584749.jpg", ...]
v5: ["1/1771584749.jpg", ...]
```

A másik változatod — egyedi kép-azonosító — szerveroldali munkát is igényelne, azt nem vittem be.

## Amit nem csináltam meg

**Kötelező HTTPS** (2015): a kódban nincs kényszerítés. Ez üzemeltetési döntés, nem fejlesztés — élesben a proxy amúgy is https, kódszinten viszont a helyi fejlesztést és a http-s klienseket törné el.

**A `misek.periodus` kilenc 0/1 mezőre bontása és a `milyen`/`nyelv` tagadás** (2015): **tárgytalan.** A `misek` táblát azóta felváltotta a `cal_masses` + `cal_periods` + rrule; ezek a problémák ott másképp, jobban meg vannak oldva. Ezt a két pontot szerintem le lehet zárni.

## Mellékesen

Az útvonal mostantól **bármilyen** verziószámot elfogad, a listát a validáció tartja. Eddig három regexben állt `v[1-4]` a `Html\Api`-ban: ha az v5-nél egy kimarad, a hívó néma átirányítást kap az `/apidocs`-ra a „hibás verzió" üzenete helyett. Most a `v9` rendes hibaüzenetet ad.

A meglévő `testValidateVersionMainRejectsVersion5` azt rögzítette, hogy az 5-ös verzió **nincs** — vagyis a kiadott verziók listájával együtt mozgó számot mért, nem invariánst. Átírtam: a legújabbnál eggyel nagyobb verzió elutasítására.

A teszt-bootstrap eddig nem ismerte a `t()` fordító-rövidítést (azt a `load.php` definiálja), ezért minden felhasználónak szánt szöveget előállító út `Call to undefined function t()`-vel szállt el a tesztekben — emiatt nem volt eddig teszt a `Church::toAPIArray()`-re sem. Pótoltam.

Az `/apidocs` a verziószámot mostantól a kódból veszi, és leírja, mi új a v5-ben.

## Teszt

14 új teszt (verzió-kezelés, a v4 változatlansága, a v5 mezői és típusai, nyelvlista, képútvonal). Teljes csomag: **897 zöld**, három egymás utáni futáson stabil.

---

# Kiegészítés: #800 — átküldött miserend az sqlite-ban

@borazslo a #800-ban ezt kérte:

> Az sqlite-ban a misék régi adat struktúrában kerülnek kiküldésre. A helyes az az lenne, hogy egy olyan változat menjen ki, amiből nagyon könnyű generálni miséket. Vagyis az a formátum kb ami az ical-ba megy ki. Vagyis minden mise a generált periódussal sokszorozva (vagyis konkrét dátumtól dátumig) és az exdates azok konkrét dátumok […] Így egyszerű táblázat, de rrule-al könnyen sokszorosítható és kerestethető.

## Mi volt eddig

A v4-ig **minden egyes előfordulás külön sor**, a keresőindexből fél évre előre felszorozva:

```
datumtol = 1129,  datumig = 1129,  idoszak = "Ezen a napon: 2026-11-29"
```

## Mi lesz a v5-ben

Periódusonként **egy** sor, a szabállyal és a kivételekkel:

```
mise_id  = 97874
idoszak  = "Advent"
datumtol = 2026-11-29        <- KONKRÉT dátum, évvel
datumig  = 2026-12-24
ido      = 07:00:00
hossz    = 45
rrule    = FREQ=WEEKLY;UNTIL=20261224T225959Z;BYDAY=MO,TU,WE,FR
exdate   = 2026-12-01,2026-12-08
```

A fejlesztői adatbázis első templomán, két évre mérve:

| | db |
|---|---:|
| v5 periódus-sor | **43** |
| konkrét előfordulás | 1229 |
| tömörítés | **28,6×** |

## Miért nem csúszhat el az iCal-tól

A forrás **ugyanaz**: `CalMass::generateMassPeriodInstancesForYears()` — pontosan az, amiből az iCal-export is dolgozik. Az `rrule` szöveges alakját ehhez közösbe emeltem (`SimpleRRule::toRfcString()` / `::exdates()`); eddig a `Html\Church\Ical` privát metódusa volt, tehát a két kimenet szétcsúszhatott volna.

## Új v5 oszlopok

- **`mise_id`** — egy mise több időszakkal is szerepel (téli/nyári/adventi); ezen ismerhető fel, hogy ugyanarról a miséről van szó
- **`hossz`** — a mise hossza percben
- **`rrule`**, **`exdate`**

A `datumtol`/`datumig` konkrét dátum lett (a v4-ben hónap+nap volt, **év nélkül**). A `nyelv` és `milyen` szélesebb, mert listát tartalmaznak.

**A v4 és korábbi változatlan** — @borazslo szerint „a v4 a fix".

## Amit NEM csináltam meg

A templomonkénti teljes miserend opcionális kiadását. A jegy is így zárul: *„De ebben nem vagyok biztos."* Ez termékdöntés, nem az enyém.

## Ellenőrzés

22 új teszt: az rrule-szerializálás (BYDAY-fordítás, UTC-s UNTIL, a dtstart és az exdate kihagyása a szabályból), a kivételek konkrét dátumokká alakítása rendezve és egyediesítve, a periódus→sor leképezés minden mezője, hiányos periódus, és hogy a generált szerkezet tartalmazza az összes mezőt, amire a leképezés épít.

```
PHP-suite: 919 teszt, 2155 állítás — zöld
```

Closes #800
