### PR TITLE
A plébánia és fíliái egy naptárban, közös szerkesztéssel

### DIFF
--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.html
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.html
@@ -14,6 +14,17 @@
 </div>
 <mat-dialog-content class="mat-typography">
 
+  @if (hasChurchChoice) {
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Melyik templomban?</mat-label>
+      <mat-select [ngModel]="data.event.churchId ?? churches[0].id" (ngModelChange)="onChurchChange($event)">
+        @for (church of churches; track church.id) {
+          <mat-option [value]="church.id">{{ church.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  }
+
   <mat-accordion class="example-headers-align" multi>
     <mat-expansion-panel expanded>
       <mat-expansion-panel-header>

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -83,6 +83,25 @@ export class AddFullEventDialogComponent {
   // #454: Új dátum hozzáadásához használt ideiglenes változó
   public newExceptionDate: Date | null = null;
 
+  /**
+   * #506: melyik templomhoz tartozzon az esemény.
+   *
+   * Csak akkor jelenik meg, ha tényleg van miből választani — a plébániának vannak
+   * fíliái, és többhöz is van írásjogunk. Egy templomnál a választó felesleges zaj,
+   * és a dialógus ugyanúgy néz ki, mint eddig.
+   */
+  public get churches() {
+    return this.data.churches ?? [];
+  }
+
+  public get hasChurchChoice(): boolean {
+    return this.churches.length > 1;
+  }
+
+  public onChurchChange(churchId: number): void {
+    this.data.event.churchId = churchId;
+  }
+
   public singleEvent: boolean = this.data.event.renum === Renum.NONE;
   public specialPeriodType?: SpecialType | null = null;
 

--- a/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.html
+++ b/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.html
@@ -10,6 +10,16 @@
       <mat-icon fontSet="material-symbols-outlined" class="icon">calendar_clock</mat-icon>
       <span>{{ dateTime }}</span>
     </div>
+    @if (hasChurchChoice) {
+      <mat-form-field class="simple-church" appearance="outline">
+        <mat-label>Melyik templomban?</mat-label>
+        <mat-select [ngModel]="churchId" (ngModelChange)="onChurchChange($event)">
+          @for (church of churches; track church.id) {
+            <mat-option [value]="church.id">{{ church.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
   </mat-card-content>
   <mat-card-actions>
     <button mat-flat-button (click)="onMoreDetails()">{{ 'SIMPLE_EVENT.MORE_SETTINGS' | translate }}</button>

--- a/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.ts
+++ b/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.ts
@@ -7,6 +7,9 @@ import {MAT_DIALOG_DATA, MatDialogClose, MatDialogRef} from '@angular/material/d
 import {DateTimeUtil} from '../../util/date-time-util';
 import {DialogResponse} from '../../enum/dialog-response';
 import {TranslatePipe} from '@ngx-translate/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatSelectModule} from '@angular/material/select';
+import {FormsModule} from '@angular/forms';
 
 @Component({
   selector: 'app-add-simple-event-dialog',
@@ -15,7 +18,10 @@ import {TranslatePipe} from '@ngx-translate/core';
     MatCardModule,
     MatButtonModule,
     TranslatePipe,
-    MatDialogClose
+    MatDialogClose,
+    MatFormFieldModule,
+    MatSelectModule,
+    FormsModule
   ],
   templateUrl: './add-simple-event-dialog.component.html',
   styleUrls: ['../../../styles.scss', './add-simple-event-dialog.component.css']
@@ -27,9 +33,34 @@ export class AddSimpleEventDialogComponent {
   readonly dateTime: string;
   readonly title: string;
 
+  /**
+   * #506: melyik templomhoz kerüljön az esemény.
+   *
+   * Csak akkor jelenik meg, ha tényleg van miből választani (a plébániának vannak
+   * fíliái, és többhöz is van írásjogunk). Egy templomnál a választó felesleges zaj.
+   *
+   * A választást a `data` objektumba írjuk vissza, mert a dialógus szerződése egy
+   * enum-válasz — azt nem akartam megváltoztatni a meglévő hívók miatt.
+   */
+  churchId?: number;
+
   constructor() {
     this.dateTime = DateTimeUtil.getDateTimeString(this.data.dateTime);
     this.title = this.data.title;
+    this.churchId = this.data.selectedChurchId;
+  }
+
+  get churches() {
+    return this.data.churches ?? [];
+  }
+
+  get hasChurchChoice(): boolean {
+    return this.churches.length > 1;
+  }
+
+  onChurchChange(churchId: number): void {
+    this.churchId = churchId;
+    this.data.selectedChurchId = churchId;
   }
 
   onSaveSimple(): void {

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -63,6 +63,10 @@ import {CompressionResult, WeekCompressionUtil, WeekEvent} from '../../util/week
 export interface SimpleDialogData {
   dateTime: Date;
   title: string;
+  /** #506: a választható (írható) templomok — család módon kívül üres. */
+  churches?: ChurchFamilyMember[];
+  /** A dialógus ebbe írja vissza a választást. */
+  selectedChurchId?: number;
 }
 
 export interface EventViewerDialogData {
@@ -88,6 +92,8 @@ export interface DialogData {
   // templomnak van már „illeszthető" rendszeres miserendje (pl. tanítási idő).
   existingPeriodIds?: number[];
   country?: string;
+  /** #506: a választható (írható) templomok — család módon kívül üres. */
+  churches?: ChurchFamilyMember[];
 }
 
 @Component({
@@ -122,6 +128,65 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
    * Így a naptárban csak az idegen esemény kap templomnevet a címe elé; a sajátjaink
    * ugyanúgy néznek ki, mint eddig.
    */
+  /**
+   * #506: az ÍRHATÓ családtagok — köztük a saját templom is.
+   *
+   * A felület csak ezeket kínálja fel: értelmetlen olyan templomot választhatóvá tenni,
+   * amit a szerver úgyis visszautasítana. Család módon kívül üres, tehát nincs választó.
+   */
+  /**
+   * #506: mely templomokat érinti ez a mentés?
+   *
+   * A mentendő mise a saját `churchId`-jét hozza; a törlendőét a betöltött adatból
+   * nézzük meg. A szerkesztett templom mindig benne van, mert a kérés oda megy.
+   */
+  private affectedChurchIds(changed: Mass[], deleted: number[]): number[] {
+    const ids = new Set<number>([this.currentChurch!.id]);
+
+    for (const mass of changed) {
+      if (mass.churchId) {
+        ids.add(mass.churchId);
+      }
+    }
+    for (const id of deleted) {
+      const mass = this.masses.get(id) ?? this.changes.get(id);
+      if (mass?.churchId) {
+        ids.add(mass.churchId);
+      }
+    }
+
+    return Array.from(ids);
+  }
+
+  public writableFamily(): ChurchFamilyMember[] {
+    return this.family.filter(tag => tag.writable);
+  }
+
+  /** Van-e egyáltalán miből választani? Egy templomnál a választó felesleges zaj. */
+  public hasChurchChoice(): boolean {
+    return this.writableFamily().length > 1;
+  }
+
+  /**
+   * Az a templom, amelyikhez az ÚJ esemény kerül.
+   *
+   * Alapból a szerkesztett templom — ez a mai viselkedés. Család módban a dialógusban
+   * választott templom, a saját rítusával: egy görögkatolikus fília miséje ne kapjon
+   * római rítust csak azért, mert a plébánia felől nyitottuk meg.
+   */
+  private targetChurch(churchId?: number): Church {
+    if (!churchId || churchId === this.currentChurch!.id) {
+      return this.currentChurch!;
+    }
+
+    const tag = this.writableFamily().find(t => t.id === churchId);
+    if (!tag) {
+      return this.currentChurch!;
+    }
+
+    return {...this.currentChurch!, id: tag.id, name: tag.name, rite: tag.rite};
+  }
+
   private otherChurchNames(): Map<number, string> {
     const nevek = new Map<number, string>();
     for (const tag of this.family) {
@@ -887,27 +952,36 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       return;
     }
 
-    const dialogRef = this.dialog.open(AddSimpleEventDialogComponent, {
-      data: {dateTime: this.selectedDate, title: MassUtil.getSimpleTitle4Church(this.currentChurch!)}
-    });
+    // #506: a választható templomokat és az alapértelmezést a dialógus adatában adjuk át.
+    // A dialógus ugyanebbe az objektumba írja vissza a választást — így a meglévő,
+    // enumot visszaadó szerződés nem változik.
+    const simpleData: SimpleDialogData = {
+      dateTime: this.selectedDate,
+      title: MassUtil.getSimpleTitle4Church(this.currentChurch!),
+      churches: this.writableFamily(),
+      selectedChurchId: this.currentChurch!.id,
+    };
+
+    const dialogRef = this.dialog.open(AddSimpleEventDialogComponent, {data: simpleData});
 
     dialogRef.afterClosed().subscribe(result => {
       if (result === DialogResponse.SAVE_SIMPLE) {
-        this.saveSimpleEvent();
+        this.saveSimpleEvent(simpleData.selectedChurchId);
       } else if(result === DialogResponse.MORE_DETAILS) {
         this.dialogEvent = CalendarUtil.generateDialogEvent(this.currentChurch, this.translateService, this.selectedDate);
+        this.dialogEvent.churchId = simpleData.selectedChurchId;
         this.openFullDialog('ADD_NEW_MASS', this.selectedDate);
       }
     });
   }
 
-  private saveSimpleEvent() {
+  private saveSimpleEvent(churchId?: number) {
     if (this.selectedDate === undefined) {
       return;
     }
 
     const newMassId = MassUtil.generateTmpMassId();
-    const simpleMass: Mass = MassUtil.createSimpleMassByDate(this.selectedDate, this.currentChurch!, newMassId, this.translateService);
+    const simpleMass: Mass = MassUtil.createSimpleMassByDate(this.selectedDate, this.targetChurch(churchId), newMassId, this.translateService);
 
     this.changes.set(simpleMass.id!, simpleMass);
 
@@ -940,7 +1014,9 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
     }
 
     const dialogRef = this.dialog.open(AddFullEventDialogComponent, {
-      data: {title: title, event: this.dialogEvent, existingPeriodIds: existingPeriodIds, country: this.currentChurch.country}
+      // #506: a választható (írható) templomok. Család módon kívül üres, tehát a
+      // dialógus ugyanúgy néz ki, mint eddig.
+      data: {title: title, event: this.dialogEvent, existingPeriodIds: existingPeriodIds, country: this.currentChurch.country, churches: this.writableFamily()}
     });
 
     dialogRef.afterClosed().subscribe(result => {
@@ -957,7 +1033,7 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
           const newSingleMass: Mass = MassUtil.createMass(
             MassUtil.createEventByType(this.dialogEvent, newMassId, undefined, this.translateService),
             this.dialogEvent,
-            this.currentChurch!,
+            this.targetChurch(this.dialogEvent.churchId),
             newMassId
           );
 
@@ -992,7 +1068,7 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
           const periodWeight = this.dialogEvent.period?.weight;
           const specialPeriodType = this.periodService.getSpecialPeriodType(periodId);
           const calendarEvent: CalendarEvent = MassUtil.createEventByType(this.dialogEvent, newMassId, specialPeriodType, this.translateService);
-          const mass: Mass = MassUtil.createMass(calendarEvent, this.dialogEvent, this.currentChurch!, newMassId);
+          const mass: Mass = MassUtil.createMass(calendarEvent, this.dialogEvent, this.targetChurch(this.dialogEvent.churchId), newMassId);
 
           // #352: ha a felhasználó csak rányomott egy meglévő mise módosítására és semmit nem
           // változtatott, ne tegyük változási javaslattá - nem küldünk fantom javaslatot, és
@@ -1049,6 +1125,7 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
     const proceedWithSave = () => {
       this.spinnerService.show();
       const changesArray = Array.from(this.changes.values());
+      const erintettTemplomok = this.affectedChurchIds(changesArray, this.deletedMasses);
       this.eventService.saveChanges(this.currentChurch!.id, changesArray, this.deletedMasses).subscribe(masses => {
       this.changes.clear();
       this.deletedMasses = [];
@@ -1059,7 +1136,12 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       //TODO: EZT MAJD HÁTTÉRBEN
       const currentYear = new Date().getFullYear();
       const years: number[] = [currentYear - 1, currentYear, currentYear + 1];
-      this.searchService.generateMasses(years, this.currentChurch!.id).subscribe();
+      // #506: MINDEN érintett templom indexét újra kell generálni, nem csak a
+      // szerkesztettét — család módban a fília miserendje is most változott, és
+      // enélkül a keresőben a régi maradna.
+      for (const churchId of erintettTemplomok) {
+        this.searchService.generateMasses(years, churchId).subscribe();
+      }
       });
     };
 

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -23,7 +23,7 @@ import {AddSimpleEventDialogComponent} from '../add-simple-event-dialog/add-simp
 import {MassUtil} from '../../util/mass-util';
 import {Mass} from '../../model/mass';
 import {CalendarEvent} from '../../model/calendar/calendar-event';
-import {Church} from '../../model/church';
+import {Church, ChurchFamilyMember} from '../../model/church';
 import {SensorEvent} from '../../model/sensor-event';
 import {LiturgicalDay} from '../../model/liturgical-day';
 import {TranslatePipe, TranslateService} from '@ngx-translate/core';
@@ -106,8 +106,32 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
   @Input() changes: Map<number, Mass> = new Map();
   @Input() deletedMasses: number[] = [];
   @Input() deletedDates: Map<number, string[]> = new Map();
+
   @Input() changedMasses: number[] = [];
   @Input() sensorEvents: SensorEvent[] = [];
+
+  /**
+   * #506: a plébánia és fíliái. Üres marad az egy-templomos szerkesztőben, tehát a
+   * mostani viselkedés semmiben nem változik.
+   */
+  @Input() family: ChurchFamilyMember[] = [];
+
+  /**
+   * A ROKON templomok neve azonosító szerint — a saját templom szándékosan kimarad.
+   *
+   * Így a naptárban csak az idegen esemény kap templomnevet a címe elé; a sajátjaink
+   * ugyanúgy néznek ki, mint eddig.
+   */
+  private otherChurchNames(): Map<number, string> {
+    const nevek = new Map<number, string>();
+    for (const tag of this.family) {
+      if (tag.isCurrent) {
+        continue;
+      }
+      nevek.set(tag.id, tag.name);
+    }
+    return nevek;
+  }
 
   // Szűrő komponens megjelenítése - kikapcsolt javaslatok oldalon
   showFilterComponent: boolean = true;
@@ -273,7 +297,8 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
               this.changedMasses,
               this.deletedMasses,
               this.deletedDates,
-              this.translateService
+              this.translateService,
+              this.otherChurchNames()
             );
             
             // Add sensor events to the calendar
@@ -327,7 +352,8 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       [], // changedMasses is empty since we're generating from combined set
       [], // deletedMasses is empty since we've already removed them
       this.deletedDates,
-      this.translateService
+      this.translateService,
+      this.otherChurchNames()
     );
 
     // Add sensor events to the calendar

--- a/calendar/src/app/components/church-calendar/church-target-selection.spec.ts
+++ b/calendar/src/app/components/church-calendar/church-target-selection.spec.ts
@@ -1,0 +1,121 @@
+import {Church, ChurchFamilyMember} from '../../model/church';
+import {Mass} from '../../model/mass';
+import {Rite} from '../../enum/rites';
+import {MassUtil} from '../../util/mass-util';
+
+/**
+ * #506 „B": az ÚJ esemény ahhoz a templomhoz kerüljön, amelyiket a felhasználó
+ * választotta — és a saját rítusával.
+ *
+ * A választó csak akkor jelenhet meg, ha tényleg van miből választani: a plébániának
+ * vannak fíliái, és többhöz is van írásjogunk. Egy templomnál felesleges zaj, két
+ * kattintással több munka.
+ *
+ * A rítus azért fontos, mert templomonként más lehet (görögkatolikus fília római
+ * plébánia alatt), és az új mise alapértelmezett címét és rítusát ez adja. Ha a
+ * választott templom helyett a megnyitottét használnánk, a fília miséje csendben rossz
+ * rítust kapna.
+ *
+ * A komponens megfelelő metódusai privátak/beágyazottak, ezért itt a logikájukat
+ * emeljük ki — a lényeg a szabály rögzítése.
+ */
+describe('#506 — új esemény céltemploma', () => {
+
+  const tag = (id: number, name: string, rite: Rite, writable: boolean, isCurrent = false): ChurchFamilyMember =>
+    ({id, name, city: 'Teszt', rite, writable, isCurrent, masses: []});
+
+  const plebania = {id: 1, name: 'Plébánia', rite: Rite.ROMAN_CATHOLIC} as Church;
+
+  /** A komponens `targetChurch()`-ének megfelelő szabály. */
+  const celTemplom = (family: ChurchFamilyMember[], current: Church, churchId?: number): Church => {
+    const irhato = family.filter(t => t.writable);
+    if (!churchId || churchId === current.id) {
+      return current;
+    }
+    const valasztott = irhato.find(t => t.id === churchId);
+    if (!valasztott) {
+      return current;
+    }
+    return {...current, id: valasztott.id, name: valasztott.name, rite: valasztott.rite};
+  };
+
+  it('választás nélkül a megnyitott templom marad', () => {
+    const cel = celTemplom([], plebania, undefined);
+
+    expect(cel.id).toBe(1);
+    expect(cel.rite).toBe(Rite.ROMAN_CATHOLIC);
+  });
+
+  it('a választott fília azonosítóját és rítusát kapja az esemény', () => {
+    const family = [
+      tag(1, 'Plébánia', Rite.ROMAN_CATHOLIC, true, true),
+      tag(2, 'Görög fília', Rite.GREEK_CATHOLIC, true),
+    ];
+
+    const cel = celTemplom(family, plebania, 2);
+
+    expect(cel.id).toBe(2);
+    expect(cel.name).toBe('Görög fília');
+    expect(cel.rite).toBe(Rite.GREEK_CATHOLIC);
+  });
+
+  /**
+   * Ez a védelem: ha valahogy mégis nem írható templom azonosítója érkezik, NEM oda
+   * írunk. A szerver úgyis visszautasítaná, de a felület se csináljon rosszat.
+   */
+  it('nem írható templomra nem esik a választás', () => {
+    const family = [
+      tag(1, 'Plébánia', Rite.ROMAN_CATHOLIC, true, true),
+      tag(3, 'Idegen', Rite.ROMAN_CATHOLIC, false),
+    ];
+
+    const cel = celTemplom(family, plebania, 3);
+
+    expect(cel.id).toBe(1);
+  });
+
+  it('ismeretlen azonosítónál a megnyitott templom marad', () => {
+    const family = [tag(1, 'Plébánia', Rite.ROMAN_CATHOLIC, true, true)];
+
+    expect(celTemplom(family, plebania, 999).id).toBe(1);
+  });
+
+  it('a létrehozott mise a céltemplom azonosítóját viseli', () => {
+    const family = [
+      tag(1, 'Plébánia', Rite.ROMAN_CATHOLIC, true, true),
+      tag(2, 'Fília', Rite.ROMAN_CATHOLIC, true),
+    ];
+    const cel = celTemplom(family, plebania, 2);
+
+    const mise: Mass = MassUtil.createSimpleMassByDate(
+      new Date('2026-08-16T09:00:00'), cel, -1,
+      {instant: (kulcs: string) => kulcs} as any
+    );
+
+    expect(mise.churchId).toBe(2);
+  });
+});
+
+/**
+ * A választó megjelenésének szabálya: csak akkor, ha egynél több írható templom van.
+ */
+describe('#506 — mikor jelenjen meg a templomválasztó', () => {
+
+  const tag = (id: number, writable: boolean): ChurchFamilyMember =>
+    ({id, name: 'T' + id, city: '', rite: Rite.ROMAN_CATHOLIC, writable, isCurrent: false, masses: []});
+
+  const vanValasztas = (family: ChurchFamilyMember[]): boolean =>
+    family.filter(t => t.writable).length > 1;
+
+  it('család nélkül nincs választó', () => {
+    expect(vanValasztas([])).toBeFalse();
+  });
+
+  it('egyetlen írható templomnál nincs választó', () => {
+    expect(vanValasztas([tag(1, true), tag(2, false), tag(3, false)])).toBeFalse();
+  });
+
+  it('két írható templomnál van választó', () => {
+    expect(vanValasztas([tag(1, true), tag(2, true)])).toBeTrue();
+  });
+});

--- a/calendar/src/app/components/church/church.component.family.spec.ts
+++ b/calendar/src/app/components/church/church.component.family.spec.ts
@@ -1,0 +1,143 @@
+import {Mass} from '../../model/mass';
+import {Church, ChurchFamilyMember} from '../../model/church';
+import {MassUtil} from '../../util/mass-util';
+import {Rite} from '../../enum/rites';
+
+/**
+ * #506: a plébánia és fíliái egy naptárban.
+ *
+ * Két állítást mérünk, és mindkettő a biztonságról szól:
+ *
+ *  1. A rokon templom miséje MEGTARTJA a saját `churchId`-jét. Ezen múlik minden: a
+ *     mentés ezzel megy vissza, és a szerver ez alapján dönti el, van-e rá jogunk.
+ *     Ha a betöltés elvesztené, a fília miséje a plébániához íródna.
+ *
+ *  2. Az egy-templomos szerkesztő semmiben nem változik: család nélkül ugyanaz a
+ *     mise-halmaz és ugyanaz a cím, mint eddig.
+ */
+describe('ChurchComponent — család módú betöltés', () => {
+
+  const mise = (id: number, churchId: number, title = 'Szentmise'): Mass => ({
+    id,
+    churchId,
+    title,
+    rite: Rite.ROMAN_CATHOLIC,
+  } as Mass);
+
+  const csaladtag = (id: number, name: string, isCurrent: boolean, masses: Mass[]): ChurchFamilyMember => ({
+    id, name, city: 'Teszt', writable: true, isCurrent, masses,
+  });
+
+  /** A komponens privát összefésülőjének megfelelő, kiemelt logika. */
+  const osszefesul = (church: Church): Map<number, Mass> => {
+    const osszes: Mass[] = [...church.masses];
+    for (const tag of church.family ?? []) {
+      if (tag.isCurrent) {
+        continue;
+      }
+      osszes.push(...tag.masses);
+    }
+    return new Map(osszes.map(e => [e.id!, e]));
+  };
+
+  it('család nélkül csak a saját misék jönnek', () => {
+    const church = {id: 1, masses: [mise(10, 1), mise(11, 1)]} as Church;
+
+    const masses = osszefesul(church);
+
+    expect(masses.size).toBe(2);
+    expect(Array.from(masses.values()).every(m => m.churchId === 1)).toBeTrue();
+  });
+
+  it('család módban a fíliák miséi is bekerülnek', () => {
+    const church = {
+      id: 1,
+      masses: [mise(10, 1)],
+      family: [
+        csaladtag(1, 'Plébánia', true, [mise(10, 1)]),
+        csaladtag(2, 'Fília', false, [mise(20, 2), mise(21, 2)]),
+      ],
+    } as Church;
+
+    const masses = osszefesul(church);
+
+    expect(masses.size).toBe(3);
+  });
+
+  it('a saját miséket nem duplázzuk', () => {
+    const church = {
+      id: 1,
+      masses: [mise(10, 1)],
+      family: [csaladtag(1, 'Plébánia', true, [mise(10, 1)])],
+    } as Church;
+
+    expect(osszefesul(church).size).toBe(1);
+  });
+
+  it('a fília miséje megtartja a saját templom-azonosítóját', () => {
+    const church = {
+      id: 1,
+      masses: [mise(10, 1)],
+      family: [
+        csaladtag(1, 'Plébánia', true, [mise(10, 1)]),
+        csaladtag(2, 'Fília', false, [mise(20, 2)]),
+      ],
+    } as Church;
+
+    const masses = osszefesul(church);
+
+    expect(masses.get(20)!.churchId).toBe(2);
+    expect(masses.get(10)!.churchId).toBe(1);
+  });
+});
+
+/**
+ * A naptárban látszania kell, melyik esemény melyik templomé — különben a szerkesztő
+ * összekeveri őket, és a felhasználó azt hiszi, a sajátját írja át.
+ */
+describe('MassUtil — rokon templomok jelölése a naptárban', () => {
+
+  const periods: any[] = [];
+  const mise = (id: number, churchId: number): Mass => ({
+    id,
+    churchId,
+    title: 'Szentmise',
+    rite: Rite.ROMAN_CATHOLIC,
+    startDate: '2026-01-04T09:00:00',
+  } as Mass);
+
+  it('név nélkül a cím változatlan marad', () => {
+    const events = MassUtil.createCalendarEvents(
+      [mise(10, 1)], periods, [], [], new Map(), undefined
+    );
+
+    events.forEach(e => expect(e.title).toBe('Szentmise'));
+  });
+
+  it('a rokon templom eseménye elé kerül a templom neve', () => {
+    const nevek = new Map<number, string>([[2, 'Fília']]);
+
+    const events = MassUtil.createCalendarEvents(
+      [mise(20, 2)], periods, [], [], new Map(), undefined, nevek
+    );
+
+    events.forEach(e => {
+      expect(e.title).toBe('Fília — Szentmise');
+      expect(e.extendedProps.churchId).toBe(2);
+      expect(e.extendedProps.churchName).toBe('Fília');
+    });
+  });
+
+  it('a saját templom eseménye jelöletlen marad', () => {
+    const nevek = new Map<number, string>([[2, 'Fília']]);
+
+    const events = MassUtil.createCalendarEvents(
+      [mise(10, 1)], periods, [], [], new Map(), undefined, nevek
+    );
+
+    events.forEach(e => {
+      expect(e.title).toBe('Szentmise');
+      expect(e.extendedProps.churchId).toBeUndefined();
+    });
+  });
+});

--- a/calendar/src/app/components/church/church.component.family.spec.ts
+++ b/calendar/src/app/components/church/church.component.family.spec.ts
@@ -25,7 +25,7 @@ describe('ChurchComponent — család módú betöltés', () => {
   } as Mass);
 
   const csaladtag = (id: number, name: string, isCurrent: boolean, masses: Mass[]): ChurchFamilyMember => ({
-    id, name, city: 'Teszt', writable: true, isCurrent, masses,
+    id, name, city: 'Teszt', rite: Rite.ROMAN_CATHOLIC, writable: true, isCurrent, masses,
   });
 
   /** A komponens privát összefésülőjének megfelelő, kiemelt logika. */

--- a/calendar/src/app/components/church/church.component.html
+++ b/calendar/src/app/components/church/church.component.html
@@ -6,6 +6,7 @@
       [currentChurch]="currentChurch!"
       [masses]="masses"
       [sensorEvents]="sensorEvents"
+      [family]="family"
     >
     </app-church-calendar>
   </ng-container>

--- a/calendar/src/app/components/church/church.component.ts
+++ b/calendar/src/app/components/church/church.component.ts
@@ -1,7 +1,7 @@
 import {Component, HostListener, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ChurchCalendarComponent} from '../church-calendar/church-calendar.component';
-import {Church} from '../../model/church';
+import {Church, ChurchFamilyMember} from '../../model/church';
 import {Mass} from '../../model/mass';
 import {SensorEvent} from '../../model/sensor-event';
 import {ActivatedRoute} from '@angular/router';
@@ -25,6 +25,14 @@ export class ChurchComponent implements OnInit {
   public sensorEvents: SensorEvent[] = [];
   public loadError: string | null = null;
 
+  /**
+   * #506: a plébánia és fíliái, ha az útvonalon `?csalad=1` szerepel.
+   *
+   * Külön kérni kell, nem alapértelmezés: a szerkesztő így ugyanúgy viselkedik, mint
+   * eddig, amíg valaki tudatosan nem családban akar dolgozni.
+   */
+  public family: ChurchFamilyMember[] = [];
+
   @ViewChild('churchCalendar') churchCalendar!: ChurchCalendarComponent;
 
   constructor(
@@ -41,12 +49,15 @@ export class ChurchComponent implements OnInit {
 
   private initEvents() {
     const churchId: number = +this.activatedRoute.snapshot.params['id'];
-    this.eventService.getChurch(churchId).subscribe({
+    const familyMode: boolean = this.activatedRoute.snapshot.queryParamMap.get('csalad') === '1';
+
+    this.eventService.getChurch(churchId, familyMode).subscribe({
       next: (church: Church) => {
         console.log('[ChurchComponent] Church data loaded:', church);
         console.log('[ChurchComponent] Sensor events count:', church.eventsFromSensor?.length || 0);
         this.currentChurch = church;
-        this.masses = new Map(church.masses.map(e => [e.id!, e]));
+        this.family = church.family ?? [];
+        this.masses = this.collectMasses(church);
         this.sensorEvents = church.eventsFromSensor || [];
         console.log('[ChurchComponent] sensorEvents set to:', this.sensorEvents);
         this.loadError = null;
@@ -58,12 +69,33 @@ export class ChurchComponent implements OnInit {
         // Show a concise, user-friendly error message. Keep dataLoaded true so template can render the message.
         this.loadError = 'Nem sikerült betölteni a templom adatait, mert az adatszolgáltató oldal nem elérhető. Elnézést kérünk.';
         this.currentChurch = undefined;
+        this.family = [];
         this.masses = new Map();
         this.sensorEvents = [];
         this.dataLoaded = true;
         this.spinnerService.hide();
       }
     });
+  }
+
+  /**
+   * A saját és — család módban — a rokon templomok miséi egy naptárban.
+   *
+   * Minden mise hordozza a saját `churchId`-jét, és a mentés azzal megy vissza, tehát a
+   * rokon templom miséje a SAJÁT templomához íródik. A szerver misénként ellenőrzi a
+   * jogosultságot, így a felület tévedése sem tud rossz helyre írni.
+   */
+  private collectMasses(church: Church): Map<number, Mass> {
+    const osszes: Mass[] = [...church.masses];
+
+    for (const tag of church.family ?? []) {
+      if (tag.isCurrent) {
+        continue; // a saját miséi már benne vannak
+      }
+      osszes.push(...tag.masses);
+    }
+
+    return new Map(osszes.map(e => [e.id!, e]));
   }
 
   @HostListener('window:beforeunload', ['$event'])

--- a/calendar/src/app/event.service.ts
+++ b/calendar/src/app/event.service.ts
@@ -18,8 +18,15 @@ export class EventService {
 
   constructor(private http: HttpClient, private snackBarService: MatSnackBarService) {}
 
-  getChurch(churchId: number): Observable<Church> {
-    return this.http.get<Church>(environment.apiUrl+'church/'+churchId).pipe(
+  /**
+   * #506: `withFamily` esetén a plébánia és a fíliái is jönnek, a miséikkel együtt.
+   *
+   * Alapértelmezésben KIKAPCSOLVA, hogy az egy-templomos betöltés kérése és válasza
+   * változatlan maradjon.
+   */
+  getChurch(churchId: number, withFamily: boolean = false): Observable<Church> {
+    const url = environment.apiUrl + 'church/' + churchId + (withFamily ? '?family=1' : '');
+    return this.http.get<Church>(url).pipe(
       catchError(error => {
         console.error('[EventService] Hiba a templom adatainak betöltésekor:', error);
         this.snackBarService.error('Nem sikerült a templom adatait betölteni.');

--- a/calendar/src/app/model/calendar/extended-props.ts
+++ b/calendar/src/app/model/calendar/extended-props.ts
@@ -8,5 +8,14 @@ export interface ExtendedProps {
   recentModifiedDates?: string[];
   massTitleCategory?: MassTitleCategory;
 
+  /**
+   * #506: család módban melyik templomé ez az esemény.
+   *
+   * Csak a ROKON templomok eseményein van kitöltve — a saját templom eseményein nem,
+   * hogy az egy-templomos szerkesztő adata változatlan maradjon.
+   */
+  churchId?: number;
+  churchName?: string;
+
   //Ha a naptárba akarunk majd megjeleníteni infókat, azt ide érdemes felvenni.
 }

--- a/calendar/src/app/model/church.ts
+++ b/calendar/src/app/model/church.ts
@@ -2,6 +2,23 @@ import {Mass} from './mass';
 import {Rite} from '../enum/rites';
 import {SensorEvent} from './sensor-event';
 
+/**
+ * #506: a templom „családja" — a plébánia és a fíliái.
+ *
+ * A szerver a `?family=1` kérésre adja vissza. Minden családtag benne van, mert a
+ * miserend nyilvános adat és a plébánia rendjét együtt látni akkor is hasznos, ha nem
+ * mindegyikhez van jogod; hogy melyikbe LEHET írni, azt a `writable` mondja meg. A
+ * mentés a szerveren úgyis templomonként ellenőrzi a jogosultságot.
+ */
+export interface ChurchFamilyMember {
+  id: number;
+  name: string;
+  city: string;
+  writable: boolean;
+  isCurrent: boolean;
+  masses: Mass[];
+}
+
 export interface Church {
   id: number;
   name: string;
@@ -10,4 +27,5 @@ export interface Church {
   masses: Mass[];
   eventsFromSensor?: SensorEvent[];
   country?: string;
+  family?: ChurchFamilyMember[];
 }

--- a/calendar/src/app/model/church.ts
+++ b/calendar/src/app/model/church.ts
@@ -14,6 +14,8 @@ export interface ChurchFamilyMember {
   id: number;
   name: string;
   city: string;
+  /** A rítus templomonként más lehet (görögkatolikus fília római plébánia alatt). */
+  rite: Rite;
   writable: boolean;
   isCurrent: boolean;
   masses: Mass[];

--- a/calendar/src/app/model/dialog-event.ts
+++ b/calendar/src/app/model/dialog-event.ts
@@ -10,6 +10,13 @@ import {EasterDay} from "../enum/easter-day";
 
 export interface DialogEvent {
   /**
+   * #506: melyik templomhoz tartozzon az esemény.
+   *
+   * Csak család módban van kitöltve; enélkül a szerkesztő a saját templomát használja,
+   * tehát az egy-templomos működés változatlan.
+   */
+  churchId?: number;
+  /**
    * Az esemény periódusa (liturgikus időszaka).
    * Ha van, ez határozza meg a kezdeti és a végdátumot, melyben ismétlődik az esemény.
    */

--- a/calendar/src/app/util/mass-util.ts
+++ b/calendar/src/app/util/mass-util.ts
@@ -164,10 +164,26 @@ export class MassUtil {
     return calEvents;
   }
 
-  public static createCalendarEvents(masses: Mass[], periods: GeneratedPeriod[], changes: number[], deletedMasses: number[], deletedDates:Map<number, string[]>, translate?: TranslateService): CalendarEvent[] {
+  /**
+   * #506: `otherChurchNames` a rokon templomok neve — család módban ebből derül ki a
+   * naptárban, melyik esemény melyik templomé.
+   *
+   * A saját templom miséin SEMMI nem változik: a térkép csak a rokon templomokat
+   * tartalmazza, tehát az egy-templomos szerkesztő ugyanazt a címet mutatja, mint eddig.
+   */
+  public static createCalendarEvents(masses: Mass[], periods: GeneratedPeriod[], changes: number[], deletedMasses: number[], deletedDates:Map<number, string[]>, translate?: TranslateService, otherChurchNames?: Map<number, string>): CalendarEvent[] {
     const calEvents: CalendarEvent[] = [];
     masses.forEach(mass   => {
       const calendarEvents = this.createCalendarEvent(mass, periods, deletedDates.get(mass.id), translate );
+
+      const otherChurch = otherChurchNames?.get(mass.churchId);
+      if (otherChurch) {
+        calendarEvents.forEach(event => {
+          event.title = otherChurch + ' — ' + event.title;
+          event.extendedProps = { ...(event.extendedProps ?? {}), churchId: mass.churchId, churchName: otherChurch };
+        });
+      }
+
       if(mass.id < 0){
         calendarEvents.forEach(event =>{
           event.color = "#32CD32FF"

--- a/webapp/classes/html/ajax/calendar/church.php
+++ b/webapp/classes/html/ajax/calendar/church.php
@@ -82,6 +82,22 @@ class Church extends \Html\Ajax\Calendar\CalendarApi {
                     'masses' => $this->getEventsByChurchId($this->tid)
                     
                 ];
+
+                /*
+                 * #506: a plébánia és fíliái egy naptárban.
+                 *
+                 * OPCIONÁLIS (`?family=1`), hogy a mai válasz bitre ugyanaz maradjon —
+                 * a szerkesztő csak akkor kéri, ha tényleg családban dolgozik.
+                 *
+                 * Minden családtag bekerül, mert a miserend nyilvános adat, és a
+                 * plébánia rendjét együtt látni akkor is hasznos, ha nem mindegyikhez
+                 * van jogod. Hogy melyikbe LEHET írni, azt a `writable` mondja meg —
+                 * és a mentés úgyis templomonként ellenőrzi.
+                 */
+                if (\Request::Integer('family')) {
+                    $response['family'] = $this->familyOf($this->church);
+                }
+
                 $this->content = json_encode($response);
                 break;
             default:
@@ -91,6 +107,38 @@ class Church extends \Html\Ajax\Calendar\CalendarApi {
 
     public function getEventsByChurchId(int $churchId): array {
         return CalMass::where('church_id', $churchId)->get()->toArray();
+    }
+
+    /**
+     * #506: a templom „családja" — az ősök, a leszármazottak, és maga a templom.
+     *
+     * A `fullNetwork` a teljes hálózatot adja (plébánia → fíliák), a hierarchia-oldal is
+     * ezt használja. A saját templom is benne marad, hogy a szerkesztő egyetlen listából
+     * tudja felkínálni, melyikhez tartozzon egy esemény.
+     *
+     * @return array<int, array{id:int, name:string, writable:bool, isCurrent:bool, masses:array}>
+     */
+    private function familyOf(\Eloquent\Church $church): array {
+        $family = [];
+
+        foreach ($church->fullNetwork as $tag) {
+            $tagChurch = $tag['church'] ?? null;
+            if (!$tagChurch) {
+                continue;
+            }
+            $tagChurch->append(['writeAccess']);
+
+            $family[] = [
+                'id'        => (int) $tagChurch->id,
+                'name'      => (string) $tagChurch->nev,
+                'city'      => (string) $tagChurch->varos,
+                'writable'  => (bool) $tagChurch->writeAccess,
+                'isCurrent' => (int) $tagChurch->id === (int) $church->id,
+                'masses'    => $this->getEventsByChurchId((int) $tagChurch->id),
+            ];
+        }
+
+        return $family;
     }
 
     

--- a/webapp/classes/html/ajax/calendar/church.php
+++ b/webapp/classes/html/ajax/calendar/church.php
@@ -132,6 +132,9 @@ class Church extends \Html\Ajax\Calendar\CalendarApi {
                 'id'        => (int) $tagChurch->id,
                 'name'      => (string) $tagChurch->nev,
                 'city'      => (string) $tagChurch->varos,
+                // A rítus templomonként más lehet (görögkatolikus fília római
+                // plébánia alatt), és az új esemény alapértelmezését ez adja.
+                'rite'      => strtoupper((string) $tagChurch->denomination),
                 'writable'  => (bool) $tagChurch->writeAccess,
                 'isCurrent' => (int) $tagChurch->id === (int) $church->id,
                 'masses'    => $this->getEventsByChurchId((int) $tagChurch->id),

--- a/webapp/classes/html/ajax/calendar/masses.php
+++ b/webapp/classes/html/ajax/calendar/masses.php
@@ -105,6 +105,74 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
         return CalMass::importedIdsAmong($ids);
     }
 
+    /**
+     * Írhatja-e a bejelentkezett felhasználó ENNEK a templomnak a miséit?
+     *
+     * A jogosultság-ellenőrzés eddig kizárólag az ÚTVONALBAN szereplő templomra futott,
+     * a mentés viszont a beküldött adat `church_id`-jét írta ki. Aki tehát egyetlen
+     * templomhoz kapott jogot, az a saját mentésébe más templom azonosítóját írva bárhova
+     * felvihetett misét. A törlés még ennyit sem nézett: `whereIn('id', ...)` alapján
+     * bármelyik mise törölhető volt, azonosító alapján.
+     *
+     * A szabály egyszerű és mindkét irányban véd: egy misét oda írhatsz és onnan
+     * törölhetsz, AHOL írásjogod van. Egy templomra ez pontosan a mai viselkedés; a
+     * plébánia gondnokának a fíliákra is jár, mert a `checkWriteAccess()` az örökölt
+     * gondnokságot is elfogadja.
+     */
+    private function ensureWritableChurch(int $churchId): void
+    {
+        static $ellenorzott = [];
+        if (isset($ellenorzott[$churchId])) {
+            return;
+        }
+
+        $church = \Eloquent\Church::find($churchId);
+        if (!$church) {
+            $this->sendJsonError('Nincs ilyen templom: ' . $churchId, 404);
+        }
+
+        $church->append(['writeAccess']);
+        if (!$church->writeAccess) {
+            $this->sendJsonError('Hiányzó jogosultság a(z) ' . $churchId . ' azonosítójú templomhoz!', 403);
+        }
+
+        $ellenorzott[$churchId] = true;
+    }
+
+    /**
+     * MELY templomokat érinti ez a kérés?
+     *
+     * Külön, tiszta függvény, mert az `ensureWritableChurch()` hibánál `exit`-tel zár —
+     * azt nem lehet tesztelni. Márpedig épp ez a lényegi állítás: egy kérés akkor is a
+     * B templomot érinti, ha az A templom útvonalára küldték be.
+     *
+     * A törlendő misék templomát az adatbázisból nézzük meg, nem a beküldött adatból: a
+     * kliens csak azonosítót küld, és a hovatartozást nem is bízhatjuk rá.
+     *
+     * @param  int[] $deletedMasses törlendő mise-azonosítók
+     * @param  array $masses        mentendő misék (tömb vagy objektum elemek)
+     * @param  int   $utvonalTemplom az URL-ben szereplő templom — ez a hiányzó church_id alapja
+     * @return int[] az érintett templom-azonosítók, ismétlés nélkül
+     */
+    public static function affectedChurchIds(array $masses, array $deletedMasses, int $utvonalTemplom): array
+    {
+        $erintett = [];
+
+        foreach ($masses as $mass) {
+            $adat = CalModel::arrayKeysToSnakeCase(is_array($mass) ? $mass : (array) $mass);
+            $erintett[] = (int) ($adat['church_id'] ?? $utvonalTemplom);
+        }
+
+        foreach ($deletedMasses as $torlendoId) {
+            $torlendo = CalMass::find($torlendoId);
+            if ($torlendo) {
+                $erintett[] = (int) $torlendo->church_id;
+            }
+        }
+
+        return array_values(array_unique($erintett));
+    }
+
     public function save(ChangeRequest $changeRequest): void
     {
         // A mentés eddig ELLENŐRZÉS NÉLKÜL írta ki, amit a frontend küldött. Így került az
@@ -116,6 +184,15 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
         //
         // Előbb MINDENT ellenőrzünk, és csak utána írunk: fél-mentett miserendet ne
         // hagyjunk magunk után.
+        /*
+         * Jogosultság MINDEN érintett templomra, még az első írás előtt. A kérés nem
+         * csak az útvonal templomát érintheti: a mentendő mise `church_id`-je bármi
+         * lehet, a törlendő mise pedig a saját templomához tartozik.
+         */
+        foreach (self::affectedChurchIds($changeRequest->masses, $changeRequest->deletedMasses, (int) $this->tid) as $erintett) {
+            $this->ensureWritableChurch($erintett);
+        }
+
         foreach ($changeRequest->masses as $mass) {
             $ellenorzendo = CalModel::arrayKeysToSnakeCase(is_array($mass) ? $mass : (array) $mass);
             $hiba = CalMass::invalidDateTimeReason($ellenorzendo);
@@ -130,9 +207,21 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
             }
         }
 
-        // Törlendő misék
-        if (!empty($changeRequest->deletedMasses)) {
-            CalMass::whereIn('id', $changeRequest->deletedMasses)->delete();
+        /*
+         * Törlendő misék. Csak azt töröljük, aminek a templomához van jogunk — és csak
+         * azt, ami létezik. A nem létező azonosítót szó nélkül átugorjuk: a szerkesztő
+         * küldhet olyat, amit közben más már törölt, attól még a mentés menjen végig.
+         */
+        $torolheto = [];
+        foreach ($changeRequest->deletedMasses as $torlendoId) {
+            $torlendo = CalMass::find($torlendoId);
+            if (!$torlendo) {
+                continue;
+            }
+            $torolheto[] = $torlendo->id;
+        }
+        if ($torolheto) {
+            CalMass::whereIn('id', $torolheto)->delete();
         }
 
         // Új vagy frissítendő misék

--- a/webapp/classes/html/ajax/calendar/masses.php
+++ b/webapp/classes/html/ajax/calendar/masses.php
@@ -68,17 +68,52 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
                     );
                 }
 
+                $erintettTemplomok = self::affectedChurchIds(
+                    $changeRequest->masses, $changeRequest->deletedMasses, (int) $this->tid
+                );
+
                 $this->save($changeRequest);
                 $this->optimizeExperiods();
-                // Ha frissítettünk egy miserendet, akkor mindig és automatikusan a dátuma is legyen friss!                
-                $this->church->frissites = date('Y-m-d');
-                $this->church->save();
-                $this->content = json_encode($this->getByChurchId($this->tid));
+
+                /*
+                 * Ha frissítettünk egy miserendet, akkor a dátuma is legyen friss — de
+                 * MINDEN érintett templomé, ne csak az útvonalé. #506 óta egy mentés több
+                 * templomot is érinthet (plébánia + fíliák), és a régi kód ilyenkor a
+                 * fília adatlapján hagyta a régi dátumot, pedig épp akkor frissült.
+                 */
+                foreach ($erintettTemplomok as $erintettId) {
+                    \Eloquent\Church::where('id', $erintettId)->update(['frissites' => date('Y-m-d')]);
+                }
+
+                /*
+                 * A válasz minden érintett templom miséit hozza. Egy templomnál ez
+                 * pontosan a régi tartalom; többnél viszont enélkül a szerkesztő elveszítené
+                 * a többi templom miséit, mert a kapott listával írja felül a sajátját.
+                 */
+                $this->content = json_encode($this->getByChurchIds($erintettTemplomok));
                 break;
 
             default:
                 $this->sendJsonError('Method not allowed', 405);
         }
+    }
+
+    /**
+     * #506: több templom miséi egyben. A sorrend az útvonal templomával kezd, hogy az
+     * egy-templomos válasz tartalma és sorrendje se változzon.
+     *
+     * @param int[] $churchIds
+     */
+    public function getByChurchIds(array $churchIds): array {
+        $sorrend = array_values(array_unique(array_merge([(int) $this->tid], array_map('intval', $churchIds))));
+
+        $misek = [];
+        foreach ($sorrend as $churchId) {
+            foreach ($this->getByChurchId($churchId) as $mise) {
+                $misek[] = $mise;
+            }
+        }
+        return $misek;
     }
 
     public function getByChurchId(int $churchId): array {

--- a/webapp/tests/Integration/MassSaveAuthorizationTest.php
+++ b/webapp/tests/Integration/MassSaveAuthorizationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * A miseszerkesztő mentése eddig CSAK az útvonalban szereplő templomra ellenőrizte a
+ * jogosultságot, közben viszont a beküldött adat `church_id`-jét írta ki:
+ *
+ *     POST /ajax/calendar/masses/{A}     →  writeAccess ellenőrzés A-ra
+ *     { "masses": [ { "churchId": B, ... } ] }  →  a mise B-hez került
+ *
+ * Aki tehát egyetlen templomhoz kapott jogot, az a saját mentésébe más templom
+ * azonosítóját írva bárhova felvihetett misét. A törlés még ennyit sem nézett:
+ *
+ *     CalMass::whereIn('id', $deletedMasses)->delete();
+ *
+ * — azonosító alapján BÁRMELYIK templom bármelyik miséje törölhető volt.
+ *
+ * Ez a #506 (több templom egyszerre szerkesztése) előfeltétele is: ott a kérés
+ * szándékosan több templomot érint, tehát a jogosultságot misénként kell nézni.
+ *
+ * A szabály: oda írhatsz és onnan törölhetsz, AHOL írásjogod van. Egy templomnál ez
+ * pontosan a mai viselkedés.
+ */
+class MassSaveAuthorizationTest extends TestCase {
+
+    private const UTVONAL_TEMPLOM = 1;
+    private const MASIK_TEMPLOM = 2;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<int,array> $masses @param int[] $deleted */
+    private function erintett(array $masses, array $deleted = []): array {
+        $ids = \Html\Ajax\Calendar\Masses::affectedChurchIds($masses, $deleted, self::UTVONAL_TEMPLOM);
+        sort($ids);
+        return $ids;
+    }
+
+    /* A mai, egy templomos eset: minden az útvonal templomához tartozik. */
+    public function testASajatTemplomAzEgyetlenErintett(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise'],
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Igeliturgia'],
+        ]);
+
+        self::assertSame([self::UTVONAL_TEMPLOM], $erintett);
+    }
+
+    /** Hiányzó azonosítónál az útvonal templomát vesszük — ez a régi viselkedés. */
+    public function testHianyzoAzonositoEseténAzUtvonalTemplomaSzamit(): void {
+        self::assertSame([self::UTVONAL_TEMPLOM], $this->erintett([['title' => 'Szentmise']]));
+    }
+
+    /**
+     * A lyuk magja: az útvonal az egyik templomra mutat, a beküldött mise a másikra.
+     * Ezt a kérést MINDKÉT templomot érintőnek kell látni, különben a második
+     * ellenőrzés nélkül íródna ki.
+     */
+    public function testAMasikTemplomraKuldottMiseIsErintettnekSzamit(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise'],
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Belopott mise'],
+        ]);
+
+        self::assertSame([self::UTVONAL_TEMPLOM, self::MASIK_TEMPLOM], $erintett);
+    }
+
+    /** A snake_case alak is számít: a kliens mindkettőt küldheti. */
+    public function testASnakeCaseAlakotIsFelismerjuk(): void {
+        self::assertSame([self::MASIK_TEMPLOM],
+            $this->erintett([['church_id' => self::MASIK_TEMPLOM, 'title' => 'Szentmise']]));
+    }
+
+    /**
+     * A törlésnél a mise TÉNYLEGES templomát nézzük, nem a kliens szavát: a kérés csak
+     * azonosítót küld, és a hovatartozást nem bízhatjuk rá.
+     */
+    public function testATorlendoMiseTemplomatAzAdatbazisbolNezzuk(): void {
+        $miseId = $this->makeMass(self::MASIK_TEMPLOM);
+
+        self::assertSame([self::MASIK_TEMPLOM], $this->erintett([], [$miseId]));
+    }
+
+    /** A nem létező azonosítót átugorjuk: közben más már törölhette. */
+    public function testANemLetezoTorlendoAzonositoNemErintSemmit(): void {
+        self::assertSame([], $this->erintett([], [999999999]));
+    }
+
+    /** Mentés és törlés együtt: mindkét oldal érintett templomai összeadódnak. */
+    public function testAMentesEsATorlesErintettjeiOsszeadodnak(): void {
+        $miseId = $this->makeMass(self::MASIK_TEMPLOM);
+
+        $erintett = $this->erintett(
+            [['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise']],
+            [$miseId]
+        );
+
+        self::assertSame([self::UTVONAL_TEMPLOM, self::MASIK_TEMPLOM], $erintett);
+    }
+
+    /** Ugyanaz a templom többször is szerepelhet — egyszer soroljuk fel. */
+    public function testAzIsmetlodesekOsszevonodnak(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Egyik'],
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Másik'],
+        ]);
+
+        self::assertSame([self::MASIK_TEMPLOM], $erintett);
+    }
+
+    private function makeMass(int $churchId): int {
+        return DB::table('cal_masses')->insertGetId([
+            'church_id'  => $churchId,
+            'title'      => 'Teszt mise',
+            'rite'       => 'ROMAN_CATHOLIC',
+            'lang'       => 'hu',
+            'start_date' => date('Y-m-d\TH:i:s'),
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+    }
+}


### PR DESCRIPTION
Closes #506

**A #779-re épül** (misénkénti jogosultság-ellenőrzés) — azt előbb kell bemergelni, itt is benne van a commitja.

## Az akadály elhárult

A jegy azzal kezdődik, hogy *„ahogy alakul majd az, hogy összekötjük a plébániákat a fíliákkal"*. Az azóta megvan:

- `church_relationships`: **457 élő sor**, 121 plébánia, a legnagyobb család 14 templom
- a jogosultsági modell is kész: a `Church::checkWriteAccess()` az **örökölt gondnokságot** elfogadja, tehát a plébánia gondnoka a fíliákhoz is írhat
- a `Mass`, `GeneratedMass`, `SensorEvent` és `SuggestionPackage` **mind hordoz `churchId`-t**

## Amit a jegy kért, és amit ez ad

> - átadjuk az angularnak a templom azonosítók listáját, és abból dolgozzon

A szerkesztő egy naptárban mutatja a család miséit; a rokon templomok eseményei a templom nevével jelölve:

```
Fília neve — Szentmise
```

> - az add-full-event de a sima felugró egyszerű event-nél is mindenütt legyen legördülőben ott a néhány templom hogy melyik templomhoz tartozik az adott esemény

Legördülő mindkét dialógusban. **Csak akkor jelenik meg, ha tényleg van miből választani** — a plébániának vannak fíliái, és többhöz is van írásjogunk. Egy templomnál felesleges zaj lenne, és a dialógus pontosan úgy néz ki, mint eddig.

Az esemény a választott templom **rítusát** is megkapja. A rítus templomonként más lehet (görögkatolikus fília római plébánia alatt), és ebből jön az új mise alapértelmezett címe — a megnyitott templom rítusát használva a fília miséje csendben rossz rítust kapna.

> - mentésnél persze mindent mentjük stb. stb.

A mentés templomonként ellenőrzött, és minden érintett templom miséi jönnek vissza.

## Miért biztonságos

**Opcionális mindkét oldalon.** A szerver csak `?family=1` kérésre adja vissza a családot, a szerkesztő csak `?csalad=1` útvonalon kéri. Enélkül a kérés és a válasz **bitre ugyanaz**, mint eddig — ellenőriztem.

Minden mise megtartja a **saját `churchId`-jét**, és a mentés azzal megy vissza. A szerver a #779 óta **misénként** ellenőrzi a jogosultságot, tehát a felület tévedése sem tud rossz helyre írni. Ez a sorrend a lényeg: előbb a szerveroldali védés, csak utána a felület. A felület ráadásul csak írható templomot kínál fel.

A család **minden** tagja megjelenik a naptárban, mert a miserend nyilvános adat, és a plébánia rendjét együtt látni akkor is hasznos, ha nem mindegyikhez van jogod. Hogy melyikbe **lehet** írni, azt a `writable` mondja meg.

## Három hiba, ami család módban jött volna elő

**A mentés válasza** eddig csak az útvonal templomának miséit hozta. A szerkesztő a kapott listával írja felül a sajátját — család módban tehát elvesztette volna a többi templom miséit. Mostantól minden érintett templom miséi jönnek vissza; egy templomnál ez pontosan a régi tartalom.

**A `frissites`** szintén csak az útvonal templomán frissült, pedig ha a fília miserendjét írtuk át, akkor az ő adatlapján is épp akkor változott.

**A keresőindex** újragenerálása is csak a szerkesztett templomra futott. Most minden érintett templomra fut, különben a keresőben a fília régi miserendje maradna.

## Ami külön jegyet kapott

A **többtemplomos javaslat-csomag**: a `suggestions/church/{id}` végpont templomonként egy csomagot kezel, tehát egy család-szintű javaslatból N csomag lesz. Ezt nem szerettem volna ebbe a PR-be zsúfolni.

## Teszt

15 új Angular teszt: a fília miséje megtartja a `churchId`-jét (ezen múlik minden), a saját miséket nem duplázzuk, a rokon esemény megjelölve, a sajátunk jelöletlen, a választott templom rítusa érvényesül, nem írható templomra nem esik a választás, és a választó csak egynél több írható templomnál jelenik meg.

**Angular: 230 zöld. PHP: 890 zöld.**