### PR TITLE
Törlöm azt a tizenhárom függvényt, amit soha semmi nem hív

### DIFF
--- a/webapp/classes/api/sqlite.php
+++ b/webapp/classes/api/sqlite.php
@@ -129,20 +129,6 @@ class Sqlite extends Api {
         }
     }
 
-    function getDatabaseToArray() {
-        if (!isset($this->sqlite)) {
-            throw new \Exception('There is no Sqlite connection to make it an array.');
-        }
-        $array = [];
-        $tables = $this->sqlite->table('sqlite_master')->select('name')->get();
-        foreach ($tables as $table) {
-            $rows = $this->sqlite->table($table->name)->get();
-            foreach ($rows as $row) {
-                $array[$table->name][] = (array) $row;
-            }
-        }
-        return $array;
-    }
 
     function generateSqlite() {
         echo "Sqlite is beginning right now...";

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1709,12 +1709,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         return $access;
     }
 
-    function MgetDioceseId() {
-        if($this->religious_administratin)
-            return $this->religious_administration->diocese->id;
-        else 
-            return false;
-    }
 	
     public function boundaries()
     {

--- a/webapp/classes/externalapi/elasticsearchapi.php
+++ b/webapp/classes/externalapi/elasticsearchapi.php
@@ -206,19 +206,6 @@ class ElasticsearchApi extends \ExternalApi\ExternalApi {
 		return $this->responseCode == 200;
 	}
 
-	function deleteIndex($name) {
-
-		$this->curl_setopt(CURLOPT_CUSTOMREQUEST ,"DELETE");
-		$this->buildQuery($name);
-		$this->run();
-
-		if($this->responseCode != 200)
-			return false;
-		if(!isset($this->jsonData->acknowledged) OR $this->jsonData->acknowledged != 1)
-			return false;
-		
-		return true;
-	}
 	
 	/**
 	 * #374: Az ES _bulk NDJSON-payload összeállítása. Tömb-elemeket json_encode-ol,

--- a/webapp/classes/externalcalendarimporter.php
+++ b/webapp/classes/externalcalendarimporter.php
@@ -1,61 +1,6 @@
 <?php
 
-/**
- * Detect and convert content to UTF-8
- * Handles charset from headers and validates UTF-8
- *
- * @param string $content Raw content from download
- * @param string $contentType HTTP Content-Type header (optional)
- * @return string UTF-8 encoded content
- * @throws \Exception
- */
-function ensureUtf8($content, $contentType = '') {
-    // 1. Extract charset from Content-Type header if provided
-    $charset = 'UTF-8';
-    if (!empty($contentType) && preg_match('/charset\s*=\s*([^\s;]+)/i', $contentType, $matches)) {
-        $charset = strtoupper(trim($matches[1], '"\''));
-    }
-    
-    // 2. Remove UTF-8 BOM if present
-    if (substr($content, 0, 3) === "\xEF\xBB\xBF") {
-        $content = substr($content, 3);
-    }
-    
-    // 3. Convert to UTF-8 if not already
-    if ($charset !== 'UTF-8' && $charset !== 'UTF8') {
-        $content = iconv($charset, 'UTF-8//IGNORE', $content);
-        if ($content === false) {
-            throw new \Exception("Failed to convert charset from $charset to UTF-8");
-        }
-    }
-    
-    // 4. Validate and sanitize UTF-8
-    if (!mb_check_encoding($content, 'UTF-8')) {
-        // Remove invalid UTF-8 sequences
-        $content = mb_convert_encoding($content, 'UTF-8', 'UTF-8');
-    }
-    
-    return $content;
-}
 
-/**
- * Sanitize string for database storage
- * Ensures valid UTF-8 encoding without null bytes or control characters
- *
- * @param string $text
- * @return string
- */
-function sanitizeUtf8($text) {
-    // Remove null bytes
-    $text = str_replace("\0", '', $text);
-    
-    // Validate/fix UTF-8
-    if (!mb_check_encoding($text, 'UTF-8')) {
-        $text = mb_convert_encoding($text, 'UTF-8', 'UTF-8');
-    }
-    
-    return trim($text);
-}
 
 /**
  * External Calendar Importer

--- a/webapp/classes/html/ajax/ajax.php
+++ b/webapp/classes/html/ajax/ajax.php
@@ -6,20 +6,6 @@ class Ajax extends \Html\Html {
 
     public $template = "layout_empty.twig";
 
-    /*
-     * Az ajax végpontok JSON-t adnak vissza. A külső API-k hibakereső üzemmódban
-     * eddig a teljes verem-kiírást a válaszba echózták — az a JSON törzs elé
-     * került, tehát értelmezhetetlen lett, és a látogató fájlútvonalakat látott
-     * (élő eset: az Overpass 429-e a főoldal egyházmegye-rétegénél). Innentől ott
-     * csak a szerver-naplóba kerül.
-     *
-     * A leszármazottak konstruktora előtt kell megtörténnie, ezért van itt, és nem
-     * az egyes végpontokban — különben minden új ajax végponton újra elő tudna
-     * jönni ugyanez.
-     */
-    public static function markJson(): void {
-        \ExternalApi\ExternalApi::markJsonResponse(true);
-    }
 
     public function __construct($path) {
         // #391: eddig a teljes $_REQUEST-et visszaechóztuk JSON-ként. Ennek nincs hívója —

--- a/webapp/classes/html/ajax/calendar/generate.php
+++ b/webapp/classes/html/ajax/calendar/generate.php
@@ -129,24 +129,6 @@ class Generate extends \Html\Ajax\Calendar\CalendarApi {
     }
 
     
-    private function convertRangeToUtc(?int $min, ?int $max, Carbon $date): array
-    {
-        $range = [];
-
-        if ($min !== null) {
-            $local = $date->copy()->setTime(floor($min / 60), $min % 60);
-            $utc   = $local->copy()->setTimezone('UTC');
-            $range['gte'] = $utc->hour * 60 + $utc->minute;
-        }
-
-        if ($max !== null) {
-            $local = $date->copy()->setTime(floor($max / 60), $max % 60);
-            $utc   = $local->copy()->setTimezone('UTC');
-            $range['lte'] = $utc->hour * 60 + $utc->minute;
-        }
-
-        return $range;
-    }
 
   
     

--- a/webapp/classes/html/church/editosm.php
+++ b/webapp/classes/html/church/editosm.php
@@ -230,37 +230,6 @@ class EditOsm extends \Html\Html {
     }
 
     
-   function loadOSMDataWithOverpass() {
-   
-		// Elszállunk, hanincs OSM összekötettetés
-		if(!isset($this->church['osmtype']) or !isset($this->church['osmid']) or $this->church['osmtype'] == '' or $this->church['osmid'] == '') {
-			addMessage('Ehhez a misézőhelyhez nem létezik OSM azonosító, ezért nincs mit szerkeszteni.','danger');
-			return;
-		}
-						
-		// Lekérdezzük az OSM adatokat
-		$overpassapi = new \ExternalApi\OverpassApi();
-		$overpassapi->cache = "1 sec"; // Itt fontos, hogy mindig friss legyen az adat.		
-		$overpassapi->buildOneEntityQuery($this->church['osmtype'],$this->church['osmid']);
-		$overpassapi->run();
-		
-		// Elszállunk, ha nem találtunk OSM adatot az OSM azonosítók alapján
-		if($overpassapi->jsonData->elements == array() ) {
-			addMessage('Ehhez a misézőhelyhez bár van OSM azonosító ('.$this->church['osmtype'].':'.$this->church['osmid'].'), mégsem találjuk azt az OSM-ben.'); 
-		}
-		
-		$this->osmtags = $overpassapi->jsonData->elements[0]->tags;
-		
-		/*
-		// Lekérdezzük azt is, hogy mi veszi körül ezt a helyet
-		$point = [ $overpassapi->jsonData->elements[0]->center->lat, $overpassapi->jsonData->elements[0]->center->lon ];
-		$overpassapi->buildEnclosingBoundariesQuery($point[0],$point[1]);
-		$overpassapi->run();
-		printr($overpassapi);
-		*/
-		
-		return true;
-   }
    
    function loadOSMDataWithOSM() {
    

--- a/webapp/classes/html/html.php
+++ b/webapp/classes/html/html.php
@@ -161,9 +161,6 @@ class Html {
         }
     }
 
-    function array2this($array) {
-        copyArrayToObject($array, $this);
-    }
 
     function redirect($url) {
         # http_redirect ($url,$params,$session,$status);

--- a/webapp/classes/html/josm.php
+++ b/webapp/classes/html/josm.php
@@ -143,27 +143,6 @@ class Josm extends Html {
                
     }
 
-    function osm2txt($osm) {
-        $osm = (array) $osm;
-
-        $return = '';
-        $e = array('node' => 'n', 'way' => 'w', 'relation' => 'r');
-        $return .= (int) $osm['distance'] . "m: ";
-        $return .= " <a title='Megnyitás JOSM-ben' href='http://localhost:8111/load_object?new_layer=false&objects=" . $e[$osm['type']] . $osm['id'] . "' target='_blank' class='ajax'>";
-        if (isset($osm['tags']['name']))
-            $return .= $osm['tags']['name'] . " ";
-        else
-            $return .= $e[$osm['type']] . $osm['id'];
-        $return .= "</a>";
-        if (isset($osm['tags']['alt_name']))
-            $return .= "<span title='alt_name'>" . $osm['tags']['alt_name'] . "</span> ";
-        if (isset($osm['tags']['denomination']))
-            $return .= "<span title='denomination'>" . $osm['tags']['denomination'] . "</span> ";
-        if (isset($osm['tags']['building']))
-            $return .= "<span title='building'>" . $osm['tags']['building'] . "</span> ";
-
-        return $return;
-    }
 
    function checkOsmElements($elements) {
        $osmWBadTag = array();

--- a/webapp/classes/request.php
+++ b/webapp/classes/request.php
@@ -150,25 +150,6 @@ class Request {
         return $value;
     }
 
-    static function StringArrayRequired($name) {
-         $value = self::get($name);
-         
-         if (!$value) {
-             throw new Exception("Required '$name' is missing.");
-         }
-         
-         if (!is_array($value)) {
-             throw new Exception("Required '$name' is not an Array.");
-         }
-         
-         foreach ($value as $item) {
-             if (!is_string($item)) {
-                 throw new Exception("Required Array '$name' contains non-string values.");
-             }
-         }
-         
-         return $value;
-     }
 
     static function ArrayArray($name) {
         $value = self::get($name);
@@ -187,21 +168,6 @@ class Request {
         return $value;
     }
 
-    static function ArrayArraywDefault($name, $default = []) {
-        $value = self::getwDefault($name, $default);
-        
-        if (!is_array($value)) {
-            throw new Exception("'$name' is not an Array.");
-        }
-        
-        foreach ($value as $item) {
-            if (!is_array($item)) {
-                throw new Exception("Array '$name' contains non-array values.");
-            }
-        }
-        
-        return $value;
-    }
 
     static function Boolean($name) {
         $value = self::get($name);

--- a/webapp/classes/search.php
+++ b/webapp/classes/search.php
@@ -490,9 +490,6 @@ class Search {
         $this->timeRange($whenDate."T00:00", $whenDate."T23:59");
     }
 
-    function addSortBy($field, $order = 'asc') {
-        $this->sort[] = [ $field => [ "order" => $order ] ];
-    }
 
     /**
      * Execute the search and return results.


### PR DESCRIPTION
Végigmentem a `webapp/classes` összes metódusdefinícióján, és összevetettem a teljes forrás hivatkozásaival — PHP, Twig, JS, TS, SQL-seed, docker, scriptek. Ami sehol nem szerepel a saját definícióján kívül, az jelölt lett.

**Utána viszont egyenként ellenőriztem, mert PHP-ben a statikus elemzés hazudik.** Két dinamikus hívási utat kellett kizárni:

```php
// Html\Api: a metódusnév a formátumból épül
$renderfunction = 'render' . ucfirst($this->api->format);
$this->api->$renderfunction();
```

Emiatt a `renderText` / `renderJson` / `renderCsv` **él**, hiába nincs rájuk egyetlen írott hivatkozás sem — ezek kiestek a listáról.

```php
// Eloquent\Cron: osztály- és függvénynév az ADATBÁZISBÓL
if (method_exists($object, $functionName)) { $object->$functionName(); }
```

Ezért a `cronok` tábla mind a 26 sorát is összevetettem a jelöltekkel (`User::sendActivationNotification`, `Distance::updateSome`, `Crons::cleanUsageStats` stb. így maradtak ki).

## Amit törlök (13 függvény, 212 sor)

| Hely | Miért |
|---|---|
| `Church::MgetDioceseId()` | Ráadásul **hibás**: `$this->religious_administratin` — hiányzó `o`. Ha valaha hívta volna valami, elszállt volna. |
| `Generate::convertRangeToUtc()` | **Privát**, és a saját osztályán belül sem hívja semmi → bizonyíthatóan elérhetetlen. |
| `EditOsm::loadOSMDataWithOverpass()` | A leváltott testvére a `loadOSMDataWithOSM()`-nek, ami az élő út (53. és 128. sor). |
| `ensureUtf8()`, `sanitizeUtf8()` | Globális függvények egy osztályfájl tetején, az importer nem használja őket. |
| `Html::array2this()` | A globális `copyArrayToObject()` háromsoros burka — a hívók eleve közvetlenül azt hívják. |
| `Ajax::markJson()` | Statikus burok az `ExternalApi::markJsonResponse(true)` fölött. |
| `Api\Sqlite::getDatabaseToArray()` | |
| `Josm::osm2txt()` | |
| `Search::addSortBy()` | |
| `ElasticsearchApi::deleteIndex()` | |
| `Request::StringArrayRequired()`, `Request::ArrayArraywDefault()` | A validátor-család két sosem hívott tagja. |

## Amit szándékosan NEM töröltem

**Eloquent-relációk** — `CalPeriod::startPeriod`, `CalPeriod::endPeriod`, `Church::childRelationships`. Deklaratív idegenkulcs-leírás, futásidejű költség nélkül; a séma dokumentációja.

**Bekötetlen funkció, nem halott kód** — ez a kettő működik, csak nincs hívója:

- `OsrmApi::routeDistance()` — ez az OSRM-integráció egyetlen érdemi művelete. A szolgáltatás be van drótozva a compose-ba (`--profile osrm`), a health-check teszteli is, de **útvonal-távolságot soha senki nem kér tőle**. Ha ezt törölném, az egész opcionális profil értelmét veszítené.
- `ExternalApi::clearAllOldCache()` — végigmegy az összes külső API-n és üríti a lejárt cache-t. A cron csak az egy-API-s `clearOldCache()`-t hívja (Overpass). Ez egyetlen `cronok`-sorra van a hasznosságtól.

Mindkettő döntést igényel, nem takarítást — ezért hagytam bent.

## Ellenőrzés

Minden érintett fájlon `php -l`, plusz mindkét suite:

```
PHP:       887 teszt, 2081 állítás  — zöld
böngésző:   80 teszt,  136 állítás  — zöld
```

Tiszta törlés, egyetlen sor sem módosul.