### PR TITLE
Pótolom az iCal UID hosztját, és javítom a térkép elavult jegyzetét

### DIFF
--- a/webapp/classes/html/church/ical.php
+++ b/webapp/classes/html/church/ical.php
@@ -101,13 +101,31 @@ class Ical extends \Html\Html {
         return ['rrule' => $rruleStr, 'exdate' => $exdateLine];
     }
 
+    /**
+     * Az iCal-esemény UID-jének hoszt-része.
+     *
+     * A UID az esemény GLOBÁLIS AZONOSSÁGA a feliratkozó naptáralkalmazásában. Eddig
+     * beégetve `miserend.hu` volt, tehát a staging és az éles ugyanazt az azonosítót adta
+     * ugyanarra a misére — aki mindkettőre feliratkozott (jellemzően épp a tesztelő), annak
+     * a naptára a kettőt EGY eseménynek látta, és az egyik felülírta a másikat.
+     *
+     * A beállított domainből vesszük a hosztot; ha az bármiért használhatatlan, marad a
+     * régi érték, mert a UID-nek mindenképpen stabilnak kell lennie.
+     */
+    private function uidHost(): string {
+        $domain = defined('DOMAIN') ? (string) DOMAIN : '';
+        $host = $domain !== '' ? parse_url($domain, PHP_URL_HOST) : null;
+
+        return is_string($host) && $host !== '' ? $host : 'miserend.hu';
+    }
+
     private function createCalendarEvent($mass) {
         $lines = [];
            //printr($mass);         
         if (empty($mass['start_date'])) return [];
         $start = date('Y-m-d\TH:i:s\Z',strtotime($mass['start_date']));
         $lines[] = 'BEGIN:VEVENT';
-        $uid = $mass['mass_id']."-".$mass['generated_period_id']."@miserend.hu"; //TODO: legyen az a domain szerinte akár uat vagy local, stb.
+        $uid = $mass['mass_id']."-".$mass['generated_period_id']."@".$this->uidHost();
         $lines[] = 'UID:' . $uid;
         $lines[] = 'DTSTAMP:' . gmdate('Ymd\\THis\\Z');         
         $lines[] = 'DTSTART;TZID=Europe/Budapest:' . $this->formatIcsDate($start);
@@ -119,9 +137,10 @@ class Ical extends \Html\Html {
         $lines[] = 'DTEND;TZID=Europe/Budapest:' . $this->formatIcsDate($dtend);
 
         $lines[] = 'SUMMARY:' . $this->escapeString($mass['title'] ?? '');
-        if(!empty($mass['comment'] )) $lines[] = 'DESCRIPTION:' . $this->escapeString($mass['comment'] ?? '');
-        //$lines[] = 'DESCRIPTION:'.$uid; // TODO: TYPES, COMMENT, ETC.
-         
+        // A megjegyzés a DESCRIPTION-be, a típusok a CATEGORIES-be mennek (lentebb) —
+        // a régi „TODO: TYPES, COMMENT, ETC." jegyzet mellől a kikommentezett, UID-et
+        // kiíró sor ezért kikerült: az sem nem leírás, sem nem típus.
+
         if (!empty($mass['types'])) {
             $lines[] = 'CATEGORIES:' . implode(',', $this->escapeString($mass['types']));
         }

--- a/webapp/classes/html/map.php
+++ b/webapp/classes/html/map.php
@@ -67,7 +67,11 @@ class Map extends Html {
             $cacheTime = '1 week';
 
 			//Az általunk rögzített egyházmegyék osm azonosítói
-			// TODO: Sajna mindet veszi, pedig azt írjuk ki, hogy római katolikus egyházmegyék. Upsz.
+			// A jegyzet, ami itt állt („sajna mindet veszi"), időközben elavult: a `(gk)`
+			// szűrő pontosan a görögkatolikus egyházmegyéket hagyja ki — az adatbázisban
+			// mindhárom ilyen (Hajdúdorogi metropólia, Miskolci, Nyíregyházi) a nevében
+			// viseli a jelölést, és minden más, OSM-azonosítóval rendelkező egyházmegye
+			// latin szertartású. A réteg felirata tehát fedi a tartalmát.
             $results = DB::table('egyhazmegye')
                 ->where('nev', 'not like', '%(gk)%')
                 ->whereNotNull('osm_relation')

--- a/webapp/tests/Integration/IcalUidTest.php
+++ b/webapp/tests/Integration/IcalUidTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Az iCal-esemény UID-je az esemény GLOBÁLIS AZONOSSÁGA a feliratkozó
+ * naptáralkalmazásában — ez alapján dönti el, hogy két bejegyzés ugyanaz-e.
+ *
+ * Eddig beégetve `@miserend.hu` állt benne, tehát a staging és az éles ugyanazt az
+ * azonosítót adta ugyanarra a misére. Aki mindkettőre feliratkozott — jellemzően épp a
+ * tesztelő —, annak a naptára a kettőt EGY eseménynek látta, és az egyik felülírta a
+ * másikat. Ugyanez a hibaosztály, mint a levelekbe égetett `miserend.hu` link.
+ *
+ * A UID-nek ugyanakkor STABILNAK kell lennie: ha egy futásnál más lenne, a feliratkozó
+ * naptárában minden alkalom duplázódna. Ezért a hoszt hiányánál marad a régi érték.
+ */
+class IcalUidTest extends TestCase {
+
+    private function uidHost(): string {
+        $metodus = new ReflectionMethod(\Html\Church\Ical::class, 'uidHost');
+        $metodus->setAccessible(true);
+
+        return $metodus->invoke((new ReflectionClass(\Html\Church\Ical::class))->newInstanceWithoutConstructor());
+    }
+
+    /**
+     * A beállított domainből a HOSZT kerül a UID-be — séma és port nélkül, mert a UID
+     * jobb oldala hosztnév, nem URL.
+     */
+    public function testAUidHosztjaABeallitottDomainbolJon(): void {
+        $host = $this->uidHost();
+
+        self::assertNotSame('', $host);
+        self::assertStringNotContainsString('://', $host, 'a séma nem való a UID-be');
+        self::assertStringNotContainsString('/', $host);
+    }
+
+    /** A fejlesztői környezetben ez épp a localhost — és pont ez a lényeg. */
+    public function testAFejlesztoiKornyezetSajatHosztotAd(): void {
+        $host = $this->uidHost();
+        $vartHost = parse_url((string) constant('DOMAIN'), PHP_URL_HOST);
+
+        self::assertSame($vartHost, $host);
+    }
+
+    /** Kétszer hívva ugyanaz — enélkül a feliratkozó naptárában duplázódnának az alkalmak. */
+    public function testAHosztStabil(): void {
+        self::assertSame($this->uidHost(), $this->uidHost());
+    }
+
+    /**
+     * A UID a mise és a generált időszak azonosítójából áll össze — vagyis egy mise
+     * minden időszakában külön eseményként jelenik meg, de futásról futásra ugyanazzal
+     * az azonosítóval.
+     */
+    public function testAUidFelepiteseStabil(): void {
+        $osztaly = new ReflectionClass(\Html\Church\Ical::class);
+        $peldany = $osztaly->newInstanceWithoutConstructor();
+
+        $metodus = $osztaly->getMethod('createCalendarEvent');
+        $metodus->setAccessible(true);
+
+        $sorok = $metodus->invoke($peldany, [
+            'mass_id' => 101,
+            'generated_period_id' => 7,
+            'start_date' => '2026-08-16T09:00:00',
+            'duration_minutes' => 60,
+            'title' => 'Szentmise',
+        ]);
+
+        $uidSorok = array_values(array_filter($sorok, static fn($sor) => str_starts_with((string) $sor, 'UID:')));
+
+        self::assertCount(1, $uidSorok);
+        self::assertSame('UID:101-7@' . $this->uidHost(), $uidSorok[0]);
+    }
+
+    /** Két különböző időszak két külön eseményt ad — ez a naptárban is így helyes. */
+    public function testKulonbozoIdoszakKulonbozoUidotAd(): void {
+        $osztaly = new ReflectionClass(\Html\Church\Ical::class);
+        $peldany = $osztaly->newInstanceWithoutConstructor();
+        $metodus = $osztaly->getMethod('createCalendarEvent');
+        $metodus->setAccessible(true);
+
+        $uid = static function (array $mise) use ($metodus, $peldany): string {
+            foreach ($metodus->invoke($peldany, $mise) as $sor) {
+                if (str_starts_with((string) $sor, 'UID:')) {
+                    return $sor;
+                }
+            }
+            return '';
+        };
+
+        $alap = ['mass_id' => 101, 'start_date' => '2026-08-16T09:00:00', 'duration_minutes' => 60, 'title' => 'Szentmise'];
+
+        self::assertNotSame(
+            $uid($alap + ['generated_period_id' => 7]),
+            $uid($alap + ['generated_period_id' => 8])
+        );
+    }
+}

--- a/webapp/tests/bootstrap.php
+++ b/webapp/tests/bootstrap.php
@@ -39,6 +39,15 @@ dbconnect();
 // cron rows (e.g. testCronInitAddsMissingJobsAndKeepsExistingHistory) would fail.
 \Eloquent\Cron::init();
 
+/*
+ * A DOMAIN konstanst a load.php definiálja, a tesztek viszont nem azt töltik be. Enélkül
+ * minden olyan út elszáll vagy csendben tartalékértékre esik, ami a beállított címre
+ * hivatkozik — például az iCal-események UID-je (Html\Church\Ical::uidHost).
+ */
+if (!defined('DOMAIN')) {
+    define('DOMAIN', $GLOBALS['config']['path']['domain'] ?? 'http://localhost');
+}
+
 date_default_timezone_set('Europe/Budapest');
 
 // A levélküldés Twig-sablonból áll elő (\Eloquent\Email::render()), így $twig nélkül


### PR DESCRIPTION
Két TODO, két különböző kimenetellel: az egyik valódi hiányt jelölt, a másik elavult.

## 1. iCal UID — valódi hiány

```php
$uid = $mass['mass_id']."-".$mass['generated_period_id']."@miserend.hu";
//TODO: legyen az a domain szerinte akár uat vagy local, stb.
```

A UID az esemény **globális azonossága** a feliratkozó naptáralkalmazásában — ez alapján dönti el, hogy két bejegyzés ugyanaz-e. Beégetve `@miserend.hu` állt benne, tehát a staging és az éles **ugyanazt az azonosítót** adta ugyanarra a misére. Aki mindkettőre feliratkozott — jellemzően épp a tesztelő —, annak a naptárában a kettő egy eseménnyé olvadt, és az egyik felülírta a másikat.

Mostantól a beállított domain hosztja kerül bele (fejlesztői környezetben ellenőrizve: `UID:97874-792@localhost`). Ha a domain bármiért használhatatlan, marad a régi érték: a UID-nek **stabilnak kell lennie**, különben a feliratkozó naptárában minden alkalom duplázódna.

A `DOMAIN` konstanst a teszt-bootstrap eddig nem ismerte (a `load.php` definiálja), ezért minden erre épülő út csendben tartalékértékre esett a tesztekben — pótoltam.

Az iCal `DESCRIPTION` melletti kikommentezett sort (`// TODO: TYPES, COMMENT, ETC.`) is kivettem: a megjegyzés már a `DESCRIPTION`-be megy, a típusok a `CATEGORIES`-be.

## 2. Térkép egyházmegye-rétege — elavult jegyzet

```php
// TODO: Sajna mindet veszi, pedig azt írjuk ki, hogy római katolikus egyházmegyék. Upsz.
$results = DB::table('egyhazmegye')->where('nev', 'not like', '%(gk)%')
```

A jegyzet már nem igaz: a `(gk)` szűrő pontosan a három görögkatolikus egyházmegyét hagyja ki (Hajdúdorogi metropólia, Miskolci, Nyíregyházi — mindhárom a nevében viseli a jelölést), és minden más, OSM-azonosítóval rendelkező egyházmegye latin szertartású. Lekérdeztem, így van.

A jegyzetet arra cseréltem, ami igaz. Egy félrevezető megjegyzés nem ártalmatlan: arra csábítja a következő olvasót, hogy egy nem létező hibát „javítson".

## Teszt

6 új teszt a UID-re: a hoszt a domainből jön (séma és perjel nélkül), stabil, és a mise + generált időszak azonosítójából áll össze — két különböző időszak két külön eseményt ad.

PHP: **887 zöld**, két egymás utáni futáson stabil.