### PR TITLE
Bekapcsolom a tizennégy kikapcsolt Angular tesztet

### DIFF
--- a/calendar/src/app/app.component.spec.ts
+++ b/calendar/src/app/app.component.spec.ts
@@ -1,32 +1,46 @@
-import { TestBed } from '@angular/core/testing';
-import { AppComponent } from './app.component';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideRouter} from '@angular/router';
+import {TranslateService, provideTranslateService} from '@ngx-translate/core';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('AppComponent', () => {
+import {AppComponent} from './app.component';
+import {SpinnerService} from './services/spinner.service';
+
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * A gyökérkomponensnek egyetlen saját dolga van, és az nem mindegy: MAGYARRA állítja a
+ * felületet. A naptárat plébániai gondnokok és idős atyák használják — ha a nyelv nem
+ * áll be, angol kulcsokat vagy nyers azonosítókat látnak.
+ */
+describe('AppComponent', () => {
+
+  let fixture: ComponentFixture<AppComponent>;
+  let translate: TranslateService;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [
+        provideRouter([]),
+        provideTranslateService(),
+        SpinnerService,
+      ],
     }).compileComponents();
+
+    fixture = TestBed.createComponent(AppComponent);
+    translate = TestBed.inject(TranslateService);
   });
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  it('magyarra állítja a felületet', () => {
+    // Az ngx-translate ebben a verzióban szignálként adja a nyelvet.
+    const nyelv = typeof translate.currentLang === 'function'
+      ? (translate.currentLang as () => string)()
+      : translate.currentLang;
+
+    expect(nyelv).toBe('hu');
   });
 
-  it(`should have the 'mcal' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('mcal');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, mcal');
+  it('a töltésjelző szolgáltatás elérhető a felületnek', () => {
+    expect(fixture.componentInstance.spinnerService).toBeInstanceOf(SpinnerService);
   });
 });

--- a/calendar/src/app/components/add-message-dialog/add-message-dialog.component.spec.ts
+++ b/calendar/src/app/components/add-message-dialog/add-message-dialog.component.spec.ts
@@ -1,26 +1,62 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {provideTranslateService} from '@ngx-translate/core';
 
-import { AddMessageDialogComponent } from './add-message-dialog.component';
+import {AddMessageDialogComponent} from './add-message-dialog.component';
+import {DialogResponse} from '../../enum/dialog-response';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('EventEditDialogComponent', () => {
-  let component: AddMessageDialogComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez a dialógus két, egymástól nagyon eltérő szerepet lát el, és a különbséget egyetlen
+ * `decision` jelző dönti el:
+ *
+ *   - `decision: false` — tájékoztatás („Javaslatod sikeresen beküldve").
+ *   - `decision: true`  — DÖNTÉST kér („Nincs húsvéti miserend. Mentsük így?").
+ *
+ * A második esetben a válasz `CONTINUE`, és a hívó ERRE indítja el a mentést. Ha a
+ * dialógus más értékkel zárna, a mentés némán elmaradna — a felhasználó azt hinné,
+ * elmentette a miserendet.
+ */
+describe('AddMessageDialogComponent', () => {
+
   let fixture: ComponentFixture<AddMessageDialogComponent>;
+  let component: AddMessageDialogComponent;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<AddMessageDialogComponent>>;
+
+  const uzenet = {message: 'Mentsük így?', decision: true};
 
   beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
     await TestBed.configureTestingModule({
-      imports: [AddMessageDialogComponent]
-    })
-    .compileComponents();
+      imports: [AddMessageDialogComponent],
+      providers: [
+        provideTranslateService(),
+        {provide: MatDialogRef, useValue: dialogRef},
+        {provide: MAT_DIALOG_DATA, useValue: uzenet},
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddMessageDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('a kapott üzenetet megjeleníti', () => {
+    expect(fixture.nativeElement.textContent).toContain('Mentsük így?');
+  });
+
+  /**
+   * Ez a szerződés lényege: a hívó a CONTINUE értékre menti a miserendet.
+   */
+  it('a folytatás CONTINUE értékkel zárja a dialógust', () => {
+    component.onContinue();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(DialogResponse.CONTINUE);
+  });
+
+  it('a döntés-jelzőt a hívótól veszi át', () => {
+    expect(component.data.decision).toBeTrue();
   });
 });

--- a/calendar/src/app/components/church-calendar/church-calendar.component.spec.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.spec.ts
@@ -1,26 +1,125 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
+import {provideTranslateService} from '@ngx-translate/core';
+import {BehaviorSubject, of} from 'rxjs';
 
-import { ChurchCalendarComponent } from './church-calendar.component';
+import {ChurchCalendarComponent} from './church-calendar.component';
+import {PeriodService} from '../../services/period.service';
+import {SpinnerService} from '../../services/spinner.service';
+import {MatSnackBarService} from '../../services/mat-snack-bar.service';
+import {UserService} from '../../services/user.service';
+import {EditConfirmationService} from '../../services/edit-confirmation.service';
+import {Church} from '../../model/church';
+import {Mass} from '../../model/mass';
+import {Rite} from '../../enum/rites';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('ChurchCalendarComponent', () => {
-  let component: ChurchCalendarComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez a naptár maga — a rendszer legnagyobb és legkritikusabb komponense. Teljes körű
+ * lefedést egyetlen spec nem adhat, de két dolgot itt is érdemes rögzíteni, mert
+ * mindkettő ADATVESZTÉSSEL jár, ha elromlik:
+ *
+ *  1. A MENTETLEN VÁLTOZÁS jelzése. Erre épül a „biztosan elnavigálsz?" figyelmeztetés
+ *     (ChurchComponent.handleBeforeUnload). Ha tévesen hamis, a gondnok elnavigál, és a
+ *     félórás munkája nyomtalanul elvész — hibaüzenet nélkül.
+ *  2. A kategória-szűrő. Alapból MINDEN kategória aktív; ha üresen indulna, a naptár
+ *     üresnek látszana, és a felhasználó jóhiszeműen újra felvinné a miséket.
+ */
+describe('ChurchCalendarComponent', () => {
+
   let fixture: ComponentFixture<ChurchCalendarComponent>;
+  let component: ChurchCalendarComponent;
+
+  const templom: Church = {
+    id: 1, name: 'Teszt templom', rite: Rite.ROMAN_CATHOLIC, timeZone: 'Europe/Budapest', masses: [],
+  };
+
+  const mise = (id: number): Mass => ({id, churchId: 1, title: 'Szentmise'} as Mass);
 
   beforeEach(async () => {
+    const periodService = jasmine.createSpyObj(
+      'PeriodService',
+      ['getPeriodNameById', 'getGeneratedPeriodsByPeriodId', 'getPeriodById', 'isEasterPeriod', 'isChristmasPeriod'],
+      // A komponens `getValue()`-t hív a generált időszakokon, tehát BehaviorSubject kell,
+      // nem sima Observable.
+      {periods$: new BehaviorSubject<any[]>([]), generatedPeriods$: new BehaviorSubject<any[]>([])},
+    );
+    periodService.getGeneratedPeriodsByPeriodId.and.returnValue([]);
+
     await TestBed.configureTestingModule({
-      imports: [ChurchCalendarComponent]
-    })
-    .compileComponents();
+      imports: [ChurchCalendarComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService(),
+        SpinnerService,
+        {provide: PeriodService, useValue: periodService},
+        {provide: MatSnackBarService, useValue: jasmine.createSpyObj('MatSnackBarService', ['error', 'success'])},
+        {provide: UserService, useValue: (() => {
+          const spy = jasmine.createSpyObj('UserService', ['loadUser']);
+          spy.loadUser.and.returnValue(of({uid: 0, name: '*vendeg*'}));
+          return spy;
+        })()},
+        {provide: EditConfirmationService, useValue: jasmine.createSpyObj('EditConfirmationService', ['isConfirmed', 'confirm', 'getMessage'])},
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ChurchCalendarComponent);
     component = fixture.componentInstance;
+    component.currentChurch = templom;
+    component.masses = new Map();
+
+    // Minden teszt inicializált komponenssel dolgozik: enélkül a lebontás hasal el,
+    // mert az `ngOnDestroy` olyan feliratkozásokat bontana, amik létre sem jöttek.
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('mentetlen változás jelzése', () => {
+
+    it('érintetlen naptárban nincs mentetlen változás', () => {
+      expect(component.hasUnsavedChanges).toBeFalse();
+    });
+
+    it('módosított mise mentetlen változás', () => {
+      component.changes.set(1, mise(1));
+
+      expect(component.hasUnsavedChanges).toBeTrue();
+    });
+
+    /**
+     * A törlés is mentetlen változás — enélkül a gondnok kitörölne egy misét, elnavigálna
+     * figyelmeztetés nélkül, és a mise visszatérne.
+     */
+    it('törölt mise is mentetlen változás', () => {
+      component.deletedMasses = [5];
+
+      expect(component.hasUnsavedChanges).toBeTrue();
+    });
+
+    it('törlés és módosítás együtt is jelez', () => {
+      component.changes.set(1, mise(1));
+      component.deletedMasses = [5];
+
+      expect(component.hasUnsavedChanges).toBeTrue();
+    });
+  });
+
+  describe('kategória-szűrő', () => {
+
+    /** Üres szűrővel a naptár üresnek LÁTSZANA — pedig tele van misével. */
+    it('induláskor minden kategória aktív', () => {
+      expect(component.activeFilterCategories.size).toBeGreaterThan(0);
+      expect(component.activeFilterCategories.size).toBe(component.categories.length);
+    });
+
+    it('minden ismert kategória szerepel a szűrőben', () => {
+      for (const kategoria of component.categories) {
+        expect(component.activeFilterCategories.has(kategoria))
+          .withContext(String(kategoria))
+          .toBeTrue();
+      }
+    });
   });
 });

--- a/calendar/src/app/components/church/church.component.spec.ts
+++ b/calendar/src/app/components/church/church.component.spec.ts
@@ -1,26 +1,107 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute} from '@angular/router';
+import {provideHttpClient} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+import {provideTranslateService} from '@ngx-translate/core';
 
-import { ChurchComponent } from './church.component';
+import {ChurchComponent} from './church.component';
+import {SpinnerService} from '../../services/spinner.service';
+import {MatSnackBarService} from '../../services/mat-snack-bar.service';
+import {environment} from '../../../environments/environment';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('ChurchComponent', () => {
-  let component: ChurchComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * A komponens a miseszerkesztő belépési pontja: az útvonalból kiolvassa a templom
+ * azonosítóját, betölti az adatait, és átadja a naptárnak. Két dolog érdemel tesztet:
+ *
+ *  - a BETÖLTÉS ÚTVONALA — ha elromlik, a szerkesztő üres marad;
+ *  - a HIBAÁG — a felhasználó kapjon értelmes üzenetet, ne néma üres lapot. A
+ *    komponens ezért hiba esetén is `dataLoaded`-re vált, hogy a sablon meg tudja
+ *    jeleníteni a magyarázatot.
+ */
+describe('ChurchComponent', () => {
+
   let fixture: ComponentFixture<ChurchComponent>;
+  let component: ChurchComponent;
+  let httpMock: HttpTestingController;
+
+  const TEMPLOM_ID = 42;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ChurchComponent]
-    })
-    .compileComponents();
+      imports: [ChurchComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService(),
+        SpinnerService,
+        {provide: MatSnackBarService, useValue: jasmine.createSpyObj('MatSnackBarService', ['error', 'success'])},
+        {
+          provide: ActivatedRoute,
+          useValue: {snapshot: {params: {id: String(TEMPLOM_ID)}, queryParamMap: new Map()}},
+        },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ChurchComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('az útvonalból vett azonosítóval tölti be a templomot', () => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID);
+    expect(req.request.method).toBe('GET');
+    req.flush({id: TEMPLOM_ID, name: 'Teszt templom', masses: []});
+  });
+
+  it('a betöltött miséket azonosító szerint tárolja', () => {
+    fixture.detectChanges();
+
+    httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID).flush({
+      id: TEMPLOM_ID,
+      name: 'Teszt templom',
+      masses: [{id: 10, churchId: TEMPLOM_ID}, {id: 11, churchId: TEMPLOM_ID}],
+    });
+
+    expect(component.masses.size).toBe(2);
+    expect(component.masses.get(10)!.churchId).toBe(TEMPLOM_ID);
+  });
+
+  it('az érzékelő-eseményeket külön veszi át', () => {
+    fixture.detectChanges();
+
+    httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID).flush({
+      id: TEMPLOM_ID, masses: [], eventsFromSensor: [{id: 'confession_1'}],
+    });
+
+    expect(component.sensorEvents.length).toBe(1);
+  });
+
+  /**
+   * A hibaág a lényeg: a felhasználó ne néma üres lapot kapjon. A `dataLoaded` hibánál
+   * is igazra vált, mert a sablon ezen az ágon jeleníti meg a magyarázatot.
+   */
+  it('hiba esetén magyarázatot ad, nem üres lapot', () => {
+    fixture.detectChanges();
+
+    httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID)
+      .flush('nem elérhető', {status: 500, statusText: 'Server Error'});
+
+    expect(component.loadError).toBeTruthy();
+    expect(component.dataLoaded).withContext('a sablonnak meg kell tudnia jeleníteni az üzenetet').toBeTrue();
+    expect(component.currentChurch).toBeUndefined();
+  });
+
+  it('hiba után nem marad ottfelejtett adat', () => {
+    fixture.detectChanges();
+
+    httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID)
+      .flush('hiba', {status: 500, statusText: 'Server Error'});
+
+    expect(component.masses.size).toBe(0);
+    expect(component.sensorEvents.length).toBe(0);
   });
 });

--- a/calendar/src/app/components/copy-period-dialog/copy-period-dialog.component.spec.ts
+++ b/calendar/src/app/components/copy-period-dialog/copy-period-dialog.component.spec.ts
@@ -1,26 +1,102 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {provideTranslateService} from '@ngx-translate/core';
 
-import { CopyPeriodDialogComponent } from './copy-period-dialog.component';
+import {CopyPeriodDialogComponent, CopyPeriodDialogData} from './copy-period-dialog.component';
+import {PeriodService} from '../../services/period.service';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('CopyPeriodDialogComponent', () => {
-  let component: CopyPeriodDialogComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez a dialógus másolja át egy időszak miséit egy másikba — épp az a művelet, ami a
+ * #747-hez vezetett („átmásolom, és az eredeti eltűnik"). Ezért itt nem elég, hogy a
+ * komponens létrejön:
+ *
+ *  - a CÉLIDŐSZAK kötelező. Üres választással a másolás értelmezhetetlen, és ha az
+ *    űrlap mégis érvényesnek látszana, a felhasználó a semmibe másolna;
+ *  - a keresőmező szűkítsen, kis-nagybetűtől függetlenül — a listában több tucat
+ *    időszak van, végiggörgetni használhatatlan.
+ */
+describe('CopyPeriodDialogComponent', () => {
+
   let fixture: ComponentFixture<CopyPeriodDialogComponent>;
+  let component: CopyPeriodDialogComponent;
+
+  const adat: CopyPeriodDialogData = {
+    sourcePeriodId: 1,
+    sourcePeriodName: 'Egész évben',
+    availablePeriods: [
+      {id: 2, name: 'Nyári időszámítás'} as any,
+      {id: 3, name: 'Téli időszámítás'} as any,
+      {id: 4, name: 'Nyári szünet'} as any,
+    ],
+    massCount: 5,
+  };
 
   beforeEach(async () => {
+    const periodService = jasmine.createSpyObj('PeriodService', ['getGeneratedPeriodsByPeriodId']);
+    periodService.getGeneratedPeriodsByPeriodId.and.returnValue([{color: '#123456'}]);
+
     await TestBed.configureTestingModule({
-      imports: [ CopyPeriodDialogComponent ]
-    })
-    .compileComponents();
+      imports: [CopyPeriodDialogComponent],
+      providers: [
+        provideTranslateService(),
+        {provide: MatDialogRef, useValue: jasmine.createSpyObj('MatDialogRef', ['close'])},
+        {provide: PeriodService, useValue: periodService},
+        {provide: MAT_DIALOG_DATA, useValue: adat},
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CopyPeriodDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  /** Célidőszak nélkül a másolás értelmezhetetlen. */
+  it('célidőszak nélkül az űrlap érvénytelen', () => {
+    expect(component.form.valid).toBeFalse();
+  });
+
+  it('célidőszakkal érvényessé válik', () => {
+    component.form.get('targetPeriodId')!.setValue(adat.availablePeriods[0]);
+
+    expect(component.form.valid).toBeTrue();
+  });
+
+  it('a választható időszakok színt kapnak a megkülönböztetéshez', () => {
+    expect(component.availablePeriodsWithColors.length).toBe(3);
+    expect(component.availablePeriodsWithColors[0].color).toBe('#123456');
+  });
+
+  /**
+   * A szűrt lista `startWith('')`-tel indul, tehát az ELSŐ kibocsátás mindig a teljes
+   * lista. A gépelés hatását csak az azutáni kibocsátáson lehet mérni — ezért iratkozunk
+   * fel előbb, és csak utána állítjuk az értéket.
+   */
+  const szurtTalalatok = (keresés?: string): string[] => {
+    let utolso: {name: string}[] = [];
+    const feliratkozas = component.filteredPeriods$.subscribe(lista => utolso = lista);
+
+    if (keresés !== undefined) {
+      // A keresőmező KÜLÖN FormControl (`targetPeriodCtr`), nem az űrlapé — az
+      // űrlap `targetPeriodId` mezője a kötelezőséget méri, a szűrés ezen a másikon megy.
+      component.targetPeriodCtr.setValue(keresés as any);
+    }
+
+    feliratkozas.unsubscribe();
+    return utolso.map(p => p.name);
+  };
+
+  it('üres keresésre minden időszak látszik', () => {
+    expect(szurtTalalatok().length).toBe(3);
+  });
+
+  /** A szűrés kis-nagybetűtől független — a felhasználó nem az adatbázist gépeli. */
+  it('a keresés kis-nagybetűtől függetlenül szűkít', () => {
+    expect(szurtTalalatok('nyári')).toEqual(['Nyári időszámítás', 'Nyári szünet']);
+  });
+
+  it('nem illeszkedő keresésre üres a lista', () => {
+    expect(szurtTalalatok('advent').length).toBe(0);
   });
 });

--- a/calendar/src/app/components/delete-period-dialog/delete-period-dialog.component.spec.ts
+++ b/calendar/src/app/components/delete-period-dialog/delete-period-dialog.component.spec.ts
@@ -1,26 +1,90 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {provideTranslateService} from '@ngx-translate/core';
 
-import { DeletePeriodDialogComponent } from './delete-period-dialog.component';
+import {DeletePeriodDialogComponent, DeletePeriodDialogData} from './delete-period-dialog.component';
+import {PeriodService} from '../../services/period.service';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('DeletePeriodDialogComponent', () => {
-  let component: DeletePeriodDialogComponent;
-  let fixture: ComponentFixture<DeletePeriodDialogComponent>;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez a dialógus IDŐSZAK TÖRLÉSÉT erősíti meg — visszafordíthatatlan művelet, ami a
+ * hozzá tartozó miséket is elviszi. Két dolog számít:
+ *
+ *  1. A válasz értéke. A hívó `true`-ra töröl; ha a mégse ág is `true`-t adna vissza,
+ *     a felhasználó a „Mégse" gombbal törölné a miserendjét.
+ *  2. A megjelenített tartomány. Az időszak határa vagy dátum (`03-30 – 10-26`), vagy
+ *     MÁSIK IDŐSZAKHOZ kötött (Nagyböjt – Húsvét). A felhasználónak látnia kell,
+ *     pontosan mit töröl.
+ */
+describe('DeletePeriodDialogComponent', () => {
 
-  beforeEach(async () => {
+  let dialogRef: jasmine.SpyObj<MatDialogRef<DeletePeriodDialogComponent>>;
+  let periodService: jasmine.SpyObj<PeriodService>;
+
+  const letrehoz = async (data: DeletePeriodDialogData): Promise<ComponentFixture<DeletePeriodDialogComponent>> => {
+    TestBed.resetTestingModule();
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+    periodService = jasmine.createSpyObj('PeriodService', ['getPeriodNameById']);
+    periodService.getPeriodNameById.and.callFake((id: number) => id === 1 ? 'Nagyböjt' : 'Húsvét');
+
     await TestBed.configureTestingModule({
-      imports: [ DeletePeriodDialogComponent ]
-    })
-    .compileComponents();
+      imports: [DeletePeriodDialogComponent],
+      providers: [
+        provideTranslateService(),
+        {provide: MatDialogRef, useValue: dialogRef},
+        {provide: PeriodService, useValue: periodService},
+        {provide: MAT_DIALOG_DATA, useValue: data},
+      ],
+    }).compileComponents();
 
-    fixture = TestBed.createComponent(DeletePeriodDialogComponent);
-    component = fixture.componentInstance;
+    const fixture = TestBed.createComponent(DeletePeriodDialogComponent);
     fixture.detectChanges();
+    return fixture;
+  };
+
+  const adat = (period: any, generatedPeriods: any[] = []): DeletePeriodDialogData =>
+    ({period, generatedPeriods, massCount: 3} as DeletePeriodDialogData);
+
+  it('dátumhatáros időszaknál a dátumokat mutatja', async () => {
+    const fixture = await letrehoz(adat({startMonthDay: '03-30', endMonthDay: '10-26'}));
+
+    expect(fixture.componentInstance.periodRangeInfo).toBe('03-30 - 10-26');
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  /** A másik időszakhoz kötött határt névvel kell megmutatni, nem azonosítóval. */
+  it('időszakhoz kötött határnál a neveket mutatja', async () => {
+    const fixture = await letrehoz(adat({startPeriodId: 1, endPeriodId: 2}));
+
+    expect(fixture.componentInstance.periodRangeInfo).toBe('Nagyböjt - Húsvét');
+  });
+
+  it('félig kötött határnál csak az ismert végét mutatja', async () => {
+    const fixture = await letrehoz(adat({startPeriodId: 1}));
+
+    expect(fixture.componentInstance.periodRangeInfo).toBe('Nagyböjt');
+  });
+
+  it('határ nélkül üresen marad, nem talál ki semmit', async () => {
+    const fixture = await letrehoz(adat({}));
+
+    expect(fixture.componentInstance.periodRangeInfo).toBe('');
+  });
+
+  it('a generált időszak színét átveszi', async () => {
+    const fixture = await letrehoz(adat({}, [{color: '#ff0000'}]));
+
+    expect(fixture.componentInstance.periodColor).toBe('#ff0000');
+  });
+
+  /** A törlés visszafordíthatatlan: a két gomb NEM adhat ugyanolyan választ. */
+  it('a megerősítés igazzal, a mégse hamissal zár', async () => {
+    const fixture = await letrehoz(adat({}));
+
+    fixture.componentInstance.onConfirmDelete();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+
+    fixture.componentInstance.onCancel();
+    expect(dialogRef.close).toHaveBeenCalledWith(false);
   });
 });

--- a/calendar/src/app/components/edit-schedule/edit-schedule.component.spec.ts
+++ b/calendar/src/app/components/edit-schedule/edit-schedule.component.spec.ts
@@ -1,26 +1,77 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute} from '@angular/router';
+import {provideHttpClient} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+import {provideTranslateService} from '@ngx-translate/core';
 
-import { EditScheduleComponent } from './edit-schedule.component';
+import {EditScheduleComponent} from './edit-schedule.component';
+import {SpinnerService} from '../../services/spinner.service';
+import {MatSnackBarService} from '../../services/mat-snack-bar.service';
+import {environment} from '../../../environments/environment';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('EditScheduleComponent', () => {
-  let component: EditScheduleComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez a szerkesztő gondnoki nézete — ugyanazt a templomot tölti be, mint a nyilvános
+ * naptár, csak szerkeszthetően. Amit rögzítünk: a betöltés útvonala és az, hogy a
+ * misék azonosító szerint, hiánytalanul kerülnek a modellbe. Ha ez elromlik, a gondnok
+ * üres miserendet lát, és jóhiszeműen újra felviszi az egészet.
+ */
+describe('EditScheduleComponent', () => {
+
   let fixture: ComponentFixture<EditScheduleComponent>;
+  let component: EditScheduleComponent;
+  let httpMock: HttpTestingController;
+
+  const TEMPLOM_ID = 7;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [EditScheduleComponent]
-    })
-    .compileComponents();
+      imports: [EditScheduleComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService(),
+        SpinnerService,
+        {provide: MatSnackBarService, useValue: jasmine.createSpyObj('MatSnackBarService', ['error', 'success'])},
+        {
+          provide: ActivatedRoute,
+          useValue: {snapshot: {params: {id: String(TEMPLOM_ID)}, queryParamMap: new Map()}},
+        },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(EditScheduleComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('az útvonalból vett azonosítóval tölt be', () => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID);
+    expect(req.request.method).toBe('GET');
+    req.flush({id: TEMPLOM_ID, masses: []});
+  });
+
+  it('a miséket azonosító szerint tárolja', () => {
+    fixture.detectChanges();
+
+    httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID).flush({
+      id: TEMPLOM_ID,
+      masses: [{id: 1, churchId: TEMPLOM_ID}, {id: 2, churchId: TEMPLOM_ID}, {id: 3, churchId: TEMPLOM_ID}],
+    });
+
+    expect(component.masses.size).toBe(3);
+    expect(component.dataLoaded).toBeTrue();
+  });
+
+  it('mise nélküli templomot is betölt', () => {
+    fixture.detectChanges();
+
+    httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID).flush({id: TEMPLOM_ID, masses: []});
+
+    expect(component.masses.size).toBe(0);
+    expect(component.currentChurch).toBeDefined();
   });
 });

--- a/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.spec.ts
+++ b/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.spec.ts
@@ -1,26 +1,141 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog';
+import {provideTranslateService} from '@ngx-translate/core';
+import {of} from 'rxjs';
 
-import { EventViewerDialogComponent } from './event-viewer-dialog.component';
+import {EventViewerDialogComponent} from './event-viewer-dialog.component';
+import {EventViewerDialogData} from '../church-calendar/church-calendar.component';
+import {PeriodService} from '../../services/period.service';
+import {EditConfirmationService} from '../../services/edit-confirmation.service';
+import {DialogResponse} from '../../enum/dialog-response';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('EventViewerDialogComponent', () => {
-  let component: EventViewerDialogComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez az ablak nyílik meg egy miséhez a naptárban, és innen indul a szerkesztés meg a
+ * TÖRLÉS is. A válaszkódok szerződése kritikus: a hívó ezek alapján dönti el, hogy egy
+ * alkalmat vagy az EGÉSZ sorozatot törli-e. Egy felcserélt válasz nem hibaüzenetet ad,
+ * hanem csendben törli az egész miserendet.
+ *
+ * A szerkesztés előtti megerősítést egy megosztott szolgáltatás jegyzi meg: ha a
+ * felhasználó egyszer rábólintott, ne kérdezzük újra minden misénél.
+ */
+describe('EventViewerDialogComponent', () => {
+
   let fixture: ComponentFixture<EventViewerDialogComponent>;
+  let component: EventViewerDialogComponent;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<EventViewerDialogComponent>>;
+  let dialog: jasmine.SpyObj<MatDialog>;
+  let editConfirmation: jasmine.SpyObj<EditConfirmationService>;
+
+  const adat: EventViewerDialogData = {
+    churchName: 'Teszt templom',
+    mass: {id: 1, churchId: 1, title: 'Szentmise'} as any,
+    suggestOrEditable: true,
+    start: new Date('2026-08-16T09:00:00'),
+  };
+
+  const valaszol = (valasz: unknown) => dialog.open.and.returnValue({afterClosed: () => of(valasz)} as any);
 
   beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+    dialog = jasmine.createSpyObj('MatDialog', ['open']);
+    editConfirmation = jasmine.createSpyObj('EditConfirmationService', ['isConfirmed', 'confirm', 'getMessage']);
+    editConfirmation.getMessage.and.returnValue('Biztos?');
+    editConfirmation.isConfirmed.and.returnValue(false);
+
     await TestBed.configureTestingModule({
-      imports: [EventViewerDialogComponent]
-    })
-    .compileComponents();
+      imports: [EventViewerDialogComponent],
+      providers: [
+        provideTranslateService(),
+        {provide: MatDialogRef, useValue: dialogRef},
+        {provide: MatDialog, useValue: dialog},
+        {provide: PeriodService, useValue: jasmine.createSpyObj('PeriodService', ['getPeriodNameById', 'getGeneratedPeriodsByPeriodId'])},
+        {provide: EditConfirmationService, useValue: editConfirmation},
+        {provide: MAT_DIALOG_DATA, useValue: adat},
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(EventViewerDialogComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('a mise kezdetét olvasható alakra hozza', () => {
+    expect(component.start).toBeTruthy();
+    expect(typeof component.start).toBe('string');
+  });
+
+  /**
+   * A két törlés-válasz NEM cserélhető fel: az egyik egy alkalmat visz el, a másik az
+   * egész sorozatot.
+   */
+  it('egy alkalom törlése DELETE_ONE választ ad', () => {
+    valaszol(DialogResponse.CONTINUE);
+
+    component.onDeleteMassOne();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(DialogResponse.DELETE_ONE);
+  });
+
+  it('a sorozat törlése DELETE_ALL választ ad', () => {
+    valaszol(DialogResponse.CONTINUE);
+
+    component.onDeleteMassAll();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(DialogResponse.DELETE_ALL);
+  });
+
+  /** Megerősítés nélkül semmit nem törlünk. */
+  it('elutasított megerősítés esetén nem törlünk', () => {
+    valaszol('MEGSE');
+
+    component.onDeleteMassOne();
+
+    expect(dialogRef.close).not.toHaveBeenCalledWith(DialogResponse.DELETE_ONE);
+  });
+
+  /** A szerkesztés két hatóköre is külön válasz — ezek sem cserélhetők fel. */
+  it('a sorozat szerkesztése EVENT_VIEWER_EDIT_ALL választ ad', () => {
+    component.onEditMassAll();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(DialogResponse.EVENT_VIEWER_EDIT_ALL);
+  });
+
+  it('egy alkalom szerkesztése EVENT_VIEWER_EDIT_ONE választ ad', () => {
+    component.onEditMassOne();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(DialogResponse.EVENT_VIEWER_EDIT_ONE);
+  });
+
+  /**
+   * Ha a felhasználó egyszer már rábólintott a szerkesztésre, ne kérdezzük újra minden
+   * misénél — a megosztott szolgáltatás ezt jegyzi meg.
+   */
+  it('korábbi megerősítés után nem kérdez újra', () => {
+    editConfirmation.isConfirmed.and.returnValue(true);
+
+    component.onSuggestClicked();
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(component.confirmedEdit).toBeTrue();
+  });
+
+  it('első alkalommal megerősítést kér, és a döntést megjegyzi', () => {
+    valaszol(DialogResponse.CONTINUE);
+
+    component.onSuggestClicked();
+
+    expect(dialog.open).toHaveBeenCalled();
+    expect(editConfirmation.confirm).toHaveBeenCalled();
+    expect(component.confirmedEdit).toBeTrue();
+  });
+
+  it('elutasított megerősítésnél bezárja az ablakot', () => {
+    valaszol('MEGSE');
+
+    component.onSuggestClicked();
+
+    expect(component.confirmedEdit).toBeFalse();
+    expect(dialogRef.close).toHaveBeenCalled();
   });
 });

--- a/calendar/src/app/components/masses-diff/masses-diff.component.spec.ts
+++ b/calendar/src/app/components/masses-diff/masses-diff.component.spec.ts
@@ -1,26 +1,94 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideTranslateService} from '@ngx-translate/core';
 
-import { MassesDiffComponent } from './masses-diff.component';
+import {MassesDiffComponent} from './masses-diff.component';
+import {ReadableMass} from '../../model/readable-mass';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('MassesDiffComponent', () => {
-  let component: MassesDiffComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * A komponens a javaslat-jóváhagyás felületén mutatja, mi változna egy misén. Egyetlen
+ * saját logikája van, és az fontos: a KIZÁRT IDŐSZAKOK (`experiod`) eltérését külön
+ * jelzi, mert az a naptárban nem látszik közvetlenül — a kezelő enélkül úgy hagyhatna
+ * jóvá egy javaslatot, hogy nem tűnik fel neki, hogy a mise láthatósága változik.
+ *
+ * Az összehasonlítás MÉLY: az `experiod` tömb, tehát a referencia-egyezés nem elég.
+ */
+describe('MassesDiffComponent', () => {
+
   let fixture: ComponentFixture<MassesDiffComponent>;
+  let component: MassesDiffComponent;
+
+  const mise = (experiod?: number[]): ReadableMass =>
+    ({title: 'Szentmise', experiod} as unknown as ReadableMass);
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MassesDiffComponent]
-    })
-    .compileComponents();
+      imports: [MassesDiffComponent],
+      providers: [provideTranslateService()],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(MassesDiffComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('azonos kizárásoknál nem jelez változást', () => {
+    component.origMass = mise([1, 2]);
+    component.newMass = mise([1, 2]);
+
+    fixture.detectChanges();
+
+    expect(component.experiodChanged).toBeFalse();
+  });
+
+  /** Külön tömb, azonos tartalom — a referencia-összehasonlítás itt tévedne. */
+  it('a tartalmat hasonlítja össze, nem a referenciát', () => {
+    const kizarasok = [3, 4];
+    component.origMass = mise([...kizarasok]);
+    component.newMass = mise([...kizarasok]);
+
+    fixture.detectChanges();
+
+    expect(component.experiodChanged).toBeFalse();
+  });
+
+  it('eltérő kizárásoknál változást jelez', () => {
+    component.origMass = mise([1]);
+    component.newMass = mise([1, 2]);
+
+    fixture.detectChanges();
+
+    expect(component.experiodChanged).toBeTrue();
+  });
+
+  it('a kizárás megjelenése változás', () => {
+    component.origMass = mise(undefined);
+    component.newMass = mise([5]);
+
+    fixture.detectChanges();
+
+    expect(component.experiodChanged).toBeTrue();
+  });
+
+  it('a kizárás eltűnése is változás', () => {
+    component.origMass = mise([5]);
+    component.newMass = mise(undefined);
+
+    fixture.detectChanges();
+
+    expect(component.experiodChanged).toBeTrue();
+  });
+
+  /** A bemenet változásakor újra kell számolni — enélkül a régi állapot ragadna be. */
+  it('bemenet-változásnál újraszámol', () => {
+    component.origMass = mise([1]);
+    component.newMass = mise([1]);
+    fixture.detectChanges();
+    expect(component.experiodChanged).toBeFalse();
+
+    component.newMass = mise([1, 9]);
+    component.ngOnChanges({} as any);
+
+    expect(component.experiodChanged).toBeTrue();
   });
 });

--- a/calendar/src/app/components/period-exclusion-dialog/period-exclusion-dialog.component.spec.ts
+++ b/calendar/src/app/components/period-exclusion-dialog/period-exclusion-dialog.component.spec.ts
@@ -1,26 +1,61 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {provideTranslateService} from '@ngx-translate/core';
 
-import { PeriodExclusionDialogComponent } from './period-exclusion-dialog.component';
+import {PeriodExclusionDialogComponent, PeriodExclusionDialogData} from './period-exclusion-dialog.component';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('PeriodExclusionDialogComponent', () => {
-  let component: PeriodExclusionDialogComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez a dialógus arról tájékoztat, hogy egy időszak miséi KIZÁRNAK más időszakokat, vagy
+ * őket zárja ki más — vagyis pontosan arról a rétegződésről, ami a #747-ben odáig
+ * vezetett, hogy egy mise némán eltűnt a naptárból. Ha a nevek nem jutnak el a
+ * felhasználóig, nem tudja, mi történt a miserendjével.
+ */
+describe('PeriodExclusionDialogComponent', () => {
+
   let fixture: ComponentFixture<PeriodExclusionDialogComponent>;
+  let component: PeriodExclusionDialogComponent;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<PeriodExclusionDialogComponent>>;
+
+  const adat: PeriodExclusionDialogData = {
+    periodName: 'Nyári szünet',
+    recentlyExcludedPeriodNames: ['Egész évben'],
+    recentlyExclusionSourcePeriodNames: ['Nyári időszámítás'],
+  };
 
   beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
     await TestBed.configureTestingModule({
-      imports: [PeriodExclusionDialogComponent]
-    })
-    .compileComponents();
+      imports: [PeriodExclusionDialogComponent],
+      providers: [
+        provideTranslateService(),
+        {provide: MatDialogRef, useValue: dialogRef},
+        {provide: MAT_DIALOG_DATA, useValue: adat},
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PeriodExclusionDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('kiírja, melyik időszakról van szó', () => {
+    expect(fixture.nativeElement.textContent).toContain('Nyári szünet');
+  });
+
+  it('kiírja, mely időszakokat zárja ki', () => {
+    expect(fixture.nativeElement.textContent).toContain('Egész évben');
+  });
+
+  it('kiírja, mely időszakok zárják ki őt', () => {
+    expect(fixture.nativeElement.textContent).toContain('Nyári időszámítás');
+  });
+
+  it('a bezárás nem ad vissza értéket — ez csak tájékoztatás', () => {
+    component.close();
+
+    expect(dialogRef.close).toHaveBeenCalledWith();
   });
 });

--- a/calendar/src/app/components/period-year-editor/period-year-editor.component.spec.ts
+++ b/calendar/src/app/components/period-year-editor/period-year-editor.component.spec.ts
@@ -1,26 +1,110 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideTranslateService} from '@ngx-translate/core';
+import {of} from 'rxjs';
 
-import { PeriodYearEditorComponent } from './period-year-editor.component';
+import {PeriodYearEditorComponent} from './period-year-editor.component';
+import {PeriodService} from '../../services/period.service';
+import {SpinnerService} from '../../services/spinner.service';
+import {MatSnackBarService} from '../../services/mat-snack-bar.service';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('PeriodYearEditorComponent', () => {
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez a felület állítja be, hogy egy liturgikus időszak MELYIK ÉVBEN mettől meddig tart
+ * — vagyis az egész naptár alapját. A #747 is innen eredt: az időszakok évenkénti
+ * tartománya dönti el, melyik mise melyiket fedi le.
+ *
+ * Amit rögzítünk: az évenkénti sorok az időszakok NEVÉVEL együtt épülnek fel (számmal a
+ * kezelő nem tud mit kezdeni), és az ismeretlen időszakra hivatkozó sor kimarad, nem
+ * dönti el az egész szerkesztőt.
+ */
+describe('PeriodYearEditorComponent', () => {
+
   let component: PeriodYearEditorComponent;
-  let fixture: ComponentFixture<PeriodYearEditorComponent>;
+  let periodService: jasmine.SpyObj<PeriodService>;
 
-  beforeEach(async () => {
+  const idoszakok = [
+    {id: 1, name: 'Nagyböjt', multiDay: true},
+    {id: 2, name: 'Advent', multiDay: true},
+  ];
+
+  const letrehoz = async (periodsYear: any[]): Promise<ComponentFixture<PeriodYearEditorComponent>> => {
+    TestBed.resetTestingModule();
+
+    periodService = jasmine.createSpyObj('PeriodService', ['getPeriodsYear', 'saveData', 'generatePeriods'], {
+      periods$: of(idoszakok as any),
+    });
+    periodService.getPeriodsYear.and.returnValue(of(periodsYear as any));
+
     await TestBed.configureTestingModule({
-      imports: [PeriodYearEditorComponent]
-    })
-    .compileComponents();
+      imports: [PeriodYearEditorComponent],
+      providers: [
+        provideTranslateService(),
+        {provide: PeriodService, useValue: periodService},
+        SpinnerService,
+        {provide: MatSnackBarService, useValue: jasmine.createSpyObj('MatSnackBarService', ['error', 'success'])},
+      ],
+    }).compileComponents();
 
-    fixture = TestBed.createComponent(PeriodYearEditorComponent);
+    const fixture = TestBed.createComponent(PeriodYearEditorComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    return fixture;
+  };
+
+  it('betölti az időszakokat azonosító szerint', async () => {
+    await letrehoz([]);
+
+    expect(component.periods.size).toBe(2);
+    expect(component.periods.get(1)!.name).toBe('Nagyböjt');
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('évenként csoportosítja a sorokat', async () => {
+    await letrehoz([
+      {id: 10, periodId: 1, startYear: 2026, startDate: '2026-02-18', endDate: '2026-04-02'},
+      {id: 11, periodId: 2, startYear: 2026, startDate: '2026-11-29', endDate: '2026-12-24'},
+      {id: 12, periodId: 1, startYear: 2027, startDate: '2027-02-10', endDate: '2027-03-25'},
+    ]);
+
+    expect(component.periodsWrapperMap.get(2026)!.periodYearEdits.length).toBe(2);
+    expect(component.periodsWrapperMap.get(2027)!.periodYearEdits.length).toBe(1);
+  });
+
+  /** Számmal a kezelő nem tud mit kezdeni — a sorhoz oda kell a név. */
+  it('a sorok az időszak nevét is hordozzák', async () => {
+    await letrehoz([{id: 10, periodId: 1, startYear: 2026, startDate: '2026-02-18', endDate: '2026-04-02'}]);
+
+    expect(component.periodsWrapperMap.get(2026)!.periodYearEdits[0].periodName).toBe('Nagyböjt');
+  });
+
+  it('a dátumokból Date lesz, hogy a naptárválasztó kezelni tudja', async () => {
+    await letrehoz([{id: 10, periodId: 1, startYear: 2026, startDate: '2026-02-18', endDate: '2026-04-02'}]);
+
+    const sor = component.periodsWrapperMap.get(2026)!.periodYearEdits[0];
+    expect(sor.startDate instanceof Date).toBeTrue();
+    expect(sor.endDate instanceof Date).toBeTrue();
+  });
+
+  it('a hiányzó dátum null marad, nem lesz belőle érvénytelen Date', async () => {
+    await letrehoz([{id: 10, periodId: 1, startYear: 2026, startDate: null, endDate: null}]);
+
+    const sor = component.periodsWrapperMap.get(2026)!.periodYearEdits[0];
+    expect(sor.startDate).toBeNull();
+    expect(sor.endDate).toBeNull();
+  });
+
+  /** Ismeretlen időszakra hivatkozó sor kimarad — nem viszi el az egész szerkesztőt. */
+  it('ismeretlen időszakra hivatkozó sort kihagy', async () => {
+    await letrehoz([
+      {id: 10, periodId: 1, startYear: 2026, startDate: '2026-02-18', endDate: '2026-04-02'},
+      {id: 11, periodId: 999, startYear: 2026, startDate: '2026-01-01', endDate: '2026-01-02'},
+    ]);
+
+    expect(component.periodsWrapperMap.get(2026)!.periodYearEdits.length).toBe(1);
+  });
+
+  it('induláskor nincs mentetlen változás', async () => {
+    await letrehoz([]);
+
+    expect(component.changed).toBeFalse();
   });
 });

--- a/calendar/src/app/components/search/search.component.spec.ts
+++ b/calendar/src/app/components/search/search.component.spec.ts
@@ -1,26 +1,116 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+import {provideTranslateService} from '@ngx-translate/core';
 
-import { SearchComponent } from './search.component';
+import {SearchComponent} from './search.component';
+import {MatSnackBarService} from '../../services/mat-snack-bar.service';
+import {environment} from '../../../environments/environment';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('SearchComponent', () => {
-  let component: SearchComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * A kereső űrlapja a szerverről kapott listákból épül fel (egyházmegyék, megyék,
+ * városok, nyelvek, rítusok, zenék, korosztályok). Amit érdemes rögzíteni:
+ *
+ *  - a listák a válaszból TÉNYLEG feltöltődnek — üres legördülőkkel a kereső
+ *    használhatatlan, és ez a hiba csendes;
+ *  - a csoportonkénti szűrés (`liturgy` / `music` / `age`) a `group` mező alapján megy,
+ *    kis-nagybetűtől és szóközöktől függetlenül — a szerver adata ebben nem egységes;
+ *  - a zenék és a korosztályok kapnak egy „meghatározatlan" tételt, hogy a hiányzó
+ *    adatra is lehessen szűrni.
+ */
+describe('SearchComponent', () => {
+
   let fixture: ComponentFixture<SearchComponent>;
+  let component: SearchComponent;
+  let httpMock: HttpTestingController;
+
+  const valasz = {
+    egyhazmegyek: {1: {id: 1, name: 'Esztergom-Budapest'}},
+    espereskeruletek: {1: {id: 1, name: 'Budai'}},
+    orszagok: {12: {id: 12, name: 'Magyarország'}},
+    megyek: {1: {id: 1, name: 'Pest'}},
+    varosok: {1: {id: 1, name: 'Szentendre'}},
+    languages: {hu: {id: 'hu', name: 'magyar'}},
+    attributes: {
+      1: {id: 1, name: 'római', group: 'liturgy'},
+      2: {id: 2, name: 'orgona', group: ' Music '},
+      3: {id: 3, name: 'ifjúsági', group: 'AGE'},
+      4: {id: 4, name: 'egyéb', group: 'other'},
+    },
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SearchComponent]
-    })
-    .compileComponents();
+      imports: [SearchComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService(),
+        {provide: MatSnackBarService, useValue: jasmine.createSpyObj('MatSnackBarService', ['error', 'success'])},
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SearchComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  const betolt = () => {
+    fixture.detectChanges();
+    httpMock.expectOne(environment.apiUrl + 'search').flush(valasz);
+  };
+
+  it('a kereső adatait a szerverről kéri', () => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(environment.apiUrl + 'search');
+    expect(req.request.method).toBe('GET');
+    req.flush(valasz);
+  });
+
+  it('feltölti a helyi listákat', () => {
+    betolt();
+
+    expect(component.egyhazmegyek.length).toBe(1);
+    expect(component.megyek.length).toBe(1);
+    expect(component.varosok.length).toBe(1);
+    expect(component.nyelvek.length).toBe(1);
+  });
+
+  /**
+   * A `group` mező a szerver adatában nem egységes: van benne vezető szóköz és
+   * nagybetű is. A szűrésnek ezt el kell viselnie, különben a rítus- vagy
+   * zene-választó némán üres marad.
+   */
+  it('a csoportokat kis-nagybetűtől és szóköztől függetlenül szűri', () => {
+    betolt();
+
+    expect(component.ritusok.map(r => r.name)).toContain('római');
+    expect(component.zenek.map(z => z.name)).toContain('orgona');
+    expect(component.korosztalyok.map(k => k.name)).toContain('ifjúsági');
+  });
+
+  it('az ismeretlen csoportú tétel egyik listába sem kerül be', () => {
+    betolt();
+
+    const mind = [...component.ritusok, ...component.zenek, ...component.korosztalyok].map(x => x.name);
+    expect(mind).not.toContain('egyéb');
+  });
+
+  /** A hiányzó adatra is lehessen szűrni — ezért kap külön tételt. */
+  it('a zenéknél és a korosztályoknál van „meghatározatlan" tétel', () => {
+    betolt();
+
+    expect(component.zenek.some(z => z.id === -1)).toBeTrue();
+    expect(component.korosztalyok.some(k => k.id === -1)).toBeTrue();
+  });
+
+  it('felépíti a kereső űrlapot', () => {
+    betolt();
+
+    expect(component.searchForm.contains('kulcsszo')).toBeTrue();
+    expect(component.searchForm.contains('telepules')).toBeTrue();
   });
 });

--- a/calendar/src/app/components/suggestions/suggestions.component.spec.ts
+++ b/calendar/src/app/components/suggestions/suggestions.component.spec.ts
@@ -1,26 +1,114 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute} from '@angular/router';
+import {provideHttpClient} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+import {provideTranslateService} from '@ngx-translate/core';
+import {of} from 'rxjs';
 
-import { SuggestionsComponent } from './suggestions.component';
+import {SuggestionsComponent} from './suggestions.component';
+import {SpinnerService} from '../../services/spinner.service';
+import {MatSnackBarService} from '../../services/mat-snack-bar.service';
+import {PeriodService} from '../../services/period.service';
+import {environment} from '../../../environments/environment';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('SuggestionsComponent', () => {
-  let component: SuggestionsComponent;
+/**
+ * #436: CLI-generált csonk volt (`should create`), `xdescribe`-bal kikapcsolva.
+ *
+ * Ez a jóváhagyó felület: itt dönti el a gondnok, hogy egy beküldött javaslat bekerül-e
+ * a miserendbe. Két betöltés fut egymás után — előbb a templom jelenlegi miséi, aztán a
+ * javaslatok —, mert a felület a KETTŐ KÜLÖNBSÉGÉT mutatja. Ha a sorrend vagy az
+ * útvonal elromlik, a kezelő üres különbséget lát, és jóváhagy valamit, amit nem látott.
+ *
+ * A `hasSuggestion` jelző azt mondja meg, van-e egyáltalán mit jóváhagyni — enélkül a
+ * felület üres táblázatot mutatna magyarázat nélkül.
+ */
+describe('SuggestionsComponent', () => {
+
   let fixture: ComponentFixture<SuggestionsComponent>;
+  let component: SuggestionsComponent;
+  let httpMock: HttpTestingController;
+
+  const TEMPLOM_ID = 3;
 
   beforeEach(async () => {
+    const periodService = jasmine.createSpyObj('PeriodService',
+      ['getPeriodNameById', 'getGeneratedPeriodsByPeriodId', 'getPeriodById'], {periods$: of([])});
+
     await TestBed.configureTestingModule({
-      imports: [SuggestionsComponent]
-    })
-    .compileComponents();
+      imports: [SuggestionsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService(),
+        SpinnerService,
+        {provide: PeriodService, useValue: periodService},
+        {provide: MatSnackBarService, useValue: jasmine.createSpyObj('MatSnackBarService', ['error', 'success'])},
+        {
+          provide: ActivatedRoute,
+          // A komponens a `packageId` query-paraméterből választ kezdő csomagot, ezért a
+          // `queryParams` nem hiányozhat a mockból.
+          useValue: {snapshot: {params: {id: String(TEMPLOM_ID)}, queryParams: {}, queryParamMap: new Map()}},
+        },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SuggestionsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  /** Előbb a jelenlegi állapot, csak utána a javaslatok — a felület a kettő különbsége. */
+  const betolt = (csomagok: any[], misek: any[] = [{id: 1, churchId: TEMPLOM_ID}]) => {
+    fixture.detectChanges();
+    httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID)
+      .flush({id: TEMPLOM_ID, masses: misek});
+    httpMock.expectOne(environment.apiUrl + 'suggestions/church/' + TEMPLOM_ID)
+      .flush(csomagok);
+  };
+
+  it('előbb a templom miséit tölti be', () => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(environment.apiUrl + 'church/' + TEMPLOM_ID);
+    expect(req.request.method).toBe('GET');
+    req.flush({id: TEMPLOM_ID, masses: []});
+
+    httpMock.expectOne(environment.apiUrl + 'suggestions/church/' + TEMPLOM_ID).flush([]);
+  });
+
+  it('a jelenlegi miséket azonosító szerint tárolja', () => {
+    betolt([], [{id: 1, churchId: TEMPLOM_ID}, {id: 2, churchId: TEMPLOM_ID}]);
+
+    expect(component.origMasses.size).toBe(2);
+    expect(component.origDataLoaded).toBeTrue();
+  });
+
+  it('a javaslat-csomagokat átveszi', () => {
+    betolt([
+      {id: 5, churchId: TEMPLOM_ID, createdAt: '2026-08-01T10:00:00', suggestions: []},
+      {id: 6, churchId: TEMPLOM_ID, createdAt: '2026-08-02T10:00:00', suggestions: []},
+    ]);
+
+    expect(component.suggestionPackages.length).toBe(2);
+  });
+
+  /** A beküldés dátumát a kezelő látja — sztringből Date kell, hogy formázni lehessen. */
+  it('a beküldés dátumából Date lesz', () => {
+    betolt([{id: 5, churchId: TEMPLOM_ID, createdAt: '2026-08-01T10:00:00', suggestions: []}]);
+
+    expect(component.suggestionPackages[0].createdAt instanceof Date).toBeTrue();
+  });
+
+  /** Üres listánál a felület mondja meg, hogy nincs mit jóváhagyni. */
+  it('javaslat nélkül jelzi, hogy nincs mit jóváhagyni', () => {
+    betolt([]);
+
+    expect(component.hasSuggestion).toBeFalse();
+  });
+
+  it('javaslattal marad a jóváhagyó nézet', () => {
+    betolt([{id: 5, churchId: TEMPLOM_ID, createdAt: '2026-08-01T10:00:00', suggestions: []}]);
+
+    expect(component.hasSuggestion).toBeTrue();
   });
 });

--- a/calendar/src/app/event.service.spec.ts
+++ b/calendar/src/app/event.service.spec.ts
@@ -1,19 +1,188 @@
-import { TestBed } from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
 
-import { EventService } from './event.service';
+import {EventService} from './event.service';
+import {MatSnackBarService} from './services/mat-snack-bar.service';
+import {environment} from '../environments/environment';
+import {SuggestionPackage, SuggestionState} from './model/suggestion-package';
+import {Mass} from './model/mass';
 
-// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
-// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
-// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
-xdescribe('EventService', () => {
+/**
+ * #436: ez a fájl egy CLI-generált csonk volt (`should be created`), `xdescribe`-bal
+ * kikapcsolva, mert nem voltak hozzá DI-providerek.
+ *
+ * A szolgáltatás a naptár EGYETLEN kapcsolata a szerverrel: minden betöltés, mentés,
+ * javaslat-beküldés és jóváhagyás rajta megy át. Amit itt érdemes rögzíteni, az nem a
+ * példányosíthatóság, hanem a SZERZŐDÉS: milyen URL-re, milyen metódussal és milyen
+ * törzzsel megyünk — mert ezt a backend oldaláról senki nem látja, és egy elgépelt
+ * útvonal csendben 404-et hoz, amit a felhasználó „nem sikerült menteni"-ként él meg.
+ *
+ * A hibaágat is mérjük: a szolgáltatás minden hívásnál üzenetet küld a felhasználónak,
+ * és TOVÁBBDOBJA a hibát. Ha csak elnyelné, a hívó azt hinné, sikerült.
+ */
+describe('EventService', () => {
+
   let service: EventService;
+  let httpMock: HttpTestingController;
+  let snackBar: jasmine.SpyObj<MatSnackBarService>;
+
+  const api = environment.apiUrl;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    snackBar = jasmine.createSpyObj('MatSnackBarService', ['error', 'success']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        EventService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {provide: MatSnackBarService, useValue: snackBar},
+      ],
+    });
+
     service = TestBed.inject(EventService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  afterEach(() => {
+    // Kiadatlan kérés = a szolgáltatás mást hívott, mint amit a teszt vár.
+    httpMock.verify();
+  });
+
+  describe('templom betöltése', () => {
+
+    it('a templom azonosítójával kéri le az adatokat', () => {
+      service.getChurch(42).subscribe();
+
+      const req = httpMock.expectOne(api + 'church/42');
+      expect(req.request.method).toBe('GET');
+      req.flush({id: 42, masses: []});
+    });
+
+    it('hiba esetén szól a felhasználónak ÉS továbbdobja a hibát', () => {
+      let kapottHiba = false;
+      service.getChurch(42).subscribe({error: () => kapottHiba = true});
+
+      httpMock.expectOne(api + 'church/42').flush('nem elérhető', {status: 500, statusText: 'Server Error'});
+
+      expect(snackBar.error).toHaveBeenCalled();
+      expect(kapottHiba).withContext('a hívónak tudnia kell, hogy elhasalt').toBeTrue();
+    });
+  });
+
+  describe('mentés', () => {
+
+    const mise = (id: number): Mass => ({id, churchId: 1, title: 'Szentmise'} as Mass);
+
+    it('a templom azonosítójára POST-ol', () => {
+      service.saveChanges(7, [mise(1)], [2, 3]).subscribe();
+
+      const req = httpMock.expectOne(api + 'masses/7');
+      expect(req.request.method).toBe('POST');
+      req.flush([]);
+    });
+
+    /**
+     * A törzs alakja a backend szerződése: a `masses` és a `deletedMasses` kulcs
+     * nevén múlik, hogy a mentés egyáltalán megtörténik-e.
+     */
+    it('a törzsben a módosított és a törölt misék külön kulcson mennek', () => {
+      service.saveChanges(7, [mise(1), mise(2)], [9]).subscribe();
+
+      const req = httpMock.expectOne(api + 'masses/7');
+      expect(req.request.body.masses.length).toBe(2);
+      expect(req.request.body.deletedMasses).toEqual([9]);
+      req.flush([]);
+    });
+
+    it('üres változtatással is elmegy a kérés', () => {
+      service.saveChanges(7, [], []).subscribe();
+
+      const req = httpMock.expectOne(api + 'masses/7');
+      expect(req.request.body.masses).toEqual([]);
+      expect(req.request.body.deletedMasses).toEqual([]);
+      req.flush([]);
+    });
+
+    it('hiba esetén szól és továbbdobja', () => {
+      let kapottHiba = false;
+      service.saveChanges(7, [], []).subscribe({error: () => kapottHiba = true});
+
+      httpMock.expectOne(api + 'masses/7').flush('hiba', {status: 403, statusText: 'Forbidden'});
+
+      expect(snackBar.error).toHaveBeenCalled();
+      expect(kapottHiba).toBeTrue();
+    });
+  });
+
+  describe('javaslatok', () => {
+
+    const csomag = (id: number): SuggestionPackage => ({id, churchId: 1, suggestions: []} as unknown as SuggestionPackage);
+
+    it('beküldés a templom javaslat-útvonalára megy', () => {
+      service.sendToApprove(5, csomag(0)).subscribe();
+
+      const req = httpMock.expectOne(api + 'suggestions/church/5');
+      expect(req.request.method).toBe('POST');
+      req.flush({success: true});
+    });
+
+    it('állapot nélkül a teljes listát kéri', () => {
+      service.getSuggestions(5).subscribe();
+
+      const req = httpMock.expectOne(api + 'suggestions/church/5');
+      expect(req.request.method).toBe('GET');
+      req.flush([]);
+    });
+
+    it('állapottal szűkítve az útvonal végére kerül a szűrő', () => {
+      service.getSuggestions(5, SuggestionState.PENDING).subscribe();
+
+      httpMock.expectOne(api + 'suggestions/church/5/' + SuggestionState.PENDING).flush([]);
+    });
+
+    it('elfogadásnál az állapot a törzsben megy', () => {
+      service.simpleAcceptSuggestionPackage(csomag(11)).subscribe();
+
+      const req = httpMock.expectOne(api + 'suggestions/accept/11');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body.state).toBe(SuggestionState.ACCEPTED);
+      req.flush({suggestionPackages: [], calendarMasses: []});
+    });
+
+    /**
+     * #543: az elutasító levél a beküldőnek CSAK akkor megy ki, ha a kezelő kérte.
+     * Az alapértelmezés `false` — ezt itt is rögzítjük, mert egy néma `true` alapérték
+     * miatt minden téves beküldésre levelet kapna a beküldő.
+     */
+    it('elutasításnál alapból NEM értesítjük a beküldőt', () => {
+      service.simpleRejectSuggestionPackage(csomag(12)).subscribe();
+
+      const req = httpMock.expectOne(api + 'suggestions/reject/12');
+      expect(req.request.body.state).toBe(SuggestionState.REJECTED);
+      expect(req.request.body.notify_sender).toBeFalse();
+      req.flush({suggestionPackages: [], calendarMasses: []});
+    });
+
+    it('elutasításnál kérésre értesítjük a beküldőt', () => {
+      service.simpleRejectSuggestionPackage(csomag(12), true).subscribe();
+
+      const req = httpMock.expectOne(api + 'suggestions/reject/12');
+      expect(req.request.body.notify_sender).toBeTrue();
+      req.flush({suggestionPackages: [], calendarMasses: []});
+    });
+  });
+
+  describe('liturgikus napok', () => {
+
+    it('a két dátum query-paraméterként megy', () => {
+      service.getLiturgicalDays('2026-01-01', '2026-12-31').subscribe();
+
+      const req = httpMock.expectOne(r => r.url === api + 'liturgicaldays');
+      expect(req.request.params.get('from')).toBe('2026-01-01');
+      expect(req.request.params.get('until')).toBe('2026-12-31');
+      req.flush({});
+    });
   });
 });


### PR DESCRIPTION
Tizennégy spec `xdescribe`-bal pendingben állt, mindegyikben ugyanazzal a jegyzettel:

```
// TODO #436: ez a stub az Angular CLI által generált, valódi TestBed mock-okat
// nem tartalmaz. Amíg ki nem egészítjük, xdescribe-bal pendingben hagyjuk, hogy a
// 'ng test' ne essen miatta piros. Promóció: vissza describe-ra + DI providerek.
```

A puszta bekapcsolás egy `should create` füsttesztet adott volna. Ezért mindegyik azt méri, ami az adott egységben elromolhat — és amelynek a romlása **csendes**, tehát a felhasználó nem hibaüzenetet kap, hanem rossz eredményt.

| Spec | Mit mér |
|---|---|
| **EventService** | az URL-ek, a törzs alakja, a hibaág. A backend felől ezt senki nem látja; egy elgépelt útvonal 404, amit a felhasználó „nem sikerült menteni"-ként él meg. A hibát tovább is kell dobni, különben a hívó azt hinné, sikerült. |
| **ChurchCalendar** | a mentetlen változás jelzése — erre épül az elnavigálás-figyelmeztetés; tévesen hamis értéknél a gondnok félórás munkája nyomtalanul elvész. Plusz a kategória-szűrő indulóhalmaza: üresen a naptár üresnek látszana. |
| **EventViewer** | a törlés- és szerkesztés-válaszkódok. „Egy alkalom" vagy „az egész sorozat" — felcserélve nem hibaüzenet jön, hanem csendben törlődik a miserend. |
| **DeletePeriod** | a megerősítés igazzal, a mégse hamissal zár; a másik időszakhoz kötött határ névvel jelenik meg, nem azonosítóval. |
| **CopyPeriod** | célidőszak nélkül az űrlap érvénytelen; a kereső kis-nagybetűtől függetlenül szűkít. |
| **Church / EditSchedule / Suggestions** | a betöltés útvonala és a hibaág — a felhasználó ne néma üres lapot kapjon. |
| **Search** | a legördülők feltöltése, és hogy a csoport-szűrés elviseli a szerver adatában lévő nagybetűt és vezető szóközt (`' Music '`, `'AGE'`). |
| **PeriodYearEditor** | évenkénti csoportosítás névvel; ismeretlen időszakra hivatkozó sor kimarad, nem viszi el a szerkesztőt. |
| **MassesDiff** | a kizárt időszakok **mély** összehasonlítása — ez a naptárban nem látszik, a kezelő enélkül észrevétlenül hagyna jóvá láthatóság-változást. |
| **AddMessage / PeriodExclusion / App** | a döntés-válasz, a kiírt időszaknevek, a magyar nyelv beállítása. |

## Amit közben megtudtam a kódról

- A `CopyPeriodDialog`-ban a keresőmező **külön `FormControl`** (`targetPeriodCtr`), nem az űrlap `targetPeriodId` mezője — a kettő külön él. Ezt a teszt most rögzíti is.
- Az `EventViewerDialog`-ban a szerkesztés-megerősítés az `onSuggestClicked()`-ben van, nem a szerkesztő metódusokban.
- A `PeriodService.generatedPeriods$` `BehaviorSubject`, mert a naptár `getValue()`-t hív rajta.

## Eredmény

**215 → 297 zöld**, és nem maradt kihagyott teszt (korábban 16 volt). A build változatlanul lefut.