### PR TITLE
A helyneveket az OSM-határokból származtatom

### DIFF
--- a/webapp/classes/api/churchrelationships.php
+++ b/webapp/classes/api/churchrelationships.php
@@ -61,7 +61,8 @@ class Churchrelationships extends Api {
                 'church' => [
                     'id'   => $c->id,
                     'name' => !empty($c->names) ? $c->names[0] : $c->nev,
-                    'city' => $c->varos,
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    'city' => $c->locationCityName(),
                     'lat'  => (float) $c->lat,
                     'lon'  => (float) $c->lon,
                     'rank' => $c->rank,

--- a/webapp/classes/api/nearbymasses.php
+++ b/webapp/classes/api/nearbymasses.php
@@ -56,7 +56,8 @@ class NearbyMasses extends Api
                 'church' => [
                     'id' => (int) $church->id,
                     'name' => $church->names[0] ?? '',
-                    'city' => is_array($church->varos) ? ($church->varos[0] ?? '') : $church->varos,
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    'city' => $church->locationCityName(),
                     'lat' => (float) $church->lat,
                     'lon' => (float) $church->lon,
                 ],

--- a/webapp/classes/api/service_times.php
+++ b/webapp/classes/api/service_times.php
@@ -72,8 +72,10 @@ class Service_times extends Api {
 					'church_id' => $church->id,
 					'name' => $church->names[0],
 					'address' => $church->location->address,
-					'city, state' => isset($church->location->city['name']) ? $church->location->city['name'] : $church->varos,
-					'country' => isset($church->location->country['name']) ? $church->location->country['name'] : $church->orszag,
+					// #497/#498: a visszaesés eddig a NYERS oszlopra ment — az `orszag`
+					// ott azonosító, tehát hiányzó boundary-nál "12" ment ki országnévként.
+					'city, state' => isset($church->location->city['name']) ? $church->location->city['name'] : $church->locationCityName(),
+					'country' => isset($church->location->country['name']) ? $church->location->country['name'] : $church->locationCountryName(),
 					'phone' => false,
 					'email' => $church->pleb_eml,
 					'url' => false,

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -8,6 +8,69 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Crons {
 
 	/**
+	 * #496: újra sorba állítja azokat a templomokat, amiknek nincs administratív
+	 * határuk, pedig már ellenőriztük őket.
+	 *
+	 * A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700
+	 * óta helyesen megkülönbözteti a HIBÁT a "lekérdeztük, de nincs határ" esettől:
+	 * hibánál nem bélyegez, tehát a templom a sor elején marad. A második eset viszont
+	 * BÉLYEGET kap — és ott is marad, amíg a teljes sor körbe nem ér.
+	 *
+	 * Ez akkor fáj, ha a "nincs határ" nem az OSM valósága volt, hanem a mi oldalunk
+	 * változott azóta. Pontosan ez történt Szlovákiában: a tárolt szintjeink elavultak
+	 * (nálunk 8=okres/9=obec, az OSM ma 6=okres/8=obec), és a szlovák minta 23%-ának
+	 * emiatt egyáltalán nincs határa. A #699 óta a lekérdezés a 4-es szintet is
+	 * behúzza, de a régen bélyegzett templomok ettől még nem próbálkoznak újra.
+	 *
+	 * Ezért a bélyeget levesszük róluk — a következő futás így elöl veszi őket.
+	 *
+	 * A 30 napos korlát SZÁNDÉKOS: enélkül azok a templomok, amiknek tényleg nincs
+	 * határuk (az OSM ott nem fed le semmit), minden futásban visszakerülnének a sor
+	 * elejére, és kiszorítanák a valóban ellenőrizendőket. Így legfeljebb havonta
+	 * egyszer próbálkozunk velük újra.
+	 *
+	 * @return int hány templomot állítottunk vissza a sorba
+	 */
+	public static function requeueChurchesWithoutBoundary(): int {
+		$hatarido = date('Y-m-d H:i:s', strtotime('-30 days'));
+
+		return DB::table('templomok')
+			->where('ok', 'i')
+			->whereNotNull('lat')->where('lat', '!=', 0)
+			->whereNotNull('lon')->where('lon', '!=', 0)
+			->whereNotNull('boundaries_checked_at')
+			->where('boundaries_checked_at', '<', $hatarido)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
+					->where('boundaries.boundary', 'administrative');
+			})
+			->update(['boundaries_checked_at' => null]);
+	}
+
+	/**
+	 * #496: hány aktív, koordinátával rendelkező templomnak nincs administratív
+	 * határa. A /health ezt írja ki, hogy a lefedettségi hiány LÁTSZÓDJON — eddig
+	 * csak abból derült volna ki, hogy egy település alatt nem jön ki a templom.
+	 */
+	public static function churchesWithoutBoundaryCount(): int {
+		return DB::table('templomok')
+			->where('ok', 'i')
+			->whereNotNull('lat')->where('lat', '!=', 0)
+			->whereNotNull('lon')->where('lon', '!=', 0)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
+					->where('boundaries.boundary', 'administrative');
+			})
+			->count();
+	}
+
+	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -8,69 +8,6 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Crons {
 
 	/**
-	 * #496: újra sorba állítja azokat a templomokat, amiknek nincs administratív
-	 * határuk, pedig már ellenőriztük őket.
-	 *
-	 * A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700
-	 * óta helyesen megkülönbözteti a HIBÁT a "lekérdeztük, de nincs határ" esettől:
-	 * hibánál nem bélyegez, tehát a templom a sor elején marad. A második eset viszont
-	 * BÉLYEGET kap — és ott is marad, amíg a teljes sor körbe nem ér.
-	 *
-	 * Ez akkor fáj, ha a "nincs határ" nem az OSM valósága volt, hanem a mi oldalunk
-	 * változott azóta. Pontosan ez történt Szlovákiában: a tárolt szintjeink elavultak
-	 * (nálunk 8=okres/9=obec, az OSM ma 6=okres/8=obec), és a szlovák minta 23%-ának
-	 * emiatt egyáltalán nincs határa. A #699 óta a lekérdezés a 4-es szintet is
-	 * behúzza, de a régen bélyegzett templomok ettől még nem próbálkoznak újra.
-	 *
-	 * Ezért a bélyeget levesszük róluk — a következő futás így elöl veszi őket.
-	 *
-	 * A 30 napos korlát SZÁNDÉKOS: enélkül azok a templomok, amiknek tényleg nincs
-	 * határuk (az OSM ott nem fed le semmit), minden futásban visszakerülnének a sor
-	 * elejére, és kiszorítanák a valóban ellenőrizendőket. Így legfeljebb havonta
-	 * egyszer próbálkozunk velük újra.
-	 *
-	 * @return int hány templomot állítottunk vissza a sorba
-	 */
-	public static function requeueChurchesWithoutBoundary(): int {
-		$hatarido = date('Y-m-d H:i:s', strtotime('-30 days'));
-
-		return DB::table('templomok')
-			->where('ok', 'i')
-			->whereNotNull('lat')->where('lat', '!=', 0)
-			->whereNotNull('lon')->where('lon', '!=', 0)
-			->whereNotNull('boundaries_checked_at')
-			->where('boundaries_checked_at', '<', $hatarido)
-			->whereNotExists(function ($q) {
-				$q->select(DB::raw(1))
-					->from('lookup_boundary_church')
-					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
-					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
-					->where('boundaries.boundary', 'administrative');
-			})
-			->update(['boundaries_checked_at' => null]);
-	}
-
-	/**
-	 * #496: hány aktív, koordinátával rendelkező templomnak nincs administratív
-	 * határa. A /health ezt írja ki, hogy a lefedettségi hiány LÁTSZÓDJON — eddig
-	 * csak abból derült volna ki, hogy egy település alatt nem jön ki a templom.
-	 */
-	public static function churchesWithoutBoundaryCount(): int {
-		return DB::table('templomok')
-			->where('ok', 'i')
-			->whereNotNull('lat')->where('lat', '!=', 0)
-			->whereNotNull('lon')->where('lon', '!=', 0)
-			->whereNotExists(function ($q) {
-				$q->select(DB::raw(1))
-					->from('lookup_boundary_church')
-					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
-					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
-					->where('boundaries.boundary', 'administrative');
-			})
-			->count();
-	}
-
-	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -885,7 +885,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                     $miseLangs = \Eloquent\CalMass::splitLanguages(
                         is_array($mise->lang) ? implode(',', $mise->lang) : $mise->lang
                     );
-                    if( $this->orszag != 12 or $miseLangs != ['hu'] ) {
+                    if( !$this->isInHungary() or $miseLangs != ['hu'] ) {
                         $translated = array_map(function($l) { return t('LANGUAGES.'.$l); }, $miseLangs);
                         if ($translated) {
                             $info .= ' ' . implode('-', $translated)." nyelven";
@@ -923,8 +923,8 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                 'nev' => !empty($this->names) ? $this->names[0] : '',
                 'frissitve' => $this->frissitesFormatted(),
                 'ismertnev' => !empty($this->alternative_names) ? $this->alternative_names[0] : '',
-                'orszag' => ( DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: "" ),
-                'varos' => $this->varos,
+                'orszag' => $this->locationCountryName(),
+                'varos' => $this->locationCityName(),
                 'misek' => $misek,
                 'adoraciok' => $adorations,
                 'gyontatas' => $this->confessions ? $this->confessions['status'] : false,
@@ -947,10 +947,10 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             'ismertnev' => !empty($this->alternative_names) ? $this->alternative_names[0] : '',
             'alternative_names' => $this->alternative_names,
             'frissitve' => $this->frissitesFormatted(),            
-            'orszag' => ( DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: "" ),
+            'orszag' => $this->locationCountryName(),
             'egyhazmegye' => ( DB::table('egyhazmegye')->where('id', $this->egyhazmegye)->value('nev') ?: "" ),
-            'megye' => ( DB::table('megye')->where('id', $this->megye)->value('megyenev') ?: "" ),
-            'varos' => $this->varos,
+            'megye' => $this->locationCountyName(),
+            'varos' => $this->locationCityName(),
             'cim' => $this->cim,
             'megkozelites' => '',
             'plebania' => str_replace('<br>', "\n", strip_tags($this->plebania, '<br>')),
@@ -1340,7 +1340,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         if (!empty($this->alternative_names)) {
             $return .= ' (' . $this->alternative_names[0] . ')';
         } else {
-            $return .= ' (' . $this->varos . ')';
+            $return .= ' (' . $this->locationCityName() . ')';
         }
         return $return;
     }
@@ -1435,6 +1435,124 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             $boundaries,
             fn($boundary) => (int) ($boundary['admin_level'] ?? 0) !== 4
         ));
+    }
+
+    /**
+     * #496 / #497 / #498: a templom helynevei az OSM-határokból, a régi oszlopokra
+     * való visszaeséssel.
+     *
+     * A három jegy a `templomok.varos`, `.megye` és `templomok.orszag` kivezetéséről
+     * szól. Ahhoz, hogy az oszlopok eldobhatók legyenek, előbb minden fogyasztónak
+     * ezeken a metódusokon kell keresztülmennie — utána a kivezetés annyi, hogy a
+     * visszaesési ág kiesik innen, és nem kell 23 fájlt átírni.
+     *
+     * A visszaesés SZÁNDÉKOSAN bent van most: a szlovák állomány 23%-ának egyáltalán
+     * nincs boundary-ja (szinkronhiány), és 47 templomnak nincs koordinátája sem.
+     * Amíg ez így van, a régi oszlop a jobb válasz, mint az üres string.
+     *
+     * A besorolás szint szerint megy, nem pozíció szerint: a location() a rendezett
+     * lista 0./1./2. elemét címkézi, ami hiányos határláncnál elcsúszik.
+     */
+    private function adminBoundaryName(array $szintek): ?string {
+        $talalat = $this->boundaries()
+                ->where('boundary', 'administrative')
+                ->whereIn('admin_level', $szintek)
+                ->orderBy('admin_level', 'desc')
+                ->first();
+
+        $nev = trim((string) ($talalat->name ?? ''));
+
+        return $nev !== '' ? $nev : null;
+    }
+
+    /**
+     * Település. Ha van kerület is, azzal együtt — így a nagyvárosi templomoknál nem
+     * vész el a pontosság.
+     *
+     * Ez SZÁNDÉKOSAN a régi oszlop alakját reprodukálja, mert az API-ban és a
+     * felületen ez látszik. Két országfüggő eset van, mindkettőt valódi adaton mértem:
+     *
+     *   Budapest, Szent Imre-templom      8=Budapest  9=XI. kerület  10=Szentimreváros
+     *       -> "Budapest XI. kerület", ami bitre a régi `templomok.varos`.
+     *       A puszta legspecifikusabb elem "Szentimreváros" lenne: pontosabb ugyan,
+     *       de a látogató szempontjából visszalépés ahhoz képest, amit ma lát.
+     *
+     *   Köln, St. Aposteln                6=Köln      9=Innenstadt   10=Altstadt-Nord
+     *       Köln kreisfreie Stadt, tehát NINCS 8-as szintje. Ha vakon a 9-esre esnénk
+     *       vissza, "Innenstadt" jönne ki "Köln" helyett.
+     *
+     * Ezért a kerületet CSAK akkor fűzzük hozzá, ha a település a 8-as szintről jött.
+     * Ha a településnek a 6-osra kellett visszaesni, a 9-es már másfajta felosztás,
+     * és a régi adat sem tartalmazta.
+     */
+    public function locationCityName(): string {
+        $telepules = $this->adminBoundaryName([8]);
+        if ($telepules !== null) {
+            $kerulet = $this->adminBoundaryName([9]);
+            return $kerulet !== null ? $telepules . ' ' . $kerulet : $telepules;
+        }
+
+        // Nincs 8-as szint (pl. német kreisfreie Stadt): a 6-os maga a település.
+        return $this->adminBoundaryName([6])
+            ?? $this->adminBoundaryName([9])
+            ?? $this->adminBoundaryName([10])
+            ?? (string) $this->varos;
+    }
+
+    /** Megye. Romániában nincs 6-os szint, ott a 4-es (judet) hordozza. */
+    public function locationCountyName(): string {
+        $boundary = $this->adminBoundaryName([6]) ?? $this->adminBoundaryName([4]);
+        if ($boundary !== null) {
+            return $boundary;
+        }
+
+        return (string) (DB::table('megye')->where('id', $this->megye)->value('megyenev') ?: '');
+    }
+
+    public function locationCountryName(): string {
+        return $this->adminBoundaryName([2])
+            ?? (string) (DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: '');
+    }
+
+    /**
+     * Magyarországi templom-e. A naptár ez alapján dönti el, kell-e nyelvi zászló a
+     * magyar mise mellé, a statisztika pedig ez alapján szűkít.
+     *
+     * Elsődlegesen az ISO-kód, mert a `templomok.orszag = 12` a kivezetéssel eltűnik.
+     */
+    public function isInHungary(): bool {
+        $kod = $this->countryCode();
+        if ($kod !== null) {
+            return $kod === 'HU';
+        }
+
+        return (int) $this->orszag === self::MAGYARORSZAG_ID;
+    }
+
+    /** A régi `orszagok` tábla magyar sorának azonosítója. */
+    public const MAGYARORSZAG_ID = 12;
+
+    /**
+     * #498: lekérdezés-szintű szűrés a magyarországi templomokra.
+     *
+     * A statisztika eddig `where('orszag', 12)`-vel szűkített — pont az az oszlop,
+     * amit ki akarunk vezetni. A boundary-alapú megfelelője az országhatáron megy.
+     *
+     * NÉVRE és ISO-kódra IS illesztünk. Az ISO a helyes hosszú távon, de ma 7964
+     * határból egyetlenegynél van kitöltve (a szinkronnak újra kell futnia), addig
+     * a puszta ISO-szűrés üres statisztikát adna.
+     */
+    public function scopeInHungary($query) {
+        return $query->whereIn('templomok.id', function ($sub) {
+            $sub->select('lookup_boundary_church.church_id')
+                ->from('lookup_boundary_church')
+                ->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+                ->where('boundaries.admin_level', 2)
+                ->where(function ($w) {
+                    $w->where('boundaries.iso3166_1', 'HU')
+                      ->orWhere('boundaries.name', 'Magyarország');
+                });
+        });
     }
 
     /**

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -414,14 +414,14 @@ class Edit extends \Html\Html {
                 ->get();
 
             foreach ($nearbyChurches as $nearby) {
-                $options[$nearby->id] = $nearby->varos . ' – ' . $nearby->names[0] . ' (~' . round($nearby->distance_km, 1) . ' km)';
+                $options[$nearby->id] = $nearby->locationCityName() . ' – ' . $nearby->names[0] . ' (~' . round($nearby->distance_km, 1) . ' km)';
             }
 
             // Ha van meglévő parent kapcsolat de nincs a common listában, hozzáadunk
             if ($currentParentId && !isset($options[$currentParentId])) {
                 $parentChurch = \Eloquent\Church::find($currentParentId);
                 if ($parentChurch) {
-                    $options[$currentParentId] = '⭐ ' . $parentChurch->varos . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
+                    $options[$currentParentId] = '⭐ ' . $parentChurch->locationCityName() . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
                 }
             }
         } else {
@@ -429,7 +429,7 @@ class Edit extends \Html\Html {
             if ($currentParentId) {
                 $parentChurch = \Eloquent\Church::find($currentParentId);
                 if ($parentChurch) {
-                    $options[$currentParentId] = '⭐ ' . $parentChurch->varos . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
+                    $options[$currentParentId] = '⭐ ' . $parentChurch->locationCityName() . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
                 }
             }
         }
@@ -444,7 +444,7 @@ class Edit extends \Html\Html {
             ->get(['id', 'varos', 'nev']);
         foreach ($allActive as $c) {
             if (!isset($options[$c->id])) {
-                $options[$c->id] = $c->varos . ' – ' . $c->nev;
+                $options[$c->id] = $c->locationCityName() . ' – ' . $c->nev;
             }
         }
 

--- a/webapp/classes/html/church/ical.php
+++ b/webapp/classes/html/church/ical.php
@@ -174,7 +174,11 @@ class Ical extends \Html\Html {
 
         $nev = is_array($church) ? ($church['nev'] ?? '') : ($church->nev ?? '');
         $ismertnev = is_array($church) ? ($church['ismertnev'] ?? '') : ($church->ismertnev ?? '');
-        $varos = is_array($church) ? ($church['varos'] ?? '') : ($church->varos ?? '');
+        // #497: tömb esetén a toAPIArray már származtatott értéket ad; objektumnál
+        // magunknak kell a boundary-ból kérni.
+        $varos = is_array($church)
+            ? ($church['varos'] ?? '')
+            : ($church instanceof \Eloquent\Church ? $church->locationCityName() : ($church->varos ?? ''));
         $calName = $nev;
         if ($ismertnev) $calName .= $calName ? ' (' . $ismertnev . ')' : $ismertnev;
         if ($varos) $calName .= $calName ? ' - ' . $varos : $varos;

--- a/webapp/classes/html/home.php
+++ b/webapp/classes/html/home.php
@@ -42,7 +42,8 @@ class Home extends Html {
                 \Eloquent\Church::select('id', 'nev', 'varos')
                     ->whereIn('id', $churchIds)
                     ->get()
-                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->varos])
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->locationCityName()])
             );
         }
          

--- a/webapp/classes/html/searchresultschurches.php
+++ b/webapp/classes/html/searchresultschurches.php
@@ -118,7 +118,8 @@ class SearchResultsChurches extends Html {
                 \Eloquent\Church::select('id', 'nev', 'varos')
                     ->whereIn('id', $params['church_ids'])
                     ->get()
-                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->varos])
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->locationCityName()])
             );
         }
         

--- a/webapp/classes/html/stat.php
+++ b/webapp/classes/html/stat.php
@@ -185,7 +185,20 @@ class Stat extends Html {
 		$stat = DB::table('templomok')
 			->selectRaw("DATEDIFF(NOW(), frissites) DIV 365 as yearago")
 			->selectRAW("count(*) as count");		
-		$stat->where('orszag',12)->where('ok','i')->where('miseaktiv',1);
+		// #498: eddig `where('orszag', 12)` állt itt — pont az az oszlop, amit kivezetünk.
+		// A boundary-alapú megfelelője az országhatáron megy. Névre ÉS ISO-kódra is
+		// illesztünk: az ISO a helyes hosszú távon, de amíg a szinkron nem futott újra,
+		// a puszta ISO-szűrés üres statisztikát adna.
+		$stat->whereIn('templomok.id', function ($sub) {
+				$sub->select('lookup_boundary_church.church_id')
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->where('boundaries.admin_level', 2)
+					->where(function ($w) {
+						$w->where('boundaries.iso3166_1', 'HU')
+						  ->orWhere('boundaries.name', 'Magyarország');
+					});
+			})->where('ok','i')->where('miseaktiv',1);
 		foreach(['%isézőhely%','%ápolna','%özösségi%', '%imaház%', '%imaterem%'] as $notlike)
 			$stat->where('nev','not like', $notlike);
 		$stat->orderBy('frissites','DESC');

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -869,7 +869,15 @@ class User {
 	
 
 			$users2notify = DB::table('templomok')
-				->select('templomok.id as tid','templomok.nev','templomok.ismertnev','templomok.varos','templomok.frissites')
+				// #497: a `varos` alias a levélsablonnak kell. Tömeges lekérdezés, ezért
+				// nem templomonként kérdezünk, hanem korrelált alkérdéssel — a boundary
+				// neve, visszaeséssel a régi oszlopra, amíg az létezik.
+				->select('templomok.id as tid','templomok.nev','templomok.ismertnev','templomok.frissites')
+				->selectRaw("COALESCE((SELECT b.name FROM lookup_boundary_church lbc"
+					. " JOIN boundaries b ON b.id = lbc.boundary_id"
+					. " WHERE lbc.church_id = templomok.id AND b.boundary = 'administrative'"
+					. " AND b.admin_level IN (8,9,10) ORDER BY b.admin_level DESC LIMIT 1),"
+					. " templomok.varos) AS varos")
 				->join('church_holders','templomok.id','=','church_holders.church_id')
 				->addSelect('church_holders.description')
 				->join('user','user.uid','=','church_holders.user_id')

--- a/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
+++ b/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
@@ -1,0 +1,192 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #496 / #497 / #498: a helynevek az OSM-határokból, a régi oszlopok helyett.
+ *
+ * A három jegy a `templomok.varos`, `.megye` és `.orszag` kivezetéséről szól. Ahhoz,
+ * hogy az oszlopok eldobhatók legyenek, előbb minden fogyasztónak ezeken a
+ * metódusokon kell keresztülmennie.
+ *
+ * A legfontosabb elvárás, hogy a látogató NE vegye észre a váltást: a származtatott
+ * érték adja vissza ugyanazt, amit a régi oszlop. Az `admin_level` jelentése viszont
+ * országonként más, ezért itt valódi, mért határláncokkal dolgozunk.
+ */
+class LocationNamesFromBoundariesTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $minta['id'] = $this->churchId;
+        $minta['nev'] = 'Helynév Teszt';
+        $minta['varos'] = 'Régi Város';
+        $minta['megye'] = 0;
+        $minta['orszag'] = 0;
+        $minta['ok'] = 'i';
+        DB::table('templomok')->insert($minta);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<int,array{0:int,1:string}> $szintek [admin_level, név] párok */
+    private function hatarlanc(array $szintek, string $iso = ''): void {
+        foreach ($szintek as [$level, $nev]) {
+            $id = DB::table('boundaries')->insertGetId([
+                'boundary'    => 'administrative',
+                'admin_level' => $level,
+                'name'        => $nev,
+                'alt_name'    => '',
+                'iso3166_1'   => $level === 2 ? $iso : '',
+                'osmtype'     => 'relation',
+                'osmid'       => 800000 + $level,
+            ]);
+            DB::table('lookup_boundary_church')->insert([
+                'boundary_id' => $id,
+                'church_id'   => $this->churchId,
+            ]);
+        }
+    }
+
+    private function templom(): \Eloquent\Church {
+        return \Eloquent\Church::find($this->churchId);
+    }
+
+    /**
+     * Budapest: a régi oszlopban "Budapest XI. kerület" áll. A legspecifikusabb
+     * határ "Szentimreváros" lenne — pontosabb, de a látogatónak visszalépés.
+     */
+    public function testBudapestiTemplomnalATelepulesEsAKeruletEgyutt(): void {
+        $this->hatarlanc([
+            [2, 'Magyarország'], [6, 'Budapest'], [8, 'Budapest'],
+            [9, 'XI. kerület'], [10, 'Szentimreváros'],
+        ], 'HU');
+
+        self::assertSame('Budapest XI. kerület', $this->templom()->locationCityName());
+    }
+
+    public function testKeruletNelkuliTelepulesnelCsakATelepules(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Szentendre', $this->templom()->locationCityName());
+    }
+
+    /**
+     * Köln kreisfreie Stadt: NINCS 8-as szintje, a település a 6-oson ül. Ha vakon a
+     * 9-esre esnénk vissza, "Innenstadt" jönne ki "Köln" helyett.
+     */
+    public function testKreisfreieStadtnalAHatosSzintATelepules(): void {
+        $this->hatarlanc([
+            [2, 'Deutschland'], [4, 'Nordrhein-Westfalen'], [5, 'Regierungsbezirk Köln'],
+            [6, 'Köln'], [9, 'Innenstadt'], [10, 'Altstadt-Nord'],
+        ], 'DE');
+
+        self::assertSame('Köln', $this->templom()->locationCityName(),
+            'A kerületet csak 8-as szintű település mellé szabad fűzni.');
+    }
+
+    /** Romániában nincs 6-os szint: a megyét (judet) a 4-es hordozza. */
+    public function testRomanTemplomnalANegyesSzintAMegye(): void {
+        $this->hatarlanc([[2, 'România'], [4, 'Alba'], [8, 'Vințu de Jos']], 'RO');
+
+        $templom = $this->templom();
+        self::assertSame('Alba', $templom->locationCountyName());
+        self::assertSame('Vințu de Jos', $templom->locationCityName());
+    }
+
+    public function testMagyarTemplomnalAHatosSzintAMegye(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [4, 'Közép-Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Pest', $this->templom()->locationCountyName(),
+            'Ahol van 6-os szint, ott a 4-es csak statisztikai nagyrégió.');
+    }
+
+    public function testAzOrszagnevAKettesSzintrolJon(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Magyarország', $this->templom()->locationCountryName());
+    }
+
+    // ---- visszaesés ----------------------------------------------------------
+
+    /**
+     * A visszaesés szándékosan bent van: a szlovák állomány 23%-ának egyáltalán
+     * nincs boundary-ja, és 47 templomnak nincs koordinátája sem.
+     */
+    public function testHatarNelkulARegiOszlopJon(): void {
+        self::assertSame('Régi Város', $this->templom()->locationCityName());
+    }
+
+    public function testCsakOrszaghatarralATelepulesMegARegiOszloprolJon(): void {
+        $this->hatarlanc([[2, 'Magyarország']], 'HU');
+
+        $templom = $this->templom();
+        self::assertSame('Magyarország', $templom->locationCountryName());
+        self::assertSame('Régi Város', $templom->locationCityName());
+    }
+
+    // ---- országhoz kötött logika --------------------------------------------
+
+    public function testAMagyarorszagiTemplomFelismereseAzIsoKodbol(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        self::assertTrue($this->templom()->isInHungary());
+    }
+
+    public function testAKulfoldiTemplomNemMagyarorszagi(): void {
+        $this->hatarlanc([[2, 'Deutschland'], [6, 'Köln']], 'DE');
+
+        self::assertFalse($this->templom()->isInHungary());
+    }
+
+    /**
+     * Az ISO ma 7964 határból egynél van kitöltve, tehát a névre illesztésnek is
+     * mennie kell — enélkül a statisztika üresen maradna.
+     */
+    public function testAStatisztikaSzurojeNevreIsIllik(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']]);
+
+        $talalat = \Eloquent\Church::inHungary()->where('templomok.id', $this->churchId)->count();
+
+        self::assertSame(1, $talalat, 'ISO-kód nélkül, puszta névre is találnia kell.');
+    }
+
+    public function testAStatisztikaSzurojeNemHozKulfoldit(): void {
+        $this->hatarlanc([[2, 'Deutschland'], [6, 'Köln']], 'DE');
+
+        self::assertSame(0, \Eloquent\Church::inHungary()->where('templomok.id', $this->churchId)->count());
+    }
+
+    // ---- ami az API-ba kikerül -----------------------------------------------
+
+    /** A publikus API mezőnevei nem változnak, csak a forrásuk. */
+    public function testAzApiValaszaAszarmaztatottNeveketAdja(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        // A `megye` csak a bővebb válaszban szerepel; a minimal a /nearby alapja.
+        $tomb = $this->templom()->toAPIArray('normal');
+
+        self::assertSame('Magyarország', $tomb['orszag']);
+        self::assertSame('Pest', $tomb['megye']);
+        self::assertSame('Szentendre', $tomb['varos']);
+    }
+
+    /** A /nearby minimal válasza is a származtatott neveket adja. */
+    public function testAMinimalValaszIsSzarmaztatott(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        $tomb = $this->templom()->toAPIArray('minimal');
+
+        self::assertSame('Magyarország', $tomb['orszag']);
+        self::assertSame('Szentendre', $tomb['varos']);
+    }
+}


### PR DESCRIPTION
A #496, #497 és #498 a `templomok.varos`, `.megye` és `.orszag` kivezetéséről szól. Ahhoz, hogy az oszlopok eldobhatók legyenek, előbb **minden fogyasztónak származtatott értéken kell keresztülmennie** — utána a kivezetés annyi, hogy a visszaesési ág kiesik egy helyről, és nem kell 23 fájlt átírni.

Felmértem a fogyasztókat: 23 fájl, ~90 hivatkozás, de ebből csak ~10 a valódi olvasás. Ez a PR mindet átállítja.

## Az új felület

```php
$templom->locationCityName();      // "Budapest XI. kerület"
$templom->locationCountyName();    // "Pest"
$templom->locationCountryName();   // "Magyarország"
$templom->isInHungary();           // ISO-kódból
\Eloquent\Church::inHungary();     // lekérdezés-szintű szűrő a statisztikának
```

Mind a boundary-ból dolgozik, **visszaeséssel a régi oszlopra**. A visszaesés szándékosan bent van: a szlovák állomány 23%-ának egyáltalán nincs boundary-ja, és 47 templomnak nincs koordinátája sem. Amíg ez így van, a régi oszlop jobb válasz, mint az üres string.

## A legfontosabb: a látogató ne vegye észre

Ezt mértem, nem feltételeztem. A fejlesztői adatbázisban minden olyan templomnál, aminek van határa:

```
boundary-vel rendelkező templom: 6 | egyezik a régivel: 6 | eltér: 0
```

Ehhez két országfüggő esetet kellett eltalálni, mindkettőt valódi adaton:

**Budapest, Szent Imre-templom** — `8=Budapest`, `9=XI. kerület`, `10=Szentimreváros`. A legspecifikusabb elem „Szentimreváros" lenne: pontosabb ugyan, de a látogató szempontjából visszalépés ahhoz képest, amit ma lát. A 8-as és 9-es összefűzése viszont bitre a régi `templomok.varos`-t adja.

**Köln, St. Aposteln** — kreisfreie Stadt, tehát **nincs 8-as szintje** (`6=Köln`, `9=Innenstadt`, `10=Altstadt-Nord`). Az első verzióm vakon a 9-esre esett vissza, és „Innenstadt" jött ki „Köln" helyett — a mérés fogta meg. Ezért a kerületet csak 8-as szintű település mellé fűzöm hozzá.

## Statisztika

A `where('orszag', 12)` boundary-alapúra vált. **Névre ÉS ISO-kódra is illeszt**: az ISO a helyes hosszú távon, de ma 7964 határból egyetlenegynél van kitöltve (a szinkronnak újra kell futnia), addig a puszta ISO-szűrés üres statisztikát adna.

## Két hibát is javít mellékesen

- **`api/service_times.php`**: a visszaesési ág a **nyers `orszag` oszlopra** ment, ami azonosító — hiányzó boundary-nál `"12"` ment ki országnévként.
- **`api/nearbymasses.php`**: `is_array($church->varos)`-ra védekezett egy Eloquent-oszlopnál, ami sosem tömb.

## Amit NEM változtat

A publikus API mezőnevei (`orszag`, `megye`, `varos`) maradnak — csak a forrásuk változik. A KAPP és a többi kliens nem vesz észre semmit.

## Ellenőrzés

14 integrációs teszt valódi, mért határláncokkal: magyar, román (nincs 6-os szint), német kreisfreie Stadt, visszaesés, statisztika-szűrő névvel és ISO nélkül, és az API-válasz mindkét hosszúságban.

```
PHP-suite: 901 teszt, 2100 állítás — zöld
```

Megjegyzés: a `stat.php` egy sorát érinti, amit a #787 komment-szinten szintén módosít — ha az megy előbb, triviális rebase kell.

Előfeltétele: #496, #497, #498