### PR TITLE
Befejezem a kis TODO-kat, és tényekre cserélem az elavultakat

### DIFF
--- a/webapp/classes/api/api.php
+++ b/webapp/classes/api/api.php
@@ -154,6 +154,10 @@ class Api {
             // 2023-02-29-et, a 2023-02-31-et és a 2026-04-31-et is — miközben ugyanezeket
             // a \Request naptár-tudatos ellenőrzése helyesen visszautasította.
             $this->throwIf($name, \Validate::dateError($input));
+        } elseif($type == 'timestamp') {
+            $this->throwIf($name, \Validate::timestampError($input));
+        } elseif($type == 'email') {
+            $this->throwIf($name, \Validate::emailError($input));
         } elseif($type == 'float') {
             $this->validateFloat($name, $details, $input);
         } elseif($type == 'string') {

--- a/webapp/classes/api/report.php
+++ b/webapp/classes/api/report.php
@@ -18,13 +18,13 @@ class Report extends Api {
             'example' => 'A mise vasárnap 11-kor van, de a honlapon 10:30 szerepel.'
         ],
         'timestamp' => [
-            'validation' => 'string', // TODO: timestamp validation
+            'validation' => 'timestamp',
             'description' => 'a beküldés időpontja (hiánya esetén aktuális pillanat)',
             'default' => 'current timestamp',
             'example' => '2024-01-16 12:34:56'
         ],
         'email' => [
-            'validation' => 'string', // TODO: email validation
+            'validation' => 'email',
             'description' => 'a beküldő email címe, hogy tudjunk neki válaszolni',
             'example' => 'somebody@no.mail'
         ],

--- a/webapp/classes/eloquent/calmass.php
+++ b/webapp/classes/eloquent/calmass.php
@@ -201,22 +201,8 @@ class CalMass extends CalModel
                 }
                 $timezone = $churchTimezones[$mass->church_id] ?? 'Europe/Budapest';
 
-                // ---- duration konvertálása percekre ----
-                $durationMinutes = 0;
-                if (!empty($mass->duration)) {
-                    if (is_string($mass->duration)) {
-                        $decoded = json_decode($mass->duration, true);
-                        if (json_last_error() === JSON_ERROR_NONE) {
-                            $mass->duration = $decoded;
-                        }
-                    }
-                    if (is_array($mass->duration)) {
-                        $days = (int)($mass->duration['days'] ?? 0);
-                        $hours = (int)($mass->duration['hours'] ?? 0);
-                        $minutes = (int)($mass->duration['minutes'] ?? 0);
-                        $durationMinutes = $days * 24 * 60 + $hours * 60 + $minutes;
-                    }
-                }
+                // A hossz átszámítása egy helyen él, l. durationInMinutes().
+                $durationMinutes = self::durationInMinutes($mass->duration);
 
                 // --- ha nincs period_id: egyszeri esemény ---
                 if (empty($mass->period_id)) {
@@ -421,22 +407,8 @@ class CalMass extends CalModel
                 }
                 $timezone = $churchTimezones[$mass->church_id] ?? 'Europe/Budapest';
 
-                // ---- duration konvertálása percekre ----
-                $durationMinutes = 0;
-                if (!empty($mass->duration)) {
-                    if (is_string($mass->duration)) {
-                        $decoded = json_decode($mass->duration, true);
-                        if (json_last_error() === JSON_ERROR_NONE) {
-                            $mass->duration = $decoded;
-                        }
-                    }
-                    if (is_array($mass->duration)) {
-                        $days = (int)($mass->duration['days'] ?? 0);
-                        $hours = (int)($mass->duration['hours'] ?? 0);
-                        $minutes = (int)($mass->duration['minutes'] ?? 0);
-                        $durationMinutes = $days * 24 * 60 + $hours * 60 + $minutes;
-                    }
-                }
+                // A hossz átszámítása egy helyen él, l. durationInMinutes().
+                $durationMinutes = self::durationInMinutes($mass->duration);
 
                 
                 // --- RRULE feldolgozás ---
@@ -705,7 +677,7 @@ class CalMass extends CalModel
                     'rite' => $mass->rite,
                     'types' => $mass->types,
                     'title' => $mass->title,
-                    'duration_minutes' => 0, // A $mass->duration-ből ki tudnánk találni. TODO
+                    'duration_minutes' => self::durationInMinutes($mass->duration),
                     'lang' => $mass->langs, // #334: lista, mert egy mise több nyelvű is lehet
                     'comment' => "extra ".$mass->comment,
                     'rrule' => $mass->rrule, 
@@ -853,6 +825,40 @@ class CalMass extends CalModel
             $results = array_merge($results, $noPeriodMasses);
         }
         return $results;
+    }
+
+    /**
+     * A mise hossza percben.
+     *
+     * A `duration` JSON: `{"days": d, "hours": h, "minutes": m}`, bármelyik mezője
+     * hiányozhat vagy lehet null. A modell tömbbé alakítja, de a hívó kaphat nyers
+     * sztringet is, ezért mindkettőt elviseljük.
+     *
+     * Ugyanez a számítás eddig kétszer szerepelt szó szerint, egy harmadik helyen pedig
+     * beégetett 0 állt helyette — ott az „extra" (időszak nélküli) miséknél a hossz
+     * elveszett, és az iCal-export emiatt egyórásnak vette őket.
+     */
+    public static function durationInMinutes($duration): int
+    {
+        if (empty($duration)) {
+            return 0;
+        }
+
+        if (is_string($duration)) {
+            $decoded = json_decode($duration, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                return 0;
+            }
+            $duration = $decoded;
+        }
+
+        if (!is_array($duration)) {
+            return 0;
+        }
+
+        return (int) ($duration['days'] ?? 0) * 24 * 60
+            + (int) ($duration['hours'] ?? 0) * 60
+            + (int) ($duration['minutes'] ?? 0);
     }
 
       /**

--- a/webapp/classes/html/help.php
+++ b/webapp/classes/html/help.php
@@ -8,11 +8,25 @@ class Help extends Html {
         $this->setTitle('Súgó');
         $this->content = '';
 
-        //TODO: validate
-        $idT = explode('-', $path[0]);
-        foreach ($idT as $id) {
+        /*
+         * A jegyzet, ami itt állt („validate"), a bemenet ellenőrzését hiányolta. A
+         * beírt érték azonban sehova nem jut el: a \Help egy `switch` a rögzített
+         * azonosítókon, `default` ágán „Nincs ilyen segítség." — nincs lekérdezés, és a
+         * bemenet nem kerül a kimenetre sem. Ellenőrizni tehát nincs mit.
+         *
+         * Ami VALÓBAN hiányzott: az argumentum nélküli /sugo hívás. Ott a `$path[0]`
+         * nem létezik, és a null `explode()`-ba adása PHP 8 óta elavult figyelmeztetést
+         * ad, majd üres lapot.
+         */
+        $azonositok = isset($path[0]) && $path[0] !== '' ? explode('-', (string) $path[0]) : [];
+
+        foreach ($azonositok as $id) {
             $help = new \Help($id);
             $this->content .= $help->html;
+        }
+
+        if ($this->content === '') {
+            $this->content = 'Nincs ilyen segítség.';
         }
     }
 

--- a/webapp/classes/html/home.php
+++ b/webapp/classes/html/home.php
@@ -112,7 +112,11 @@ class Home extends Html {
         $this->langs = array_keys($langCounts);
         
         $this->photo = \Eloquent\Photo::big()->vertical()->where('flag', 'i')->orderbyRaw('RAND()')->first();
-        if($this->photo->church) //TODO: Van, hogy a random képhez nem is tartozik templom. Valami régi hiba miatt.
+        // A védés marad, de a mögötte álló jegyzet („van, hogy a random képhez nem is
+        // tartozik templom, valami régi hiba miatt") már nem igaz: 29 451 képből NULLA
+        // az árva, és nulla a törölt templomhoz tartozó. A `first()` viszont null-t adhat,
+        // ha egyáltalán nincs megfelelő kép — ezért a `photo` létét is nézzük.
+        if($this->photo AND $this->photo->church)
             $this->photo->church->location;
 
         $this->favorites = $user->getFavorites();

--- a/webapp/classes/validate.php
+++ b/webapp/classes/validate.php
@@ -75,6 +75,41 @@ class Validate {
         return $date && $date->format('Y-m-d') === $value;
     }
 
+    /**
+     * Beküldési időpont: `yyyy-mm-dd hh:mm:ss`.
+     *
+     * A dátumhoz hasonlóan naptár-tudatos: a `DateTime::createFromFormat` magától
+     * átfordítja a túlcsorduló értéket (2023-02-31 → 2023-03-03, 25:00 → másnap 01:00),
+     * ezért vetjük össze a visszaformázott alakot az eredetivel. Enélkül az API
+     * elfogadna olyan időpontot, ami nem létezik — és utána más napra kerülne a bejegyzés.
+     */
+    public static function timestampError($value): ?string {
+        return self::isTimestamp($value) ? null : 'should be a timestamp (yyyy-mm-dd hh:mm:ss).';
+    }
+
+    public static function isTimestamp($value): bool {
+        if (!is_string($value) || !preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $value)) {
+            return false;
+        }
+        $datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+        return $datetime && $datetime->format('Y-m-d H:i:s') === $value;
+    }
+
+    /**
+     * Email-cím.
+     *
+     * Ugyanaz a szűrő, amivel a PHPMailer is ellenőriz, tehát amit itt elfogadunk, azt
+     * ki is tudjuk küldeni. A visszajelzés-beküldésnél ez nem formaság: a megadott címre
+     * MEGY válasz, és a rossz cím miatt a beküldő némán nem kap semmit.
+     */
+    public static function emailError($value): ?string {
+        return self::isEmail($value) ? null : 'should be an e-mail address.';
+    }
+
+    public static function isEmail($value): bool {
+        return is_string($value) && filter_var(trim($value), FILTER_VALIDATE_EMAIL) !== false;
+    }
+
     private static function rangeError($value, array $rules): ?string {
         if (isset($rules['minimum']) && $value < $rules['minimum']) {
             return 'should be at least ' . $rules['minimum'] . '.';

--- a/webapp/tests/Unit/MassDurationTest.php
+++ b/webapp/tests/Unit/MassDurationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A mise hosszának átszámítása percre.
+ *
+ * Ugyanez a számítás kétszer szerepelt szó szerint a generálásban, egy harmadik helyen
+ * pedig beégetett `0` állt helyette, egy TODO kíséretében („a $mass->duration-ből ki
+ * tudnánk találni"). Az a hely az „extra", időszak nélküli miséket állítja elő —
+ * náluk tehát a hossz elveszett.
+ *
+ * Ennek látható következménye is volt: az iCal-export a nulla hosszt egyórásra pótolja
+ * (`ical.php`: `$duration = ($mass['duration_minutes']!=0) ? ... : 60;`), tehát egy
+ * húszperces alkalom a feliratkozó naptárában egy órát foglalt.
+ */
+class MassDurationTest extends TestCase {
+
+    public function testOrabolEsPercbolSzamol(): void {
+        self::assertSame(90, \Eloquent\CalMass::durationInMinutes(['hours' => 1, 'minutes' => 30]));
+    }
+
+    public function testANapokatIsBeszamitja(): void {
+        self::assertSame(24 * 60 + 60 + 5, \Eloquent\CalMass::durationInMinutes(
+            ['days' => 1, 'hours' => 1, 'minutes' => 5]
+        ));
+    }
+
+    /** Az élő adatban a `hours` gyakran null — a `{"hours": null, "minutes": 30}` alak. */
+    public function testANullMezotNullanakVeszi(): void {
+        self::assertSame(30, \Eloquent\CalMass::durationInMinutes(['hours' => null, 'minutes' => 30]));
+    }
+
+    public function testAHianyzoMezotNullanakVeszi(): void {
+        self::assertSame(45, \Eloquent\CalMass::durationInMinutes(['minutes' => 45]));
+    }
+
+    /** A modell tömbbé alakít, de a hívó kaphat nyers JSON-sztringet is. */
+    public function testASztringetIsErtelmezi(): void {
+        self::assertSame(30, \Eloquent\CalMass::durationInMinutes('{"hours": 0, "minutes": 30}'));
+    }
+
+    /** @dataProvider ertelmezhetetlenErtekek */
+    public function testAzErtelmezhetetlenErtekNulla($ertek): void {
+        self::assertSame(0, \Eloquent\CalMass::durationInMinutes($ertek));
+    }
+
+    public static function ertelmezhetetlenErtekek(): array {
+        return [
+            'null'          => [null],
+            'üres tömb'     => [[]],
+            'üres sztring'  => [''],
+            'hibás JSON'    => ['{nem json}'],
+            'szám'          => [42],
+            'nulla'         => [0],
+        ];
+    }
+
+    /** Nulla hossz nulla marad — ez az „ismeretlen", nem az „azonnal véget ér". */
+    public function testANullaHosszNullaMarad(): void {
+        self::assertSame(0, \Eloquent\CalMass::durationInMinutes(['hours' => 0, 'minutes' => 0]));
+    }
+}

--- a/webapp/tests/Unit/ReportValidationTest.php
+++ b/webapp/tests/Unit/ReportValidationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A visszajelzés-beküldő végpont két mezője `string`-ként volt megadva, mellettük egy-egy
+ * TODO-val („timestamp validation", „email validation"). Vagyis bármit elfogadtunk.
+ *
+ * Egyik sem formaság:
+ *
+ *  - az EMAIL-re válasz megy a beküldőnek. Rossz cím esetén a beküldő némán nem kap
+ *    semmit, mi meg egy kézbesíthetetlen sort — pontosan azt a hibaosztályt, amit a
+ *    user_pleaselogin-nál is takarítottunk.
+ *  - a TIMESTAMP naptár-tudatos ellenőrzés nélkül átfordul: a `DateTime` a 2023-02-31-ből
+ *    március 3-át, a 25:00-ból másnap 01:00-t csinál, tehát a bejegyzés MÁS NAPRA kerül,
+ *    mint amit a beküldő állított.
+ */
+class ReportValidationTest extends TestCase {
+
+    /** @dataProvider ervenyesIdopontok */
+    public function testAzErvenyesIdopontotElfogadjuk(string $ertek): void {
+        self::assertNull(\Validate::timestampError($ertek), $ertek);
+    }
+
+    public static function ervenyesIdopontok(): array {
+        return [
+            'szokőév'      => ['2024-02-29 12:34:56'],
+            'éjfél'        => ['2026-01-01 00:00:00'],
+            'nap vége'     => ['2026-12-31 23:59:59'],
+        ];
+    }
+
+    /** @dataProvider ervenytelenIdopontok */
+    public function testAzErvenytelenIdopontotElutasitjuk($ertek): void {
+        self::assertNotNull(\Validate::timestampError($ertek), var_export($ertek, true));
+    }
+
+    public static function ervenytelenIdopontok(): array {
+        return [
+            'nem létező nap'   => ['2023-02-31 10:00:00'],
+            'nem szökőév'      => ['2023-02-29 10:00:00'],
+            'huszonötödik óra' => ['2026-01-01 25:00:00'],
+            'hatvanadik perc'  => ['2026-01-01 10:60:00'],
+            'csak dátum'       => ['2026-01-01'],
+            'ISO alak'         => ['2026-01-01T10:00:00'],
+            'üres'             => [''],
+            'szöveg'           => ['tegnap'],
+            'szám'             => [1737024896],
+            'null'             => [null],
+        ];
+    }
+
+    /** @dataProvider ervenyesCimek */
+    public function testAzErvenyesEmailtElfogadjuk(string $ertek): void {
+        self::assertNull(\Validate::emailError($ertek), $ertek);
+    }
+
+    public static function ervenyesCimek(): array {
+        return [
+            'egyszerű'      => ['valaki@example.com'],
+            'aldomain'      => ['valaki@mail.example.com'],
+            'pont a névben' => ['vezetek.kereszt@example.com'],
+            'plusz jel'     => ['valaki+cimke@example.com'],
+            'körülötte szóköz' => ['  valaki@example.com  '],
+        ];
+    }
+
+    /** @dataProvider ervenytelenCimek */
+    public function testAzErvenytelenEmailtElutasitjuk($ertek): void {
+        self::assertNotNull(\Validate::emailError($ertek), var_export($ertek, true));
+    }
+
+    public static function ervenytelenCimek(): array {
+        return [
+            'nincs kukac'  => ['valaki.example.com'],
+            'nincs domain' => ['valaki@'],
+            'nincs név'    => ['@example.com'],
+            'szóköz benne' => ['ez nem cim'],
+            'üres'         => [''],
+            'null'         => [null],
+            'szám'         => [42],
+        ];
+    }
+
+    /**
+     * A végpont tényleg ezeket a szabályokat használja — enélkül a `\Validate` helyes
+     * lehetne, miközben a beküldés változatlanul bármit elfogad.
+     */
+    public function testAVegpontAMegfeleloSzabalyokatHasznalja(): void {
+        $mezok = (new \Api\Report())->fields;
+
+        self::assertSame('timestamp', $mezok['timestamp']['validation']);
+        self::assertSame('email', $mezok['email']['validation']);
+    }
+}


### PR DESCRIPTION
Végigmentem a kód **összes** TODO/FIXME jelölőjén (61 találat, ebből 15 vendorolt vagy buildelt fájlban, illetve a #436-os spec-csonkokban). Az eredmény három csoport.

## 1. Amit itt befejeztem

**Visszajelzés-beküldés: hiányzó ellenőrzés.** Az időpont és az email `string`-ként volt megadva, egy-egy TODO-val mellette — bármit elfogadtunk. Egyik sem formaság:

- az **email**-re válasz megy a beküldőnek; rossz címnél némán nem kap semmit, nekünk meg egy kézbesíthetetlen sor marad — pont az a hibaosztály, amit a `user_pleaselogin`-nál takarítottunk;
- az **időpont** naptár-tudatos ellenőrzés nélkül átfordul: `2023-02-31` → március 3., `25:00` → másnap 01:00. A bejegyzés tehát más napra kerül, mint amit a beküldő állított.

Mindkettő a közös `\Validate`-be került, ahol a dátumé is él. Éles ellenőrzés:

```
Field 'email' should be an e-mail address.
Field 'timestamp' should be a timestamp (yyyy-mm-dd hh:mm:ss).
```

**Mise hossza: háromszoros logika, egy helyen beégetett nulla.** Ugyanaz az átszámítás kétszer szerepelt szó szerint, egy harmadik helyen pedig `'duration_minutes' => 0` állt egy TODO-val („a `$mass->duration`-ből ki tudnánk találni"). Az a hely az **„extra", időszak nélküli miséket** állítja elő — náluk a hossz elveszett. És mivel az iCal-export a nullát egy órára pótolja (`$duration = ($mass['duration_minutes']!=0) ? ... : 60`), egy húszperces alkalom **egy órát foglalt** a feliratkozó naptárában. Közös `durationInMinutes()`, mind a három helyen.

**`/help` argumentum nélkül.** A `$path[0]` hiányában null ment az `explode()`-ba (PHP 8 óta elavult), majd üres lap. Most üzenetet ad.

## 2. Amit tényekre cseréltem — mert a jegyzet már nem igaz

**`help.php` „TODO: validate"** — tárgytalan: a `\Help` egy `switch` a rögzített azonosítókon, `default` ágán „Nincs ilyen segítség." Nincs lekérdezés, és a bemenet a kimenetre sem kerül. Ellenőrizni nincs mit.

**`home.php` „van, hogy a random képhez nem is tartozik templom, valami régi hiba miatt"** — lekérdeztem: **29 451 képből nulla** az árva, és nulla a törölt templomhoz tartozó. A védés marad (a `first()` adhat null-t, ezt ki is egészítettem), de a jegyzet félrevezető volt.

Egy félrevezető megjegyzés nem ártalmatlan: arra csábítja a következő olvasót, hogy nem létező hibát „javítson".

## 3. Nagy építések — csak listázom

| Hely | Mi |
|---|---|
| **8 × `FIXME for Issue #257`** (`collection.php`, `catalogue.php` ×2, `church.php:1074`, `table.php`, `stat.php`, `nearby-churches.js`, `_panelneighbours.twig`) | Az OSM-ből gyűjtött névhalmaz helyett ezek a helyek **még mindig a helyi `nev`/`ismertnev` oszlopot** olvassák. **A #257 le van zárva (2025-02-28), de ezek a helyek nem készültek el** — érdemes lehet újranyitni. Nem töröltem a jelölőket: valódi, hátralévő munkát mutatnak. |
| `church.php:26` — `#174 sémakisimítás` | Az oszlopoknak null vagy alapérték kellene. Séma-migráció, deploy-lépéssel. |
| `church.php:463` | Elismert hiba: a periódus-keresés nem a konkrét generált időszakban néz szét. A `getMassRRulesByPeriodAttribute` a templomoldalt szolgálja ki — a #753 által érintett terület, önálló jegyet érdemel. |
| `calmass.php:532`, `:557` | „valamiért itt volt egy `subDay`", és „az átfedésre nem biztos, hogy ez jó" — a kizárás-logika legérzékenyebb pontja. borazslo maga írta a #753-nál, hogy ehhez csak megfontoltan szabad hozzányúlni. |
| `user.php:246–251` | Regisztrációs validáció: duplikált login+email, kötelező mezők visszajelzése. Ez a regisztrációs út átírása. |
| `osm.php:432` | „biztosan fejetlenül átkötjük?" — ha az OSM-ben a címke másik elemre kerül, az átkötés magától átvált. Tervezési kérdés. |
| `api/api.php:64` | Hierarchikus mezők validálása (a `lorawan.php` sok ilyet használ). |
| `api/user.php:50`, `api/favorites.php:56` | „delete global somehow" — a `global $user` kivezetése, széles hatókörű refaktor. |
| `distance.php:99`, `:147` | BBOX-on belüli távolságok törlése, és duplikált kódrészlet. |
| `ical.php:191` | LOCATION és GEO mező az iCal-eseménybe. |
| `api.php:114` | Az elválasztó karakter a szövegben. |
| calendar: `//TODO: EZT MAJD HÁTTÉRBEN` ×2 | Az újraindexelés háttérbe tolása mentés után — architektúra-kérdés. |

Amit más nyitott PR már elintéz: `osm.php:272` (#776), `ical.php:110` és `:123`, `map.php:70` (#785), a 14 spec-csonk (#784).

## Teszt

38 új teszt (időpont- és email-ellenőrzés minden határesetre, a hossz-átszámítás null/hiányzó/sztring/hibás JSON bemenetekre). **PHP: 920 zöld.**