### PR TITLE
Nyolc böngészős teszt évek óta üresben futott

### DIFF
--- a/webapp/tests/Functional/MapInitializationTest.php
+++ b/webapp/tests/Functional/MapInitializationTest.php
@@ -107,10 +107,20 @@ final class MapInitializationTest extends FunctionalTestCase {
     public function testMapDoesNotStartBeforeItScrollsIntoView(): void {
         $client = $this->client();
 
-        // ALACSONY ablak, hogy a térkép biztosan a hajtás ALÁ kerüljön. Enélkül a teszt a
-        // futtató ablakméretétől függ: egy magas headless ablakban a templomoldal térképe
-        // eleve látszik, és akkor jogosan indul is el (a CI-ban pont ezért bukott).
-        $client->manage()->window()->setSize(new WebDriverDimension(1024, 300));
+        /*
+         * KESKENY és alacsony ablak, hogy a térkép biztosan a hajtás alá kerüljön.
+         *
+         * Alacsony ablak önmagában nem elég, és emiatt ez a teszt eddig MINDIG kihagyásra
+         * ment: a térkép fölötti tartalom magassága nem függ az ablak MAGASSÁGÁTÓL, csak a
+         * szélességétől. 1024 px széles ablakban a térkép teteje 193 px-nél van, a lenti
+         * feltétel viszont 200 px ráhagyást kér a hajtáson túl — azt semmilyen magassággal
+         * nem lehet teljesíteni.
+         *
+         * Keskeny ablakban a panelek egymás alá torlódnak, és a térkép lejjebb kerül.
+         * Mérve: 1024x300 -> top=193 (ih=157, kellene 357);  360x200 -> top=358 (ih=57,
+         * kell 257). Ezért a mobil méret.
+         */
+        $client->manage()->window()->setSize(new WebDriverDimension(360, 200));
         $client->request('GET', '/templom/1');
 
         // Megvárjuk, hogy a szkript betöltődjön és lefusson (de NE görgetünk).

--- a/webapp/tests/Functional/UnifiedAutocompleteTest.php
+++ b/webapp/tests/Functional/UnifiedAutocompleteTest.php
@@ -14,6 +14,36 @@ namespace Tests\Functional;
  */
 final class UnifiedAutocompleteTest extends FunctionalTestCase
 {
+
+    /**
+     * A találati sor típusát a BADGE osztálya árulja el (l. unified-autocomplete.js):
+     * a misézőhely külön `unified-dropdown-church-badge`-et kap, a területi találat
+     * csak a sima `unified-dropdown-badge`-et.
+     *
+     * A tesztek eddig `unified-dropdown-church-icon`-ra illesztettek — az az osztálynév
+     * viszont KIZÁRÓLAG a stíluslapban létezik, a felület sosem teszi ki. Így a
+     * feltétel akkor sem teljesülhetett volna, ha a HTML-olvasás működik.
+     */
+    private const TEMPLOM_JELOLO = '.unified-dropdown-church-badge';
+    private const HATAR_JELOLO = '.unified-dropdown-badge:not(.unified-dropdown-church-badge)';
+
+    /**
+     * Tartalmazza-e a találati sor a keresett elemet?
+     *
+     * Eddig `$item->getAttribute('innerHTML')`-lel néztük, sztring-illesztéssel. Csakhogy
+     * az `innerHTML` nem ATTRIBÚTUM, hanem property: a W3C WebDriver
+     * `getElementAttribute` hívása NULL-t ad rá. A `strpos(null, ...)` PHP 8.1 óta
+     * elavult figyelmeztetést ír — a valódi kár viszont az, hogy a feltétel SOSEM
+     * teljesült, tehát a tesztek fele „nincs megfelelő találat" indokkal kihagyásra ment.
+     * Ebben az osztályban 13 tesztből 7 futott így, üresben, évek óta.
+     *
+     * A böngészőtől nem a nyers HTML-t kérjük, hanem magát az elemet: ez az, amit a
+     * WebDriver támogat, és egyben pontosabb is, mint osztálynevekre illeszteni.
+     */
+    private static function tartalmaz(\Facebook\WebDriver\WebDriverElement $item, string $selector): bool
+    {
+        return $item->findElements(\Facebook\WebDriver\WebDriverBy::cssSelector($selector)) !== [];
+    }
     private static $client;
 
     public static function setUpBeforeClass(): void
@@ -123,7 +153,7 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         // Find first church item
         $churchItem = null;
         foreach ($items as $item) {
-            if (strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false) {
+            if (self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $churchItem = $item;
                 break;
             }
@@ -153,7 +183,7 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         $items = self::$client->getCrawler()->filter('.unified-dropdown.visible .unified-dropdown-item');
         $churchItem = null;
         foreach ($items as $item) {
-            if (strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false) {
+            if (self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $churchItem = $item;
                 break;
             }
@@ -180,7 +210,7 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         $items = self::$client->getCrawler()->filter('.unified-dropdown.visible .unified-dropdown-item');
         $churchItem = null;
         foreach ($items as $item) {
-            if (strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false) {
+            if (self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $churchItem = $item;
                 break;
             }
@@ -210,7 +240,7 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         $items = self::$client->getCrawler()->filter('.unified-dropdown.visible .unified-dropdown-item');
         $churchItem = null;
         foreach ($items as $item) {
-            if (strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false) {
+            if (self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $churchItem = $item;
                 break;
             }
@@ -244,7 +274,7 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         $items = self::$client->getCrawler()->filter('.unified-dropdown.visible .unified-dropdown-item');
         $churchItem = null;
         foreach ($items as $item) {
-            if (strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false) {
+            if (self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $churchItem = $item;
                 break;
             }
@@ -284,7 +314,7 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         $items = self::$client->getCrawler()->filter('.unified-dropdown.visible .unified-dropdown-item');
         $first = null;
         foreach ($items as $item) {
-            if (strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false) {
+            if (self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $first = $item;
                 break;
             }
@@ -303,7 +333,7 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         $items2 = self::$client->getCrawler()->filter('.unified-dropdown.visible .unified-dropdown-item');
         $second = null;
         foreach ($items2 as $item) {
-            if (strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false) {
+            if (self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $second = $item;
                 break;
             }
@@ -338,11 +368,10 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         $churchItem   = null;
 
         foreach ($items as $item) {
-            $html = $item->getAttribute('innerHTML');
-            if ($boundaryItem === null && strpos($html, 'unified-dropdown-badge') !== false) {
+            if ($boundaryItem === null && self::tartalmaz($item, self::HATAR_JELOLO)) {
                 $boundaryItem = $item;
             }
-            if ($churchItem === null && strpos($html, 'unified-dropdown-church-icon') !== false) {
+            if ($churchItem === null && self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $churchItem = $item;
             }
         }
@@ -362,7 +391,7 @@ final class UnifiedAutocompleteTest extends FunctionalTestCase
         $items2 = self::$client->getCrawler()->filter('.unified-dropdown.visible .unified-dropdown-item');
         $churchItem2 = null;
         foreach ($items2 as $item) {
-            if (strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false) {
+            if (self::tartalmaz($item, self::TEMPLOM_JELOLO)) {
                 $churchItem2 = $item;
                 break;
             }


### PR DESCRIPTION
Egy CI-figyelmeztetés nyomán indultam el, és a végén nyolc olyan böngészős teszt jött elő, amelyik évek óta lefutott, zöld volt, és közben nem mért semmit. Mind a nyolc a saját kihagyás-ágán ült.

A böngészős suite mérlege: **8 kihagyásból 0**, **136 helyett 150 állítás**, **nulla figyelmeztetés**.

---

## 1. Az autocomplete-tesztek fele (7 teszt)

A CI eseménynaplójában nyolc PHP-figyelmeztetés állt:

```
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
  in UnifiedAutocompleteTest.php:342 és :345
```

A figyelmeztetés a kisebbik baj. A tesztek a találati sor típusát így nézték:

```php
strpos($item->getAttribute('innerHTML'), 'unified-dropdown-church-icon') !== false
```

**Az `innerHTML` nem attribútum, hanem property.** A W3C WebDriver `getElementAttribute` hívása `null`-t ad rá — innen a `strpos(null, …)`. A feltétel tehát sosem teljesült, és a tesztek „nincs megfelelő találat" indokkal kihagyásra mentek.

**És ha a HTML-olvasás működött volna, akkor sem találtak volna semmit.** Az `unified-dropdown-church-icon` osztálynév kizárólag a stíluslapban létezik (`unified-autocomplete.js:131`) — a felület sosem teszi ki. A misézőhelyet a `unified-dropdown-church-badge` jelöli, a területi találatot a sima `unified-dropdown-badge`. A minta kilenc helyen szerepelt a fájlban, és egyik sem működhetett.

Javítás: nem a nyers HTML-t olvasom, hanem a gyerekelemet kérdezem le a böngészőtől.

```php
$item->findElements(WebDriverBy::cssSelector('.unified-dropdown-church-badge')) !== []
```

Ezt a WebDriver támogatja, és pontosabb is, mint osztálynévre illeszteni egy HTML-sztringben.

```
előtte:  Tests: 13, Assertions: 7,  Deprecations: 8, Skipped: 7
utána:   Tests: 13, Assertions: 19, Skipped: 0
```

## 2. A térkép lusta indítását mérő teszt (1 teszt)

Ezt először adatfüggő kihagyásnak néztem — **tévedtem, a feltétel volt teljesíthetetlen.**

A teszt alacsony ablakot állít be, hogy a térkép a hajtás alá kerüljön, és megköveteli, hogy a térkép teteje legalább 200 px-szel a látótávolság alatt legyen — ennyi az IntersectionObserver ráhagyása, ezen belül jogosan el is indulna a térkép. Csakhogy a térkép fölötti tartalom magassága nem az ablak **magasságától** függ, hanem a **szélességétől**, így a feltétel két oldalát ugyanaz a paraméter nem mozgatja egymáshoz képest. Mérve:

| ablak | térkép teteje | kellene |
|---|---|---|
| 1024×300 | 193 | > 357 |
| 400×300 | 337 | > 357 |
| 380×240 | 337 | > 297 ✓ |
| 360×200 | 358 | > 257 ✓ |

Széles ablakban semmilyen magassággal nem jön ki — a teszt mindig a kihagyás ágra futott. Keskeny ablakban viszont a panelek egymás alá torlódnak, és a térkép lejjebb csúszik, ezért mobil méretre (360×200) állítom.

---

Nincs éles kód érintve, csak tesztek. Teljes böngészős suite: **80 teszt, 150 állítás, 0 kihagyás.**
