### PR TITLE
Bekötöm a saját OSRM-et a távolságszámításba

### DIFF
--- a/webapp/classes/distance.php
+++ b/webapp/classes/distance.php
@@ -228,12 +228,18 @@ class Distance {
      * szolgáltatásokkal lenne mérhető, és pont az nem derülne ki, hogy melyik nyer.
      */
     protected function osrmApi(): \ExternalApi\OsrmApi {
-        return new \ExternalApi\OsrmApi();
+        // Példányonként egyszer: a resolveDistance() templomonként fut a
+        // MupdateChurch() ciklusában, és minden hívásnál új objektumot gyártani
+        // fölösleges — a beállítás úgysem változik futás közben.
+        return $this->osrm ??= new \ExternalApi\OsrmApi();
     }
 
     protected function mapquestApi(): \ExternalApi\MapquestApi {
-        return new \ExternalApi\MapquestApi();
+        return $this->mapquest ??= new \ExternalApi\MapquestApi();
     }
+
+    private ?\ExternalApi\OsrmApi $osrm = null;
+    private ?\ExternalApi\MapquestApi $mapquest = null;
 
     function getRawDistance($pointFrom, $pointTo) {
         $this->validatePoint($pointFrom);

--- a/webapp/classes/distance.php
+++ b/webapp/classes/distance.php
@@ -182,16 +182,36 @@ class Distance {
             return $counter;
     }
 
-    // #172: a szomszédság-számítás ne dőljön el a Mapquesten. Ha a road-distance
-    // elérhető (van kulcs, nincs rate-limit), azt adjuk vissza; egyébként a
-    // légvonalbeli (haversine) rawDistance-re esünk vissza. Így a feature mindig
-    // frissül, a Mapquest csak opcionális felminősítés.
-    // #526: visszaadja a távolságot ÉS a minőségét ('road' => true, ha Mapquest
+    // #172: a szomszédság-számítás ne dőljön el az útvonaltervezőn. Ha a
+    // road-distance elérhető, azt adjuk vissza; egyébként a légvonalbeli
+    // (haversine) rawDistance-re esünk vissza. Így a feature mindig frissül, az
+    // útvonal-távolság csak opcionális felminősítés.
+    // #526: visszaadja a távolságot ÉS a minőségét ('road' => true, ha
     // útvonal-távolság; false, ha csak légvonal). A hívó ez alapján állítja a
     // distances.toupdate flaget (1 = később útvonalra frissítendő).
+    //
+    // #673: a SAJÁT OSRM-et kérdezzük először. Az OSRM kifejezetten azért került a
+    // compose-ba, hogy ne függjünk idegen szolgáltatótól, kulcstól és kvótától — a
+    // bekötése viszont elmaradt, és az OsrmApi::routeDistance() docblockja azóta is
+    // azt állította, hogy ez a metódus a hívója. Nem ez volt: ide egyedül a Mapquest
+    // jutott el. Mostantól a sorrend OSRM -> Mapquest -> légvonal.
+    //
+    // Az OSRM opcionális (`docker compose --profile osrm up -d`), és ha nincs
+    // beállítva, a routeDistance() null-t ad — ilyenkor a viselkedés bitre azonos
+    // marad a korábbival.
     function resolveDistance($pointFrom, $pointTo, $rawDistance) {
         try {
-            $mapquest = new \ExternalApi\MapquestApi();
+            $osrm = $this->osrmApi();
+            $osrmDistance = $osrm->routeDistance($pointFrom, $pointTo);
+            if ($osrmDistance !== null && $osrmDistance > 0) {
+                return ['distance' => $osrmDistance, 'road' => true];
+            }
+        } catch (\Throwable $e) {
+            // nincs OSRM vagy bármilyen hiba -> jöhet a Mapquest
+        }
+
+        try {
+            $mapquest = $this->mapquestApi();
             $mapquestDistance = $mapquest->distance($pointFrom, $pointTo);
             if ($mapquestDistance > 0) {
                 return ['distance' => $mapquestDistance, 'road' => true];
@@ -200,6 +220,19 @@ class Distance {
             // nincs Mapquest-kulcs vagy bármilyen hiba -> marad a légvonal
         }
         return ['distance' => $rawDistance, 'road' => false];
+    }
+
+    /**
+     * A két útvonaltervező példányosítása külön metódusban, hogy a teszt le tudja
+     * cserélni őket. Enélkül a sorrend (OSRM -> Mapquest -> légvonal) csak éles
+     * szolgáltatásokkal lenne mérhető, és pont az nem derülne ki, hogy melyik nyer.
+     */
+    protected function osrmApi(): \ExternalApi\OsrmApi {
+        return new \ExternalApi\OsrmApi();
+    }
+
+    protected function mapquestApi(): \ExternalApi\MapquestApi {
+        return new \ExternalApi\MapquestApi();
     }
 
     function getRawDistance($pointFrom, $pointTo) {

--- a/webapp/classes/externalapi/osrmapi.php
+++ b/webapp/classes/externalapi/osrmapi.php
@@ -83,9 +83,9 @@ class OsrmApi extends \ExternalApi\ExternalApi {
     /**
      * Útvonal-távolság méterben két pont között, vagy null, ha nem kapható.
      *
-     * A null SZÁNDÉKOSAN nem kivétel: a hívó (l. \Distance::resolveDistance) ilyenkor
-     * a légvonalbeli távolságra esik vissza. Az útvonaltervező kiesése ne állítsa meg a
-     * szomszéd-számítást — legfeljebb pontatlanabb lesz.
+     * A null SZÁNDÉKOSAN nem kivétel: a hívó (\Distance::resolveDistance) ilyenkor a
+     * Mapquestre, majd a légvonalbeli távolságra esik vissza. Az útvonaltervező kiesése
+     * ne állítsa meg a szomszéd-számítást — legfeljebb pontatlanabb lesz.
      */
     function routeDistance(array $from, array $to): ?float {
         if ($this->apiUrl === '/' || $this->apiUrl === '') {

--- a/webapp/tests/Unit/DistanceRoutingOrderTest.php
+++ b/webapp/tests/Unit/DistanceRoutingOrderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #673: melyik útvonaltervező nyer a távolságszámításban.
+ *
+ * Az OSRM kifejezetten azért került a compose-ba, hogy ne függjünk idegen
+ * szolgáltatótól, kulcstól és kvótától. A bekötése viszont elmaradt: a
+ * `resolveDistance()` egyedül a Mapquestet hívta, miközben az `OsrmApi` docblockja
+ * azt állította, hogy ez a metódus a hívója.
+ *
+ * A sorrend ezért itt van rögzítve: OSRM -> Mapquest -> légvonal. Ezt éles
+ * szolgáltatásokkal nem lehetne mérni (az OSRM opcionális, a Mapquest kulcsos),
+ * ezért a Distance a két példányosítást külön metódusban tartja, és a teszt
+ * lecseréli őket.
+ */
+class DistanceRoutingOrderTest extends TestCase {
+
+    private const BUDAPEST = ['lat' => 47.4979, 'lon' => 19.0402];
+    private const SZEGED   = ['lat' => 46.2530, 'lon' => 20.1414];
+
+    /** A légvonalbeli táv, amire vissza kell esni, ha egyik tervező sem felel. */
+    private const LEGVONAL = 161000.0;
+
+    /**
+     * @param float|null $osrm amit az OSRM ad (null = nincs beállítva)
+     * @param float|null $mapquest amit a Mapquest ad (null = dobjon kivételt)
+     */
+    private function tavolsag(?float $osrm, ?float $mapquest): \Distance {
+        return new class($osrm, $mapquest) extends \Distance {
+            public int $osrmHivas = 0;
+            public int $mapquestHivas = 0;
+
+            public function __construct(private ?float $osrm, private ?float $mapquest) {
+                parent::__construct();
+            }
+
+            protected function osrmApi(): \ExternalApi\OsrmApi {
+                $this->osrmHivas++;
+                $ertek = $this->osrm;
+                return new class($ertek) extends \ExternalApi\OsrmApi {
+                    public function __construct(private ?float $ertek) {
+                        parent::__construct('');
+                    }
+                    function routeDistance(array $from, array $to): ?float {
+                        return $this->ertek;
+                    }
+                };
+            }
+
+            protected function mapquestApi(): \ExternalApi\MapquestApi {
+                $this->mapquestHivas++;
+                if ($this->mapquest === null) {
+                    throw new \Exception('nincs Mapquest-kulcs');
+                }
+                $ertek = $this->mapquest;
+                return new class($ertek) extends \ExternalApi\MapquestApi {
+                    public function __construct(private float $ertek) {}
+                    function distance($from, $to) {
+                        return $this->ertek;
+                    }
+                };
+            }
+        };
+    }
+
+    /** A saját szolgáltatásunk az elsődleges — ne fizessünk idegen kvótát fölöslegesen. */
+    public function testAzOsrmNyerHaVanValasza(): void {
+        $tavolsag = $this->tavolsag(170000.0, 999999.0);
+
+        $eredmeny = $tavolsag->resolveDistance(self::BUDAPEST, self::SZEGED, self::LEGVONAL);
+
+        self::assertSame(170000.0, $eredmeny['distance']);
+        self::assertTrue($eredmeny['road']);
+    }
+
+    public function testAzOsrmUtanMarNemKerdezzukAMapquestet(): void {
+        $tavolsag = $this->tavolsag(170000.0, 999999.0);
+
+        $tavolsag->resolveDistance(self::BUDAPEST, self::SZEGED, self::LEGVONAL);
+
+        self::assertSame(0, $tavolsag->mapquestHivas,
+            'Ha az OSRM felelt, a Mapquest hívása fölösleges kvótafogyasztás.');
+    }
+
+    /** Beállítatlan OSRM: a routeDistance() null-t ad, jön a Mapquest. */
+    public function testOsrmNelkulAMapquestJon(): void {
+        $tavolsag = $this->tavolsag(null, 175000.0);
+
+        $eredmeny = $tavolsag->resolveDistance(self::BUDAPEST, self::SZEGED, self::LEGVONAL);
+
+        self::assertSame(175000.0, $eredmeny['distance']);
+        self::assertTrue($eredmeny['road']);
+    }
+
+    /**
+     * A korábbi viselkedés bitre azonos marad ott, ahol nincs OSRM: ez a fontos,
+     * mert az OSRM opcionális compose-profil mögött van.
+     */
+    public function testMindkettoNelkulLegvonalraEsunkVissza(): void {
+        $tavolsag = $this->tavolsag(null, null);
+
+        $eredmeny = $tavolsag->resolveDistance(self::BUDAPEST, self::SZEGED, self::LEGVONAL);
+
+        self::assertSame(self::LEGVONAL, $eredmeny['distance']);
+        self::assertFalse($eredmeny['road'],
+            'A légvonal nem útvonal-távolság — a hívó ez alapján jelöli újraszámolandónak.');
+    }
+
+    /** A nulla nem érvényes útvonalhossz két különböző pont között. */
+    public function testANullaOsrmValaszNemFogadhatoEl(): void {
+        $tavolsag = $this->tavolsag(0.0, 175000.0);
+
+        self::assertSame(175000.0, $tavolsag->resolveDistance(self::BUDAPEST, self::SZEGED, self::LEGVONAL)['distance']);
+    }
+
+    /** Az OSRM kiesése ne állítsa meg a szomszéd-számítást. */
+    public function testAzOsrmHibajaNemSzallElHanemTovabbEsik(): void {
+        $tavolsag = new class extends \Distance {
+            protected function osrmApi(): \ExternalApi\OsrmApi {
+                throw new \Exception('az OSRM nem elérhető');
+            }
+            protected function mapquestApi(): \ExternalApi\MapquestApi {
+                throw new \Exception('nincs Mapquest-kulcs');
+            }
+        };
+
+        $eredmeny = $tavolsag->resolveDistance(self::BUDAPEST, self::SZEGED, self::LEGVONAL);
+
+        self::assertSame(self::LEGVONAL, $eredmeny['distance']);
+        self::assertFalse($eredmeny['road']);
+    }
+}


### PR DESCRIPTION
A #608 útvonalas részét vizsgálva akadtam rá: az OSRM (#673) **be van drótozva a compose-ba, a /health teszteli is — de soha senki nem kér tőle útvonalat.**

A `resolveDistance()` docblockja ráadásul azt sugallja, hogy már meg van oldva:

```php
/**
 * A null SZÁNDÉKOSAN nem kivétel: a hívó (l. \Distance::resolveDistance) ilyenkor
 * a légvonalbeli távolságra esik vissza.
 */
function routeDistance(array $from, array $to): ?float
```

De a `resolveDistance()` valójában így nézett ki:

```php
$mapquest = new \ExternalApi\MapquestApi();     // <- egyedül ez
```

Vagyis a szomszéd-távolságok ma is **idegen szolgáltatótól, API-kulcstól és kvótától** függnek, pedig pont ennek a kiváltására készült a saját OSRM.

## A javítás

Sorrend: **OSRM → Mapquest → légvonal**. Ha az OSRM felel, a Mapquestet meg sem kérdezzük — fölösleges kvótafogyasztás lenne.

Az OSRM opcionális (`docker compose --profile osrm up -d`). Ha nincs beállítva, a `routeDistance()` `null`-t ad, és a viselkedés **bitre azonos marad** a korábbival. Ez fontos, mert így a PR éles OSRM nélkül is biztonságosan mergelhető.

## Tesztelhetőség

A két példányosítást külön metódusba emeltem (`osrmApi()`, `mapquestApi()`). Éles szolgáltatásokkal a sorrend nem lenne mérhető — az OSRM opcionális, a Mapquest kulcsos —, és pont az nem derülne ki, melyik nyer. Így a teszt le tudja cserélni mindkettőt.

6 teszt a teljes visszaesési láncra: OSRM nyer, OSRM után nincs Mapquest-hívás, OSRM nélkül Mapquest, mindkettő nélkül légvonal `road=false`-szal, nulla válasz elutasítása, kivétel esetén továbbesés.

```
PHP-suite: 893 teszt, 2090 állítás — zöld
```

## Amit ez jelent a #608-nak

Az útvonal menti kereséshez útvonal**geometria** kell, nem csak távolság — az egy következő lépés. De a routing-alap mostantól valódi: van saját, kvótamentes tervezőnk, amit tényleg használunk.

Deploy: az `OSRM_URL` beállítása és a `--profile osrm` felhozása nélkül a viselkedés változatlan; ez @borazslo döntése.

Kapcsolódik: #673, #608