### PR TITLE
Kiveszem a requirejs-t: nem használjuk, viszont sérülékeny

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,8 +20,7 @@
         "leaflet": "1.9.*",
         "leaflet-polylinedecorator": "1.6.*",
         "leaflet-textpath": "1.2.*",
-        "lightbox2": "2.*",
-        "requirejs": "2.1.11"
+        "lightbox2": "2.*"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
@@ -155,17 +154,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/requirejs": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.11.tgz",
-      "integrity": "sha512-eJJ1xgjNzjlpSWF8fdmaFLavIvbDS55ItVtSMHi0bCAKn20X0KH0sadOnDvEW7QiOWCeFeL+/idpG9yi3kzWqw==",
-      "bin": {
-        "r.js": "bin/r.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/use": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,8 +15,7 @@
     "leaflet": "1.9.*",
     "leaflet-polylinedecorator": "1.6.*",
     "leaflet-textpath": "1.2.*",
-    "lightbox2": "2.*",
-    "requirejs": "2.1.11"
+    "lightbox2": "2.*"
   },
   "config": {
     "unsafe-perm": true


### PR DESCRIPTION
Az `npm audit` egyetlen **high** súlyosságú találata a `webapp` oldalon:

```
requirejs  <=2.3.6
Severity: high
jrburke requirejs vulnerable to prototype pollution — GHSA-x3m3-4wpv-5vgc
```

## Nem használjuk

Végigkerestem: **semmi nem hivatkozik rá** — sem `.twig`, sem `.php`, sem `.js`, sem `.html`, és a `docker/`, `scripts/`, `.github/` alatt sem. A repóban egyetlen említése egy dependabot-ág neve (`dependabot/npm_and_yarn/webapp/requirejs-2.3.7`), vagyis a bot évek óta próbálja bumpolni azt, amit nem használunk.

## Miért törlés, nem verzióemelés

A `webapp/node_modules` **kiszolgált könyvtár** — a sablonok innen töltik a jQuery-t, a Bootstrapot, a Leafletet (`/node_modules/leaflet/dist/leaflet.js`). Egy nem használt csomag tehát nem csak a függőségi fában van benne, hanem a webszerverről **el is érhető**. Amit nem használunk, azt ne szállítsuk ki.

A `npm audit fix --force` egyébként 2.3.8-ra emelné, ami kilóg a megadott verziótartományból — vagyis a „javítás" itt is beavatkozást kívánna. Törléssel a probléma nem tér vissza.

## Ellenőrzés

- `npm audit`: **0 sérülékenység** (előtte 1 high)
- PHP: **882 zöld**
- böngészős suite: **80 zöld** — ez valódi oldalakat tölt be, tehát hiányzó erőforrásra kibukna