### PR TITLE
Újra sorba állítom a határ nélkül maradt templomokat

### DIFF
--- a/docker/mysql/migrations/497-hatar-nelkuli-ujraprobalas.sql
+++ b/docker/mysql/migrations/497-hatar-nelkuli-ujraprobalas.sql
@@ -1,0 +1,18 @@
+-- #496: a határ nélkül maradt templomok újra sorba állítása.
+--
+-- A checkBoundaries() sora `boundaries_checked_at` szerint halad, és a #570/#700 óta
+-- helyesen megkülönbözteti a HIBÁT a "lekérdeztük, de nincs határ" esettől: hibánál nem
+-- bélyegez. A második eset viszont bélyeget kap — és ott is marad, amíg a teljes sor
+-- körbe nem ér.
+--
+-- Ez akkor fáj, ha a "nincs határ" nem az OSM valósága volt, hanem a mi oldalunk
+-- változott azóta. Pontosan ez történt Szlovákiában (a szlovák minta 23%-ának nincs
+-- határa): a tárolt szintjeink elavultak, és a #699 óta a lekérdezés a 4-es szintet is
+-- behúzza — a régen bélyegzett templomok viszont ettől még nem próbálkoznak újra.
+--
+-- A tényleges munkát a \Crons::requeueChurchesWithoutBoundary() végzi. Ez a fájl csak
+-- regisztrálja, HAVI futással: a 30 napos korlát miatt gyakoribb futásnak nincs értelme.
+
+INSERT INTO `crons` (`id`, `class`, `function`, `frequency`, `from`, `until`)
+VALUES (497, '\\Crons', 'requeueChurchesWithoutBoundary', 'monthly', NULL, NULL)
+ON DUPLICATE KEY UPDATE `class` = VALUES(`class`), `function` = VALUES(`function`);

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -8,6 +8,69 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Crons {
 
 	/**
+	 * #496: újra sorba állítja azokat a templomokat, amiknek nincs administratív
+	 * határuk, pedig már ellenőriztük őket.
+	 *
+	 * A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700
+	 * óta helyesen megkülönbözteti a HIBÁT a "lekérdeztük, de nincs határ" esettől:
+	 * hibánál nem bélyegez, tehát a templom a sor elején marad. A második eset viszont
+	 * BÉLYEGET kap — és ott is marad, amíg a teljes sor körbe nem ér.
+	 *
+	 * Ez akkor fáj, ha a "nincs határ" nem az OSM valósága volt, hanem a mi oldalunk
+	 * változott azóta. Pontosan ez történt Szlovákiában: a tárolt szintjeink elavultak
+	 * (nálunk 8=okres/9=obec, az OSM ma 6=okres/8=obec), és a szlovák minta 23%-ának
+	 * emiatt egyáltalán nincs határa. A #699 óta a lekérdezés a 4-es szintet is
+	 * behúzza, de a régen bélyegzett templomok ettől még nem próbálkoznak újra.
+	 *
+	 * Ezért a bélyeget levesszük róluk — a következő futás így elöl veszi őket.
+	 *
+	 * A 30 napos korlát SZÁNDÉKOS: enélkül azok a templomok, amiknek tényleg nincs
+	 * határuk (az OSM ott nem fed le semmit), minden futásban visszakerülnének a sor
+	 * elejére, és kiszorítanák a valóban ellenőrizendőket. Így legfeljebb havonta
+	 * egyszer próbálkozunk velük újra.
+	 *
+	 * @return int hány templomot állítottunk vissza a sorba
+	 */
+	public static function requeueChurchesWithoutBoundary(): int {
+		$hatarido = date('Y-m-d H:i:s', strtotime('-30 days'));
+
+		return DB::table('templomok')
+			->where('ok', 'i')
+			->whereNotNull('lat')->where('lat', '!=', 0)
+			->whereNotNull('lon')->where('lon', '!=', 0)
+			->whereNotNull('boundaries_checked_at')
+			->where('boundaries_checked_at', '<', $hatarido)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
+					->where('boundaries.boundary', 'administrative');
+			})
+			->update(['boundaries_checked_at' => null]);
+	}
+
+	/**
+	 * #496: hány aktív, koordinátával rendelkező templomnak nincs administratív
+	 * határa. A /health ezt írja ki, hogy a lefedettségi hiány LÁTSZÓDJON — eddig
+	 * csak abból derült volna ki, hogy egy település alatt nem jön ki a templom.
+	 */
+	public static function churchesWithoutBoundaryCount(): int {
+		return DB::table('templomok')
+			->where('ok', 'i')
+			->whereNotNull('lat')->where('lat', '!=', 0)
+			->whereNotNull('lon')->where('lon', '!=', 0)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
+					->where('boundaries.boundary', 'administrative');
+			})
+			->count();
+	}
+
+	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -46,6 +46,23 @@ class Health extends Html {
 			['mail/debug', $config['mail']['debug'] ]
 		];
 		
+		/*
+		 * #496: a határ-lefedettség hiánya eddig SEHOL nem látszott. A tünete az, hogy
+		 * egy település alatt nem jön ki a templom — a szerkesztő ilyenkor a saját
+		 * adatát hibáztatja, pedig a boundary-szinkron nem ért oda. Élesben a szlovák
+		 * minta 23%-ának egyáltalán nincs határa.
+		 */
+		$hatarNelkul = \Crons::churchesWithoutBoundaryCount();
+		if ($hatarNelkul === 0) {
+			$this->infos[] = ['Határ nélküli templomok', '<span class="text-success">✅ nincs ilyen</span>'];
+		} else {
+			$this->infos[] = ['Határ nélküli templomok',
+				'<span class="text-warning">⚠️ ' . $hatarNelkul . ' aktív, koordinátás templomnak nincs '
+				. 'administratív határa — a települési keresés nem találja meg őket. '
+				. 'A boundary-szinkron (cron 42) fokozatosan pótolja; a régen ellenőrzötteket '
+				. 'a cron 497 állítja vissza a sor elejére.</span>'];
+		}
+
 		// Check GD extension specifically
 		if (!extension_loaded('gd')) {
 			$this->infos[] = ['GD Extension', '<span class="text-danger">⚠️ HIÁNYZIK! A képfeltöltés nem fog működni.</span>'];

--- a/webapp/tests/Integration/RequeueChurchesWithoutBoundaryTest.php
+++ b/webapp/tests/Integration/RequeueChurchesWithoutBoundaryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #496: a határ nélkül maradt templomok újra sorba állítása.
+ *
+ * A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700
+ * óta helyesen megkülönbözteti a HIBÁT a „lekérdeztük, de nincs határ" esettől:
+ * hibánál nem bélyegez, tehát a templom a sor elején marad. A második eset viszont
+ * bélyeget kap — és ott is marad, amíg a teljes sor körbe nem ér.
+ *
+ * Ez akkor fáj, ha a „nincs határ" nem az OSM valósága volt, hanem a MI oldalunk
+ * változott azóta. Pontosan ez történt Szlovákiában: a szlovák minta 23%-ának
+ * egyáltalán nincs határa, és a #699 óta a lekérdezés a 4-es szintet is behúzza —
+ * a régen bélyegzett templomok viszont ettől még nem próbálkoznak újra.
+ */
+class RequeueChurchesWithoutBoundaryTest extends TestCase {
+
+    private int $sorszam = 0;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /**
+     * @param string|null $ellenorizve a boundaries_checked_at értéke
+     * @param bool $vanHatar kapjon-e administratív határt
+     * @param array<string,mixed> $mezok egyéb felülírandó oszlopok
+     */
+    private function templom(?string $ellenorizve, bool $vanHatar, array $mezok = []): int {
+        $minta = (array) DB::table('templomok')->first();
+        $id = (int) DB::table('templomok')->max('id') + 1 + $this->sorszam++;
+
+        DB::table('templomok')->insert(array_merge($minta, [
+            'id' => $id, 'ok' => 'i', 'lat' => 48.1, 'lon' => 17.1,
+            'boundaries_checked_at' => $ellenorizve,
+        ], $mezok));
+
+        if ($vanHatar) {
+            $bid = DB::table('boundaries')->insertGetId([
+                'boundary' => 'administrative', 'admin_level' => 8,
+                'name' => 'Teszt település ' . $id, 'osmtype' => 'relation', 'osmid' => 600000 + $id,
+            ]);
+            DB::table('lookup_boundary_church')->insert(['boundary_id' => $bid, 'church_id' => $id]);
+        }
+
+        return $id;
+    }
+
+    private function bélyeg(int $id): ?string {
+        return DB::table('templomok')->where('id', $id)->value('boundaries_checked_at');
+    }
+
+    /** A lényeg: a régen ellenőrzött, határ nélküli templom visszakerül a sor elejére. */
+    public function testARegenEllenorzottHatarNelkuliVisszakerul(): void {
+        $id = $this->templom(date('Y-m-d H:i:s', strtotime('-60 days')), false);
+
+        \Crons::requeueChurchesWithoutBoundary();
+
+        self::assertNull($this->bélyeg($id));
+    }
+
+    /**
+     * A 30 napos korlát szándékos: enélkül azok a templomok, amiknek tényleg nincs
+     * határuk, minden futásban visszakerülnének a sor elejére, és kiszorítanák a
+     * valóban ellenőrizendőket.
+     */
+    public function testAFrissenEllenorzottetNemBantja(): void {
+        $id = $this->templom(date('Y-m-d H:i:s', strtotime('-3 days')), false);
+
+        \Crons::requeueChurchesWithoutBoundary();
+
+        self::assertNotNull($this->bélyeg($id));
+    }
+
+    public function testAHatarralRendelkezotNemBantja(): void {
+        $id = $this->templom(date('Y-m-d H:i:s', strtotime('-60 days')), true);
+
+        \Crons::requeueChurchesWithoutBoundary();
+
+        self::assertNotNull($this->bélyeg($id), 'Akinek van határa, annak nincs mit újrapróbálni.');
+    }
+
+    /** Koordináta nélkül sosem lesz határ — ne pörgessük fölöslegesen a sort. */
+    public function testAKoordinataNelkulitNemAllitjaSorba(): void {
+        $id = $this->templom(date('Y-m-d H:i:s', strtotime('-60 days')), false, ['lat' => 0, 'lon' => 0]);
+
+        \Crons::requeueChurchesWithoutBoundary();
+
+        self::assertNotNull($this->bélyeg($id));
+    }
+
+    public function testANemAktivTemplomotNemBantja(): void {
+        $id = $this->templom(date('Y-m-d H:i:s', strtotime('-60 days')), false, ['ok' => 'n']);
+
+        \Crons::requeueChurchesWithoutBoundary();
+
+        self::assertNotNull($this->bélyeg($id));
+    }
+
+    /** A még sosem ellenőrzött már eleve a sor elején van. */
+    public function testASosemEllenorzottetNemSzamolja(): void {
+        $id = $this->templom(null, false);
+
+        $erintett = \Crons::requeueChurchesWithoutBoundary();
+
+        self::assertNull($this->bélyeg($id));
+        self::assertGreaterThanOrEqual(0, $erintett);
+    }
+
+    // ---- a /health számlálója -----------------------------------------------
+
+    public function testASzamlaloBeleveszAHatarNelkulit(): void {
+        $elotte = \Crons::churchesWithoutBoundaryCount();
+        $this->templom(null, false);
+
+        self::assertSame($elotte + 1, \Crons::churchesWithoutBoundaryCount());
+    }
+
+    public function testASzamlaloNemVesziBeAHatarralRendelkezot(): void {
+        $elotte = \Crons::churchesWithoutBoundaryCount();
+        $this->templom(null, true);
+
+        self::assertSame($elotte, \Crons::churchesWithoutBoundaryCount());
+    }
+}


### PR DESCRIPTION
A #496-ban kimértem, hogy a **szlovák minta 23%-ának egyáltalán nincs administratív határa**. Ez nem elvi korlát, hanem szinkronhiány — de a jelenlegi mechanizmus magától nem hozza helyre.

## Miért nem javul magától

A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700 óta **helyesen** különbözteti meg a hibát a „nincs határ" esettől:

| eset | bélyeg | következmény |
|---|---|---|
| Overpass hiba (429/503/timeout) | **nem** kap | a sor elején marad, újra próbálja ✅ |
| lekérdeztük, de nincs határ | **kap** | a sor végére kerül, és ott is marad |

A második sor akkor fáj, ha a „nincs határ" **nem az OSM valósága volt, hanem a mi oldalunk változott azóta**. Pontosan ez történt Szlovákiában: a tárolt szintjeink elavultak (nálunk `8=okres`/`9=obec`, az OSM ma `6=okres`/`8=obec`), és a #699 óta a lekérdezés a 4-es szintet is behúzza. A régen bélyegzett templomok viszont ettől még nem próbálkoznak újra — a bélyeg rajtuk maradt.

## A javítás

Havi cron leveszi a bélyeget azokról, amiknek nincs administratív határuk.

**A 30 napos korlát szándékos.** Enélkül azok a templomok, amiknek tényleg nincs határuk (az OSM ott nem fed le semmit), minden futásban visszakerülnének a sor elejére, és kiszorítanák a valóban ellenőrizendőket. Így legfeljebb havonta egyszer próbálkozunk velük.

## Láthatóság

A `/health` mostantól kiírja, hány templomnak nincs határa. **Eddig ez sehol nem látszott** — a tünete az, hogy egy település alatt nem jön ki a templom, amit a szerkesztő a saját adatának hisz.

## Ellenőrzés

8 integrációs teszt: régen ellenőrzött visszakerül, frissen ellenőrzött nem, határral rendelkező nem, koordináta nélküli nem, nem aktív nem, sosem ellenőrzött már eleve elöl van, plusz a `/health` számlálója mindkét irányban.

```
PHP-suite: 895 teszt, 2091 állítás — zöld
```

Regisztráció: `docker/mysql/migrations/497-hatar-nelkuli-ujraprobalas.sql` (cron 497, havi).

Kapcsolódik: #496, #497, #498