### PR TITLE
Egyetlen szomszédnál eltűnt a szomszéd-panel

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -749,39 +749,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         $distance->MupdateChurch($this);
     }
     
-    public function neighbours() {
-        return $this->where('templomok.id',$this->id)
-                ->join('distances', function($join)
-                    {
-                      $join->on('distances.fromLon', '=', 'lon');
-                      $join->on('distances.fromLat', '=', 'lat');
-
-                    })
-                  ->join('templomok as churchTo',function($join)
-                    {
-                      $join->on('distances.toLon', '=', 'churchTo.lon');
-                      $join->on('distances.toLat', '=', 'churchTo.lat');
-                    })
-                ->select('distances.*','churchTo.*')    
-                ->where('churchTo.ok', 'i')
-                ->orderBy('distances.distance', 'ASC');
-
-    }
-    
-    public function neighbourss() {
-        return \Eloquent\Church::join('distances', function($join)
-                    {
-                      $join->on('distances.toLon', '=', 'lon');
-                      $join->on('distances.toLat', '=', 'lat');
-
-                    })
-                    ->where('distances.fromLon',$this->lon)
-                    ->where('distances.fromLat',$this->lat)
-                    ->where('ok','i')
-                            ->select('templomok.*','distances.distance')
-                    ->orderBy('distances.distance', 'ASC');                                               
-    }
-
     public function getNeighboursAttribute () {
         // #103: mindkét irányban keresünk. Egy pár a distances-ben csak EGYSZER szerepel
         // (from→to), a régi accessor viszont csak a `from = ez` sorokat nézte — ezért ha a

--- a/webapp/classes/html/church/church.php
+++ b/webapp/classes/html/church/church.php
@@ -154,10 +154,12 @@ class Church extends \Html\Html {
 
         $church->MgetReligious_administration();
         
-        if( count($church->neighbours) < 1 ) {
-           // $distance = new \Distance();        
-           // $distance->MupdateChurch($church);
-        }        
+        // A `neighbours` accessor NINCS gyorsítótárazva: minden olvasása újra lefuttatja a
+        // lekérdezést (1 sor a distances-ből + koordinátánként egy templom-keresés, max 60).
+        // Itt korábban egy `if (count($church->neighbours) < 1)` állt, aminek a TÖRZSE
+        // teljes egészében ki volt kommentelve — a feltétele viszont lefutott, és ezzel
+        // minden templomoldal kétszer fizette ki ugyanazt a lekérdezés-sorozatot.
+        // Az egyetlen valódi olvasás lentebb van: $this->neighbours = $church->neighbours.
   
 								
         copyArrayToObject($church->toArray(), $this);

--- a/webapp/templates/church/_panelneighbours.twig
+++ b/webapp/templates/church/_panelneighbours.twig
@@ -3,11 +3,14 @@
 {% set title = 'Szomszédos templomok' %}
 
 {% block body %}
-    {% if neighbours|length > 1 %}
+    {% if neighbours|length > 0 %}
         <ul style="-webkit-padding-start: 20px;-webkit-margin-before: 0em;">
             {% for i in 0..9 %}
                 {% if neighbours[i] %} {{ _self.neighbour(neighbours[i],location) }} {% endif %}
             {% endfor %}
+            {# A Church::getNeighboursAttribute() 10 találatnál levágja a listát, ezért a
+               `> 9` pontosan azt jelenti, hogy a vágás életbe lépett: van még tovább.
+               Nem elcsúszás — a ciklus is szándékosan 10 elemet ír ki. #}
             {% if neighbours|length > 9 %}<li style="display:inline">...</li>{% endif %}
         </ul>
     {% endif %}    

--- a/webapp/templates/church/church.twig
+++ b/webapp/templates/church/church.twig
@@ -278,7 +278,7 @@
         {% include "panel.twig" with {title:'Jó tudni','body': megjegyzes } %}
     {% endif %}
 		
-    {% if neighbours|length > 1 %}
+    {% if neighbours|length > 0 %}
         {% include 'church/_panelneighbours.twig' %}
     {% endif %}
     

--- a/webapp/tests/Unit/ChurchNeighboursPanelTest.php
+++ b/webapp/tests/Unit/ChurchNeighboursPanelTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A "Szomszédos templomok" panel megjelenési küszöbe.
+ *
+ * A panel valaha KÉT részből állt: egy "Legközelebbi:" blokkból, ami mindig látszott,
+ * és egy "10 km-en belül:" listából, aminek `length > 1` volt a feltétele. Amikor a
+ * kettő egyetlen listává olvadt, a MÁSODIK blokk küszöbe maradt meg az EGÉSZ panelre.
+ * Azóta egyetlen szomszédnál az egész panel eltűnt, pedig pont azt az egyet kellett
+ * volna kiírnia — a `getNeighboursAttribute()` magát a templomot amúgy is kiszűri,
+ * tehát az 1 hosszú lista egy valódi szomszédot jelent.
+ */
+class ChurchNeighboursPanelTest extends TestCase {
+
+    private const SABLON = 'church/_panelneighbours.twig';
+
+    /** @return array<int,array<string,mixed>> */
+    private function szomszedok(int $darab): array {
+        $lista = [];
+        for ($i = 1; $i <= $darab; $i++) {
+            $lista[] = [
+                'id'         => 100 + $i,
+                'nev'        => 'Szomszéd ' . $i,
+                'ismertnev'  => 'Szomszéd ' . $i . ' temploma',
+                'distance'   => 1000 * $i,
+                'location'   => ['city' => ['name' => 'Budapest']],
+            ];
+        }
+        return $lista;
+    }
+
+    private function render(int $darab): string {
+        return $GLOBALS['twig']->render(self::SABLON, [
+            'neighbours' => $this->szomszedok($darab),
+            'location'   => ['city' => ['name' => 'Budapest']],
+        ]);
+    }
+
+    private function talalatokSzama(string $html): int {
+        return preg_match_all('#<a\s[^>]*href="/templom/\d+"#', $html);
+    }
+
+    /** A javítás lényege: egyetlen szomszéd is megjelenik. */
+    public function testEgyetlenSzomszedIsMegjelenik(): void {
+        $html = $this->render(1);
+
+        self::assertSame(1, $this->talalatokSzama($html),
+            'Egy szomszédnál a panel üresen maradt — visszajött a régi `length > 1` küszöb.');
+        self::assertStringContainsString('/templom/101', $html);
+    }
+
+    public function testTobbSzomszedMindegyikeKikerul(): void {
+        self::assertSame(5, $this->talalatokSzama($this->render(5)));
+    }
+
+    /** Szomszéd nélkül nincs mit kiírni. */
+    public function testSzomszedNelkulNincsLista(): void {
+        $html = $this->render(0);
+
+        self::assertSame(0, $this->talalatokSzama($html));
+        self::assertStringNotContainsString('<ul', $html);
+    }
+
+    /**
+     * A `getNeighboursAttribute()` 10 találatnál levágja a listát, ezért a 10 hosszú
+     * lista azt jelenti: "van még". A "..." tehát NEM elcsúszás, hanem a vágás jelzése.
+     */
+    public function testTizSzomszednalKikerulAFolytatasJelzes(): void {
+        $html = $this->render(10);
+
+        self::assertSame(10, $this->talalatokSzama($html), 'Mind a tíz szomszédnak ki kell kerülnie.');
+        self::assertStringContainsString('...', $html);
+    }
+
+    public function testKilencSzomszednalMegNincsFolytatasJelzes(): void {
+        self::assertStringNotContainsString('...', $this->render(9));
+    }
+
+    /**
+     * A panelt a `church.twig` is lekapuzza, mielőtt beemelné — ha a két küszöb
+     * elcsúszik egymástól, a panel megint eltűnhet ott, ahol itt már megjelenne.
+     * Pontosan ez a fajta másolgatás okozta az eredeti hibát.
+     */
+    public function testAKetKuszobNemCsuszhatEl(): void {
+        $minta = '#\{%\s*if\s+neighbours\|length\s*>\s*(\d+)\s*%\}#';
+        $kuszobok = [];
+
+        foreach (['church/church.twig', self::SABLON] as $sablon) {
+            $forras = file_get_contents(PATH . 'templates/' . $sablon);
+            self::assertMatchesRegularExpression($minta, $forras,
+                $sablon . ': nem találom a szomszéd-küszöböt.');
+            preg_match($minta, $forras, $m);
+            $kuszobok[$sablon] = (int) $m[1];
+        }
+
+        self::assertSame([0, 0], array_values($kuszobok),
+            'Mindkét helyen `> 0` a küszöb, különben egy szomszédnál megint eltűnik a panel: '
+            . json_encode($kuszobok, JSON_UNESCAPED_SLASHES));
+    }
+}


### PR DESCRIPTION
Három maradék egy helyen, a templomoldal szomszéd-panelje körül.

## 1. Egy szomszédnál eltűnt az egész panel

A panel valaha két blokkból állt:

```twig
<b><i>Legközelebbi:</i></b>              {# nincs küszöb, mindig látszott #}
{{ _self.neighbour(closestNeighbour) }}

{% if neighbourWithinDistance|length > 1 %}   {# a MÁSODIK blokk küszöbe #}
<b><i>10 km-en belül:</i></b>
```

Amikor a kettő egyetlen `neighbours` listává olvadt (`b27e38f7`), a **második** blokk küszöbe maradt meg az **egész** panelre. Azóta pontosan egy szomszédnál a panel néma — pedig azt az egyet kellene mutatnia. A `getNeighboursAttribute()` magát a templomot kiszűri (`$church->id == $this->id` → continue), tehát az 1 hosszú lista egy valódi szomszéd.

Küszöb mindkét helyen (`church.twig` és a panel) `> 0`-ra megy.

## 2. Minden templomoldal kétszer futtatta a szomszéd-lekérdezést

```php
if( count($church->neighbours) < 1 ) {
   // $distance = new \Distance();
   // $distance->MupdateChurch($church);
}
```

A törzs teljesen ki van kommentelve, a **feltétel viszont lefut**. A `neighbours` accessor pedig nincs gyorsítótárazva — lemértem:

```
1x accessor: 1 lekérdezés
2x accessor: 2 lekérdezés
```

Egy hívás ára: egy `distances`-lekérdezés (max 60 sor) + koordinátánként egy `Church::where(lat,lon)->first()`. Ezt fizette ki minden templomoldal kétszer. Az `if`-et kiveszem.

## 3. `neighbours()` és `neighbourss()` — halott kód

A template és a PHP is a `neighbours` **property**-t olvassa, ami a `getNeighboursAttribute()` accessorra megy. A két query-metódusra az egyetlen hivatkozás a `church.php:1814` kikommentelt sora. 33 sor törölve.

## Amit NEM javítottam

A `{% if neighbours|length > 9 %}` „..." jelzést először elcsúszásnak néztem, de nem az: az accessor 10 találatnál `break`-el, tehát a 10 hosszú lista azt jelenti, hogy van még. Kommentbe tettem, hogy ne „javítsa ki" más se.

## Teszt

`ChurchNeighboursPanelTest` — a panel renderelése 0/1/5/9/10 szomszédra, plusz egy őr arra, hogy a `church.twig` és a panel küszöbe ne csúszhasson el egymástól (pont az a másolás okozta az eredeti hibát). Ellenőriztem, hogy a régi `> 1`-gyel bukik:

```
Tests: 6, Assertions: 10, Failures: 2     <- régi küszöbbel
Tests: 6, Assertions: 11, OK              <- javítva
```

Teljes PHP-suite: 893 teszt, 2092 állítás, zöld.