### PR TITLE
Kivezetem a szerkesztő kaszkádos ország/megye/város választóját

### DIFF
--- a/webapp/classes/api/churchrelationships.php
+++ b/webapp/classes/api/churchrelationships.php
@@ -61,7 +61,8 @@ class Churchrelationships extends Api {
                 'church' => [
                     'id'   => $c->id,
                     'name' => !empty($c->names) ? $c->names[0] : $c->nev,
-                    'city' => $c->varos,
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    'city' => $c->locationCityName(),
                     'lat'  => (float) $c->lat,
                     'lon'  => (float) $c->lon,
                     'rank' => $c->rank,

--- a/webapp/classes/api/nearbymasses.php
+++ b/webapp/classes/api/nearbymasses.php
@@ -56,7 +56,8 @@ class NearbyMasses extends Api
                 'church' => [
                     'id' => (int) $church->id,
                     'name' => $church->names[0] ?? '',
-                    'city' => is_array($church->varos) ? ($church->varos[0] ?? '') : $church->varos,
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    'city' => $church->locationCityName(),
                     'lat' => (float) $church->lat,
                     'lon' => (float) $church->lon,
                 ],

--- a/webapp/classes/api/service_times.php
+++ b/webapp/classes/api/service_times.php
@@ -72,8 +72,10 @@ class Service_times extends Api {
 					'church_id' => $church->id,
 					'name' => $church->names[0],
 					'address' => $church->location->address,
-					'city, state' => isset($church->location->city['name']) ? $church->location->city['name'] : $church->varos,
-					'country' => isset($church->location->country['name']) ? $church->location->country['name'] : $church->orszag,
+					// #497/#498: a visszaesés eddig a NYERS oszlopra ment — az `orszag`
+					// ott azonosító, tehát hiányzó boundary-nál "12" ment ki országnévként.
+					'city, state' => isset($church->location->city['name']) ? $church->location->city['name'] : $church->locationCityName(),
+					'country' => isset($church->location->country['name']) ? $church->location->country['name'] : $church->locationCountryName(),
 					'phone' => false,
 					'email' => $church->pleb_eml,
 					'url' => false,

--- a/webapp/classes/campaign.php
+++ b/webapp/classes/campaign.php
@@ -270,7 +270,8 @@ class Campaign {
                     'id' => $c->id,
                     'nev' => $c->nev,
                     'ismertnev' => $c->ismertnev,
-                    'varos' => $c->varos,
+                    // #497: a levélben a település a boundary-ból, mint mindenhol máshol.
+                    'varos' => $c->locationCityName(),
                     'frissites' => $c->frissites,
                 ];
             }, $churches),

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -8,6 +8,69 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Crons {
 
 	/**
+	 * #496: újra sorba állítja azokat a templomokat, amiknek nincs administratív
+	 * határuk, pedig már ellenőriztük őket.
+	 *
+	 * A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700
+	 * óta helyesen megkülönbözteti a HIBÁT a "lekérdeztük, de nincs határ" esettől:
+	 * hibánál nem bélyegez, tehát a templom a sor elején marad. A második eset viszont
+	 * BÉLYEGET kap — és ott is marad, amíg a teljes sor körbe nem ér.
+	 *
+	 * Ez akkor fáj, ha a "nincs határ" nem az OSM valósága volt, hanem a mi oldalunk
+	 * változott azóta. Pontosan ez történt Szlovákiában: a tárolt szintjeink elavultak
+	 * (nálunk 8=okres/9=obec, az OSM ma 6=okres/8=obec), és a szlovák minta 23%-ának
+	 * emiatt egyáltalán nincs határa. A #699 óta a lekérdezés a 4-es szintet is
+	 * behúzza, de a régen bélyegzett templomok ettől még nem próbálkoznak újra.
+	 *
+	 * Ezért a bélyeget levesszük róluk — a következő futás így elöl veszi őket.
+	 *
+	 * A 30 napos korlát SZÁNDÉKOS: enélkül azok a templomok, amiknek tényleg nincs
+	 * határuk (az OSM ott nem fed le semmit), minden futásban visszakerülnének a sor
+	 * elejére, és kiszorítanák a valóban ellenőrizendőket. Így legfeljebb havonta
+	 * egyszer próbálkozunk velük újra.
+	 *
+	 * @return int hány templomot állítottunk vissza a sorba
+	 */
+	public static function requeueChurchesWithoutBoundary(): int {
+		$hatarido = date('Y-m-d H:i:s', strtotime('-30 days'));
+
+		return DB::table('templomok')
+			->where('ok', 'i')
+			->whereNotNull('lat')->where('lat', '!=', 0)
+			->whereNotNull('lon')->where('lon', '!=', 0)
+			->whereNotNull('boundaries_checked_at')
+			->where('boundaries_checked_at', '<', $hatarido)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
+					->where('boundaries.boundary', 'administrative');
+			})
+			->update(['boundaries_checked_at' => null]);
+	}
+
+	/**
+	 * #496: hány aktív, koordinátával rendelkező templomnak nincs administratív
+	 * határa. A /health ezt írja ki, hogy a lefedettségi hiány LÁTSZÓDJON — eddig
+	 * csak abból derült volna ki, hogy egy település alatt nem jön ki a templom.
+	 */
+	public static function churchesWithoutBoundaryCount(): int {
+		return DB::table('templomok')
+			->where('ok', 'i')
+			->whereNotNull('lat')->where('lat', '!=', 0)
+			->whereNotNull('lon')->where('lon', '!=', 0)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
+					->where('boundaries.boundary', 'administrative');
+			})
+			->count();
+	}
+
+	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -8,69 +8,6 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Crons {
 
 	/**
-	 * #496: újra sorba állítja azokat a templomokat, amiknek nincs administratív
-	 * határuk, pedig már ellenőriztük őket.
-	 *
-	 * A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700
-	 * óta helyesen megkülönbözteti a HIBÁT a "lekérdeztük, de nincs határ" esettől:
-	 * hibánál nem bélyegez, tehát a templom a sor elején marad. A második eset viszont
-	 * BÉLYEGET kap — és ott is marad, amíg a teljes sor körbe nem ér.
-	 *
-	 * Ez akkor fáj, ha a "nincs határ" nem az OSM valósága volt, hanem a mi oldalunk
-	 * változott azóta. Pontosan ez történt Szlovákiában: a tárolt szintjeink elavultak
-	 * (nálunk 8=okres/9=obec, az OSM ma 6=okres/8=obec), és a szlovák minta 23%-ának
-	 * emiatt egyáltalán nincs határa. A #699 óta a lekérdezés a 4-es szintet is
-	 * behúzza, de a régen bélyegzett templomok ettől még nem próbálkoznak újra.
-	 *
-	 * Ezért a bélyeget levesszük róluk — a következő futás így elöl veszi őket.
-	 *
-	 * A 30 napos korlát SZÁNDÉKOS: enélkül azok a templomok, amiknek tényleg nincs
-	 * határuk (az OSM ott nem fed le semmit), minden futásban visszakerülnének a sor
-	 * elejére, és kiszorítanák a valóban ellenőrizendőket. Így legfeljebb havonta
-	 * egyszer próbálkozunk velük újra.
-	 *
-	 * @return int hány templomot állítottunk vissza a sorba
-	 */
-	public static function requeueChurchesWithoutBoundary(): int {
-		$hatarido = date('Y-m-d H:i:s', strtotime('-30 days'));
-
-		return DB::table('templomok')
-			->where('ok', 'i')
-			->whereNotNull('lat')->where('lat', '!=', 0)
-			->whereNotNull('lon')->where('lon', '!=', 0)
-			->whereNotNull('boundaries_checked_at')
-			->where('boundaries_checked_at', '<', $hatarido)
-			->whereNotExists(function ($q) {
-				$q->select(DB::raw(1))
-					->from('lookup_boundary_church')
-					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
-					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
-					->where('boundaries.boundary', 'administrative');
-			})
-			->update(['boundaries_checked_at' => null]);
-	}
-
-	/**
-	 * #496: hány aktív, koordinátával rendelkező templomnak nincs administratív
-	 * határa. A /health ezt írja ki, hogy a lefedettségi hiány LÁTSZÓDJON — eddig
-	 * csak abból derült volna ki, hogy egy település alatt nem jön ki a templom.
-	 */
-	public static function churchesWithoutBoundaryCount(): int {
-		return DB::table('templomok')
-			->where('ok', 'i')
-			->whereNotNull('lat')->where('lat', '!=', 0)
-			->whereNotNull('lon')->where('lon', '!=', 0)
-			->whereNotExists(function ($q) {
-				$q->select(DB::raw(1))
-					->from('lookup_boundary_church')
-					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
-					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
-					->where('boundaries.boundary', 'administrative');
-			})
-			->count();
-	}
-
-	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -885,7 +885,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                     $miseLangs = \Eloquent\CalMass::splitLanguages(
                         is_array($mise->lang) ? implode(',', $mise->lang) : $mise->lang
                     );
-                    if( $this->orszag != 12 or $miseLangs != ['hu'] ) {
+                    if( !$this->isInHungary() or $miseLangs != ['hu'] ) {
                         $translated = array_map(function($l) { return t('LANGUAGES.'.$l); }, $miseLangs);
                         if ($translated) {
                             $info .= ' ' . implode('-', $translated)." nyelven";
@@ -923,8 +923,8 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                 'nev' => !empty($this->names) ? $this->names[0] : '',
                 'frissitve' => $this->frissitesFormatted(),
                 'ismertnev' => !empty($this->alternative_names) ? $this->alternative_names[0] : '',
-                'orszag' => ( DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: "" ),
-                'varos' => $this->varos,
+                'orszag' => $this->locationCountryName(),
+                'varos' => $this->locationCityName(),
                 'misek' => $misek,
                 'adoraciok' => $adorations,
                 'gyontatas' => $this->confessions ? $this->confessions['status'] : false,
@@ -947,10 +947,10 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             'ismertnev' => !empty($this->alternative_names) ? $this->alternative_names[0] : '',
             'alternative_names' => $this->alternative_names,
             'frissitve' => $this->frissitesFormatted(),            
-            'orszag' => ( DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: "" ),
+            'orszag' => $this->locationCountryName(),
             'egyhazmegye' => ( DB::table('egyhazmegye')->where('id', $this->egyhazmegye)->value('nev') ?: "" ),
-            'megye' => ( DB::table('megye')->where('id', $this->megye)->value('megyenev') ?: "" ),
-            'varos' => $this->varos,
+            'megye' => $this->locationCountyName(),
+            'varos' => $this->locationCityName(),
             'cim' => $this->cim,
             'megkozelites' => '',
             'plebania' => str_replace('<br>', "\n", strip_tags($this->plebania, '<br>')),
@@ -1340,7 +1340,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         if (!empty($this->alternative_names)) {
             $return .= ' (' . $this->alternative_names[0] . ')';
         } else {
-            $return .= ' (' . $this->varos . ')';
+            $return .= ' (' . $this->locationCityName() . ')';
         }
         return $return;
     }
@@ -1435,6 +1435,124 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             $boundaries,
             fn($boundary) => (int) ($boundary['admin_level'] ?? 0) !== 4
         ));
+    }
+
+    /**
+     * #496 / #497 / #498: a templom helynevei az OSM-határokból, a régi oszlopokra
+     * való visszaeséssel.
+     *
+     * A három jegy a `templomok.varos`, `.megye` és `templomok.orszag` kivezetéséről
+     * szól. Ahhoz, hogy az oszlopok eldobhatók legyenek, előbb minden fogyasztónak
+     * ezeken a metódusokon kell keresztülmennie — utána a kivezetés annyi, hogy a
+     * visszaesési ág kiesik innen, és nem kell 23 fájlt átírni.
+     *
+     * A visszaesés SZÁNDÉKOSAN bent van most: a szlovák állomány 23%-ának egyáltalán
+     * nincs boundary-ja (szinkronhiány), és 47 templomnak nincs koordinátája sem.
+     * Amíg ez így van, a régi oszlop a jobb válasz, mint az üres string.
+     *
+     * A besorolás szint szerint megy, nem pozíció szerint: a location() a rendezett
+     * lista 0./1./2. elemét címkézi, ami hiányos határláncnál elcsúszik.
+     */
+    private function adminBoundaryName(array $szintek): ?string {
+        $talalat = $this->boundaries()
+                ->where('boundary', 'administrative')
+                ->whereIn('admin_level', $szintek)
+                ->orderBy('admin_level', 'desc')
+                ->first();
+
+        $nev = trim((string) ($talalat->name ?? ''));
+
+        return $nev !== '' ? $nev : null;
+    }
+
+    /**
+     * Település. Ha van kerület is, azzal együtt — így a nagyvárosi templomoknál nem
+     * vész el a pontosság.
+     *
+     * Ez SZÁNDÉKOSAN a régi oszlop alakját reprodukálja, mert az API-ban és a
+     * felületen ez látszik. Két országfüggő eset van, mindkettőt valódi adaton mértem:
+     *
+     *   Budapest, Szent Imre-templom      8=Budapest  9=XI. kerület  10=Szentimreváros
+     *       -> "Budapest XI. kerület", ami bitre a régi `templomok.varos`.
+     *       A puszta legspecifikusabb elem "Szentimreváros" lenne: pontosabb ugyan,
+     *       de a látogató szempontjából visszalépés ahhoz képest, amit ma lát.
+     *
+     *   Köln, St. Aposteln                6=Köln      9=Innenstadt   10=Altstadt-Nord
+     *       Köln kreisfreie Stadt, tehát NINCS 8-as szintje. Ha vakon a 9-esre esnénk
+     *       vissza, "Innenstadt" jönne ki "Köln" helyett.
+     *
+     * Ezért a kerületet CSAK akkor fűzzük hozzá, ha a település a 8-as szintről jött.
+     * Ha a településnek a 6-osra kellett visszaesni, a 9-es már másfajta felosztás,
+     * és a régi adat sem tartalmazta.
+     */
+    public function locationCityName(): string {
+        $telepules = $this->adminBoundaryName([8]);
+        if ($telepules !== null) {
+            $kerulet = $this->adminBoundaryName([9]);
+            return $kerulet !== null ? $telepules . ' ' . $kerulet : $telepules;
+        }
+
+        // Nincs 8-as szint (pl. német kreisfreie Stadt): a 6-os maga a település.
+        return $this->adminBoundaryName([6])
+            ?? $this->adminBoundaryName([9])
+            ?? $this->adminBoundaryName([10])
+            ?? (string) $this->varos;
+    }
+
+    /** Megye. Romániában nincs 6-os szint, ott a 4-es (judet) hordozza. */
+    public function locationCountyName(): string {
+        $boundary = $this->adminBoundaryName([6]) ?? $this->adminBoundaryName([4]);
+        if ($boundary !== null) {
+            return $boundary;
+        }
+
+        return (string) (DB::table('megye')->where('id', $this->megye)->value('megyenev') ?: '');
+    }
+
+    public function locationCountryName(): string {
+        return $this->adminBoundaryName([2])
+            ?? (string) (DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: '');
+    }
+
+    /**
+     * Magyarországi templom-e. A naptár ez alapján dönti el, kell-e nyelvi zászló a
+     * magyar mise mellé, a statisztika pedig ez alapján szűkít.
+     *
+     * Elsődlegesen az ISO-kód, mert a `templomok.orszag = 12` a kivezetéssel eltűnik.
+     */
+    public function isInHungary(): bool {
+        $kod = $this->countryCode();
+        if ($kod !== null) {
+            return $kod === 'HU';
+        }
+
+        return (int) $this->orszag === self::MAGYARORSZAG_ID;
+    }
+
+    /** A régi `orszagok` tábla magyar sorának azonosítója. */
+    public const MAGYARORSZAG_ID = 12;
+
+    /**
+     * #498: lekérdezés-szintű szűrés a magyarországi templomokra.
+     *
+     * A statisztika eddig `where('orszag', 12)`-vel szűkített — pont az az oszlop,
+     * amit ki akarunk vezetni. A boundary-alapú megfelelője az országhatáron megy.
+     *
+     * NÉVRE és ISO-kódra IS illesztünk. Az ISO a helyes hosszú távon, de ma 7964
+     * határból egyetlenegynél van kitöltve (a szinkronnak újra kell futnia), addig
+     * a puszta ISO-szűrés üres statisztikát adna.
+     */
+    public function scopeInHungary($query) {
+        return $query->whereIn('templomok.id', function ($sub) {
+            $sub->select('lookup_boundary_church.church_id')
+                ->from('lookup_boundary_church')
+                ->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+                ->where('boundaries.admin_level', 2)
+                ->where(function ($w) {
+                    $w->where('boundaries.iso3166_1', 'HU')
+                      ->orWhere('boundaries.name', 'Magyarország');
+                });
+        });
     }
 
     /**

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -74,8 +74,14 @@ class Edit extends \Html\Html {
             return; // Nincs church form, nincs mit menteni
         }
 
-        $allowedFields = ['adminmegj', 'nev',
-            'orszag', 'megye', 'varos', 'cim',
+        /*
+         * #496 / #497 / #498: az `orszag`, `megye` és `varos` KIKERÜLT a menthető
+         * mezők közül. A helyet a koordináta és az OSM-határok adják; a szerkesztő
+         * kaszkádos ország/megye/város választója ezért megszűnt, és ha itt bent
+         * maradnának, egy beküldött űrlap felülírhatná a származtatott adatot azzal,
+         * ami a böngészőben ragadt.
+         */
+        $allowedFields = ['adminmegj', 'nev', 'cim',
             'egyhazmegye', 'espereskerulet', 'plebania', 'pleb_eml',
             'megjegyzes', 'miseaktiv', 'misemegj', 'leiras', 'ok', 'frissites',
             'lat','lon'];
@@ -273,85 +279,19 @@ class Edit extends \Html\Html {
     
     function addFormAdministrative() {
         $options = [0 => 'Válassz/Nem tudom'];
-        $countries = \Illuminate\Database\Capsule\Manager::table('orszagok')
-                        ->select('id', 'nev')
-                        ->orderBy('nev')->get();
-        foreach ($countries as $selectibleCountry) {
-            $options[$selectibleCountry->id] = $selectibleCountry->nev;
-        }
-        $this->form['country'] = array(
-            'type' => 'select',
-            'name' => 'church[orszag]',
-            'id' => 'selectOrszag',
-            'options' => $options,
-            'selected' => $this->church->orszag
-        );
+        /*
+         * #496 / #497 / #498: itt épült a kaszkádos ország -> megye -> város választó
+         * az `orszagok`, `megye` és `varosok` táblákból (75 sor, három egymásba ágyazott
+         * ciklussal, ami országonként és megyénként külön <select>-et gyártott, majd
+         * CSS-sel rejtette el a nem aktuálisakat).
+         *
+         * A hely mostantól a koordinátából és az OSM-határokból jön, tehát nincs mit
+         * választani: a `church/edit.twig` a származtatott elhelyezkedést írja ki.
+         * A választó amúgy is csak azoknál a templomoknál jelent meg, amiknek nem volt
+         * `varos` értékük (`{% if not church.varos %}`), tehát a szerkesztők többsége
+         * sosem találkozott vele.
+         */
 
-        foreach ($countries as $selectibleCountry) {
-            $options = [0 => 'Válassz/Nem tudom'];
-            $counties = \Illuminate\Database\Capsule\Manager::table('megye')
-                            ->select('id', 'megyenev', 'orszag')
-                            ->where('orszag', $selectibleCountry->id)
-                            ->orderBy('megyenev')->get();
-
-            foreach ($counties as $selectibleCounty) {
-                $options[$selectibleCounty->id] = $selectibleCounty->megyenev . " megye";
-                $allCounties[] = $selectibleCounty;
-            }
-
-            $this->form['counties'][$selectibleCountry->id] = array(
-                'type' => 'select',
-                'name' => 'church[megye]',
-                'id' => 'selectMegyeCountry' . $selectibleCountry->id,
-                'class' => 'selectMegyeCountry',
-                'data' => $selectibleCountry->id,
-                'options' => $options,
-                'selected' => $this->church->megye
-            );
-            if ($selectibleCountry->id == $this->church->orszag) {
-                $this->form['counties'][$selectibleCountry->id]['style'] = 'display: inline';
-            } else {
-                $this->form['counties'][$selectibleCountry->id]['style'] = 'display: none';
-                $this->form['counties'][$selectibleCountry->id]['disabled'] = 'disabled';
-            }
-
-            if (count($counties) < 1) {
-                $extra = new \stdClass();
-                $extra->id = 0;
-                $extra->megyenev = '(Nincs megadva)';
-                $extra->orszag = $selectibleCountry->id;
-                $allCounties[] = $extra;
-            }
-        }
-
-        foreach ($allCounties as $selectibleCounty) {
-            $options = [0 => 'Válassz/Nem tudom'];
-            $cities = \Illuminate\Database\Capsule\Manager::table('varosok')
-                            ->select('id', 'nev')
-                            ->where('orszag', $selectibleCounty->orszag)
-                            ->where('megye_id', $selectibleCounty->id)
-                            ->orderBy('nev')->get();
-            foreach ($cities as $selectibleCity) {
-                $options[$selectibleCity->nev] = $selectibleCity->nev;
-            }
-            $this->form['cities'][$selectibleCounty->orszag . "-" . $selectibleCounty->id] = array(
-                'type' => 'select',
-                'name' => 'church[varos]',
-                'id' => 'selectVarosCounty' . $selectibleCounty->orszag . "-" . $selectibleCounty->id,
-                'class' => 'selectVarosCounty',
-                'options' => $options,
-                'selected' => $this->church->varos
-            );
-            if ($selectibleCounty->id == $this->church->megye AND $this->church->orszag == $selectibleCounty->orszag) {
-                $this->form['cities'][$selectibleCounty->orszag . "-" . $selectibleCounty->id]['style'] = 'display: inline';
-            } else {
-                $this->form['cities'][$selectibleCounty->orszag . "-" . $selectibleCounty->id]['style'] = 'display: none';
-                $this->form['cities'][$selectibleCounty->orszag . "-" . $selectibleCounty->id]['disabled'] = 'disabled';
-            }
-        }
-    }
-
-    function addFormReligiousAdministration() {
         $selected = ['diocese' => $this->church->egyhazmegye, 'deanery' => $this->church->espereskerulet];
         $selectReligiousAdministration = \Form::religiousAdministrationSelection($selected);
         $this->form['dioceses'] = $selectReligiousAdministration['dioceses'];

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -414,14 +414,14 @@ class Edit extends \Html\Html {
                 ->get();
 
             foreach ($nearbyChurches as $nearby) {
-                $options[$nearby->id] = $nearby->varos . ' – ' . $nearby->names[0] . ' (~' . round($nearby->distance_km, 1) . ' km)';
+                $options[$nearby->id] = $nearby->locationCityName() . ' – ' . $nearby->names[0] . ' (~' . round($nearby->distance_km, 1) . ' km)';
             }
 
             // Ha van meglévő parent kapcsolat de nincs a common listában, hozzáadunk
             if ($currentParentId && !isset($options[$currentParentId])) {
                 $parentChurch = \Eloquent\Church::find($currentParentId);
                 if ($parentChurch) {
-                    $options[$currentParentId] = '⭐ ' . $parentChurch->varos . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
+                    $options[$currentParentId] = '⭐ ' . $parentChurch->locationCityName() . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
                 }
             }
         } else {
@@ -429,7 +429,7 @@ class Edit extends \Html\Html {
             if ($currentParentId) {
                 $parentChurch = \Eloquent\Church::find($currentParentId);
                 if ($parentChurch) {
-                    $options[$currentParentId] = '⭐ ' . $parentChurch->varos . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
+                    $options[$currentParentId] = '⭐ ' . $parentChurch->locationCityName() . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
                 }
             }
         }
@@ -444,7 +444,7 @@ class Edit extends \Html\Html {
             ->get(['id', 'varos', 'nev']);
         foreach ($allActive as $c) {
             if (!isset($options[$c->id])) {
-                $options[$c->id] = $c->varos . ' – ' . $c->nev;
+                $options[$c->id] = $c->locationCityName() . ' – ' . $c->nev;
             }
         }
 

--- a/webapp/classes/html/church/ical.php
+++ b/webapp/classes/html/church/ical.php
@@ -174,7 +174,11 @@ class Ical extends \Html\Html {
 
         $nev = is_array($church) ? ($church['nev'] ?? '') : ($church->nev ?? '');
         $ismertnev = is_array($church) ? ($church['ismertnev'] ?? '') : ($church->ismertnev ?? '');
-        $varos = is_array($church) ? ($church['varos'] ?? '') : ($church->varos ?? '');
+        // #497: tömb esetén a toAPIArray már származtatott értéket ad; objektumnál
+        // magunknak kell a boundary-ból kérni.
+        $varos = is_array($church)
+            ? ($church['varos'] ?? '')
+            : ($church instanceof \Eloquent\Church ? $church->locationCityName() : ($church->varos ?? ''));
         $calName = $nev;
         if ($ismertnev) $calName .= $calName ? ' (' . $ismertnev . ')' : $ismertnev;
         if ($varos) $calName .= $calName ? ' - ' . $varos : $varos;

--- a/webapp/classes/html/home.php
+++ b/webapp/classes/html/home.php
@@ -42,7 +42,8 @@ class Home extends Html {
                 \Eloquent\Church::select('id', 'nev', 'varos')
                     ->whereIn('id', $churchIds)
                     ->get()
-                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->varos])
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->locationCityName()])
             );
         }
          

--- a/webapp/classes/html/searchresultschurches.php
+++ b/webapp/classes/html/searchresultschurches.php
@@ -118,7 +118,8 @@ class SearchResultsChurches extends Html {
                 \Eloquent\Church::select('id', 'nev', 'varos')
                     ->whereIn('id', $params['church_ids'])
                     ->get()
-                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->varos])
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->locationCityName()])
             );
         }
         

--- a/webapp/classes/html/stat.php
+++ b/webapp/classes/html/stat.php
@@ -185,7 +185,20 @@ class Stat extends Html {
 		$stat = DB::table('templomok')
 			->selectRaw("DATEDIFF(NOW(), frissites) DIV 365 as yearago")
 			->selectRAW("count(*) as count");		
-		$stat->where('orszag',12)->where('ok','i')->where('miseaktiv',1);
+		// #498: eddig `where('orszag', 12)` állt itt — pont az az oszlop, amit kivezetünk.
+		// A boundary-alapú megfelelője az országhatáron megy. Névre ÉS ISO-kódra is
+		// illesztünk: az ISO a helyes hosszú távon, de amíg a szinkron nem futott újra,
+		// a puszta ISO-szűrés üres statisztikát adna.
+		$stat->whereIn('templomok.id', function ($sub) {
+				$sub->select('lookup_boundary_church.church_id')
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->where('boundaries.admin_level', 2)
+					->where(function ($w) {
+						$w->where('boundaries.iso3166_1', 'HU')
+						  ->orWhere('boundaries.name', 'Magyarország');
+					});
+			})->where('ok','i')->where('miseaktiv',1);
 		foreach(['%isézőhely%','%ápolna','%özösségi%', '%imaház%', '%imaterem%'] as $notlike)
 			$stat->where('nev','not like', $notlike);
 		$stat->orderBy('frissites','DESC');

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -869,7 +869,15 @@ class User {
 	
 
 			$users2notify = DB::table('templomok')
-				->select('templomok.id as tid','templomok.nev','templomok.ismertnev','templomok.varos','templomok.frissites')
+				// #497: a `varos` alias a levélsablonnak kell. Tömeges lekérdezés, ezért
+				// nem templomonként kérdezünk, hanem korrelált alkérdéssel — a boundary
+				// neve, visszaeséssel a régi oszlopra, amíg az létezik.
+				->select('templomok.id as tid','templomok.nev','templomok.ismertnev','templomok.frissites')
+				->selectRaw("COALESCE((SELECT b.name FROM lookup_boundary_church lbc"
+					. " JOIN boundaries b ON b.id = lbc.boundary_id"
+					. " WHERE lbc.church_id = templomok.id AND b.boundary = 'administrative'"
+					. " AND b.admin_level IN (8,9,10) ORDER BY b.admin_level DESC LIMIT 1),"
+					. " templomok.varos) AS varos")
 				->join('church_holders','templomok.id','=','church_holders.church_id')
 				->addSelect('church_holders.description')
 				->join('user','user.uid','=','church_holders.user_id')

--- a/webapp/templates/church/edit.twig
+++ b/webapp/templates/church/edit.twig
@@ -62,28 +62,30 @@
                 <td></td>
             </tr>
            
-            {% if not church.varos %}
+            {#
+                #496 / #497 / #498: itt állt a kaszkádos ország -> megye -> város
+                választó. A hely mostantól a koordinátából és az OSM-határokból jön,
+                tehát nincs mit választani — csak megmutatjuk, mi jött ki belőle.
+                A közterület (`cim`) marad szerkeszthető: az nincs a határokban.
+            #}
             <tr>
                 <td class=kiscim align=right>Elhelyezkedés:</td>
                 <td>
-                    {% if church.osm.administrative %}
-                        OSM 
-                        {% for key,administraion in church.osm.administrative %}
-                            > {{ administraion.name }}
-                        {% endfor %}   
+                    {% if church.location.country or church.location.city %}
+                        <span class="alap">
+                            {{ church.location.country.name }}{% if church.location.county %} &gt; {{ church.location.county.name }}{% endif %}{% if church.location.city %} &gt; {{ church.location.city.name }}{% endif %}{% if church.location.district %} &gt; {{ church.location.district.name }}{% endif %}
+                        </span>
+                        <small class="text-muted d-block">Az OSM-határokból, a térképi elhelyezés alapján.</small>
+                    {% else %}
+                        <small class="text-muted d-block">
+                            Nincs OSM-határ ehhez a templomhoz. Az elhelyezkedés a koordináta
+                            megadása után, a határok szinkronizálásakor jelenik meg.
+                        </small>
                     {% endif %}
-                    {{ forms.select(form.country) }}
-                    {% for county in form.counties %}
-                        {{ forms.select(county) }}
-                    {% endfor %}
-                    {% for city in form.cities %}
-                        {{ forms.select(city) }}
-                    {% endfor %}
-                    <input type=text name=church[cim] value="{{ church.cim }}" class=form-control  placeholder="Utca házszám">                                                    
+                    <input type=text name=church[cim] value="{{ church.cim }}" class=form-control  placeholder="Utca házszám">
                 </td>
                 <td></td>
             </tr>
-            {%  endif %}
             {% if church.location.osm %}
                 <tr>
                     <td class=kiscim align=right>OSM azonosító:</td>

--- a/webapp/tests/Integration/ChurchEditFormTest.php
+++ b/webapp/tests/Integration/ChurchEditFormTest.php
@@ -106,13 +106,34 @@ class ChurchEditFormTest extends TestCase {
         $this->post('/templom/' . $this->churchId . '/edit', $this->editFields([
             'church[cim]'        => 'Harmadik cím',
             'church[megjegyzes]' => 'Teszt megjegyzés',
-            'church[varos]'      => 'Debrecen',
         ]));
 
         $row = $this->churchRow();
         $this->assertSame('Harmadik cím', $row->cim);
         $this->assertSame('Teszt megjegyzés', $row->megjegyzes);
-        $this->assertSame('Debrecen', $row->varos);
+    }
+
+    /**
+     * #496 / #497 / #498: a hely a koordinátából és az OSM-határokból jön, a
+     * szerkesztő kaszkádos ország/megye/város választója megszűnt.
+     *
+     * Ez nem kozmetika: ha a mező bent maradna a menthetők között, egy beküldött
+     * űrlap felülírhatná a származtatott adatot azzal, ami a böngészőben ragadt —
+     * és a régi érték csendben visszaszivárogna oda, ahonnan épp kivezetjük.
+     */
+    public function testATelepulesMarNemMenthetoAzUrlaprol(): void {
+        $eredeti = $this->churchRow()->varos;
+
+        $this->post('/templom/' . $this->churchId . '/edit', $this->editFields([
+            'church[varos]'  => 'Debrecen',
+            'church[megye]'  => '9999',
+            'church[orszag]' => '9999',
+        ]));
+
+        $row = $this->churchRow();
+        $this->assertSame($eredeti, $row->varos, 'A település nem írható felül az űrlapról.');
+        $this->assertNotSame('9999', (string) $row->megye);
+        $this->assertNotSame('9999', (string) $row->orszag);
     }
 
     /**

--- a/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
+++ b/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
@@ -1,0 +1,192 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #496 / #497 / #498: a helynevek az OSM-határokból, a régi oszlopok helyett.
+ *
+ * A három jegy a `templomok.varos`, `.megye` és `.orszag` kivezetéséről szól. Ahhoz,
+ * hogy az oszlopok eldobhatók legyenek, előbb minden fogyasztónak ezeken a
+ * metódusokon kell keresztülmennie.
+ *
+ * A legfontosabb elvárás, hogy a látogató NE vegye észre a váltást: a származtatott
+ * érték adja vissza ugyanazt, amit a régi oszlop. Az `admin_level` jelentése viszont
+ * országonként más, ezért itt valódi, mért határláncokkal dolgozunk.
+ */
+class LocationNamesFromBoundariesTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $minta['id'] = $this->churchId;
+        $minta['nev'] = 'Helynév Teszt';
+        $minta['varos'] = 'Régi Város';
+        $minta['megye'] = 0;
+        $minta['orszag'] = 0;
+        $minta['ok'] = 'i';
+        DB::table('templomok')->insert($minta);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<int,array{0:int,1:string}> $szintek [admin_level, név] párok */
+    private function hatarlanc(array $szintek, string $iso = ''): void {
+        foreach ($szintek as [$level, $nev]) {
+            $id = DB::table('boundaries')->insertGetId([
+                'boundary'    => 'administrative',
+                'admin_level' => $level,
+                'name'        => $nev,
+                'alt_name'    => '',
+                'iso3166_1'   => $level === 2 ? $iso : '',
+                'osmtype'     => 'relation',
+                'osmid'       => 800000 + $level,
+            ]);
+            DB::table('lookup_boundary_church')->insert([
+                'boundary_id' => $id,
+                'church_id'   => $this->churchId,
+            ]);
+        }
+    }
+
+    private function templom(): \Eloquent\Church {
+        return \Eloquent\Church::find($this->churchId);
+    }
+
+    /**
+     * Budapest: a régi oszlopban "Budapest XI. kerület" áll. A legspecifikusabb
+     * határ "Szentimreváros" lenne — pontosabb, de a látogatónak visszalépés.
+     */
+    public function testBudapestiTemplomnalATelepulesEsAKeruletEgyutt(): void {
+        $this->hatarlanc([
+            [2, 'Magyarország'], [6, 'Budapest'], [8, 'Budapest'],
+            [9, 'XI. kerület'], [10, 'Szentimreváros'],
+        ], 'HU');
+
+        self::assertSame('Budapest XI. kerület', $this->templom()->locationCityName());
+    }
+
+    public function testKeruletNelkuliTelepulesnelCsakATelepules(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Szentendre', $this->templom()->locationCityName());
+    }
+
+    /**
+     * Köln kreisfreie Stadt: NINCS 8-as szintje, a település a 6-oson ül. Ha vakon a
+     * 9-esre esnénk vissza, "Innenstadt" jönne ki "Köln" helyett.
+     */
+    public function testKreisfreieStadtnalAHatosSzintATelepules(): void {
+        $this->hatarlanc([
+            [2, 'Deutschland'], [4, 'Nordrhein-Westfalen'], [5, 'Regierungsbezirk Köln'],
+            [6, 'Köln'], [9, 'Innenstadt'], [10, 'Altstadt-Nord'],
+        ], 'DE');
+
+        self::assertSame('Köln', $this->templom()->locationCityName(),
+            'A kerületet csak 8-as szintű település mellé szabad fűzni.');
+    }
+
+    /** Romániában nincs 6-os szint: a megyét (judet) a 4-es hordozza. */
+    public function testRomanTemplomnalANegyesSzintAMegye(): void {
+        $this->hatarlanc([[2, 'România'], [4, 'Alba'], [8, 'Vințu de Jos']], 'RO');
+
+        $templom = $this->templom();
+        self::assertSame('Alba', $templom->locationCountyName());
+        self::assertSame('Vințu de Jos', $templom->locationCityName());
+    }
+
+    public function testMagyarTemplomnalAHatosSzintAMegye(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [4, 'Közép-Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Pest', $this->templom()->locationCountyName(),
+            'Ahol van 6-os szint, ott a 4-es csak statisztikai nagyrégió.');
+    }
+
+    public function testAzOrszagnevAKettesSzintrolJon(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Magyarország', $this->templom()->locationCountryName());
+    }
+
+    // ---- visszaesés ----------------------------------------------------------
+
+    /**
+     * A visszaesés szándékosan bent van: a szlovák állomány 23%-ának egyáltalán
+     * nincs boundary-ja, és 47 templomnak nincs koordinátája sem.
+     */
+    public function testHatarNelkulARegiOszlopJon(): void {
+        self::assertSame('Régi Város', $this->templom()->locationCityName());
+    }
+
+    public function testCsakOrszaghatarralATelepulesMegARegiOszloprolJon(): void {
+        $this->hatarlanc([[2, 'Magyarország']], 'HU');
+
+        $templom = $this->templom();
+        self::assertSame('Magyarország', $templom->locationCountryName());
+        self::assertSame('Régi Város', $templom->locationCityName());
+    }
+
+    // ---- országhoz kötött logika --------------------------------------------
+
+    public function testAMagyarorszagiTemplomFelismereseAzIsoKodbol(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        self::assertTrue($this->templom()->isInHungary());
+    }
+
+    public function testAKulfoldiTemplomNemMagyarorszagi(): void {
+        $this->hatarlanc([[2, 'Deutschland'], [6, 'Köln']], 'DE');
+
+        self::assertFalse($this->templom()->isInHungary());
+    }
+
+    /**
+     * Az ISO ma 7964 határból egynél van kitöltve, tehát a névre illesztésnek is
+     * mennie kell — enélkül a statisztika üresen maradna.
+     */
+    public function testAStatisztikaSzurojeNevreIsIllik(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']]);
+
+        $talalat = \Eloquent\Church::inHungary()->where('templomok.id', $this->churchId)->count();
+
+        self::assertSame(1, $talalat, 'ISO-kód nélkül, puszta névre is találnia kell.');
+    }
+
+    public function testAStatisztikaSzurojeNemHozKulfoldit(): void {
+        $this->hatarlanc([[2, 'Deutschland'], [6, 'Köln']], 'DE');
+
+        self::assertSame(0, \Eloquent\Church::inHungary()->where('templomok.id', $this->churchId)->count());
+    }
+
+    // ---- ami az API-ba kikerül -----------------------------------------------
+
+    /** A publikus API mezőnevei nem változnak, csak a forrásuk. */
+    public function testAzApiValaszaAszarmaztatottNeveketAdja(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        // A `megye` csak a bővebb válaszban szerepel; a minimal a /nearby alapja.
+        $tomb = $this->templom()->toAPIArray('normal');
+
+        self::assertSame('Magyarország', $tomb['orszag']);
+        self::assertSame('Pest', $tomb['megye']);
+        self::assertSame('Szentendre', $tomb['varos']);
+    }
+
+    /** A /nearby minimal válasza is a származtatott neveket adja. */
+    public function testAMinimalValaszIsSzarmaztatott(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        $tomb = $this->templom()->toAPIArray('minimal');
+
+        self::assertSame('Magyarország', $tomb['orszag']);
+        self::assertSame('Szentendre', $tomb['varos']);
+    }
+}


### PR DESCRIPTION
A #496, #497 és #498 kivezetéséhez a szerkesztőnek is le kell szoknia a régi oszlopokról — ez volt a legnagyobb kódfüggés, **24 hivatkozás** az `edit.php`-ben.

> **Épül a #797-re** (a származtatott helynév-metódusokra). Külön nem mergelhető.

## Kisebb változás, mint elsőre látszott

A választó **már ma is feltételes**:

```twig
{% if not church.varos %}
    ... kaszkádos ország -> megye -> város ...
{% endif %}
```

Vagyis csak azoknál a templomoknál jelent meg, amiknek **nem volt** települése. A szerkesztők többsége sosem találkozott vele.

## Mit csinálok

Törlöm a felépítését — 79 sor, három egymásba ágyazott ciklussal, ami országonként és megyénként **külön `<select>`-et gyártott**, majd CSS-sel rejtette el a nem aktuálisakat. Helyette a sablon a származtatott elhelyezkedést írja ki:

```
Magyarország > Pest > Szentendre
Az OSM-határokból, a térképi elhelyezés alapján.
```

Ha nincs határ, azt is megmondjuk, miért nincs — nem üres mezőt mutatunk.

A közterület (`cim`) marad szerkeszthető: az nincs benne a határokban.

## A menthető mezők

Az `orszag`, `megye` és `varos` kikerül az `allowedFields`-ből. **Ez nem kozmetika**: ha bent maradnának, egy beküldött űrlap felülírhatná a származtatott adatot azzal, ami a böngészőben ragadt — a régi érték csendben visszaszivárogna oda, ahonnan épp kivezetjük.

Teszt is van rá: az űrlapról beküldött `varos`/`megye`/`orszag` **nem** írja felül a mentett adatot.

## A meglévő tesztet átírtam, nem töröltem

A `ChurchEditFormTest::testTobbMezoEgyszerreMentheto` azt várta, hogy a `varos` menthető — a változás után jogosan bukott. Most azt méri, hogy **nem** írható felül. (Érdekesség: a teljes suite-ban elsőre átment, csak szűrve bukott — sorrendfüggő volt.)

## Ellenőrzés

```
PHP-suite:  902 teszt, 2103 állítás — zöld
böngészős:   80 teszt — zöld
```

Előfeltétele: #496, #497, #498