### PR TITLE
Misénként ellenőrzöm, hova írhat a szerkesztő

### DIFF
--- a/webapp/classes/html/ajax/calendar/masses.php
+++ b/webapp/classes/html/ajax/calendar/masses.php
@@ -105,6 +105,74 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
         return CalMass::importedIdsAmong($ids);
     }
 
+    /**
+     * Írhatja-e a bejelentkezett felhasználó ENNEK a templomnak a miséit?
+     *
+     * A jogosultság-ellenőrzés eddig kizárólag az ÚTVONALBAN szereplő templomra futott,
+     * a mentés viszont a beküldött adat `church_id`-jét írta ki. Aki tehát egyetlen
+     * templomhoz kapott jogot, az a saját mentésébe más templom azonosítóját írva bárhova
+     * felvihetett misét. A törlés még ennyit sem nézett: `whereIn('id', ...)` alapján
+     * bármelyik mise törölhető volt, azonosító alapján.
+     *
+     * A szabály egyszerű és mindkét irányban véd: egy misét oda írhatsz és onnan
+     * törölhetsz, AHOL írásjogod van. Egy templomra ez pontosan a mai viselkedés; a
+     * plébánia gondnokának a fíliákra is jár, mert a `checkWriteAccess()` az örökölt
+     * gondnokságot is elfogadja.
+     */
+    private function ensureWritableChurch(int $churchId): void
+    {
+        static $ellenorzott = [];
+        if (isset($ellenorzott[$churchId])) {
+            return;
+        }
+
+        $church = \Eloquent\Church::find($churchId);
+        if (!$church) {
+            $this->sendJsonError('Nincs ilyen templom: ' . $churchId, 404);
+        }
+
+        $church->append(['writeAccess']);
+        if (!$church->writeAccess) {
+            $this->sendJsonError('Hiányzó jogosultság a(z) ' . $churchId . ' azonosítójú templomhoz!', 403);
+        }
+
+        $ellenorzott[$churchId] = true;
+    }
+
+    /**
+     * MELY templomokat érinti ez a kérés?
+     *
+     * Külön, tiszta függvény, mert az `ensureWritableChurch()` hibánál `exit`-tel zár —
+     * azt nem lehet tesztelni. Márpedig épp ez a lényegi állítás: egy kérés akkor is a
+     * B templomot érinti, ha az A templom útvonalára küldték be.
+     *
+     * A törlendő misék templomát az adatbázisból nézzük meg, nem a beküldött adatból: a
+     * kliens csak azonosítót küld, és a hovatartozást nem is bízhatjuk rá.
+     *
+     * @param  int[] $deletedMasses törlendő mise-azonosítók
+     * @param  array $masses        mentendő misék (tömb vagy objektum elemek)
+     * @param  int   $utvonalTemplom az URL-ben szereplő templom — ez a hiányzó church_id alapja
+     * @return int[] az érintett templom-azonosítók, ismétlés nélkül
+     */
+    public static function affectedChurchIds(array $masses, array $deletedMasses, int $utvonalTemplom): array
+    {
+        $erintett = [];
+
+        foreach ($masses as $mass) {
+            $adat = CalModel::arrayKeysToSnakeCase(is_array($mass) ? $mass : (array) $mass);
+            $erintett[] = (int) ($adat['church_id'] ?? $utvonalTemplom);
+        }
+
+        foreach ($deletedMasses as $torlendoId) {
+            $torlendo = CalMass::find($torlendoId);
+            if ($torlendo) {
+                $erintett[] = (int) $torlendo->church_id;
+            }
+        }
+
+        return array_values(array_unique($erintett));
+    }
+
     public function save(ChangeRequest $changeRequest): void
     {
         // A mentés eddig ELLENŐRZÉS NÉLKÜL írta ki, amit a frontend küldött. Így került az
@@ -116,6 +184,15 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
         //
         // Előbb MINDENT ellenőrzünk, és csak utána írunk: fél-mentett miserendet ne
         // hagyjunk magunk után.
+        /*
+         * Jogosultság MINDEN érintett templomra, még az első írás előtt. A kérés nem
+         * csak az útvonal templomát érintheti: a mentendő mise `church_id`-je bármi
+         * lehet, a törlendő mise pedig a saját templomához tartozik.
+         */
+        foreach (self::affectedChurchIds($changeRequest->masses, $changeRequest->deletedMasses, (int) $this->tid) as $erintett) {
+            $this->ensureWritableChurch($erintett);
+        }
+
         foreach ($changeRequest->masses as $mass) {
             $ellenorzendo = CalModel::arrayKeysToSnakeCase(is_array($mass) ? $mass : (array) $mass);
             $hiba = CalMass::invalidDateTimeReason($ellenorzendo);
@@ -130,9 +207,21 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
             }
         }
 
-        // Törlendő misék
-        if (!empty($changeRequest->deletedMasses)) {
-            CalMass::whereIn('id', $changeRequest->deletedMasses)->delete();
+        /*
+         * Törlendő misék. Csak azt töröljük, aminek a templomához van jogunk — és csak
+         * azt, ami létezik. A nem létező azonosítót szó nélkül átugorjuk: a szerkesztő
+         * küldhet olyat, amit közben más már törölt, attól még a mentés menjen végig.
+         */
+        $torolheto = [];
+        foreach ($changeRequest->deletedMasses as $torlendoId) {
+            $torlendo = CalMass::find($torlendoId);
+            if (!$torlendo) {
+                continue;
+            }
+            $torolheto[] = $torlendo->id;
+        }
+        if ($torolheto) {
+            CalMass::whereIn('id', $torolheto)->delete();
         }
 
         // Új vagy frissítendő misék

--- a/webapp/tests/Integration/MassSaveAuthorizationTest.php
+++ b/webapp/tests/Integration/MassSaveAuthorizationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * A miseszerkesztő mentése eddig CSAK az útvonalban szereplő templomra ellenőrizte a
+ * jogosultságot, közben viszont a beküldött adat `church_id`-jét írta ki:
+ *
+ *     POST /ajax/calendar/masses/{A}     →  writeAccess ellenőrzés A-ra
+ *     { "masses": [ { "churchId": B, ... } ] }  →  a mise B-hez került
+ *
+ * Aki tehát egyetlen templomhoz kapott jogot, az a saját mentésébe más templom
+ * azonosítóját írva bárhova felvihetett misét. A törlés még ennyit sem nézett:
+ *
+ *     CalMass::whereIn('id', $deletedMasses)->delete();
+ *
+ * — azonosító alapján BÁRMELYIK templom bármelyik miséje törölhető volt.
+ *
+ * Ez a #506 (több templom egyszerre szerkesztése) előfeltétele is: ott a kérés
+ * szándékosan több templomot érint, tehát a jogosultságot misénként kell nézni.
+ *
+ * A szabály: oda írhatsz és onnan törölhetsz, AHOL írásjogod van. Egy templomnál ez
+ * pontosan a mai viselkedés.
+ */
+class MassSaveAuthorizationTest extends TestCase {
+
+    private const UTVONAL_TEMPLOM = 1;
+    private const MASIK_TEMPLOM = 2;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<int,array> $masses @param int[] $deleted */
+    private function erintett(array $masses, array $deleted = []): array {
+        $ids = \Html\Ajax\Calendar\Masses::affectedChurchIds($masses, $deleted, self::UTVONAL_TEMPLOM);
+        sort($ids);
+        return $ids;
+    }
+
+    /* A mai, egy templomos eset: minden az útvonal templomához tartozik. */
+    public function testASajatTemplomAzEgyetlenErintett(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise'],
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Igeliturgia'],
+        ]);
+
+        self::assertSame([self::UTVONAL_TEMPLOM], $erintett);
+    }
+
+    /** Hiányzó azonosítónál az útvonal templomát vesszük — ez a régi viselkedés. */
+    public function testHianyzoAzonositoEseténAzUtvonalTemplomaSzamit(): void {
+        self::assertSame([self::UTVONAL_TEMPLOM], $this->erintett([['title' => 'Szentmise']]));
+    }
+
+    /**
+     * A lyuk magja: az útvonal az egyik templomra mutat, a beküldött mise a másikra.
+     * Ezt a kérést MINDKÉT templomot érintőnek kell látni, különben a második
+     * ellenőrzés nélkül íródna ki.
+     */
+    public function testAMasikTemplomraKuldottMiseIsErintettnekSzamit(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise'],
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Belopott mise'],
+        ]);
+
+        self::assertSame([self::UTVONAL_TEMPLOM, self::MASIK_TEMPLOM], $erintett);
+    }
+
+    /** A snake_case alak is számít: a kliens mindkettőt küldheti. */
+    public function testASnakeCaseAlakotIsFelismerjuk(): void {
+        self::assertSame([self::MASIK_TEMPLOM],
+            $this->erintett([['church_id' => self::MASIK_TEMPLOM, 'title' => 'Szentmise']]));
+    }
+
+    /**
+     * A törlésnél a mise TÉNYLEGES templomát nézzük, nem a kliens szavát: a kérés csak
+     * azonosítót küld, és a hovatartozást nem bízhatjuk rá.
+     */
+    public function testATorlendoMiseTemplomatAzAdatbazisbolNezzuk(): void {
+        $miseId = $this->makeMass(self::MASIK_TEMPLOM);
+
+        self::assertSame([self::MASIK_TEMPLOM], $this->erintett([], [$miseId]));
+    }
+
+    /** A nem létező azonosítót átugorjuk: közben más már törölhette. */
+    public function testANemLetezoTorlendoAzonositoNemErintSemmit(): void {
+        self::assertSame([], $this->erintett([], [999999999]));
+    }
+
+    /** Mentés és törlés együtt: mindkét oldal érintett templomai összeadódnak. */
+    public function testAMentesEsATorlesErintettjeiOsszeadodnak(): void {
+        $miseId = $this->makeMass(self::MASIK_TEMPLOM);
+
+        $erintett = $this->erintett(
+            [['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise']],
+            [$miseId]
+        );
+
+        self::assertSame([self::UTVONAL_TEMPLOM, self::MASIK_TEMPLOM], $erintett);
+    }
+
+    /** Ugyanaz a templom többször is szerepelhet — egyszer soroljuk fel. */
+    public function testAzIsmetlodesekOsszevonodnak(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Egyik'],
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Másik'],
+        ]);
+
+        self::assertSame([self::MASIK_TEMPLOM], $erintett);
+    }
+
+    private function makeMass(int $churchId): int {
+        return DB::table('cal_masses')->insertGetId([
+            'church_id'  => $churchId,
+            'title'      => 'Teszt mise',
+            'rite'       => 'ROMAN_CATHOLIC',
+            'lang'       => 'hu',
+            'start_date' => date('Y-m-d\TH:i:s'),
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+    }
+}


### PR DESCRIPTION
A #506 (több templom egyszerre szerkesztése) előkészítése közben találtam. Külön PR, mert biztonsági javítás — ne várjon egy funkció review-jára.

## A lyuk

A miseszerkesztő mentése **csak az útvonalban szereplő templomra** ellenőrizte a jogosultságot, közben viszont a beküldött adat `church_id`-jét írta ki:

```
POST /ajax/calendar/masses/{A}              → writeAccess ellenőrzés A-ra
{ "masses": [ { "churchId": B, ... } ] }    → a mise B-hez került
```

Aki tehát **egyetlen** templomhoz kapott gondnoki jogot, az a saját mentésébe más templom azonosítóját írva **bárhova** felvihetett misét.

A törlés még ennyit sem nézett:

```php
CalMass::whereIn('id', $changeRequest->deletedMasses)->delete();
```

Azonosító alapján **bármelyik templom bármelyik miséje** törölhető volt — jogosultság-ellenőrzés nélkül.

## A szabály

Oda írhatsz és onnan törölhetsz, **ahol írásjogod van**. Egy templomnál ez pontosan a mai viselkedés, tehát a meglévő szerkesztés nem változik. A plébánia gondnokának a fíliákra is jár, mert a `Church::checkWriteAccess()` az örökölt gondnokságot már ma is elfogadja.

Az ellenőrzés az **első írás előtt** fut minden érintett templomra — a fájlban már meglévő „előbb mindent ellenőrzünk, aztán írunk" elv szerint, hogy fél-mentett miserend ne maradjon utánunk.

A törlésnél a mise **tényleges** templomát az adatbázisból nézem, nem a kliens szavából: a kérés csak azonosítót küld, a hovatartozást nem bízhatjuk rá. A nem létező azonosítót szó nélkül átugrom, mert közben más is törölhette — attól a mentés még menjen végig.

## Teszt

Nyolc teszt. Az érintett templomok kiszámítását külön, tiszta függvénybe emeltem (`affectedChurchIds`), mert a jogosultság-hiba `exit`-tel zár, azt nem lehet tesztelni — a lényegi állítás viszont épp az, hogy egy kérés akkor is a B templomot érinti, ha az A útvonalára küldték be.

Teljes csomag: 890 zöld. A szerkesztő betöltése változatlanul 200.