### PR TITLE
Megírom a tíz teszteletlen Angular egység tesztjét

### DIFF
--- a/calendar/src/app/components/sensor-event-popup/sensor-event-popup.component.spec.ts
+++ b/calendar/src/app/components/sensor-event-popup/sensor-event-popup.component.spec.ts
@@ -1,0 +1,139 @@
+import {MatDialogRef} from '@angular/material/dialog';
+
+import {SensorEventPopupComponent, SensorEventDialogData} from './sensor-event-popup.component';
+
+/**
+ * Ez a felugró ablak mutatja meg, mit érzékelt a templomban a szenzor — például meddig
+ * tartott a gyóntatás. A szerver csak KEZDETET és MÁSODPERCBEN mért hosszt küld, a
+ * befejezést és az emberi formátumot ez a komponens számolja.
+ *
+ * Az időszámítás a lényeg: az órahatár átlépése, a nap átlépése, és a másodpercekből
+ * összerakott óra:perc:mp. Ezeket a felületen csak akkor venné észre valaki, ha kiszúrja,
+ * hogy egy 23:50-kor kezdődő, hosszú esemény vége „rossz napra" esik.
+ *
+ * A komponenst közvetlenül példányosítjuk — nincs benne más állapot, csak a kapott adat.
+ */
+describe('SensorEventPopupComponent', () => {
+
+  let dialogRef: jasmine.SpyObj<MatDialogRef<SensorEventPopupComponent>>;
+
+  beforeEach(() => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+  });
+
+  /**
+   * @param startDate az esemény kezdete
+   * @param duration hossz másodpercben
+   * @param id a szenzor azonosítója (ebből derül ki a típusa)
+   */
+  function komponens(startDate: string, duration: number, id = 'confession_1'): SensorEventPopupComponent {
+    const adat: SensorEventDialogData = {
+      sensorEvent: {id, startDate, duration} as any,
+      churchName: 'Teszt-templom',
+    };
+    return new SensorEventPopupComponent(dialogRef, adat);
+  }
+
+  describe('időszámítás', () => {
+
+    it('a kezdetet dátum és idő alakban adja', () => {
+      const {start} = komponens('2026-03-15T09:05:00', 0).getTimeRange();
+      expect(start).toBe('2026.03.15 09:05:00');
+    });
+
+    it('a hosszt hozzáadja a kezdethez', () => {
+      const {end} = komponens('2026-03-15T09:00:00', 30 * 60).getTimeRange();
+      expect(end).toBe('2026.03.15 09:30:00');
+    });
+
+    it('átlépi az órahatárt', () => {
+      const {end} = komponens('2026-03-15T09:45:00', 30 * 60).getTimeRange();
+      expect(end).toBe('2026.03.15 10:15:00');
+    });
+
+    /** Éjfél átlépésekor a dátumnak is fordulnia kell. */
+    it('átlépi a napot is', () => {
+      const {end} = komponens('2026-03-15T23:50:00', 20 * 60).getTimeRange();
+      expect(end)
+        .withContext('éjfél után már a következő nap van')
+        .toBe('2026.03.16 00:10:00');
+    });
+
+    it('a hosszt óra:perc:mp alakban írja ki', () => {
+      const {duration} = komponens('2026-03-15T09:00:00', 3661).getTimeRange();
+      expect(duration).toBe('01:01:01');
+    });
+
+    it('a rövid hosszt is két számjegyre tölti', () => {
+      const {duration} = komponens('2026-03-15T09:00:00', 5).getTimeRange();
+      expect(duration).toBe('00:00:05');
+    });
+
+    it('a több órás hosszt is kezeli', () => {
+      const {duration} = komponens('2026-03-15T09:00:00', 10 * 3600 + 30 * 60).getTimeRange();
+      expect(duration).toBe('10:30:00');
+    });
+
+    /** Hiányzó hossznál a vég a kezdet, nem "Invalid Date". */
+    it('hiányzó hossznál a vég egyenlő a kezdettel', () => {
+      const {start, end, duration} = komponens('2026-03-15T09:00:00', undefined as any).getTimeRange();
+
+      expect(end).toBe(start);
+      expect(duration).toBe('00:00:00');
+    });
+  });
+
+  describe('információs hivatkozások', () => {
+
+    it('gyóntatásnál a gyóntatás-specifikus linkeket adja', () => {
+      const linkek = komponens('2026-03-15T09:00:00', 60, 'confession_1').getInfoUrls();
+
+      expect(linkek.length).toBe(2);
+      expect(linkek[0].url).toContain('/confession');
+    });
+
+    it('ismeretlen szenzortípusnál általános linket ad', () => {
+      const linkek = komponens('2026-03-15T09:00:00', 60, 'valami_5').getInfoUrls();
+
+      expect(linkek.length).toBe(1);
+      expect(linkek[0].url).toContain('/sensor-info');
+    });
+
+    /** Azonosító nélkül sem maradhat link nélkül a felugró ablak. */
+    it('azonosító nélkül is ad hivatkozást', () => {
+      // Szándékosan NEM a segédfüggvényen át: ott az alapértelmezett paraméterérték
+      // visszahozná a 'confession_1'-et, és a teszt sosem mérné az azonosító hiányát.
+      const c = new SensorEventPopupComponent(dialogRef, {
+        sensorEvent: {startDate: '2026-03-15T09:00:00', duration: 60} as any,
+        churchName: 'Teszt-templom',
+      });
+
+      const linkek = c.getInfoUrls();
+      expect(linkek.length).toBe(1);
+      expect(linkek[0].url).toContain('/sensor-info');
+    });
+
+    it('minden hivatkozásnak van felirata és címe', () => {
+      for (const link of komponens('2026-03-15T09:00:00', 60).getInfoUrls()) {
+        expect(link.label.length).toBeGreaterThan(0);
+        expect(link.url).toMatch(/^https:\/\//);
+      }
+    });
+  });
+
+  describe('kezelés', () => {
+
+    it('a bezárás tényleg becsukja az ablakot', () => {
+      komponens('2026-03-15T09:00:00', 60).onClose();
+      expect(dialogRef.close).toHaveBeenCalled();
+    });
+
+    it('a hivatkozást új lapon nyitja', () => {
+      spyOn(window, 'open');
+
+      komponens('2026-03-15T09:00:00', 60).openLink('https://miserend.hu/confession');
+
+      expect(window.open).toHaveBeenCalledWith('https://miserend.hu/confession', '_blank');
+    });
+  });
+});

--- a/calendar/src/app/components/widget/widget.component.spec.ts
+++ b/calendar/src/app/components/widget/widget.component.spec.ts
@@ -1,0 +1,153 @@
+import {convertToParamMap} from '@angular/router';
+import {of, throwError} from 'rxjs';
+
+import {WidgetComponent} from './widget.component';
+import {EventService} from '../../event.service';
+
+/**
+ * A widget az a nézet, amit IDEGEN oldalak ágyaznak be (`/templom/:id/widget`). Nincs
+ * körülötte se menü, se hibalap: ha elszáll, a beágyazó oldalon egy üres doboz marad,
+ * és a plébánia annyit lát, hogy „nem működik".
+ *
+ * Ezért a hangsúly a rossz bemeneten. A templom azonosítója az útvonalból jön, tehát
+ * kívülről írható: hiányozhat, és lehet szemét is. Mindkettőre kilépéssel kell
+ * válaszolni — és ami a legfontosabb, a töltésjelzőt MINDEN ágon le kell venni,
+ * különben a widget örökre pörög.
+ *
+ * A komponenst közvetlenül példányosítjuk: a teljes logikája az `ngOnInit`-ben van, a
+ * sablonja pedig a naptár-komponenst húzná be a maga teljes függőségi fájával.
+ */
+describe('WidgetComponent', () => {
+
+  let eventService: jasmine.SpyObj<EventService>;
+
+  beforeEach(() => {
+    eventService = jasmine.createSpyObj('EventService', ['getChurch']);
+  });
+
+  /** @param id az útvonalban álló templom-azonosító (null = nincs megadva) */
+  function komponens(id: string | null): WidgetComponent {
+    const route = {snapshot: {paramMap: convertToParamMap(id === null ? {} : {id})}} as any;
+    return new WidgetComponent(route, eventService);
+  }
+
+  describe('rossz bemenet', () => {
+
+    it('azonosító nélkül hibát jelez és nem hív szervert', () => {
+      const c = komponens(null);
+      c.ngOnInit();
+
+      expect(c.error).toBe('church_id missing');
+      expect(eventService.getChurch).not.toHaveBeenCalled();
+    });
+
+    it('azonosító nélkül leveszi a töltésjelzőt', () => {
+      const c = komponens(null);
+      c.ngOnInit();
+
+      expect(c.loading)
+        .withContext('különben a beágyazott widget örökre pörög')
+        .toBeFalse();
+    });
+
+    it('nem számot kapva hibát jelez és nem hív szervert', () => {
+      const c = komponens('abc');
+      c.ngOnInit();
+
+      expect(c.error).toBe('invalid church_id');
+      expect(c.loading).toBeFalse();
+      expect(eventService.getChurch).not.toHaveBeenCalled();
+    });
+
+    /**
+     * A `parseInt('12abc', 10)` 12-t ad — ez a JavaScript viselkedése, nem hiba.
+     * Rögzítem, hogy tudatos maradjon: a widget ilyenkor a 12-es templomot mutatja.
+     */
+    it('a számmal kezdődő szemetet a szám-előtagként veszi', () => {
+      eventService.getChurch.and.returnValue(of({id: 12, masses: []} as any));
+
+      const c = komponens('12abc');
+      c.ngOnInit();
+
+      expect(eventService.getChurch).toHaveBeenCalledWith(12);
+      expect(c.error).toBeNull();
+    });
+  });
+
+  describe('betöltés', () => {
+
+    it('az útvonalbeli azonosítóval kéri le a templomot', () => {
+      eventService.getChurch.and.returnValue(of({id: 7, masses: []} as any));
+
+      komponens('7').ngOnInit();
+
+      expect(eventService.getChurch).toHaveBeenCalledWith(7);
+    });
+
+    it('sikeres betöltés után nincs hiba és nincs töltésjelző', () => {
+      eventService.getChurch.and.returnValue(of({id: 7, masses: []} as any));
+
+      const c = komponens('7');
+      c.ngOnInit();
+
+      expect(c.church).toBeDefined();
+      expect(c.error).toBeNull();
+      expect(c.loading).toBeFalse();
+    });
+
+    /** A naptár-komponens Map-et vár, a szerver tömböt ad — a widget fordít. */
+    it('a mise-tömbből azonosító szerinti Map-et épít', () => {
+      eventService.getChurch.and.returnValue(of({
+        id: 7,
+        masses: [{id: 101, title: 'Reggeli'}, {id: 202, title: 'Esti'}],
+      } as any));
+
+      const c = komponens('7');
+      c.ngOnInit();
+
+      expect(c.massesMap.size).toBe(2);
+      expect(c.massesMap.get(101).title).toBe('Reggeli');
+      expect(c.massesMap.get(202).title).toBe('Esti');
+    });
+
+    it('mise nélküli templomnál üres marad a Map', () => {
+      eventService.getChurch.and.returnValue(of({id: 7, masses: []} as any));
+
+      const c = komponens('7');
+      c.ngOnInit();
+
+      expect(c.massesMap.size).toBe(0);
+    });
+
+    /** Ha a szerver nem tömböt ad (régi API, hiányzó mező), nem szabad elszállni. */
+    it('hiányzó mise-mezőnél sem dob', () => {
+      eventService.getChurch.and.returnValue(of({id: 7} as any));
+
+      const c = komponens('7');
+      expect(() => c.ngOnInit()).not.toThrow();
+      expect(c.massesMap.size).toBe(0);
+    });
+  });
+
+  describe('szerverhiba', () => {
+
+    it('magyar üzenetet mutat, nem a nyers hibát', () => {
+      eventService.getChurch.and.returnValue(throwError(() => new Error('boom')));
+
+      const c = komponens('7');
+      c.ngOnInit();
+
+      expect(c.error).toBe('Nem sikerült betölteni a templom adatait.');
+    });
+
+    it('hiba után is leveszi a töltésjelzőt', () => {
+      eventService.getChurch.and.returnValue(throwError(() => new Error('boom')));
+
+      const c = komponens('7');
+      c.ngOnInit();
+
+      expect(c.loading).toBeFalse();
+      expect(c.church).toBeUndefined();
+    });
+  });
+});

--- a/calendar/src/app/http-error.interceptor.spec.ts
+++ b/calendar/src/app/http-error.interceptor.spec.ts
@@ -1,0 +1,136 @@
+import {TestBed} from '@angular/core/testing';
+import {HTTP_INTERCEPTORS, HttpClient, provideHttpClient, withInterceptorsFromDi} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+import {throwError} from 'rxjs';
+
+import {HttpErrorInterceptor} from './http-error.interceptor';
+import {MatSnackBarService} from './services/mat-snack-bar.service';
+
+/**
+ * Ez az interceptor dönti el, MIT LÁT a felhasználó, amikor a szerver hibázik. A naptár
+ * minden kérése átmegy rajta, és a felületen nincs más hibajelzés — ha itt rossz szöveg
+ * áll elő, a kezelő nem tudja eldönteni, hogy ő rontott-e el valamit, vagy a szerver.
+ *
+ * A tesztek egy VALÓDI kérésen keresztül mérnek (interceptor + HttpClient együtt), mert
+ * az `intercept()` közvetlen hívása nem mutatná meg, hogy a hibaobjektum tényleg olyan
+ * alakban érkezik-e, amilyet a kód vár.
+ *
+ * Egy hibát is rögzítenek: a HTTP-ág üzenetét korábban felülírta a záró
+ * `if (error.message)`, mert a HttpErrorResponse-nak az Angular MINDIG ad `.message`-t.
+ */
+describe('HttpErrorInterceptor', () => {
+
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let snackBar: jasmine.SpyObj<MatSnackBarService>;
+
+  beforeEach(() => {
+    snackBar = jasmine.createSpyObj('MatSnackBarService', ['error', 'success']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        {provide: MatSnackBarService, useValue: snackBar},
+        {provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true},
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  /** @return a felhasználónak megjelenített szöveg */
+  function megjelenitettUzenet(): string {
+    return snackBar.error.calls.mostRecent().args[0] as string;
+  }
+
+  it('sikeres válasznál nem szól bele', () => {
+    let valasz: any;
+    http.get('/proba').subscribe(v => valasz = v);
+    httpMock.expectOne('/proba').flush({ok: true});
+
+    expect(valasz).toEqual({ok: true});
+    expect(snackBar.error).not.toHaveBeenCalled();
+  });
+
+  it('a hibát továbbdobja, nem nyeli el', () => {
+    let hiba: any = null;
+    http.get('/proba').subscribe({next: () => {}, error: e => hiba = e});
+    httpMock.expectOne('/proba').flush('hiba', {status: 500, statusText: 'Internal Server Error'});
+
+    expect(hiba)
+      .withContext('ha elnyelné, a hívó sikernek hinné a hibát')
+      .not.toBeNull();
+  });
+
+  /**
+   * A javítás lényege. Korábban itt az Angular generikus, angol szövege jelent meg
+   * ("Http failure response for /proba: 500 Internal Server Error"), mert a záró
+   * `if (error.message)` mindig lefutott.
+   */
+  it('HTTP-hibánál az állapotkódot és a szerver szövegét mutatja', () => {
+    http.get('/proba').subscribe({next: () => {}, error: () => {}});
+    httpMock.expectOne('/proba').flush('hiba', {status: 500, statusText: 'Internal Server Error'});
+
+    expect(megjelenitettUzenet())
+      .withContext('a HttpErrorResponse .message-e nem írhatja felül a saját szövegünket')
+      .toBe('API hiba 500: Internal Server Error');
+  });
+
+  it('404-nél is a saját szövegünk megy ki', () => {
+    http.get('/nincs').subscribe({next: () => {}, error: () => {}});
+    httpMock.expectOne('/nincs').flush('nincs', {status: 404, statusText: 'Not Found'});
+
+    expect(megjelenitettUzenet()).toBe('API hiba 404: Not Found');
+  });
+
+  /**
+   * Ez az az eset, amiért a `.message` átvétele egyáltalán készült: a
+   * HttpTimeoutInterceptor SIMA objektumot dob a saját magyar szövegével.
+   */
+  it('a timeout-interceptor saját üzenetét átveszi', () => {
+    const sajat = {
+      status: 408,
+      statusText: 'Request Timeout',
+      message: 'Az API szerver nem válaszolt időben. Kérjük, ellenőrizze az internet kapcsolatot és próbálja újra később.',
+    };
+
+    const interceptor = new HttpErrorInterceptor(snackBar);
+    const kovetkezo = {handle: () => throwError(() => sajat)} as any;
+
+    interceptor.intercept({} as any, kovetkezo).subscribe({next: () => {}, error: () => {}});
+
+    expect(megjelenitettUzenet())
+      .withContext('sima objektumnál a .message-t igenis át kell venni')
+      .toBe(sajat.message);
+  });
+
+  /** Üzenet nélküli, ismeretlen alakú hibánál sem maradhat a felhasználó szöveg nélkül. */
+  it('ismeretlen hibánál is ad valamilyen üzenetet', () => {
+    const interceptor = new HttpErrorInterceptor(snackBar);
+    const kovetkezo = {handle: () => throwError(() => ({}))} as any;
+
+    interceptor.intercept({} as any, kovetkezo).subscribe({next: () => {}, error: () => {}});
+
+    expect(megjelenitettUzenet()).toBe('Ismeretlen hiba történt');
+  });
+
+  it('hálózati hibánál a kapcsolódásra figyelmeztet', () => {
+    http.get('/proba').subscribe({next: () => {}, error: () => {}});
+    httpMock.expectOne('/proba').error(new ProgressEvent('network error'), {status: 0, statusText: ''});
+
+    expect(megjelenitettUzenet()).toContain('Nem lehet kapcsolódni');
+  });
+
+  it('a hibaüzenet hosszabban látszik az alapértelmezettnél', () => {
+    http.get('/proba').subscribe({next: () => {}, error: () => {}});
+    httpMock.expectOne('/proba').flush('hiba', {status: 500, statusText: 'Internal Server Error'});
+
+    expect(snackBar.error.calls.mostRecent().args[1])
+      .withContext('hibát legyen ideje elolvasni')
+      .toBe(6000);
+  });
+});

--- a/calendar/src/app/http-error.interceptor.ts
+++ b/calendar/src/app/http-error.interceptor.ts
@@ -32,8 +32,16 @@ export class HttpErrorInterceptor implements HttpInterceptor {
           errorMessage = `API hiba ${error.status}: ${error.statusText}`;
         }
 
-        // Egyéni üzenet ha az interceptor már beállított
-        if (error.message) {
+        // Egyéni üzenet, ha a HttpTimeoutInterceptor már beállított egyet: az sima
+        // objektumot dob a saját, magyar szövegével, azt vesszük át.
+        //
+        // HttpErrorResponse-nál viszont NEM szabad átvenni. Annak az Angular MINDIG
+        // beállítja a .message-ét ("Http failure response for <url>: 500 ..."), tehát a
+        // feltétel ott mindig igaz volt, és felülírta a fenti, célzottan összerakott
+        // üzenetet — a felhasználó az angol, URL-t is kiíró alapszöveget kapta a
+        // szánt "API hiba 500: Internal Server Error" helyett. A fenti HTTP-ág emiatt
+        // gyakorlatilag sosem látszott.
+        if (error.message && !(error instanceof HttpErrorResponse)) {
           errorMessage = error.message;
         }
 

--- a/calendar/src/app/http.interceptor.spec.ts
+++ b/calendar/src/app/http.interceptor.spec.ts
@@ -1,0 +1,106 @@
+import {fakeAsync, tick} from '@angular/core/testing';
+import {HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import {NEVER, of, throwError} from 'rxjs';
+
+import {HttpTimeoutInterceptor} from './http.interceptor';
+
+/**
+ * Ez az interceptor a naptár védelme a néma szerver ellen: ha 15 másodpercig nem jön
+ * válasz, elvágja a kérést. Nélküle a felület örökre pörgő töltésjelzőn állna, és a
+ * kezelő nem tudná, hogy várjon-e még vagy töltse újra.
+ *
+ * A kifelé adott hibaalak SZERZŐDÉS: a HttpErrorInterceptor épp ezekre a mezőkre
+ * támaszkodik (`status`, `statusText`, `message`), amikor eldönti, mit írjon ki. Ha itt
+ * elcsúszik az alak, a felhasználó "Ismeretlen hiba" szöveget kap a pontos magyarázat
+ * helyett — a két fájl külön él, ezt csak teszt köti össze.
+ *
+ * A méréshez közvetlenül az `intercept()`-et hajtjuk meg egy vezérelhető `next`-tel:
+ * a 15 másodpercet így lehet pontosan kivárni, valódi HTTP-háttér nélkül.
+ */
+describe('HttpTimeoutInterceptor', () => {
+
+  let interceptor: HttpTimeoutInterceptor;
+
+  /** @param forras amit a lánc következő eleme ad vissza */
+  function futtat(forras: any): {ertek: any; hiba: any} {
+    const eredmeny: {ertek: any; hiba: any} = {ertek: undefined, hiba: null};
+    interceptor
+      .intercept({} as any, {handle: () => forras} as any)
+      .subscribe({next: v => eredmeny.ertek = v, error: e => eredmeny.hiba = e});
+    return eredmeny;
+  }
+
+  beforeEach(() => {
+    interceptor = new HttpTimeoutInterceptor();
+  });
+
+  it('a sikeres választ változatlanul engedi át', () => {
+    const valasz = new HttpResponse({status: 200, body: {ok: true}});
+    const eredmeny = futtat(of(valasz));
+
+    expect(eredmeny.ertek).toBe(valasz);
+    expect(eredmeny.hiba).toBeNull();
+  });
+
+  it('a 15 másodpercen belül érkező válasz átmegy', fakeAsync(() => {
+    const eredmeny = futtat(of(new HttpResponse({status: 200})));
+    tick(14999);
+
+    expect(eredmeny.hiba).toBeNull();
+    expect(eredmeny.ertek).toBeDefined();
+  }));
+
+  it('15 másodperc után elvágja a néma kérést', fakeAsync(() => {
+    const eredmeny = futtat(NEVER);
+
+    tick(14999);
+    expect(eredmeny.hiba)
+      .withContext('a határidő előtt még várni kell')
+      .toBeNull();
+
+    tick(2);
+    expect(eredmeny.hiba).not.toBeNull();
+  }));
+
+  /** A HttpErrorInterceptor pontosan ezekre a mezőkre épít. */
+  it('a timeout 408-as alakban megy tovább, magyar üzenettel', fakeAsync(() => {
+    const eredmeny = futtat(NEVER);
+    tick(15001);
+
+    expect(eredmeny.hiba.status).toBe(408);
+    expect(eredmeny.hiba.statusText).toBe('Request Timeout');
+    expect(eredmeny.hiba.message).toContain('nem válaszolt időben');
+  }));
+
+  it('hálózati hibából saját, magyarázó alakot csinál', () => {
+    const halozati = new HttpErrorResponse({status: 0, statusText: 'Unknown Error'});
+    const eredmeny = futtat(throwError(() => halozati));
+
+    expect(eredmeny.hiba.status).toBe(0);
+    expect(eredmeny.hiba.statusText).toBe('Network Error');
+    expect(eredmeny.hiba.message).toContain('Nem lehet kapcsolódni');
+  });
+
+  /**
+   * A valódi HTTP-hibát (404, 500) NEM alakítja át — azt a HttpErrorInterceptor
+   * fordítja le, mert csak ott ismerjük az állapotkódot és a szerver szövegét.
+   */
+  it('a valódi HTTP-hibát változatlanul dobja tovább', () => {
+    const szerverHiba = new HttpErrorResponse({status: 500, statusText: 'Internal Server Error'});
+    const eredmeny = futtat(throwError(() => szerverHiba));
+
+    expect(eredmeny.hiba)
+      .withContext('nem szabad átcsomagolni, különben elvész az állapotkód')
+      .toBe(szerverHiba);
+  });
+
+  it('a 404-et is érintetlenül hagyja', () => {
+    const nincs = new HttpErrorResponse({status: 404, statusText: 'Not Found'});
+    expect(futtat(throwError(() => nincs)).hiba).toBe(nincs);
+  });
+
+  it('az ismeretlen alakú hibát is továbbdobja', () => {
+    const ismeretlen = {valami: 'más'};
+    expect(futtat(throwError(() => ismeretlen)).hiba).toBe(ismeretlen);
+  });
+});

--- a/calendar/src/app/inline-overlay-container.spec.ts
+++ b/calendar/src/app/inline-overlay-container.spec.ts
@@ -1,0 +1,86 @@
+import {TestBed} from '@angular/core/testing';
+
+import {InlineOverlayContainer} from './inline-overlay-container';
+
+/**
+ * A naptár beágyazható a miserend.hu oldalaiba, és ilyenkor shadow DOM-ban fut. A
+ * Material lebegő elemei (párbeszédablak, legördülő, tooltip) viszont alapból a
+ * `document.body` végére kerülnek — vagyis a shadow rooton KÍVÜLRE, ahol a naptár
+ * stílusai nem érik el őket. Az eredmény: megjelenő, de stílus nélküli párbeszédablak.
+ *
+ * Ez az osztály ezt oldja meg: ha van shadow root, oda teszi a tárolót. Ha nincs
+ * (önálló oldalként fut), a Material eredeti viselkedése marad. A visszaesés legalább
+ * olyan fontos, mint maga a javítás — enélkül az önálló naptárban tűnne el minden
+ * lebegő elem.
+ */
+describe('InlineOverlayContainer', () => {
+
+  let container: InlineOverlayContainer;
+  let appRoot: HTMLElement | null = null;
+
+  beforeEach(() => {
+    // A CDK OverlayContainer az ősében `inject(Platform)`-ot hív, tehát ez az osztály
+    // csak injektálási környezetben példányosítható — sima `new`-val NG0203-mal elszáll.
+    TestBed.configureTestingModule({providers: [InlineOverlayContainer]});
+    container = TestBed.inject(InlineOverlayContainer);
+  });
+
+  afterEach(() => {
+    appRoot?.remove();
+    appRoot = null;
+    document.querySelectorAll('.cdk-overlay-container').forEach(e => e.remove());
+  });
+
+  /** @param shadowal legyen-e shadow rootja a felvett app-root elemnek */
+  function appRootFelvetel(shadowal: boolean): ShadowRoot | null {
+    appRoot = document.createElement('app-root');
+    document.body.appendChild(appRoot);
+    return shadowal ? appRoot.attachShadow({mode: 'open'}) : null;
+  }
+
+  it('shadow rootba teszi a tárolót, ha van', () => {
+    const shadow = appRootFelvetel(true)!;
+
+    container._createContainer();
+
+    const tarolo = shadow.querySelector('.cdk-overlay-container');
+    expect(tarolo)
+      .withContext('shadow DOM-ban a tárolónak is odabent a helye, különben stílus nélkül marad')
+      .not.toBeNull();
+  });
+
+  it('a shadow rootos tároló megkapja a Material osztálynevét', () => {
+    const shadow = appRootFelvetel(true)!;
+
+    container._createContainer();
+
+    expect(shadow.querySelector('div')!.classList.contains('cdk-overlay-container')).toBeTrue();
+  });
+
+  it('nem a body-ba teszi, ha van shadow root', () => {
+    appRootFelvetel(true);
+
+    container._createContainer();
+
+    expect(document.body.querySelector(':scope > .cdk-overlay-container'))
+      .withContext('a body-ba kerülő tárolót nem érnék el a naptár stílusai')
+      .toBeNull();
+  });
+
+  /** Önálló oldalként futva maradjon a Material eredeti viselkedése. */
+  it('shadow root nélkül a Material alapértelmezésére esik vissza', () => {
+    appRootFelvetel(false);
+
+    container._createContainer();
+
+    expect(document.querySelector('.cdk-overlay-container'))
+      .withContext('enélkül az önálló naptárban tűnne el minden lebegő elem')
+      .not.toBeNull();
+  });
+
+  it('app-root nélkül is felépül a tároló', () => {
+    container._createContainer();
+
+    expect(document.querySelector('.cdk-overlay-container')).not.toBeNull();
+  });
+});

--- a/calendar/src/app/services/edit-confirmation.service.spec.ts
+++ b/calendar/src/app/services/edit-confirmation.service.spec.ts
@@ -1,0 +1,58 @@
+import {TestBed} from '@angular/core/testing';
+
+import {EditConfirmationService} from './edit-confirmation.service';
+
+/**
+ * Ez tartja számon, hogy a látogató RÁBÓLINTOTT-e a szerkesztésre. A naptár ez alapján
+ * dönti el, kell-e még egyszer megkérdezni, mielőtt javaslatot enged beküldeni.
+ *
+ * Két dolgot érdemes rögzíteni. Az egyik, hogy a jóváhagyás EGYIRÁNYÚ: nincs visszavonás,
+ * tehát ha egyszer igent mondtak, a munkamenet végéig az marad — aki visszavonhatónak
+ * hinné, hibás felületet építene rá. A másik, hogy a szolgáltatás `providedIn: 'root'`,
+ * tehát a jóváhagyás az egész alkalmazásra szól, nem komponensenként külön.
+ */
+describe('EditConfirmationService', () => {
+
+  let service: EditConfirmationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [EditConfirmationService]});
+    service = TestBed.inject(EditConfirmationService);
+  });
+
+  it('alapból nincs jóváhagyás', () => {
+    expect(service.isConfirmed()).toBeFalse();
+  });
+
+  it('a confirm() után jóváhagyottnak számít', () => {
+    service.confirm();
+    expect(service.isConfirmed()).toBeTrue();
+  });
+
+  it('a jóváhagyás nem vonható vissza, és ismételhető is', () => {
+    service.confirm();
+    service.confirm();
+
+    expect(service.isConfirmed())
+      .withContext('nincs visszavonó művelet — ha lesz, ezt a tesztet kell átírni')
+      .toBeTrue();
+  });
+
+  it('van alapértelmezett kérdés, és az a szerkesztésről szól', () => {
+    const uzenet = service.getMessage();
+
+    expect(uzenet.length).toBeGreaterThan(0);
+    expect(uzenet).toContain('javaslat');
+  });
+
+  it('a kérdés felülírható', () => {
+    service.setMessage('Biztosan szerkeszted?');
+    expect(service.getMessage()).toBe('Biztosan szerkeszted?');
+  });
+
+  /** A szöveg cseréje nem érintheti a jóváhagyás állapotát. */
+  it('a kérdés cseréje nem hagy jóvá semmit', () => {
+    service.setMessage('Más szöveg');
+    expect(service.isConfirmed()).toBeFalse();
+  });
+});

--- a/calendar/src/app/services/mat-snack-bar.service.spec.ts
+++ b/calendar/src/app/services/mat-snack-bar.service.spec.ts
@@ -1,0 +1,82 @@
+import {TestBed} from '@angular/core/testing';
+import {MatSnackBar} from '@angular/material/snack-bar';
+
+import {MatSnackBarService} from './mat-snack-bar.service';
+
+/**
+ * Minden felhasználói visszajelzés ezen a szolgáltatáson megy át — a naptár összes
+ * hibaüzenete, mentés-visszaigazolása és figyelmeztetése.
+ *
+ * A lényeg a CSS-osztály: a színt (zöld/piros/sárga) a `panelClass` adja, és ha az
+ * elcsúszik, a hibaüzenet zöld dobozban jelenik meg. Ezt a felületen csak szemre lehet
+ * észrevenni, kódból nem — ezért érdemes rögzíteni. A másik a hossz: a hibaüzenet
+ * hívója felülírhatja, de az alapértelmezettnek stabilnak kell lennie.
+ */
+describe('MatSnackBarService', () => {
+
+  let service: MatSnackBarService;
+  let snackBar: jasmine.SpyObj<MatSnackBar>;
+
+  beforeEach(() => {
+    snackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        MatSnackBarService,
+        {provide: MatSnackBar, useValue: snackBar},
+      ],
+    });
+
+    service = TestBed.inject(MatSnackBarService);
+  });
+
+  /** @return a `matSnackBar.open()` utolsó hívásának argumentumai */
+  function utolsoHivas(): [string, string, {panelClass: string; duration: number}] {
+    return snackBar.open.calls.mostRecent().args as any;
+  }
+
+  it('a siker zöld dobozba megy', () => {
+    service.success('Elmentve');
+
+    const [uzenet, gomb, opciok] = utolsoHivas();
+    expect(uzenet).toBe('Elmentve');
+    expect(gomb).toBe('x');
+    expect(opciok.panelClass).toBe('success-snackbar');
+  });
+
+  it('a hiba piros dobozba megy', () => {
+    service.error('Nem sikerült');
+    expect(utolsoHivas()[2].panelClass).toBe('error-snackbar');
+  });
+
+  it('a figyelmeztetés sárga dobozba megy', () => {
+    service.warning('Vigyázz');
+    expect(utolsoHivas()[2].panelClass).toBe('warning-snackbar');
+  });
+
+  it('alapból 4 másodpercig látszik', () => {
+    service.success('Elmentve');
+    expect(utolsoHivas()[2].duration).toBe(4000);
+  });
+
+  it('a hívó felülírhatja a megjelenítés hosszát', () => {
+    service.error('Hosszabb hiba', 6000);
+    expect(utolsoHivas()[2].duration).toBe(6000);
+  });
+
+  /**
+   * A figyelmeztetés SZÁNDÉKOSAN nem vesz át hosszt — ha valaki felvenné a paramétert,
+   * itt derüljön ki, hogy a hívási felület megváltozott.
+   */
+  it('a figyelmeztetés az alapértelmezett hosszal megy', () => {
+    service.warning('Vigyázz');
+    expect(utolsoHivas()[2].duration).toBe(4000);
+  });
+
+  it('a végtelen hossz nulla, és ezt a kívülről hívók is látják', () => {
+    expect(MatSnackBarService.INFINITE_DURATION).toBe(0);
+
+    service.show('Marad', 'success-snackbar', MatSnackBarService.INFINITE_DURATION);
+    expect(utolsoHivas()[2].duration).toBe(0);
+  });
+});

--- a/calendar/src/app/services/search.service.spec.ts
+++ b/calendar/src/app/services/search.service.spec.ts
@@ -1,0 +1,155 @@
+import {TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+
+import {SearchService} from './search.service';
+import {MatSnackBarService} from './mat-snack-bar.service';
+import {environment} from '../../environments/environment';
+
+/**
+ * A keresőfelület szerverkapcsolata: a szűrőlisták betöltése, maga a keresés, és a
+ * miseidőpontok újragenerálása.
+ *
+ * A legtörékenyebb pont a `generateMasses()` paraméterezése. Az évek `years[]` néven,
+ * ISMÉTELT paraméterként mennek — nem vesszős listaként —, mert a PHP oldal így látja
+ * őket tömbnek. Egy `HttpParams.set()` a sok `append()` helyett csendben az utolsó évre
+ * szűkítené a generálást, és ez a hiba a felületen semmilyen hibaüzenetet nem adna:
+ * egyszerűen kevesebb év generálódna le, mint amit a kezelő kért.
+ *
+ * A hibaágat is mérjük: mindhárom művelet szól a felhasználónak ÉS továbbdobja a hibát.
+ * Ha csak elnyelné, a hívó sikerként értelmezné.
+ */
+describe('SearchService', () => {
+
+  let service: SearchService;
+  let httpMock: HttpTestingController;
+  let snackBar: jasmine.SpyObj<MatSnackBarService>;
+
+  const api = environment.apiUrl;
+
+  beforeEach(() => {
+    snackBar = jasmine.createSpyObj('MatSnackBarService', ['error', 'success']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        SearchService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {provide: MatSnackBarService, useValue: snackBar},
+      ],
+    });
+
+    service = TestBed.inject(SearchService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  describe('szűrőlisták betöltése', () => {
+
+    it('a search végpontról GET-tel kéri', () => {
+      service.getData().subscribe();
+
+      const keres = httpMock.expectOne(`${api}search`);
+      expect(keres.request.method).toBe('GET');
+      keres.flush({});
+    });
+
+    it('hiba esetén szól és továbbdobja', () => {
+      let hiba: any = null;
+      service.getData().subscribe({next: () => {}, error: e => hiba = e});
+
+      httpMock.expectOne(`${api}search`).flush('nem jó', {status: 500, statusText: 'Server Error'});
+
+      expect(snackBar.error).toHaveBeenCalled();
+      expect(hiba).withContext('a hibát tovább kell dobni, nem elnyelni').not.toBeNull();
+    });
+  });
+
+  describe('keresés', () => {
+
+    it('POST-tal megy, a kifejezés és a templom a törzsben', () => {
+      service.search('rorate', 42).subscribe();
+
+      const keres = httpMock.expectOne(`${api}search`);
+      expect(keres.request.method).toBe('POST');
+      expect(keres.request.body).toEqual({params: {q: 'rorate', templom: 42}});
+      keres.flush([]);
+    });
+
+    it('üres kifejezéssel is elmegy a kérés', () => {
+      service.search('', null).subscribe();
+
+      const keres = httpMock.expectOne(`${api}search`);
+      expect(keres.request.body.params.q).toBe('');
+      keres.flush([]);
+    });
+
+    it('hiba esetén szól és továbbdobja', () => {
+      let hiba: any = null;
+      service.search('x', 1).subscribe({next: () => {}, error: e => hiba = e});
+
+      httpMock.expectOne(`${api}search`).flush('hiba', {status: 500, statusText: 'Server Error'});
+
+      expect(snackBar.error).toHaveBeenCalled();
+      expect(hiba).not.toBeNull();
+    });
+  });
+
+  describe('generálás', () => {
+
+    it('PUT-tal megy a generate végpontra', () => {
+      service.generateMasses([2026], 7).subscribe();
+
+      const keres = httpMock.expectOne(r => r.url === `${api}generate`);
+      expect(keres.request.method).toBe('PUT');
+      keres.flush({});
+    });
+
+    it('a templom tids[] néven megy', () => {
+      service.generateMasses([2026], 7).subscribe();
+
+      const keres = httpMock.expectOne(r => r.url === `${api}generate`);
+      expect(keres.request.params.getAll('tids[]')).toEqual(['7']);
+      keres.flush({});
+    });
+
+    /** A lényeg: MINDEN év külön paraméterként, különben csendben kevesebb generálódik. */
+    it('minden év külön years[] paraméterként megy', () => {
+      service.generateMasses([2025, 2026, 2027], 7).subscribe();
+
+      const keres = httpMock.expectOne(r => r.url === `${api}generate`);
+      expect(keres.request.params.getAll('years[]'))
+        .withContext('ismételt paraméter kell, nem egyetlen összefűzött érték')
+        .toEqual(['2025', '2026', '2027']);
+      keres.flush({});
+    });
+
+    it('év nélkül nem megy years[] paraméter', () => {
+      service.generateMasses([], 7).subscribe();
+
+      const keres = httpMock.expectOne(r => r.url === `${api}generate`);
+      expect(keres.request.params.getAll('years[]')).toBeNull();
+      keres.flush({});
+    });
+
+    it('a törzs üres — az adat a paraméterekben megy', () => {
+      service.generateMasses([2026], 7).subscribe();
+
+      const keres = httpMock.expectOne(r => r.url === `${api}generate`);
+      expect(keres.request.body).toBeNull();
+      keres.flush({});
+    });
+
+    it('hiba esetén szól és továbbdobja', () => {
+      let hiba: any = null;
+      service.generateMasses([2026], 7).subscribe({next: () => {}, error: e => hiba = e});
+
+      httpMock.expectOne(r => r.url === `${api}generate`)
+        .flush('hiba', {status: 500, statusText: 'Server Error'});
+
+      expect(snackBar.error).toHaveBeenCalled();
+      expect(hiba).not.toBeNull();
+    });
+  });
+});

--- a/calendar/src/app/services/spinner.service.spec.ts
+++ b/calendar/src/app/services/spinner.service.spec.ts
@@ -1,0 +1,63 @@
+import {TestBed} from '@angular/core/testing';
+import {fakeAsync, tick} from '@angular/core/testing';
+
+import {SpinnerService} from './spinner.service';
+
+/**
+ * A töltésjelző kapcsolója. Egy sor a lényeg, mégis van benne egy csapda: a
+ * `show()`/`hide()` NEM azonnal állítja át a jelzőt, hanem `setTimeout`-ba teszi.
+ *
+ * Ez szándékos — a hívók a változásdetektálás közben kapcsolgatják, és a közvetlen
+ * értékadás `ExpressionChangedAfterItHasBeenCheckedError`-t dobna. A késleltetésnek
+ * viszont van egy következménye, amit rögzíteni kell: közvetlenül a `show()` UTÁN a
+ * jelző MÉG hamis. Aki szinkron olvasná, rosszat lát.
+ */
+describe('SpinnerService', () => {
+
+  let service: SpinnerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [SpinnerService]});
+    service = TestBed.inject(SpinnerService);
+  });
+
+  it('alapból nem látszik', () => {
+    expect(service.spinnerVisible).toBeFalse();
+  });
+
+  it('a show() nem azonnal kapcsol, hanem a következő körben', fakeAsync(() => {
+    service.show();
+    expect(service.spinnerVisible)
+      .withContext('a show() szinkron módon még nem kapcsolhat át')
+      .toBeFalse();
+
+    tick();
+    expect(service.spinnerVisible).toBeTrue();
+  }));
+
+  it('a hide() ugyanígy késleltetve kapcsol vissza', fakeAsync(() => {
+    service.show();
+    tick();
+
+    service.hide();
+    expect(service.spinnerVisible)
+      .withContext('a hide() szinkron módon még nem kapcsolhat vissza')
+      .toBeTrue();
+
+    tick();
+    expect(service.spinnerVisible).toBeFalse();
+  }));
+
+  /**
+   * Egymásra torlódó kérésnél gyakori: több show() után egy hide(). A jelenlegi
+   * viselkedés NEM számláló alapú, tehát az utolsó hívás dönt.
+   */
+  it('több show() után egyetlen hide() is eltünteti', fakeAsync(() => {
+    service.show();
+    service.show();
+    service.hide();
+    tick();
+
+    expect(service.spinnerVisible).toBeFalse();
+  }));
+});

--- a/calendar/src/app/services/user.service.spec.ts
+++ b/calendar/src/app/services/user.service.spec.ts
@@ -1,0 +1,111 @@
+import {TestBed} from '@angular/core/testing';
+import {provideHttpClient} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+
+import {UserService} from './user.service';
+import {environment} from '../../environments/environment';
+import {User} from '../model/user';
+
+/**
+ * A naptár innen tudja meg, ki nézi — és ami fontosabb, mit szabad neki.
+ *
+ * A szolgáltatás egyetlen érdemi döntése az, hogy HIBÁNÁL NEM DOB, hanem üres
+ * alapfelhasználót ad vissza. Ez szándékos: a naptárnak be kell tudnia töltődni akkor
+ * is, ha a látogató nincs bejelentkezve (a `caluser` ilyenkor 401-et ad). Viszont épp
+ * ezért kell rögzíteni, hogy az alapfelhasználó tényleg ÜRES — ha valaha kapna
+ * kedvenceket vagy nevet, a nem bejelentkezett látogató idegen adatot látna.
+ */
+describe('UserService', () => {
+
+  let service: UserService;
+  let httpMock: HttpTestingController;
+
+  const url = `${environment.apiUrl}caluser`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        UserService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(UserService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('a caluser végpontról tölt', () => {
+    service.loadUser().subscribe();
+
+    const keres = httpMock.expectOne(url);
+    expect(keres.request.method).toBe('GET');
+    keres.flush(null);
+  });
+
+  it('a megkapott felhasználót adja tovább', () => {
+    const felhasznalo: User = {
+      username: 'gondnok',
+      nickname: 'Gondnok',
+      name: 'Teszt Gondnok',
+      email: 'gondnok@example.com',
+      favorites: [12, 34],
+    } as User;
+
+    let eredmeny: any;
+    service.loadUser().subscribe(u => eredmeny = u);
+    httpMock.expectOne(url).flush(felhasznalo);
+
+    expect(eredmeny).toEqual(felhasznalo);
+  });
+
+  /** Nem bejelentkezett látogató: a szerver 401-et ad, a naptárnak mégis mennie kell. */
+  it('hibánál nem dob, hanem üres alapfelhasználót ad', () => {
+    let eredmeny: any;
+    let hiba: any = null;
+
+    service.loadUser().subscribe({
+      next: u => eredmeny = u,
+      error: e => hiba = e,
+    });
+    httpMock.expectOne(url).flush('Unauthorized', {status: 401, statusText: 'Unauthorized'});
+
+    expect(hiba)
+      .withContext('a hiba nem juthat el a hívóig, különben a naptár be sem töltődik')
+      .toBeNull();
+    expect(eredmeny.username).toBe('');
+    expect(eredmeny.favorites).toEqual([]);
+  });
+
+  it('hálózati hibánál is az alapfelhasználó jön', () => {
+    let eredmeny: any;
+    service.loadUser().subscribe(u => eredmeny = u);
+    httpMock.expectOne(url).error(new ProgressEvent('network error'));
+
+    expect(eredmeny.username).toBe('');
+  });
+
+  /** Üres válasznál (a szerver `null`-t ad) ugyanaz az alapfelhasználó kell. */
+  it('üres válasznál is az alapfelhasználó jön', () => {
+    let eredmeny: any;
+    service.loadUser().subscribe(u => eredmeny = u);
+    httpMock.expectOne(url).flush(null);
+
+    expect(eredmeny.username).toBe('');
+    expect(eredmeny.email).toBe('');
+  });
+
+  /**
+   * Ha az alapfelhasználó bármikor adatot kapna, a nem bejelentkezett látogató
+   * idegen kedvenceket látna a naptárában.
+   */
+  it('az alapfelhasználó minden mezője üres', () => {
+    expect(service.defaultUser.username).toBe('');
+    expect(service.defaultUser.nickname).toBe('');
+    expect(service.defaultUser.name).toBe('');
+    expect(service.defaultUser.email).toBe('');
+    expect(service.defaultUser.favorites).toEqual([]);
+  });
+});


### PR DESCRIPTION
Az `xdescribe`-os csonkokat a #784 már felszámolta, de a kép attól még nem volt teljes. Nem az volt a kérdés, hány spec van kikapcsolva, hanem hogy **mihez nincs egyáltalán spec-fájl**:

```
Angular egységek: 29    spec-fájl: 27    spec NÉLKÜL: 10
   8 service
   2 komponens
```

Köztük a **két HTTP-interceptor**, ami az egész naptár hibakezelését viszi, és a **UserService**, amitől a bejelentkezési állapot függ.

**80 teszt, 297 → 377.** Nem `should create` csonkok: mindegyik a szerződést méri — milyen URL-re, milyen alakban megyünk, és mit lát a felhasználó, ha elromlik.

## Közben egy valódi hibát is javítok

A `HttpErrorInterceptor` gondosan összerakja az üzenetet…

```ts
else if (error instanceof HttpErrorResponse) {
  errorMessage = `API hiba ${error.status}: ${error.statusText}`;
}

if (error.message) {          // <- és itt azonnal felül is írja
  errorMessage = error.message;
}
```

…majd a záró feltétel azonnal el is dobja. A `HttpErrorResponse`-nak az Angular **mindig** ad `.message`-t (`Http failure response for <url>: 500 Internal Server Error`), tehát a feltétel ott sosem hamis. **A HTTP-ág gyakorlatilag soha nem látszott**: a felhasználó az angol, URL-t is kiíró alapszöveget kapta a szánt magyar üzenet helyett.

A feltétel eredetileg a `HttpTimeoutInterceptor` sima objektumaira készült — azt megtartom, `HttpErrorResponse`-nál viszont kihagyom. Ellenőriztem, hogy a javítás nélkül bukik:

```
javítás nélkül:  TOTAL: 3 FAILED, 374 SUCCESS
javítva:         TOTAL: 377 SUCCESS
```

## Amit a tesztek rögzítenek, mert kódból nem látszik

- **`generateMasses()` minden évet KÜLÖN `years[]` paraméterként küld.** Egy `set()` a sok `append()` helyett csendben egyetlen évre szűkítené a generálást — hibaüzenet nélkül, egyszerűen kevesebb év generálódna, mint amit a kezelő kért.
- **A timeout-interceptor hibaalakja szerződés.** A `HttpErrorInterceptor` pontosan a `status` / `statusText` / `message` mezőkre épít; a két fájl között más kapocs nincs, csak ez a teszt.
- **A `UserService` hibánál üres alapfelhasználót ad, nem dob.** Enélkül a naptár kijelentkezve be sem töltődne (a `caluser` 401-et ad). A teszt azt is rögzíti, hogy az alapfelhasználó tényleg üres — ha valaha kedvenceket kapna, a nem bejelentkezett látogató idegen adatot látna.
- **A widget minden hibaágon leveszi a töltésjelzőt.** Ez idegen oldalakba ágyazva fut; ha ottmarad, a plébánia annyit lát, hogy „nem működik".
- **A `SpinnerService` késleltetve kapcsol** (`setTimeout`), tehát közvetlenül a `show()` után a jelző még hamis. Aki szinkron olvasná, rosszat lát.
- **Az `InlineOverlayContainer` visszaesési ága** legalább olyan fontos, mint a javítás: shadow root nélkül a Material eredeti viselkedése kell, különben az önálló naptárban tűnne el minden lebegő elem.

## Ellenőrzés

```
Angular-suite:  377 teszt, zöld
tsc --noEmit:   tsconfig.spec.json és tsconfig.app.json — tiszta
```

Két teszt írás közben elsőre hamisan zöldült, mindkettőt javítottam: az `InlineOverlayContainer` csak injektálási környezetben példányosítható (a CDK őse `inject(Platform)`-ot hív), a szenzor-teszt `undefined` azonosítója pedig a segédfüggvény alapértelmezett paraméterértékét hozta vissza, így sosem mérte az azonosító hiányát.