### PR TITLE
Átmentem a koordináta nélküli templomok helyadatát

### DIFF
--- a/docker/mysql/migrations/496-koordinata-nelkuli-helyadat.sql
+++ b/docker/mysql/migrations/496-koordinata-nelkuli-helyadat.sql
@@ -1,0 +1,22 @@
+-- #496 / #497 / #498: a koordináta nélküli templomok helyadatának átmentése.
+--
+-- A három jegy a templomok.orszag, .megye és .varos kivezetéséről szól: a helyet
+-- ezután a koordináta és az OSM-határok adják. Ez mindenre igaz, KIVÉVE azt a
+-- néhány misézőhelyet, aminek egyáltalán nincs koordinátája — azoknak sosem lesz
+-- boundary-juk, tehát az oszlopok eldobásával az EGYETLEN helymegjelölésük veszne
+-- el. Élesben 47 ilyen templom van (22 magyar, 25 határon túli).
+--
+-- borazslo a #496-ban két lehetőséget adott: törlés, vagy a megjegyzés mezőbe.
+-- Ez a nem-destruktív ág.
+--
+-- A tényleges átmentést a \Crons::archiveLocationOfChurchesWithoutCoordinates()
+-- végzi (idempotens, az azonosítókat nevekre oldja fel). Ez a fájl csak
+-- REGISZTRÁLJA cronként, hogy élesben futtatható legyen:
+--
+--     docker exec miserend php index.php q=cron cron_id=496
+--
+-- Futtatás UTÁN a cron-sor törölhető, egyszeri feladat.
+
+INSERT INTO `crons` (`id`, `class`, `function`, `frequency`, `from`, `until`)
+VALUES (496, '\\Crons', 'archiveLocationOfChurchesWithoutCoordinates', 'never', NULL, NULL)
+ON DUPLICATE KEY UPDATE `class` = VALUES(`class`), `function` = VALUES(`function`);

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -8,6 +8,84 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Crons {
 
 	/**
+	 * #496 / #497 / #498: a koordináta nélküli templomok helyadatának mentése.
+	 *
+	 * A három jegy a `templomok.orszag`, `.megye` és `.varos` kivezetéséről szól: a
+	 * helyet a koordináta és az OSM-határok adják. Ez mindenre igaz, KIVÉVE azt a
+	 * néhány misézőhelyet, aminek egyáltalán nincs koordinátája — azoknak sosem lesz
+	 * boundary-juk, tehát az oszlopok eldobásával az egyetlen helymegjelölésük veszne
+	 * el. Élesben 47 ilyen templom van (22 magyar, 25 határon túli).
+	 *
+	 * borazslo a #496-ban erre két lehetőséget adott: törlés, vagy a megjegyzés
+	 * mezőbe. Ez a nem-destruktív ág — a szöveget átmentjük, hogy a templom a
+	 * kivezetés után is beazonosítható maradjon.
+	 *
+	 * IDEMPOTENS: a jelölőt keresi, tehát többször lefuttatva sem duplikál.
+	 *
+	 * @return int hány templom megjegyzése egészült ki
+	 */
+	public const HELYADAT_JELOLO = '[Helyadat a koordináta nélküli időszakból]';
+
+	public static function archiveLocationOfChurchesWithoutCoordinates(): int {
+		$templomok = DB::table('templomok')
+			->where(function ($q) {
+				$q->whereNull('lat')->orWhere('lat', 0)->orWhere('lat', '');
+			})
+			->select('id', 'orszag', 'megye', 'varos', 'megjegyzes')
+			->get();
+
+		$erintett = 0;
+		foreach ($templomok as $templom) {
+			if (str_contains((string) $templom->megjegyzes, self::HELYADAT_JELOLO)) {
+				continue;
+			}
+
+			$reszek = self::helyadatSzovege($templom);
+			if ($reszek === '') {
+				continue;
+			}
+
+			$uj = trim((string) $templom->megjegyzes);
+			$uj = ($uj === '' ? '' : $uj . "\n\n") . self::HELYADAT_JELOLO . ' ' . $reszek;
+
+			DB::table('templomok')->where('id', $templom->id)->update(['megjegyzes' => $uj]);
+			$erintett++;
+		}
+
+		return $erintett;
+	}
+
+	/**
+	 * A régi oszlopokból olvasható helymegjelölés emberi szöveggé.
+	 *
+	 * Az azonosítókat NEVEKRE oldjuk fel — egy megjegyzésben a "orszag=25" semmit nem
+	 * mond annak, aki később elolvassa.
+	 */
+	private static function helyadatSzovege(object $templom): string {
+		$reszek = [];
+
+		$orszag = $templom->orszag
+			? DB::table('orszagok')->where('id', $templom->orszag)->value('nev')
+			: null;
+		if ($orszag) {
+			$reszek[] = $orszag;
+		}
+
+		$megye = $templom->megye
+			? DB::table('megye')->where('id', $templom->megye)->value('megyenev')
+			: null;
+		if ($megye) {
+			$reszek[] = $megye . ' megye';
+		}
+
+		if (trim((string) $templom->varos) !== '') {
+			$reszek[] = trim((string) $templom->varos);
+		}
+
+		return implode(', ', $reszek);
+	}
+
+	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/tests/Integration/ArchiveLocationWithoutCoordinatesTest.php
+++ b/webapp/tests/Integration/ArchiveLocationWithoutCoordinatesTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #496 / #497 / #498: a koordináta nélküli templomok helyadatának átmentése.
+ *
+ * A három jegy a `templomok.orszag`, `.megye`, `.varos` kivezetéséről szól — a helyet
+ * ezután a koordináta és az OSM-határok adják. Csakhogy néhány misézőhelynek nincs
+ * koordinátája, tehát sosem lesz boundary-ja: nekik ezek az oszlopok az EGYETLEN
+ * helymegjelölésük. Élesben 47 ilyen van.
+ *
+ * borazslo a #496-ban két lehetőséget adott (törlés vagy megjegyzés mező). Ez a
+ * nem-destruktív ág.
+ */
+class ArchiveLocationWithoutCoordinatesTest extends TestCase {
+
+    private array $letrehozott = [];
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string,mixed> $mezok felülírandó oszlopok
+     * @return int az új templom azonosítója
+     */
+    private function templom(array $mezok): int {
+        $minta = (array) DB::table('templomok')->first();
+        $id = (int) DB::table('templomok')->max('id') + 1 + count($this->letrehozott);
+        $this->letrehozott[] = $id;
+
+        DB::table('templomok')->insert(array_merge($minta, $mezok, ['id' => $id]));
+        return $id;
+    }
+
+    private function megjegyzes(int $id): string {
+        return (string) DB::table('templomok')->where('id', $id)->value('megjegyzes');
+    }
+
+    /** @return int|null egy létező ország azonosítója, ha van */
+    private function letezoOrszag(): ?int {
+        $sor = DB::table('orszagok')->whereNotNull('nev')->where('nev', '!=', '')->first();
+        return $sor ? (int) $sor->id : null;
+    }
+
+    public function testAKoordinataNelkuliTemplomHelyadataAtkerul(): void {
+        $id = $this->templom(['lat' => 0, 'lon' => 0, 'varos' => 'Bótrágy', 'megjegyzes' => '']);
+
+        \Crons::archiveLocationOfChurchesWithoutCoordinates();
+
+        $megjegyzes = $this->megjegyzes($id);
+        self::assertStringContainsString('Bótrágy', $megjegyzes);
+        self::assertStringContainsString(\Crons::HELYADAT_JELOLO, $megjegyzes);
+    }
+
+    /** A meglévő megjegyzés nem veszhet el — hozzáfűzünk, nem felülírunk. */
+    public function testAMeglevoMegjegyzesMegmarad(): void {
+        $id = $this->templom(['lat' => 0, 'lon' => 0, 'varos' => 'Bótrágy', 'megjegyzes' => 'Régi feljegyzés']);
+
+        \Crons::archiveLocationOfChurchesWithoutCoordinates();
+
+        self::assertStringContainsString('Régi feljegyzés', $this->megjegyzes($id));
+        self::assertStringContainsString('Bótrágy', $this->megjegyzes($id));
+    }
+
+    /** Deploy közben előfordul, hogy egy job kétszer fut le. */
+    public function testTobbszorFuttatvaSemDuplikal(): void {
+        $id = $this->templom(['lat' => 0, 'lon' => 0, 'varos' => 'Bótrágy', 'megjegyzes' => '']);
+
+        \Crons::archiveLocationOfChurchesWithoutCoordinates();
+        \Crons::archiveLocationOfChurchesWithoutCoordinates();
+        \Crons::archiveLocationOfChurchesWithoutCoordinates();
+
+        self::assertSame(1, substr_count($this->megjegyzes($id), 'Bótrágy'),
+            'A jelölő ellenére duplikálódott a helyadat.');
+    }
+
+    /** Akinek van koordinátája, annak lesz boundary-ja — nincs mit menteni. */
+    public function testAKoordinatavalRendelkezoTemplomotNemBantja(): void {
+        $id = $this->templom(['lat' => 47.5, 'lon' => 19.05, 'varos' => 'Budapest', 'megjegyzes' => 'Érintetlen']);
+
+        \Crons::archiveLocationOfChurchesWithoutCoordinates();
+
+        self::assertSame('Érintetlen', $this->megjegyzes($id));
+    }
+
+    /** Üres helyadatból nincs mit átmenteni — ne szemeteljünk a megjegyzésbe. */
+    public function testUresHelyadatnalNemIrSemmit(): void {
+        $id = $this->templom(['lat' => 0, 'lon' => 0, 'varos' => '', 'megye' => 0, 'orszag' => 0, 'megjegyzes' => '']);
+
+        \Crons::archiveLocationOfChurchesWithoutCoordinates();
+
+        self::assertSame('', $this->megjegyzes($id));
+    }
+
+    /**
+     * Az azonosítókat nevekre kell feloldani: egy megjegyzésben az "orszag=25"
+     * semmit nem mond annak, aki később elolvassa.
+     */
+    public function testAzAzonositokHelyettNevekKerulnekBe(): void {
+        $orszagId = $this->letezoOrszag();
+        if ($orszagId === null) {
+            self::markTestSkipped('Nincs ország a teszt-adatbázisban.');
+        }
+        $orszagNev = DB::table('orszagok')->where('id', $orszagId)->value('nev');
+
+        $id = $this->templom(['lat' => 0, 'lon' => 0, 'orszag' => $orszagId, 'varos' => 'Bótrágy', 'megjegyzes' => '']);
+
+        \Crons::archiveLocationOfChurchesWithoutCoordinates();
+
+        $megjegyzes = $this->megjegyzes($id);
+        self::assertStringContainsString((string) $orszagNev, $megjegyzes);
+        self::assertStringNotContainsString('orszag=', $megjegyzes);
+    }
+
+    public function testVisszaadjaHanyTemplomotErintett(): void {
+        $this->templom(['lat' => 0, 'lon' => 0, 'varos' => 'Egyik', 'megjegyzes' => '']);
+        $this->templom(['lat' => 0, 'lon' => 0, 'varos' => 'Másik', 'megjegyzes' => '']);
+
+        $elso = \Crons::archiveLocationOfChurchesWithoutCoordinates();
+        $masodik = \Crons::archiveLocationOfChurchesWithoutCoordinates();
+
+        self::assertGreaterThanOrEqual(2, $elso);
+        self::assertSame(0, $masodik, 'A második futásnak már nem kell dolgoznia.');
+    }
+}


### PR DESCRIPTION
A #496, #497 és #498 a `templomok.orszag`, `.megye` és `.varos` kivezetéséről szól: a helyet ezután a koordináta és az OSM-határok adják.

Ez mindenre igaz, **kivéve azt a néhány misézőhelyet, aminek egyáltalán nincs koordinátája**. Azoknak sosem lesz boundary-juk, tehát az oszlopok eldobásával az egyetlen helymegjelölésük veszne el.

```
élesben:              47 ilyen templom (22 magyar, 25 határon túli)
fejlesztői adatbázis: 15, és MINDEGYIKNEK van elveszíthető helyadata
```

Példák a fejlesztői adatbázisból:

```
#3645  Nagyboldogasszony templom   orszag=47  varos=Borzsava
#3651  Kisboldogasszony templom    orszag=47  varos=Bótrágy
#4807  nem ismert templom          orszag=25  varos=Szigetkamara
```

## A megoldás

@borazslo a #496-ban két lehetőséget adott:

> Annyiban lehet értelme a "megye"-nek, hogy a misézőhelyeknél ahol egyáltalán nincs koordináta ott segíthet beazonosítani hogy ki is ő. De ilyen pár maradt csak, azt is inkább töröljük. Vagy mehet a megjegyzés mezőbe a megye

Ez a **nem-destruktív ág**: a szöveget átmentem a megjegyzés mezőbe, hogy a templom a kivezetés után is beazonosítható maradjon. A törlés visszafordíthatatlan, azt nem én döntöm el.

Három részlet, ami számít:

- **Az azonosítókat nevekre oldom fel.** Egy megjegyzésben az `orszag=25` semmit nem mond annak, aki később elolvassa.
- **Hozzáfűzök, nem felülírok.** A meglévő megjegyzés nem veszhet el.
- **Idempotens.** Jelölővel dolgozik, tehát deploy közbeni kétszeri futás sem duplikál — ezt teszt is fedi.

## Futtatás

Cronként regisztrálom (496), hogy élesben futtatható legyen:

```
docker exec miserend php index.php q=cron cron_id=496
```

Egyszeri feladat, utána a cron-sor törölhető.

## Ellenőrzés

7 integrációs teszt: átmentés, meglévő megjegyzés megőrzése, háromszori futás után sem duplikál, koordinátás templom érintetlen, üres helyadatnál nem szemetel, azonosító helyett név, és a visszaadott darabszám.

```
PHP-suite: 894 teszt, 2093 állítás — zöld
```

Előkészíti: #496, #497, #498