### PR TITLE
A böngészős tesztek ne várjanak idegen szerverek képeire

### DIFF
--- a/webapp/tests/Functional/FunctionalTestCase.php
+++ b/webapp/tests/Functional/FunctionalTestCase.php
@@ -61,6 +61,26 @@ abstract class FunctionalTestCase extends PantherTestCase
             [
                 'connection_timeout_in_ms' => self::CONNECTION_TIMEOUT_MS,
                 'request_timeout_in_ms' => self::REQUEST_TIMEOUT_MS,
+                /*
+                 * A betöltés ne várja meg a képeket és a többi alerőforrást.
+                 *
+                 * Az alapértelmezett `normal` stratégiánál a WebDriver a `load` eseményig
+                 * vár, abba pedig minden `<img>` beleszámít — a templomok LEÍRÁSA viszont
+                 * szabad HTML, amibe a szerkesztők idegen kiszolgálókról ágyaznak be
+                 * képeket. A #2474-es templom leírásában például hat kép mutat a
+                 * `rakosliget.plebania.hu`-ra, sima HTTP-n. Ha az a szerver épp lassú a
+                 * futtatóról, a lap sosem készül el, és a teszt időtúllépéssel bukik —
+                 * miközben az alkalmazás a HTML-t 200-zal, azonnal kiszolgálta.
+                 *
+                 * Ez adta a korábbi néma beakadásokat is: a szerver rendben válaszolt, a
+                 * böngésző viszont egy harmadik fél képére várt. `eager` mellett a
+                 * betöltés a DOMContentLoaded-nél tér vissza. A tesztjeink a DOM
+                 * tartalmát mérik, és ahol tényleg megjelenésre várnak, ott úgyis
+                 * kifejezett `waitFor()` áll.
+                 */
+                'capabilities' => [
+                    'pageLoadStrategy' => 'eager',
+                ],
             ]
         );
     }


### PR DESCRIPTION
Megvan a néma beakadások oka. A #775 óta a CI meg is mondja, min akad meg — most először tudtam elolvasni.

## A tünet

A functional lépés elbukott, a `ChurchDetailPageTest` **mind a tizenegy tesztje** ugyanazzal:

```
Curl error thrown for http POST to /session/…/url
with params: {"url":"http://127.0.0.1:8000/templom/2474"}
Operation timed out after 30002 milliseconds with 0 bytes received
```

## A szerver közben rendben válaszolt

A docker-napló szerint ugyanazt a lapot **háromszor is kiszolgálta**, HTTP 200-zal:

```
[16/Aug/2026:11:25:43 +0000] "GET /templom/2474 HTTP/1.1" 200 13535
[16/Aug/2026:11:28:58 +0000] "GET /templom/2474 HTTP/1.1" 200 13534
[16/Aug/2026:11:31:13 +0000] "GET /templom/2474 HTTP/1.1" 200 13546
```

Tehát nem az alkalmazás lassult be — a böngésző várt valamire.

## Az ok: hat idegen kép a templom leírásában

```html
<img src="http://rakosliget.plebania.hu/files/u14/ligeti_templom_szabadon.jpeg" …>
<img src="http://rakosliget.plebania.hu/files/u14/ligeti_fooltar.jpeg" …>
… összesen hat
```

A templom **leírása szabad HTML**, amit a szerkesztők töltenek — ide bárki beágyazhat képet bárhonnan. Az `<img>` pedig beleszámít a `load` eseménybe, amire az alapértelmezett `normal` betöltési stratégia vár. Ha az az idegen szerver épp lassú a futtatóról, a lap sosem készül el.

Ez magyarázza a korábbi **néma** beakadásokat is (12 perc, nulla kimenet), és azt is, **miért alkalmi**: egy harmadik fél pillanatnyi elérhetőségén múlt. Ezért ment át ötször egymás után, majd bukott a hatodikon.

## A javítás

`pageLoadStrategy: eager` — a betöltés a `DOMContentLoaded`-nél tér vissza, nem várja meg a képeket.

Ez nem kompromisszum: a tesztjeink a **DOM tartalmát** mérik, és ahol tényleg megjelenésre várnak (térkép-elemek, kártyák), ott úgyis kifejezett `waitFor()` áll. Cserébe a suite immunis lesz arra, hogy egy szerkesztő beágyaz egy lassú képet.

Mellékesen gyorsabb is: **80 teszt 27,8 helyett 22,4 másodperc** alatt.

## Ami ettől függ

A **#787** (OSM-nevek) CI-ja pontosan ezen bukott el — a változtatásaihoz semmi köze, helyben 80/80 zöld. Ha ez bemegy, az is zöldül.