### PR TITLE
Eldobom a templomok.orszag, .megye és .varos oszlopokat

### DIFF
--- a/docker/mysql/initdb.d/10-location-columns-drop.sql
+++ b/docker/mysql/initdb.d/10-location-columns-drop.sql
@@ -1,0 +1,19 @@
+-- #496 / #497 / #498: friss adatbázisnál is essenek ki a régi helyoszlopok.
+--
+-- Ez a fájl SZÁNDÉKOSAN az adatbetöltés (05-data.sh) UTÁN fut, nem a séma
+-- definíciójában dobja el őket. Így a `data/templomok.sql` seed változatlan maradhat,
+-- és a seed-fájlokat nem kell újragyártani ahhoz, hogy a fejlesztői adatbázis a
+-- production utáni állapotot tükrözze.
+--
+-- Az éles migrációt lásd: docker/mysql/migrations/496-497-498-oszlopok-eldobasa.sql
+
+USE `miserend`;
+
+ALTER TABLE `templomok`
+  DROP COLUMN IF EXISTS `orszag`,
+  DROP COLUMN IF EXISTS `megye`,
+  DROP COLUMN IF EXISTS `varos`;
+
+DROP TABLE IF EXISTS `varosok`;
+DROP TABLE IF EXISTS `megye`;
+DROP TABLE IF EXISTS `orszagok`;

--- a/docker/mysql/migrations/496-497-498-oszlopok-eldobasa.sql
+++ b/docker/mysql/migrations/496-497-498-oszlopok-eldobasa.sql
@@ -1,0 +1,32 @@
+-- #496 / #497 / #498: a templomok.orszag, .megye és .varos oszlopok, valamint az
+-- orszagok, megye és varosok táblák eldobása.
+--
+-- A helyet innentől kizárólag a koordináta és az OSM-határok adják.
+--
+-- ============================ ELŐFELTÉTELEK ============================
+--
+-- EZT A FÁJLT UTOLSÓKÉNT KELL FUTTATNI, és csak akkor, ha az alábbiak megvannak.
+-- A művelet VISSZAFORDÍTHATATLAN — előtte mentés kell.
+--
+--   1. A kód már nem olvassa az oszlopokat (#797, #798 mergelve).
+--   2. A koordináta nélküli templomok helyadata átkerült a megjegyzés mezőbe:
+--        docker exec miserend php index.php q=cron cron_id=496
+--      Ellenőrzés: keress a megjegyzésekben a "[Helyadat a koordináta nélküli
+--      időszakból]" jelölőre — élesben 47 templomnál kell megjelennie.
+--   3. A határ-lefedettség elfogadható. A /health kiírja, hány aktív, koordinátás
+--      templomnak NINCS administratív határa. Ez a szám a drop után már nem
+--      pótolható a régi oszlopból — ezek a templomok helynév nélkül maradnak.
+--      Élesben a szlovák minta 23%-a volt érintett; a cron 497 havonta újrapróbálja.
+--   4. Teljes templom-újraindexelés lefutott (cron_id=38), hogy a keresőindex a
+--      származtatott neveket tartalmazza.
+--
+-- =======================================================================
+
+ALTER TABLE `templomok`
+  DROP COLUMN `orszag`,
+  DROP COLUMN `megye`,
+  DROP COLUMN `varos`;
+
+DROP TABLE IF EXISTS `varosok`;
+DROP TABLE IF EXISTS `megye`;
+DROP TABLE IF EXISTS `orszagok`;

--- a/webapp/classes/api/churchrelationships.php
+++ b/webapp/classes/api/churchrelationships.php
@@ -61,7 +61,8 @@ class Churchrelationships extends Api {
                 'church' => [
                     'id'   => $c->id,
                     'name' => !empty($c->names) ? $c->names[0] : $c->nev,
-                    'city' => $c->varos,
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    'city' => $c->locationCityName(),
                     'lat'  => (float) $c->lat,
                     'lon'  => (float) $c->lon,
                     'rank' => $c->rank,

--- a/webapp/classes/api/nearbymasses.php
+++ b/webapp/classes/api/nearbymasses.php
@@ -56,7 +56,8 @@ class NearbyMasses extends Api
                 'church' => [
                     'id' => (int) $church->id,
                     'name' => $church->names[0] ?? '',
-                    'city' => is_array($church->varos) ? ($church->varos[0] ?? '') : $church->varos,
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    'city' => $church->locationCityName(),
                     'lat' => (float) $church->lat,
                     'lon' => (float) $church->lon,
                 ],

--- a/webapp/classes/api/service_times.php
+++ b/webapp/classes/api/service_times.php
@@ -72,8 +72,10 @@ class Service_times extends Api {
 					'church_id' => $church->id,
 					'name' => $church->names[0],
 					'address' => $church->location->address,
-					'city, state' => isset($church->location->city['name']) ? $church->location->city['name'] : $church->varos,
-					'country' => isset($church->location->country['name']) ? $church->location->country['name'] : $church->orszag,
+					// #497/#498: a visszaesés eddig a NYERS oszlopra ment — az `orszag`
+					// ott azonosító, tehát hiányzó boundary-nál "12" ment ki országnévként.
+					'city, state' => isset($church->location->city['name']) ? $church->location->city['name'] : $church->locationCityName(),
+					'country' => isset($church->location->country['name']) ? $church->location->country['name'] : $church->locationCountryName(),
 					'phone' => false,
 					'email' => $church->pleb_eml,
 					'url' => false,

--- a/webapp/classes/api/table.php
+++ b/webapp/classes/api/table.php
@@ -108,10 +108,32 @@ class Table extends Api {
         switch ($this->tableName) {
             case 'templomok':
                 
+                /*
+                 * #496 / #497 / #498: az `orszag`, `megye` és `varos` mezők a publikus
+                 * API szerződésének részei — a nevük és a jelentésük NEM változhat.
+                 * A forrásuk viszont igen: eddig az `orszagok`/`megye` táblákhoz
+                 * kapcsolt join adta őket, mostantól az OSM-határok.
+                 *
+                 * Korrelált alkérdéssel, nem join-nal: egy templomhoz több határ
+                 * tartozik, a join megsokszorozná a sorokat.
+                 */
+                $orszag = self::boundaryNameSql([2]);
+                $megye = self::boundaryNameSql([6, 4]);
+                $telepules = self::boundaryNameSql([8]);
+                $kerulet = self::boundaryNameSql([9]);
+                $tartalek = self::boundaryNameSql([6, 9, 10]);
+
                 $this->table = DB::table("templomok as t")
-                        ->SELECT("t.*","orszagok.nev as orszag","megye.megyenev as megye")
-                        ->leftJoin('orszagok', 'orszagok.id','=','t.orszag')
-                        ->leftJoin('megye', 'megye.id',"=","megye")
+                        ->select("t.*")
+                        ->selectRaw("$orszag AS orszag")
+                        ->selectRaw("$megye AS megye")
+                        // Ugyanaz a szabály, mint a Church::locationCityName()-ben: a
+                        // kerület csak 8-as szintű település mellé fűzhető (Köln
+                        // kreisfreie Stadt, tehát nincs 8-asa — ott a 6-os a település).
+                        ->selectRaw(
+                            "TRIM(CONCAT_WS(' ', COALESCE($telepules, $tartalek),"
+                            . " CASE WHEN $telepules IS NOT NULL THEN $kerulet END)) AS varos"
+                        )
                         ->where('t.ok',"=","i")
                         ->limit(10000)
                         ->get();
@@ -133,6 +155,22 @@ class Table extends Api {
     }
     
   
+    /**
+     * #496 / #497 / #498: egy administratív határ nevének korrelált alkérdése.
+     *
+     * @param array<int,int> $szintek admin_level-ek, PREFERENCIA sorrendben
+     * @return string beilleszthető SQL-részlet (a külső lekérdezésben `t` a templom)
+     */
+    private static function boundaryNameSql(array $szintek): string {
+        $lista = implode(', ', array_map('intval', $szintek));
+
+        return "(SELECT b.name FROM lookup_boundary_church lbc"
+            . " JOIN boundaries b ON b.id = lbc.boundary_id"
+            . " WHERE lbc.church_id = t.id AND b.boundary = 'administrative'"
+            . " AND b.admin_level IN ($lista)"
+            . " ORDER BY FIELD(b.admin_level, $lista) LIMIT 1)";
+    }
+
     function mapTemplomok() {
         $output = array();
 

--- a/webapp/classes/campaign.php
+++ b/webapp/classes/campaign.php
@@ -80,9 +80,20 @@ class Campaign {
         //    régen frissített (>2 év), nincs aktuális update / észrevétel.
         $staleDate = (new DateTime())->modify('-' . self::STALE_MONTHS . ' months')->format('Y-m-d');
         $assignableChurches = DB::table('templomok AS t')
-            ->select('t.id', 't.nev', 't.ismertnev', 't.varos', 't.frissites')
+            ->select('t.id', 't.nev', 't.ismertnev', 't.frissites')
             ->where('t.ok', 'i')
-            ->where('t.orszag', 12)
+            // #498: a `t.orszag = 12` helyett országhatár. Névre és ISO-kódra is
+            // illesztünk, mert az ISO ma még alig van kitöltve.
+            ->whereIn('t.id', function ($sub) {
+                $sub->select('lookup_boundary_church.church_id')
+                    ->from('lookup_boundary_church')
+                    ->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+                    ->where('boundaries.admin_level', 2)
+                    ->where(function ($w) {
+                        $w->where('boundaries.iso3166_1', 'HU')
+                          ->orWhere('boundaries.name', 'Magyarország');
+                    });
+            })
             ->where(function ($q) {
                 $q->where('t.nev', 'LIKE', '%templom%')
                   ->orWhere('t.nev', 'LIKE', '%bazilika%')

--- a/webapp/classes/campaign.php
+++ b/webapp/classes/campaign.php
@@ -270,7 +270,8 @@ class Campaign {
                     'id' => $c->id,
                     'nev' => $c->nev,
                     'ismertnev' => $c->ismertnev,
-                    'varos' => $c->varos,
+                    // #497: a levélben a település a boundary-ból, mint mindenhol máshol.
+                    'varos' => $c->locationCityName(),
                     'frissites' => $c->frissites,
                 ];
             }, $churches),

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -8,6 +8,69 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Crons {
 
 	/**
+	 * #496: újra sorba állítja azokat a templomokat, amiknek nincs administratív
+	 * határuk, pedig már ellenőriztük őket.
+	 *
+	 * A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700
+	 * óta helyesen megkülönbözteti a HIBÁT a "lekérdeztük, de nincs határ" esettől:
+	 * hibánál nem bélyegez, tehát a templom a sor elején marad. A második eset viszont
+	 * BÉLYEGET kap — és ott is marad, amíg a teljes sor körbe nem ér.
+	 *
+	 * Ez akkor fáj, ha a "nincs határ" nem az OSM valósága volt, hanem a mi oldalunk
+	 * változott azóta. Pontosan ez történt Szlovákiában: a tárolt szintjeink elavultak
+	 * (nálunk 8=okres/9=obec, az OSM ma 6=okres/8=obec), és a szlovák minta 23%-ának
+	 * emiatt egyáltalán nincs határa. A #699 óta a lekérdezés a 4-es szintet is
+	 * behúzza, de a régen bélyegzett templomok ettől még nem próbálkoznak újra.
+	 *
+	 * Ezért a bélyeget levesszük róluk — a következő futás így elöl veszi őket.
+	 *
+	 * A 30 napos korlát SZÁNDÉKOS: enélkül azok a templomok, amiknek tényleg nincs
+	 * határuk (az OSM ott nem fed le semmit), minden futásban visszakerülnének a sor
+	 * elejére, és kiszorítanák a valóban ellenőrizendőket. Így legfeljebb havonta
+	 * egyszer próbálkozunk velük újra.
+	 *
+	 * @return int hány templomot állítottunk vissza a sorba
+	 */
+	public static function requeueChurchesWithoutBoundary(): int {
+		$hatarido = date('Y-m-d H:i:s', strtotime('-30 days'));
+
+		return DB::table('templomok')
+			->where('ok', 'i')
+			->whereNotNull('lat')->where('lat', '!=', 0)
+			->whereNotNull('lon')->where('lon', '!=', 0)
+			->whereNotNull('boundaries_checked_at')
+			->where('boundaries_checked_at', '<', $hatarido)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
+					->where('boundaries.boundary', 'administrative');
+			})
+			->update(['boundaries_checked_at' => null]);
+	}
+
+	/**
+	 * #496: hány aktív, koordinátával rendelkező templomnak nincs administratív
+	 * határa. A /health ezt írja ki, hogy a lefedettségi hiány LÁTSZÓDJON — eddig
+	 * csak abból derült volna ki, hogy egy település alatt nem jön ki a templom.
+	 */
+	public static function churchesWithoutBoundaryCount(): int {
+		return DB::table('templomok')
+			->where('ok', 'i')
+			->whereNotNull('lat')->where('lat', '!=', 0)
+			->whereNotNull('lon')->where('lon', '!=', 0)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
+					->where('boundaries.boundary', 'administrative');
+			})
+			->count();
+	}
+
+	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -8,69 +8,6 @@ use Illuminate\Database\Capsule\Manager as DB;
 class Crons {
 
 	/**
-	 * #496: újra sorba állítja azokat a templomokat, amiknek nincs administratív
-	 * határuk, pedig már ellenőriztük őket.
-	 *
-	 * A `checkBoundaries()` sora `boundaries_checked_at` szerint halad, és a #570/#700
-	 * óta helyesen megkülönbözteti a HIBÁT a "lekérdeztük, de nincs határ" esettől:
-	 * hibánál nem bélyegez, tehát a templom a sor elején marad. A második eset viszont
-	 * BÉLYEGET kap — és ott is marad, amíg a teljes sor körbe nem ér.
-	 *
-	 * Ez akkor fáj, ha a "nincs határ" nem az OSM valósága volt, hanem a mi oldalunk
-	 * változott azóta. Pontosan ez történt Szlovákiában: a tárolt szintjeink elavultak
-	 * (nálunk 8=okres/9=obec, az OSM ma 6=okres/8=obec), és a szlovák minta 23%-ának
-	 * emiatt egyáltalán nincs határa. A #699 óta a lekérdezés a 4-es szintet is
-	 * behúzza, de a régen bélyegzett templomok ettől még nem próbálkoznak újra.
-	 *
-	 * Ezért a bélyeget levesszük róluk — a következő futás így elöl veszi őket.
-	 *
-	 * A 30 napos korlát SZÁNDÉKOS: enélkül azok a templomok, amiknek tényleg nincs
-	 * határuk (az OSM ott nem fed le semmit), minden futásban visszakerülnének a sor
-	 * elejére, és kiszorítanák a valóban ellenőrizendőket. Így legfeljebb havonta
-	 * egyszer próbálkozunk velük újra.
-	 *
-	 * @return int hány templomot állítottunk vissza a sorba
-	 */
-	public static function requeueChurchesWithoutBoundary(): int {
-		$hatarido = date('Y-m-d H:i:s', strtotime('-30 days'));
-
-		return DB::table('templomok')
-			->where('ok', 'i')
-			->whereNotNull('lat')->where('lat', '!=', 0)
-			->whereNotNull('lon')->where('lon', '!=', 0)
-			->whereNotNull('boundaries_checked_at')
-			->where('boundaries_checked_at', '<', $hatarido)
-			->whereNotExists(function ($q) {
-				$q->select(DB::raw(1))
-					->from('lookup_boundary_church')
-					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
-					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
-					->where('boundaries.boundary', 'administrative');
-			})
-			->update(['boundaries_checked_at' => null]);
-	}
-
-	/**
-	 * #496: hány aktív, koordinátával rendelkező templomnak nincs administratív
-	 * határa. A /health ezt írja ki, hogy a lefedettségi hiány LÁTSZÓDJON — eddig
-	 * csak abból derült volna ki, hogy egy település alatt nem jön ki a templom.
-	 */
-	public static function churchesWithoutBoundaryCount(): int {
-		return DB::table('templomok')
-			->where('ok', 'i')
-			->whereNotNull('lat')->where('lat', '!=', 0)
-			->whereNotNull('lon')->where('lon', '!=', 0)
-			->whereNotExists(function ($q) {
-				$q->select(DB::raw(1))
-					->from('lookup_boundary_church')
-					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
-					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
-					->where('boundaries.boundary', 'administrative');
-			})
-			->count();
-	}
-
-	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1496,22 +1496,16 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         return $this->adminBoundaryName([6])
             ?? $this->adminBoundaryName([9])
             ?? $this->adminBoundaryName([10])
-            ?? (string) $this->varos;
+            ?? '';
     }
 
     /** Megye. Romániában nincs 6-os szint, ott a 4-es (judet) hordozza. */
     public function locationCountyName(): string {
-        $boundary = $this->adminBoundaryName([6]) ?? $this->adminBoundaryName([4]);
-        if ($boundary !== null) {
-            return $boundary;
-        }
-
-        return (string) (DB::table('megye')->where('id', $this->megye)->value('megyenev') ?: '');
+        return $this->adminBoundaryName([6]) ?? $this->adminBoundaryName([4]) ?? '';
     }
 
     public function locationCountryName(): string {
-        return $this->adminBoundaryName([2])
-            ?? (string) (DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: '');
+        return $this->adminBoundaryName([2]) ?? '';
     }
 
     /**
@@ -1521,16 +1515,26 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * Elsődlegesen az ISO-kód, mert a `templomok.orszag = 12` a kivezetéssel eltűnik.
      */
     public function isInHungary(): bool {
-        $kod = $this->countryCode();
-        if ($kod !== null) {
-            return $kod === 'HU';
-        }
-
-        return (int) $this->orszag === self::MAGYARORSZAG_ID;
+        return $this->countryCode() === 'HU';
     }
 
-    /** A régi `orszagok` tábla magyar sorának azonosítója. */
-    public const MAGYARORSZAG_ID = 12;
+    /**
+     * #497: rendezés a település szerint, boundary-alapon.
+     *
+     * A katalógusok eddig `orderBy('varos')`-t használtak. Az oszlop megszűnt, a
+     * település viszont továbbra is rendezési szempont — korrelált alkérdéssel
+     * kérjük le. Nem olcsó, de ezek admin/katalógus oldalak, nem forgalmas útvonalak,
+     * és a lista használhatatlan lenne település szerinti csoportosítás nélkül.
+     */
+    public function scopeOrderByCity($query, string $irany = 'asc') {
+        return $query->orderByRaw(
+            "(SELECT b.name FROM lookup_boundary_church lbc"
+            . " JOIN boundaries b ON b.id = lbc.boundary_id"
+            . " WHERE lbc.church_id = templomok.id AND b.boundary = 'administrative'"
+            . " AND b.admin_level IN (8, 6, 9, 10)"
+            . " ORDER BY FIELD(b.admin_level, 8, 6, 9, 10) LIMIT 1) " . ($irany === 'desc' ? 'DESC' : 'ASC')
+        );
+    }
 
     /**
      * #498: lekérdezés-szintű szűrés a magyarországi templomokra.
@@ -1854,9 +1858,6 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         // Ha nincs átadva (pl. egyedi hívásból), akkor töltjük be helyben.
         $_egyhazmegyek     = $referenceData['egyhazmegyek']     ?? collect(DB::table('egyhazmegye')->get())->keyBy('id')->sortBy('sorrend');
         $_espereskeruletek = $referenceData['espereskeruletek'] ?? collect(DB::table('espereskerulet')->get())->keyBy('id');
-        $_orszagok         = $referenceData['orszagok']         ?? collect(DB::table('orszagok')->get())->keyBy('id');
-        $_megyek           = $referenceData['megyek']           ?? collect(DB::table('megye')->select('*','megyenev as nev')->get())->keyBy('id');
-        $_varosok          = isset($referenceData['varosok']) ? $referenceData['varosok'] : collect([]);
         
         /* egyházmegye */
         $tmp = $this->boundaries()
@@ -1886,44 +1887,19 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             }
         }
         
-        /* ország */
-        $tmp = $this->boundaries()
-                ->where('boundary','administrative')
-                ->where('admin_level',2)
-                ->get()->toArray();
-        if($tmp == array()) {
-            if(isset($_orszagok[$this->orszag]) && $_orszagok[$this->orszag]->nev) {
-                $boundary = \Eloquent\Boundary::firstOrNew(['boundary' => 'administrative', 'admin_level' => 2, 'name' => $_orszagok[$this->orszag]->nev]);
-                $boundary->save();
-                $this->boundaries()->attach($boundary->id);
-            }
-        }
-        
-        /* megye */
-        $tmp = $this->boundaries()
-                ->where('boundary','administrative')
-                ->where('admin_level',6)
-                ->get()->toArray();
-        if($tmp == array()) {
-            if(isset($_megyek[$this->megye]) && $_megyek[$this->megye]->nev) {
-                $boundary = \Eloquent\Boundary::firstOrNew(['boundary' => 'administrative', 'admin_level' => 6, 'name' => $_megyek[$this->megye]->nev." megye"]);
-                $boundary->save();
-                $this->boundaries()->attach($boundary->id);
-            }
-        }
-
-        /* város */
-        $tmp = $this->boundaries()
-                ->where('boundary','administrative')
-                ->where('admin_level',8)
-                ->get()->toArray();
-        if($tmp == array()) {
-            if(!empty($this->varos)) {
-                $boundary = \Eloquent\Boundary::firstOrNew(['boundary' => 'administrative', 'admin_level' => 8, 'name' => $this->varos]);
-                $boundary->save();
-                $this->boundaries()->attach($boundary->id);
-            }
-        }
+        /*
+         * #496 / #497 / #498: itt épült ország-, megye- és város-boundary a régi
+         * `templomok.orszag`, `.megye` és `.varos` oszlopokból, ha az OSM nem adott
+         * ilyet. Az oszlopok megszűntek, tehát nincs miből.
+         *
+         * A már legyártott boundary-sorok a helyükön maradnak — csak új nem készül
+         * belőlük. A földrajzi határok innentől kizárólag az OSM-ből jönnek
+         * (OSM::checkBoundaries), a hiányzó lefedettséget pedig a /health mutatja és
+         * a cron 497 próbálja újra.
+         *
+         * Az egyházmegye és az esperesi kerület MARAD: azok nem OSM-adatok, és nem is
+         * ez a három jegy tárgya.
+         */
 
     }
 

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -885,7 +885,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                     $miseLangs = \Eloquent\CalMass::splitLanguages(
                         is_array($mise->lang) ? implode(',', $mise->lang) : $mise->lang
                     );
-                    if( $this->orszag != 12 or $miseLangs != ['hu'] ) {
+                    if( !$this->isInHungary() or $miseLangs != ['hu'] ) {
                         $translated = array_map(function($l) { return t('LANGUAGES.'.$l); }, $miseLangs);
                         if ($translated) {
                             $info .= ' ' . implode('-', $translated)." nyelven";
@@ -923,8 +923,8 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                 'nev' => !empty($this->names) ? $this->names[0] : '',
                 'frissitve' => $this->frissitesFormatted(),
                 'ismertnev' => !empty($this->alternative_names) ? $this->alternative_names[0] : '',
-                'orszag' => ( DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: "" ),
-                'varos' => $this->varos,
+                'orszag' => $this->locationCountryName(),
+                'varos' => $this->locationCityName(),
                 'misek' => $misek,
                 'adoraciok' => $adorations,
                 'gyontatas' => $this->confessions ? $this->confessions['status'] : false,
@@ -947,10 +947,10 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             'ismertnev' => !empty($this->alternative_names) ? $this->alternative_names[0] : '',
             'alternative_names' => $this->alternative_names,
             'frissitve' => $this->frissitesFormatted(),            
-            'orszag' => ( DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: "" ),
+            'orszag' => $this->locationCountryName(),
             'egyhazmegye' => ( DB::table('egyhazmegye')->where('id', $this->egyhazmegye)->value('nev') ?: "" ),
-            'megye' => ( DB::table('megye')->where('id', $this->megye)->value('megyenev') ?: "" ),
-            'varos' => $this->varos,
+            'megye' => $this->locationCountyName(),
+            'varos' => $this->locationCityName(),
             'cim' => $this->cim,
             'megkozelites' => '',
             'plebania' => str_replace('<br>', "\n", strip_tags($this->plebania, '<br>')),
@@ -1340,7 +1340,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         if (!empty($this->alternative_names)) {
             $return .= ' (' . $this->alternative_names[0] . ')';
         } else {
-            $return .= ' (' . $this->varos . ')';
+            $return .= ' (' . $this->locationCityName() . ')';
         }
         return $return;
     }
@@ -1435,6 +1435,124 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             $boundaries,
             fn($boundary) => (int) ($boundary['admin_level'] ?? 0) !== 4
         ));
+    }
+
+    /**
+     * #496 / #497 / #498: a templom helynevei az OSM-határokból, a régi oszlopokra
+     * való visszaeséssel.
+     *
+     * A három jegy a `templomok.varos`, `.megye` és `templomok.orszag` kivezetéséről
+     * szól. Ahhoz, hogy az oszlopok eldobhatók legyenek, előbb minden fogyasztónak
+     * ezeken a metódusokon kell keresztülmennie — utána a kivezetés annyi, hogy a
+     * visszaesési ág kiesik innen, és nem kell 23 fájlt átírni.
+     *
+     * A visszaesés SZÁNDÉKOSAN bent van most: a szlovák állomány 23%-ának egyáltalán
+     * nincs boundary-ja (szinkronhiány), és 47 templomnak nincs koordinátája sem.
+     * Amíg ez így van, a régi oszlop a jobb válasz, mint az üres string.
+     *
+     * A besorolás szint szerint megy, nem pozíció szerint: a location() a rendezett
+     * lista 0./1./2. elemét címkézi, ami hiányos határláncnál elcsúszik.
+     */
+    private function adminBoundaryName(array $szintek): ?string {
+        $talalat = $this->boundaries()
+                ->where('boundary', 'administrative')
+                ->whereIn('admin_level', $szintek)
+                ->orderBy('admin_level', 'desc')
+                ->first();
+
+        $nev = trim((string) ($talalat->name ?? ''));
+
+        return $nev !== '' ? $nev : null;
+    }
+
+    /**
+     * Település. Ha van kerület is, azzal együtt — így a nagyvárosi templomoknál nem
+     * vész el a pontosság.
+     *
+     * Ez SZÁNDÉKOSAN a régi oszlop alakját reprodukálja, mert az API-ban és a
+     * felületen ez látszik. Két országfüggő eset van, mindkettőt valódi adaton mértem:
+     *
+     *   Budapest, Szent Imre-templom      8=Budapest  9=XI. kerület  10=Szentimreváros
+     *       -> "Budapest XI. kerület", ami bitre a régi `templomok.varos`.
+     *       A puszta legspecifikusabb elem "Szentimreváros" lenne: pontosabb ugyan,
+     *       de a látogató szempontjából visszalépés ahhoz képest, amit ma lát.
+     *
+     *   Köln, St. Aposteln                6=Köln      9=Innenstadt   10=Altstadt-Nord
+     *       Köln kreisfreie Stadt, tehát NINCS 8-as szintje. Ha vakon a 9-esre esnénk
+     *       vissza, "Innenstadt" jönne ki "Köln" helyett.
+     *
+     * Ezért a kerületet CSAK akkor fűzzük hozzá, ha a település a 8-as szintről jött.
+     * Ha a településnek a 6-osra kellett visszaesni, a 9-es már másfajta felosztás,
+     * és a régi adat sem tartalmazta.
+     */
+    public function locationCityName(): string {
+        $telepules = $this->adminBoundaryName([8]);
+        if ($telepules !== null) {
+            $kerulet = $this->adminBoundaryName([9]);
+            return $kerulet !== null ? $telepules . ' ' . $kerulet : $telepules;
+        }
+
+        // Nincs 8-as szint (pl. német kreisfreie Stadt): a 6-os maga a település.
+        return $this->adminBoundaryName([6])
+            ?? $this->adminBoundaryName([9])
+            ?? $this->adminBoundaryName([10])
+            ?? (string) $this->varos;
+    }
+
+    /** Megye. Romániában nincs 6-os szint, ott a 4-es (judet) hordozza. */
+    public function locationCountyName(): string {
+        $boundary = $this->adminBoundaryName([6]) ?? $this->adminBoundaryName([4]);
+        if ($boundary !== null) {
+            return $boundary;
+        }
+
+        return (string) (DB::table('megye')->where('id', $this->megye)->value('megyenev') ?: '');
+    }
+
+    public function locationCountryName(): string {
+        return $this->adminBoundaryName([2])
+            ?? (string) (DB::table('orszagok')->where('id', $this->orszag)->value('nev') ?: '');
+    }
+
+    /**
+     * Magyarországi templom-e. A naptár ez alapján dönti el, kell-e nyelvi zászló a
+     * magyar mise mellé, a statisztika pedig ez alapján szűkít.
+     *
+     * Elsődlegesen az ISO-kód, mert a `templomok.orszag = 12` a kivezetéssel eltűnik.
+     */
+    public function isInHungary(): bool {
+        $kod = $this->countryCode();
+        if ($kod !== null) {
+            return $kod === 'HU';
+        }
+
+        return (int) $this->orszag === self::MAGYARORSZAG_ID;
+    }
+
+    /** A régi `orszagok` tábla magyar sorának azonosítója. */
+    public const MAGYARORSZAG_ID = 12;
+
+    /**
+     * #498: lekérdezés-szintű szűrés a magyarországi templomokra.
+     *
+     * A statisztika eddig `where('orszag', 12)`-vel szűkített — pont az az oszlop,
+     * amit ki akarunk vezetni. A boundary-alapú megfelelője az országhatáron megy.
+     *
+     * NÉVRE és ISO-kódra IS illesztünk. Az ISO a helyes hosszú távon, de ma 7964
+     * határból egyetlenegynél van kitöltve (a szinkronnak újra kell futnia), addig
+     * a puszta ISO-szűrés üres statisztikát adna.
+     */
+    public function scopeInHungary($query) {
+        return $query->whereIn('templomok.id', function ($sub) {
+            $sub->select('lookup_boundary_church.church_id')
+                ->from('lookup_boundary_church')
+                ->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+                ->where('boundaries.admin_level', 2)
+                ->where(function ($w) {
+                    $w->where('boundaries.iso3166_1', 'HU')
+                      ->orWhere('boundaries.name', 'Magyarország');
+                });
+        });
     }
 
     /**

--- a/webapp/classes/eloquent/churchupdatetoken.php
+++ b/webapp/classes/eloquent/churchupdatetoken.php
@@ -42,7 +42,13 @@ class ChurchUpdateToken extends Model {
             Church::whereIn('id', $churchIds)->update(['frissites' => $today]);
             self::where('email_batch_id', $record->email_batch_id)->update(['used_at' => $now]);
 
-            $churches = Church::whereIn('id', $churchIds)->get(['id', 'nev', 'ismertnev', 'varos'])->toArray();
+            // #497: a település a boundary-ból jön, nem oszlopból — ezért utólag tesszük rá.
+            $churches = Church::whereIn('id', $churchIds)->get(['id', 'nev', 'ismertnev'])
+                ->map(function ($templom) {
+                    $tomb = $templom->toArray();
+                    $tomb['varos'] = $templom->locationCityName();
+                    return $tomb;
+                })->toArray();
 
             return ['success' => true, 'church_id' => $churchIds->first(), 'churches' => $churches];
         } else {

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -74,8 +74,14 @@ class Edit extends \Html\Html {
             return; // Nincs church form, nincs mit menteni
         }
 
-        $allowedFields = ['adminmegj', 'nev',
-            'orszag', 'megye', 'varos', 'cim',
+        /*
+         * #496 / #497 / #498: az `orszag`, `megye` és `varos` KIKERÜLT a menthető
+         * mezők közül. A helyet a koordináta és az OSM-határok adják; a szerkesztő
+         * kaszkádos ország/megye/város választója ezért megszűnt, és ha itt bent
+         * maradnának, egy beküldött űrlap felülírhatná a származtatott adatot azzal,
+         * ami a böngészőben ragadt.
+         */
+        $allowedFields = ['adminmegj', 'nev', 'cim',
             'egyhazmegye', 'espereskerulet', 'plebania', 'pleb_eml',
             'megjegyzes', 'miseaktiv', 'misemegj', 'leiras', 'ok', 'frissites',
             'lat','lon'];
@@ -273,85 +279,19 @@ class Edit extends \Html\Html {
     
     function addFormAdministrative() {
         $options = [0 => 'Válassz/Nem tudom'];
-        $countries = \Illuminate\Database\Capsule\Manager::table('orszagok')
-                        ->select('id', 'nev')
-                        ->orderBy('nev')->get();
-        foreach ($countries as $selectibleCountry) {
-            $options[$selectibleCountry->id] = $selectibleCountry->nev;
-        }
-        $this->form['country'] = array(
-            'type' => 'select',
-            'name' => 'church[orszag]',
-            'id' => 'selectOrszag',
-            'options' => $options,
-            'selected' => $this->church->orszag
-        );
+        /*
+         * #496 / #497 / #498: itt épült a kaszkádos ország -> megye -> város választó
+         * az `orszagok`, `megye` és `varosok` táblákból (75 sor, három egymásba ágyazott
+         * ciklussal, ami országonként és megyénként külön <select>-et gyártott, majd
+         * CSS-sel rejtette el a nem aktuálisakat).
+         *
+         * A hely mostantól a koordinátából és az OSM-határokból jön, tehát nincs mit
+         * választani: a `church/edit.twig` a származtatott elhelyezkedést írja ki.
+         * A választó amúgy is csak azoknál a templomoknál jelent meg, amiknek nem volt
+         * `varos` értékük (`{% if not church.varos %}`), tehát a szerkesztők többsége
+         * sosem találkozott vele.
+         */
 
-        foreach ($countries as $selectibleCountry) {
-            $options = [0 => 'Válassz/Nem tudom'];
-            $counties = \Illuminate\Database\Capsule\Manager::table('megye')
-                            ->select('id', 'megyenev', 'orszag')
-                            ->where('orszag', $selectibleCountry->id)
-                            ->orderBy('megyenev')->get();
-
-            foreach ($counties as $selectibleCounty) {
-                $options[$selectibleCounty->id] = $selectibleCounty->megyenev . " megye";
-                $allCounties[] = $selectibleCounty;
-            }
-
-            $this->form['counties'][$selectibleCountry->id] = array(
-                'type' => 'select',
-                'name' => 'church[megye]',
-                'id' => 'selectMegyeCountry' . $selectibleCountry->id,
-                'class' => 'selectMegyeCountry',
-                'data' => $selectibleCountry->id,
-                'options' => $options,
-                'selected' => $this->church->megye
-            );
-            if ($selectibleCountry->id == $this->church->orszag) {
-                $this->form['counties'][$selectibleCountry->id]['style'] = 'display: inline';
-            } else {
-                $this->form['counties'][$selectibleCountry->id]['style'] = 'display: none';
-                $this->form['counties'][$selectibleCountry->id]['disabled'] = 'disabled';
-            }
-
-            if (count($counties) < 1) {
-                $extra = new \stdClass();
-                $extra->id = 0;
-                $extra->megyenev = '(Nincs megadva)';
-                $extra->orszag = $selectibleCountry->id;
-                $allCounties[] = $extra;
-            }
-        }
-
-        foreach ($allCounties as $selectibleCounty) {
-            $options = [0 => 'Válassz/Nem tudom'];
-            $cities = \Illuminate\Database\Capsule\Manager::table('varosok')
-                            ->select('id', 'nev')
-                            ->where('orszag', $selectibleCounty->orszag)
-                            ->where('megye_id', $selectibleCounty->id)
-                            ->orderBy('nev')->get();
-            foreach ($cities as $selectibleCity) {
-                $options[$selectibleCity->nev] = $selectibleCity->nev;
-            }
-            $this->form['cities'][$selectibleCounty->orszag . "-" . $selectibleCounty->id] = array(
-                'type' => 'select',
-                'name' => 'church[varos]',
-                'id' => 'selectVarosCounty' . $selectibleCounty->orszag . "-" . $selectibleCounty->id,
-                'class' => 'selectVarosCounty',
-                'options' => $options,
-                'selected' => $this->church->varos
-            );
-            if ($selectibleCounty->id == $this->church->megye AND $this->church->orszag == $selectibleCounty->orszag) {
-                $this->form['cities'][$selectibleCounty->orszag . "-" . $selectibleCounty->id]['style'] = 'display: inline';
-            } else {
-                $this->form['cities'][$selectibleCounty->orszag . "-" . $selectibleCounty->id]['style'] = 'display: none';
-                $this->form['cities'][$selectibleCounty->orszag . "-" . $selectibleCounty->id]['disabled'] = 'disabled';
-            }
-        }
-    }
-
-    function addFormReligiousAdministration() {
         $selected = ['diocese' => $this->church->egyhazmegye, 'deanery' => $this->church->espereskerulet];
         $selectReligiousAdministration = \Form::religiousAdministrationSelection($selected);
         $this->form['dioceses'] = $selectReligiousAdministration['dioceses'];

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -414,14 +414,14 @@ class Edit extends \Html\Html {
                 ->get();
 
             foreach ($nearbyChurches as $nearby) {
-                $options[$nearby->id] = $nearby->varos . ' – ' . $nearby->names[0] . ' (~' . round($nearby->distance_km, 1) . ' km)';
+                $options[$nearby->id] = $nearby->locationCityName() . ' – ' . $nearby->names[0] . ' (~' . round($nearby->distance_km, 1) . ' km)';
             }
 
             // Ha van meglévő parent kapcsolat de nincs a common listában, hozzáadunk
             if ($currentParentId && !isset($options[$currentParentId])) {
                 $parentChurch = \Eloquent\Church::find($currentParentId);
                 if ($parentChurch) {
-                    $options[$currentParentId] = '⭐ ' . $parentChurch->varos . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
+                    $options[$currentParentId] = '⭐ ' . $parentChurch->locationCityName() . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
                 }
             }
         } else {
@@ -429,7 +429,7 @@ class Edit extends \Html\Html {
             if ($currentParentId) {
                 $parentChurch = \Eloquent\Church::find($currentParentId);
                 if ($parentChurch) {
-                    $options[$currentParentId] = '⭐ ' . $parentChurch->varos . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
+                    $options[$currentParentId] = '⭐ ' . $parentChurch->locationCityName() . ' – ' . $parentChurch->names[0] . ' (kiválasztott)';
                 }
             }
         }
@@ -444,7 +444,7 @@ class Edit extends \Html\Html {
             ->get(['id', 'varos', 'nev']);
         foreach ($allActive as $c) {
             if (!isset($options[$c->id])) {
-                $options[$c->id] = $c->varos . ' – ' . $c->nev;
+                $options[$c->id] = $c->locationCityName() . ' – ' . $c->nev;
             }
         }
 

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -380,8 +380,8 @@ class Edit extends \Html\Html {
         // Így JS nélkül is elérhető minden templom (a combobox csak a gépelést adja rá).
         $allActive = \Eloquent\Church::where('ok', 'i')
             ->where('id', '!=', $this->tid)
-            ->orderBy('varos')->orderBy('nev')
-            ->get(['id', 'varos', 'nev']);
+            ->orderByCity()->orderBy('nev')
+            ->get(['id', 'nev']);
         foreach ($allActive as $c) {
             if (!isset($options[$c->id])) {
                 $options[$c->id] = $c->locationCityName() . ' – ' . $c->nev;

--- a/webapp/classes/html/church/ical.php
+++ b/webapp/classes/html/church/ical.php
@@ -174,7 +174,11 @@ class Ical extends \Html\Html {
 
         $nev = is_array($church) ? ($church['nev'] ?? '') : ($church->nev ?? '');
         $ismertnev = is_array($church) ? ($church['ismertnev'] ?? '') : ($church->ismertnev ?? '');
-        $varos = is_array($church) ? ($church['varos'] ?? '') : ($church->varos ?? '');
+        // #497: tömb esetén a toAPIArray már származtatott értéket ad; objektumnál
+        // magunknak kell a boundary-ból kérni.
+        $varos = is_array($church)
+            ? ($church['varos'] ?? '')
+            : ($church instanceof \Eloquent\Church ? $church->locationCityName() : ($church->varos ?? ''));
         $calName = $nev;
         if ($ismertnev) $calName .= $calName ? ' (' . $ismertnev . ')' : $ismertnev;
         if ($varos) $calName .= $calName ? ' - ' . $varos : $varos;

--- a/webapp/classes/html/diocesecatalogue.php
+++ b/webapp/classes/html/diocesecatalogue.php
@@ -48,7 +48,7 @@ class DioceseCatalogue extends Html {
           
             $this->churchesGroupByEspker = \Eloquent\Church::where('ok','i')
                     ->where('egyhazmegye',$ehm)
-                    ->orderBy('varos')->orderBy('nev')
+                    ->orderByCity()->orderBy('nev')
                     ->get()->groupBy('espereskerulet');
             }
             

--- a/webapp/classes/html/home.php
+++ b/webapp/classes/html/home.php
@@ -39,7 +39,7 @@ class Home extends Html {
         $churchIds = \Request::IntegerArray('church_ids') ?: [];
         if (!empty($churchIds)) {
             $this->churchDataJson = json_encode(
-                \Eloquent\Church::select('id', 'nev', 'varos')
+                \Eloquent\Church::select('id', 'nev')
                     ->whereIn('id', $churchIds)
                     ->get()
                     // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.

--- a/webapp/classes/html/home.php
+++ b/webapp/classes/html/home.php
@@ -42,7 +42,8 @@ class Home extends Html {
                 \Eloquent\Church::select('id', 'nev', 'varos')
                     ->whereIn('id', $churchIds)
                     ->get()
-                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->varos])
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->locationCityName()])
             );
         }
          

--- a/webapp/classes/html/josm.php
+++ b/webapp/classes/html/josm.php
@@ -83,13 +83,13 @@ class Josm extends Html {
                     $query->whereNull('osmtype')
                         ->orWhereNull('osmid');
                 })
-                ->orderBy('orszag')->orderBy('megye')->orderBy('varos')->orderBy('nev')
+                ->orderByCity()->orderBy('nev')
                 ->get();
         
         $this->churchesWBadOsm = \Eloquent\Church::where('ok','i')
                 ->whereNotIn('id',$goodIDs)
                 ->whereNotNull('osmtype')->whereNotNull('osmid')
-                ->orderBy('orszag')->orderBy('megye')->orderBy('varos')->orderBy('nev')
+                ->orderByCity()->orderBy('nev')
                 ->get();
         
         $this->churchesWBad = \Eloquent\Church::where('ok','i')

--- a/webapp/classes/html/searchresultschurches.php
+++ b/webapp/classes/html/searchresultschurches.php
@@ -115,7 +115,7 @@ class SearchResultsChurches extends Html {
         if (!empty($params['church_ids'])) {
             $search->churchIds($params['church_ids']);
             $this->churchDataJson = json_encode(
-                \Eloquent\Church::select('id', 'nev', 'varos')
+                \Eloquent\Church::select('id', 'nev')
                     ->whereIn('id', $params['church_ids'])
                     ->get()
                     // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.

--- a/webapp/classes/html/searchresultschurches.php
+++ b/webapp/classes/html/searchresultschurches.php
@@ -118,7 +118,8 @@ class SearchResultsChurches extends Html {
                 \Eloquent\Church::select('id', 'nev', 'varos')
                     ->whereIn('id', $params['church_ids'])
                     ->get()
-                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->varos])
+                    // #497: a település a boundary-ból, visszaeséssel a régi oszlopra.
+                    ->map(fn($c) => ['id' => $c->id, 'name' => $c->nev, 'city' => $c->locationCityName()])
             );
         }
         

--- a/webapp/classes/html/stat.php
+++ b/webapp/classes/html/stat.php
@@ -185,7 +185,20 @@ class Stat extends Html {
 		$stat = DB::table('templomok')
 			->selectRaw("DATEDIFF(NOW(), frissites) DIV 365 as yearago")
 			->selectRAW("count(*) as count");		
-		$stat->where('orszag',12)->where('ok','i')->where('miseaktiv',1);
+		// #498: eddig `where('orszag', 12)` állt itt — pont az az oszlop, amit kivezetünk.
+		// A boundary-alapú megfelelője az országhatáron megy. Névre ÉS ISO-kódra is
+		// illesztünk: az ISO a helyes hosszú távon, de amíg a szinkron nem futott újra,
+		// a puszta ISO-szűrés üres statisztikát adna.
+		$stat->whereIn('templomok.id', function ($sub) {
+				$sub->select('lookup_boundary_church.church_id')
+					->from('lookup_boundary_church')
+					->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+					->where('boundaries.admin_level', 2)
+					->where(function ($w) {
+						$w->where('boundaries.iso3166_1', 'HU')
+						  ->orWhere('boundaries.name', 'Magyarország');
+					});
+			})->where('ok','i')->where('miseaktiv',1);
 		foreach(['%isézőhely%','%ápolna','%özösségi%', '%imaház%', '%imaterem%'] as $notlike)
 			$stat->where('nev','not like', $notlike);
 		$stat->orderBy('frissites','DESC');

--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -31,8 +31,6 @@ class OSM {
         $referenceData = [
             'egyhazmegyek'     => collect(DB::table('egyhazmegye')->get())->keyBy('id'),
             'espereskeruletek' => collect(DB::table('espereskerulet')->get())->keyBy('id'),
-            'orszagok'         => collect(DB::table('orszagok')->get())->keyBy('id'),
-            'megyek'           => collect(DB::table('megye')->select('*', 'megyenev as nev')->get())->keyBy('id'),
         ];
 
         foreach ($churches as $church) {

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -869,7 +869,15 @@ class User {
 	
 
 			$users2notify = DB::table('templomok')
-				->select('templomok.id as tid','templomok.nev','templomok.ismertnev','templomok.varos','templomok.frissites')
+				// #497: a `varos` alias a levélsablonnak kell. Tömeges lekérdezés, ezért
+				// nem templomonként kérdezünk, hanem korrelált alkérdéssel — a boundary
+				// neve, visszaeséssel a régi oszlopra, amíg az létezik.
+				->select('templomok.id as tid','templomok.nev','templomok.ismertnev','templomok.frissites')
+				->selectRaw("COALESCE((SELECT b.name FROM lookup_boundary_church lbc"
+					. " JOIN boundaries b ON b.id = lbc.boundary_id"
+					. " WHERE lbc.church_id = templomok.id AND b.boundary = 'administrative'"
+					. " AND b.admin_level IN (8,9,10) ORDER BY b.admin_level DESC LIMIT 1),"
+					. " templomok.varos) AS varos")
 				->join('church_holders','templomok.id','=','church_holders.church_id')
 				->addSelect('church_holders.description')
 				->join('user','user.uid','=','church_holders.user_id')

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -1,3266 +1,3116 @@
 {
-    "tables": {
-        "attributes": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "bigint(20)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "key": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "value": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "fromOSM": {
-                    "type": "tinyint(1)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "church_id": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "key_church": {
-                    "unique": false,
-                    "columns": [
-                        "key",
-                        "church_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+  "tables": {
+    "attributes": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "bigint(20)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
         },
-        "boundaries": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(10)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "boundary": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "admin_level": {
-                    "type": "int(2)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "name": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "alt_name": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "denomination": {
-                    "type": "varchar(50)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "iso3166_1": {
-                    "type": "varchar(2)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "osmtype": {
-                    "type": "varchar(9)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "osmid": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "index1": {
-                    "unique": false,
-                    "columns": [
-                        "boundary",
-                        "admin_level"
-                    ]
-                },
-                "index2": {
-                    "unique": false,
-                    "columns": [
-                        "osmtype",
-                        "osmid"
-                    ]
-                },
-                "index3": {
-                    "unique": false,
-                    "columns": [
-                        "iso3166_1"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "cal_generated_periods": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "period_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "name": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "weight": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "start_date": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "end_date": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": "curdate()",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": "curdate()",
-                    "extra": ""
-                },
-                "color": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "period_id": {
-                    "unique": false,
-                    "columns": [
-                        "period_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "key": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "cal_masses": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "period_id": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "title": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "types": {
-                    "type": "text",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "rite": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "start_date": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "duration": {
-                    "type": "longtext",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "rrule": {
-                    "type": "longtext",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "experiod": {
-                    "type": "longtext",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "manual_experiod": {
-                    "type": "longtext",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "exdate": {
-                    "type": "longtext",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "lang": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "comment": {
-                    "type": "text",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": "curdate()",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": "curdate()",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "church_id": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "period_id": {
-                    "unique": false,
-                    "columns": [
-                        "period_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "value": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "cal_periods": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "name": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "weight": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "start_month_day": {
-                    "type": "varchar(5)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "end_month_day": {
-                    "type": "varchar(5)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "start_period_id": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "end_period_id": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "all_inclusive": {
-                    "type": "tinyint(1)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "multi_day": {
-                    "type": "tinyint(1)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": "curdate()",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": "curdate()",
-                    "extra": ""
-                },
-                "special_type": {
-                    "type": "enum('christmas','easter')",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "selectable": {
-                    "type": "tinyint(1)",
-                    "nullable": true,
-                    "default": "1",
-                    "extra": ""
-                },
-                "color": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "end_period_id": {
-                    "unique": false,
-                    "columns": [
-                        "end_period_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "start_period_id": {
-                    "unique": false,
-                    "columns": [
-                        "start_period_id"
-                    ]
-                }
-            }
+        "fromOSM": {
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "church_id": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
         },
-        "cal_period_years": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "period_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "start_year": {
-                    "type": "int(4)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "start_date": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "end_date": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": "curdate()",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": "curdate()",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "period_id": {
-                    "unique": false,
-                    "columns": [
-                        "period_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "key_church": {
+          "unique": false,
+          "columns": [
+            "key",
+            "church_id"
+          ]
         },
-        "cal_suggestions": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "bigint(20) unsigned",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "package_id": {
-                    "type": "bigint(20) unsigned",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "period_id": {
-                    "type": "bigint(20) unsigned",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "mass_id": {
-                    "type": "bigint(20) unsigned",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "mass_state": {
-                    "type": "enum('new','deleted','modified')",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "changes": {
-                    "type": "longtext",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "package_id": {
-                    "unique": false,
-                    "columns": [
-                        "package_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "boundaries": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(10)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
         },
-        "cal_suggestion_packages": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "bigint(20) unsigned",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "bigint(20) unsigned",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "sender_name": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "sender_email": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "sender_user_id": {
-                    "type": "bigint(20) unsigned",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "sender_message": {
-                    "type": "text",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "state": {
-                    "type": "enum('accepted','rejected','pending')",
-                    "nullable": true,
-                    "default": "PENDING",
-                    "extra": ""
-                },
-                "handled_by_user_id": {
-                    "type": "bigint(20) unsigned",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "handled_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "church_id": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "boundary": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "chat": {
-            "engine": "MyISAM",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "datum": {
-                    "type": "datetime",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "user": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "kinek": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "szoveg": {
-                    "type": "tinytext",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "admin_level": {
+          "type": "int(2)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "church_holders": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(10)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "user_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "church_id": {
-                    "type": "int(10)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "description": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "status": {
-                    "type": "enum('asked','allowed','denied','revoked')",
-                    "nullable": false,
-                    "default": "asked",
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "deleted_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "name": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "church_links": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(10)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "int(10)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "href": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "title": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "deleted_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "alt_name": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "church_relationships": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "parent_church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "child_church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": "on update current_timestamp()"
-                }
-            },
-            "indexes": {
-                "child_idx": {
-                    "unique": false,
-                    "columns": [
-                        "child_church_id"
-                    ]
-                },
-                "parent_idx": {
-                    "unique": false,
-                    "columns": [
-                        "parent_church_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "unique_pair": {
-                    "unique": true,
-                    "columns": [
-                        "parent_church_id",
-                        "child_church_id"
-                    ]
-                }
-            }
+        "denomination": {
+          "type": "varchar(50)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "church_update_tokens": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "token": {
-                    "type": "varchar(64)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "uid": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "email_batch_id": {
-                    "type": "varchar(64)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "expires_at": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "used_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": "current_timestamp",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "token"
-                    ]
-                }
-            }
+        "iso3166_1": {
+          "type": "varchar(2)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "confessions": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "deduplicationId": {
-                    "type": "char(36)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "local_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "timestamp": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": "on update current_timestamp()"
-                },
-                "fulldata": {
-                    "type": "longtext",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "status": {
-                    "type": "enum('on','off')",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "deduplicationId": {
-                    "unique": true,
-                    "columns": [
-                        "deduplicationId"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "osmtype": {
+          "type": "varchar(9)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "crons": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "class": {
-                    "type": "varchar(45)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "function": {
-                    "type": "varchar(45)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "frequency": {
-                    "type": "varchar(45)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "from": {
-                    "type": "varchar(45)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "until": {
-                    "type": "varchar(45)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "deadline_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "attempts": {
-                    "type": "int(2)",
-                    "nullable": true,
-                    "default": "0",
-                    "extra": ""
-                },
-                "lastsuccess_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_At": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "osmid": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "distances": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "fromLat": {
-                    "type": "decimal(11,7)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "fromLon": {
-                    "type": "decimal(11,7)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "toLat": {
-                    "type": "decimal(11,7)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "toLon": {
-                    "type": "decimal(11,7)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "distance": {
-                    "type": "float",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "toupdate": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "Coord": {
-                    "unique": true,
-                    "columns": [
-                        "fromLat",
-                        "fromLon",
-                        "toLat",
-                        "toLon"
-                    ]
-                },
-                "From": {
-                    "unique": false,
-                    "columns": [
-                        "fromLat",
-                        "fromLon"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "created_at": {
+          "type": "date",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "egyhazmegye": {
-            "engine": "MyISAM",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "nev": {
-                    "type": "varchar(250)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "sorrend": {
-                    "type": "int(3)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "ok": {
-                    "type": "enum('i','n')",
-                    "nullable": false,
-                    "default": "i",
-                    "extra": ""
-                },
-                "felelos": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "email": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "csakez": {
-                    "type": "enum('i','n')",
-                    "nullable": false,
-                    "default": "i",
-                    "extra": ""
-                },
-                "osm_relation": {
-                    "type": "int(45)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "id": {
-                    "unique": false,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "updated_at": {
+          "type": "date",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "index1": {
+          "unique": false,
+          "columns": [
+            "boundary",
+            "admin_level"
+          ]
         },
-        "emails": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "type": {
-                    "type": "varchar(30)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "to": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "header": {
-                    "type": "text",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "subject": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "body": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "status": {
-                    "type": "varchar(45)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "index2": {
+          "unique": false,
+          "columns": [
+            "osmtype",
+            "osmid"
+          ]
         },
-        "espereskerulet": {
-            "engine": "MyISAM",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(3)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "ehm": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "nev": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "index3": {
+          "unique": false,
+          "columns": [
+            "iso3166_1"
+          ]
         },
-        "events": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "name": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "year": {
-                    "type": "varchar(4)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "date": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "id_UNIQUE": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "name+year": {
-                    "unique": true,
-                    "columns": [
-                        "name",
-                        "year"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "cal_generated_periods": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
         },
-        "external_calendars": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "name": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "url": {
-                    "type": "varchar(2048)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "active": {
-                    "type": "tinyint(1)",
-                    "nullable": true,
-                    "default": "1",
-                    "extra": ""
-                },
-                "last_import_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": "on update current_timestamp()"
-                }
-            },
-            "indexes": {
-                "fk_external_calendars_church_id": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "unique_church_external": {
-                    "unique": true,
-                    "columns": [
-                        "church_id",
-                        "name"
-                    ]
-                }
-            }
+        "period_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "favorites": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(10) unsigned",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "uid": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "tid": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "uid_tid_UNIQUE": {
-                    "unique": true,
-                    "columns": [
-                        "uid",
-                        "tid"
-                    ]
-                }
-            }
+        "name": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "keyword_shortcuts": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "osmtag_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "type": {
-                    "type": "varchar(30)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "value": {
-                    "type": "varchar(200)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "church_type_value": {
-                    "unique": false,
-                    "columns": [
-                        "church_id",
-                        "type",
-                        "value"
-                    ]
-                },
-                "FK_keyword_shortchuts_church_idx": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "FK_keyword_shortchuts_osmtag_idx": {
-                    "unique": false,
-                    "columns": [
-                        "osmtag_id"
-                    ]
-                },
-                "index_value": {
-                    "unique": false,
-                    "columns": [
-                        "value"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "type_value": {
-                    "unique": false,
-                    "columns": [
-                        "type",
-                        "value"
-                    ]
-                }
-            }
+        "weight": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "lookup_boundary_church": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "boundary_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "FK_boundary_id_idx": {
-                    "unique": false,
-                    "columns": [
-                        "boundary_id"
-                    ]
-                },
-                "FK_church_id_idx": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "unique": {
-                    "unique": true,
-                    "columns": [
-                        "church_id",
-                        "boundary_id"
-                    ]
-                }
-            }
+        "start_date": {
+          "type": "date",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "lookup_church_osm": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "osm_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "FK_church_id_idx": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "FK_osm_id_idx": {
-                    "unique": false,
-                    "columns": [
-                        "osm_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "unique": {
-                    "unique": true,
-                    "columns": [
-                        "church_id",
-                        "osm_id"
-                    ]
-                }
-            }
+        "end_date": {
+          "type": "date",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "lookup_osm_enclosed": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "osm_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "enclosing_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "varchar(45)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "FK_osm_enclosing_id_idx": {
-                    "unique": false,
-                    "columns": [
-                        "enclosing_id"
-                    ]
-                },
-                "FK_osm_id_idx": {
-                    "unique": false,
-                    "columns": [
-                        "osm_id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "unique": {
-                    "unique": true,
-                    "columns": [
-                        "enclosing_id",
-                        "osm_id"
-                    ]
-                }
-            }
+        "created_at": {
+          "type": "date",
+          "nullable": false,
+          "default": "curdate()",
+          "extra": ""
         },
-        "megye": {
-            "engine": "MyISAM",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "megyenev": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "orszag": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "12",
-                    "extra": ""
-                },
-                "egyeb": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "updated_at": {
+          "type": "date",
+          "nullable": true,
+          "default": "curdate()",
+          "extra": ""
         },
-        "messages": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "sid": {
-                    "type": "varchar(45)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "timestamp": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "severity": {
-                    "type": "varchar(10)",
-                    "nullable": true,
-                    "default": "info",
-                    "extra": ""
-                },
-                "text": {
-                    "type": "text",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "shown": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": "0",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "color": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "period_id": {
+          "unique": false,
+          "columns": [
+            "period_id"
+          ]
         },
-        "orszagok": {
-            "engine": "MyISAM",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(3)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "nev": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "telkod": {
-                    "type": "varchar(5)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "ok": {
-                    "type": "enum('i','n')",
-                    "nullable": false,
-                    "default": "i",
-                    "extra": ""
-                },
-                "kiemelt": {
-                    "type": "enum('i','n')",
-                    "nullable": false,
-                    "default": "n",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "cal_masses": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
         },
-        "osm": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "osmid": {
-                    "type": "varchar(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "osmtype": {
-                    "type": "varchar(9)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "lon": {
-                    "type": "decimal(10,8)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "lat": {
-                    "type": "decimal(11,8)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "idUNIQUE": {
-                    "unique": true,
-                    "columns": [
-                        "osmid",
-                        "osmtype"
-                    ]
-                },
-                "id_UNIQUE": {
-                    "unique": true,
-                    "columns": [
-                        "osmid",
-                        "osmtype"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "photos": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "filename": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "title": {
-                    "type": "varchar(250)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "weight": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "flag": {
-                    "type": "enum('i','n')",
-                    "nullable": false,
-                    "default": "i",
-                    "extra": ""
-                },
-                "height": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "width": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "FKchurch": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "kiemelt": {
-                    "unique": false,
-                    "columns": [
-                        "flag"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "period_id": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "remarks": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(10)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "nev": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "login": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "email": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "megbizhato": {
-                    "type": "enum('?','i','n','e')",
-                    "nullable": false,
-                    "default": "?",
-                    "extra": ""
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "allapot": {
-                    "type": "enum('u','f','j')",
-                    "nullable": false,
-                    "default": "u",
-                    "extra": ""
-                },
-                "admin": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "admindatum": {
-                    "type": "datetime",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "leiras": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "adminmegj": {
-                    "type": "text",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "log": {
-                    "type": "text",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "FK_church_id": {
-                    "unique": false,
-                    "columns": [
-                        "church_id"
-                    ]
-                },
-                "index1": {
-                    "unique": false,
-                    "columns": [
-                        "id",
-                        "church_id"
-                    ]
-                },
-                "index2": {
-                    "unique": false,
-                    "columns": [
-                        "id",
-                        "church_id",
-                        "allapot"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "title": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "stats_externalapi": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_bin",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "name": {
-                    "type": "varchar(45)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "url": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "responsecode": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "rawdata": {
-                    "type": "longtext",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "date": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "count": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "diff": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "fast": {
-                    "unique": false,
-                    "columns": [
-                        "url",
-                        "date"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "types": {
+          "type": "text",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "stats_pageviews": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "date": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "route": {
-                    "type": "varchar(120)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "kind": {
-                    "type": "enum('html','api','ajax')",
-                    "nullable": false,
-                    "default": "html",
-                    "extra": ""
-                },
-                "count": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "nap": {
-                    "unique": false,
-                    "columns": [
-                        "date"
-                    ]
-                },
-                "nap_utvonal": {
-                    "unique": true,
-                    "columns": [
-                        "date",
-                        "route",
-                        "kind"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "rite": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "stats_searches": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "date": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "keyword": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "hits": {
-                    "type": "tinyint(1)",
-                    "nullable": false,
-                    "default": "1",
-                    "extra": ""
-                },
-                "count": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "nap": {
-                    "unique": false,
-                    "columns": [
-                        "date"
-                    ]
-                },
-                "nap_kulcsszo": {
-                    "unique": true,
-                    "columns": [
-                        "date",
-                        "keyword",
-                        "hits"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "start_date": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         },
-        "szentsegimadasok": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "church_id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "date": {
-                    "type": "date",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "starttime": {
-                    "type": "varchar(5)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "endtime": {
-                    "type": "varchar(5)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "type": {
-                    "type": "varchar(40)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "info": {
-                    "type": "varchar(255)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "duration": {
+          "type": "longtext",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "templomok": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "nev": {
-                    "type": "varchar(150)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "ismertnev": {
-                    "type": "varchar(150)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "orszag": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "megye": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "varos": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "cim": {
-                    "type": "varchar(250)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "megkozelites": {
-                    "type": "tinytext",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "plebania": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "pleb_url": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "pleb_eml": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "egyhazmegye": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "espereskerulet": {
-                    "type": "int(3)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "leiras": {
-                    "type": "mediumtext",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "megjegyzes": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "miseaktiv": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": "1",
-                    "extra": ""
-                },
-                "misemegj": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "bucsu": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "frissites": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "kontakt": {
-                    "type": "varchar(250)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "kontaktmail": {
-                    "type": "varchar(70)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "adminmegj": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "letrehozta": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "megbizhato": {
-                    "type": "enum('i','n')",
-                    "nullable": false,
-                    "default": "n",
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "modositotta": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "moddatum": {
-                    "type": "datetime",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "log": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "ok": {
-                    "type": "enum('i','n','f')",
-                    "nullable": false,
-                    "default": "i",
-                    "extra": ""
-                },
-                "eszrevetel": {
-                    "type": "enum('i','n','f')",
-                    "nullable": false,
-                    "default": "n",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "deleted_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "osmid": {
-                    "type": "varchar(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "osmtype": {
-                    "type": "varchar(9)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "lat": {
-                    "type": "decimal(11,7)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "lon": {
-                    "type": "decimal(10,7)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "boundaries_checked_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "boundaries_checked_at": {
-                    "unique": false,
-                    "columns": [
-                        "boundaries_checked_at"
-                    ]
-                },
-                "egyhazmegye": {
-                    "unique": false,
-                    "columns": [
-                        "egyhazmegye"
-                    ]
-                },
-                "espereskerulet": {
-                    "unique": false,
-                    "columns": [
-                        "espereskerulet"
-                    ]
-                },
-                "id": {
-                    "unique": false,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "ismertnev": {
-                    "unique": false,
-                    "columns": [
-                        "ismertnev"
-                    ]
-                },
-                "osm": {
-                    "unique": false,
-                    "columns": [
-                        "osmid",
-                        "osmtype"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "varos": {
-                    "unique": false,
-                    "columns": [
-                        "varos"
-                    ]
-                }
-            }
+        "rrule": {
+          "type": "longtext",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "templomok_full": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "nev": {
-                    "type": "varchar(150)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "ismertnev": {
-                    "type": "varchar(150)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "orszag": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "megye": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "varos": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "cim": {
-                    "type": "varchar(250)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "megkozelites": {
-                    "type": "tinytext",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "plebania": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "pleb_url": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "pleb_eml": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "egyhazmegye": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "espereskerulet": {
-                    "type": "int(3)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "leiras": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "megjegyzes": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "miseaktiv": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": "1",
-                    "extra": ""
-                },
-                "misemegj": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "bucsu": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "frissites": {
-                    "type": "date",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "kontakt": {
-                    "type": "varchar(250)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "kontaktmail": {
-                    "type": "varchar(70)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "adminmegj": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "letrehozta": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "megbizhato": {
-                    "type": "enum('i','n')",
-                    "nullable": false,
-                    "default": "n",
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "modositotta": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "moddatum": {
-                    "type": "datetime",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "log": {
-                    "type": "text",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "ok": {
-                    "type": "enum('i','n','f')",
-                    "nullable": false,
-                    "default": "i",
-                    "extra": ""
-                },
-                "eszrevetel": {
-                    "type": "enum('i','n','f')",
-                    "nullable": false,
-                    "default": "n",
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "deleted_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "osmid": {
-                    "type": "varchar(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "osmtype": {
-                    "type": "varchar(9)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "lat": {
-                    "type": "decimal(11,7)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "lon": {
-                    "type": "decimal(10,7)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "egyhazmegye": {
-                    "unique": false,
-                    "columns": [
-                        "egyhazmegye"
-                    ]
-                },
-                "espereskerulet": {
-                    "unique": false,
-                    "columns": [
-                        "espereskerulet"
-                    ]
-                },
-                "id": {
-                    "unique": false,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "ismertnev": {
-                    "unique": false,
-                    "columns": [
-                        "ismertnev"
-                    ]
-                },
-                "osm": {
-                    "unique": false,
-                    "columns": [
-                        "osmid",
-                        "osmtype"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "varos": {
-                    "unique": false,
-                    "columns": [
-                        "varos"
-                    ]
-                }
-            }
+        "experiod": {
+          "type": "longtext",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "tokens": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "type": {
-                    "type": "varchar(15)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "name": {
-                    "type": "varchar(40)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "uid": {
-                    "type": "int(11)",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "timeout": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "created_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "updated_at": {
-                    "type": "timestamp",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "id_UNIQUE": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "name_UNIQUE": {
-                    "unique": true,
-                    "columns": [
-                        "name"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "manual_experiod": {
+          "type": "longtext",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         },
-        "updates": {
-            "engine": "InnoDB",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "uid": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "tid": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": ""
-                },
-                "timestamp": {
-                    "type": "timestamp",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "id_UNIQUE": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                },
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "exdate": {
+          "type": "longtext",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "lang": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "comment": {
+          "type": "text",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "date",
+          "nullable": false,
+          "default": "curdate()",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "date",
+          "nullable": true,
+          "default": "curdate()",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "church_id": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
+        },
+        "period_id": {
+          "unique": false,
+          "columns": [
+            "period_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "cal_periods": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "name": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "weight": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "start_month_day": {
+          "type": "varchar(5)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "end_month_day": {
+          "type": "varchar(5)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "start_period_id": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "end_period_id": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "all_inclusive": {
+          "type": "tinyint(1)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "multi_day": {
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "created_at": {
+          "type": "date",
+          "nullable": false,
+          "default": "curdate()",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "date",
+          "nullable": true,
+          "default": "curdate()",
+          "extra": ""
+        },
+        "special_type": {
+          "type": "enum('christmas','easter')",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "selectable": {
+          "type": "tinyint(1)",
+          "nullable": true,
+          "default": "1",
+          "extra": ""
+        },
+        "color": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "end_period_id": {
+          "unique": false,
+          "columns": [
+            "end_period_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "start_period_id": {
+          "unique": false,
+          "columns": [
+            "start_period_id"
+          ]
+        }
+      }
+    },
+    "cal_period_years": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "period_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "start_year": {
+          "type": "int(4)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "start_date": {
+          "type": "date",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "end_date": {
+          "type": "date",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "date",
+          "nullable": false,
+          "default": "curdate()",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "date",
+          "nullable": true,
+          "default": "curdate()",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "period_id": {
+          "unique": false,
+          "columns": [
+            "period_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "cal_suggestions": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "bigint(20) unsigned",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "package_id": {
+          "type": "bigint(20) unsigned",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "period_id": {
+          "type": "bigint(20) unsigned",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "mass_id": {
+          "type": "bigint(20) unsigned",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "mass_state": {
+          "type": "enum('new','deleted','modified')",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "changes": {
+          "type": "longtext",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "package_id": {
+          "unique": false,
+          "columns": [
+            "package_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "cal_suggestion_packages": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "bigint(20) unsigned",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "church_id": {
+          "type": "bigint(20) unsigned",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "sender_name": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "sender_email": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "sender_user_id": {
+          "type": "bigint(20) unsigned",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "sender_message": {
+          "type": "text",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "state": {
+          "type": "enum('accepted','rejected','pending')",
+          "nullable": true,
+          "default": "PENDING",
+          "extra": ""
+        },
+        "handled_by_user_id": {
+          "type": "bigint(20) unsigned",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "handled_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "church_id": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "chat": {
+      "engine": "MyISAM",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "datum": {
+          "type": "datetime",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
         },
         "user": {
-            "engine": "MyISAM",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "uid": {
-                    "type": "int(11)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "login": {
-                    "type": "varchar(20)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "jelszo": {
-                    "type": "varchar(255)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "jogok": {
-                    "type": "varchar(200)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "regdatum": {
-                    "type": "datetime",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "lastlogin": {
-                    "type": "datetime",
-                    "nullable": false,
-                    "default": "current_timestamp",
-                    "extra": ""
-                },
-                "lastactive": {
-                    "type": "datetime",
-                    "nullable": true,
-                    "default": null,
-                    "extra": ""
-                },
-                "email": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "notifications": {
-                    "type": "int(1)",
-                    "nullable": true,
-                    "default": "1",
-                    "extra": ""
-                },
-                "becenev": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "nev": {
-                    "type": "varchar(100)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                },
-                "volunteer": {
-                    "type": "int(1)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "uid"
-                    ]
-                }
-            }
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
         },
-        "varosok": {
-            "engine": "MyISAM",
-            "collation": "utf8mb4_unicode_ci",
-            "columns": {
-                "id": {
-                    "type": "int(3)",
-                    "nullable": false,
-                    "default": null,
-                    "extra": "auto_increment"
-                },
-                "irsz": {
-                    "type": "int(4)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "megye_id": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "0",
-                    "extra": ""
-                },
-                "orszag": {
-                    "type": "int(2)",
-                    "nullable": false,
-                    "default": "46",
-                    "extra": ""
-                },
-                "nev": {
-                    "type": "varchar(50)",
-                    "nullable": false,
-                    "default": "",
-                    "extra": ""
-                }
-            },
-            "indexes": {
-                "PRIMARY": {
-                    "unique": true,
-                    "columns": [
-                        "id"
-                    ]
-                }
-            }
+        "kinek": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "szoveg": {
+          "type": "tinytext",
+          "nullable": false,
+          "default": null,
+          "extra": ""
         }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
     },
-    "_meta": {
-        "generated_at": "2026-08-10T18:36:26+02:00",
-        "source_schema": "miserend",
-        "initdb_fingerprint": "0e7a7451023e81f73e62b23d418801aad4c4bf2501edd9160e93f8729aab08ae",
-        "initdb_files": {
-            "00-users.sh": "e4f1149c70b9b0b44ce0ba172110ca07ad099fffaf720876e45e8a0a5cb910f8",
-            "01-create-database.sql": "dec66da6495a0d5ee007beda9e2be684b104cb4875b12ba0cf21ebae81874385",
-            "02-schema.sql": "40fdcedfd73cc57f8cb24e64c5785c91286de80d22c42700e0704cd42d657b7a",
-            "03-migrations.sql": "b17a6da4226a09f95c8249d6886802fe1087b944644f705d75a716a9a562f644",
-            "04-attributes-index.sql": "b2cf9ff6b616a8679c944fb6eb09baf6daeaa53793c0395e8d921525a91ea61a",
-            "04-mass-languages.sql": "9df189d0de091724f0b3119bd9fc088a5960885e4a35487df11d5a6422c2bcf5",
-            "05-data.sh": "5cf4dcd42e89288863792ed219c41937abcca249da22fbbf623d30dcd176874f",
-            "06-data-integrity.sql": "d0afff9288b6b7ccd60aae9e9f9e14c903732f4560e7eb7efde299ff946a944a",
-            "06-relationship-type-drop.sql": "04ac1538b42e0d9ad1f8106762013c8e9003965b70bc76ae1b27891273da938e",
-            "07-boundaries-iso.sql": "120cd5b6a656e754c8eef74d34415e03d987a09dce6ba998cb5c6ad1604fc03b"
+    "church_holders": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(10)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "user_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "church_id": {
+          "type": "int(10)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "description": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "status": {
+          "type": "enum('asked','allowed','denied','revoked')",
+          "nullable": false,
+          "default": "asked",
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "deleted_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "church_links": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(10)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "church_id": {
+          "type": "int(10)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "href": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "title": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "deleted_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "church_relationships": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "parent_church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "child_church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": "on update current_timestamp()"
+        }
+      },
+      "indexes": {
+        "child_idx": {
+          "unique": false,
+          "columns": [
+            "child_church_id"
+          ]
+        },
+        "parent_idx": {
+          "unique": false,
+          "columns": [
+            "parent_church_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "unique_pair": {
+          "unique": true,
+          "columns": [
+            "parent_church_id",
+            "child_church_id"
+          ]
+        }
+      }
+    },
+    "church_update_tokens": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "token": {
+          "type": "varchar(64)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "uid": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "email_batch_id": {
+          "type": "varchar(64)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "expires_at": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "used_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": "current_timestamp",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "confessions": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "deduplicationId": {
+          "type": "char(36)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "local_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "timestamp": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": "on update current_timestamp()"
+        },
+        "fulldata": {
+          "type": "longtext",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "status": {
+          "type": "enum('on','off')",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "deduplicationId": {
+          "unique": true,
+          "columns": [
+            "deduplicationId"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "crons": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "class": {
+          "type": "varchar(45)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "function": {
+          "type": "varchar(45)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "frequency": {
+          "type": "varchar(45)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "from": {
+          "type": "varchar(45)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "until": {
+          "type": "varchar(45)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "deadline_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "attempts": {
+          "type": "int(2)",
+          "nullable": true,
+          "default": "0",
+          "extra": ""
+        },
+        "lastsuccess_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_At": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "distances": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "fromLat": {
+          "type": "decimal(11,7)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "fromLon": {
+          "type": "decimal(11,7)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "toLat": {
+          "type": "decimal(11,7)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "toLon": {
+          "type": "decimal(11,7)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "distance": {
+          "type": "float",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "toupdate": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "Coord": {
+          "unique": true,
+          "columns": [
+            "fromLat",
+            "fromLon",
+            "toLat",
+            "toLon"
+          ]
+        },
+        "From": {
+          "unique": false,
+          "columns": [
+            "fromLat",
+            "fromLon"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "egyhazmegye": {
+      "engine": "MyISAM",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "nev": {
+          "type": "varchar(250)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "sorrend": {
+          "type": "int(3)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "ok": {
+          "type": "enum('i','n')",
+          "nullable": false,
+          "default": "i",
+          "extra": ""
+        },
+        "felelos": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "email": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "csakez": {
+          "type": "enum('i','n')",
+          "nullable": false,
+          "default": "i",
+          "extra": ""
+        },
+        "osm_relation": {
+          "type": "int(45)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "id": {
+          "unique": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "emails": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "type": {
+          "type": "varchar(30)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "to": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "header": {
+          "type": "text",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "subject": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "body": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "status": {
+          "type": "varchar(45)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "espereskerulet": {
+      "engine": "MyISAM",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(3)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "ehm": {
+          "type": "int(2)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "nev": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "events": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "name": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "year": {
+          "type": "varchar(4)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "date": {
+          "type": "date",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "id_UNIQUE": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "name+year": {
+          "unique": true,
+          "columns": [
+            "name",
+            "year"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "external_calendars": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "name": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "url": {
+          "type": "varchar(2048)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "active": {
+          "type": "tinyint(1)",
+          "nullable": true,
+          "default": "1",
+          "extra": ""
+        },
+        "last_import_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": "on update current_timestamp()"
+        }
+      },
+      "indexes": {
+        "fk_external_calendars_church_id": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "unique_church_external": {
+          "unique": true,
+          "columns": [
+            "church_id",
+            "name"
+          ]
+        }
+      }
+    },
+    "favorites": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(10) unsigned",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "uid": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "tid": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "uid_tid_UNIQUE": {
+          "unique": true,
+          "columns": [
+            "uid",
+            "tid"
+          ]
+        }
+      }
+    },
+    "keyword_shortcuts": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "osmtag_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "type": {
+          "type": "varchar(30)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "value": {
+          "type": "varchar(200)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "church_type_value": {
+          "unique": false,
+          "columns": [
+            "church_id",
+            "type",
+            "value"
+          ]
+        },
+        "FK_keyword_shortchuts_church_idx": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
+        },
+        "FK_keyword_shortchuts_osmtag_idx": {
+          "unique": false,
+          "columns": [
+            "osmtag_id"
+          ]
+        },
+        "index_value": {
+          "unique": false,
+          "columns": [
+            "value"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "type_value": {
+          "unique": false,
+          "columns": [
+            "type",
+            "value"
+          ]
+        }
+      }
+    },
+    "lookup_boundary_church": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "boundary_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "FK_boundary_id_idx": {
+          "unique": false,
+          "columns": [
+            "boundary_id"
+          ]
+        },
+        "FK_church_id_idx": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "unique": {
+          "unique": true,
+          "columns": [
+            "church_id",
+            "boundary_id"
+          ]
+        }
+      }
+    },
+    "lookup_church_osm": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "osm_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "FK_church_id_idx": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
+        },
+        "FK_osm_id_idx": {
+          "unique": false,
+          "columns": [
+            "osm_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "unique": {
+          "unique": true,
+          "columns": [
+            "church_id",
+            "osm_id"
+          ]
+        }
+      }
+    },
+    "lookup_osm_enclosed": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "osm_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "enclosing_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "varchar(45)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "FK_osm_enclosing_id_idx": {
+          "unique": false,
+          "columns": [
+            "enclosing_id"
+          ]
+        },
+        "FK_osm_id_idx": {
+          "unique": false,
+          "columns": [
+            "osm_id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "unique": {
+          "unique": true,
+          "columns": [
+            "enclosing_id",
+            "osm_id"
+          ]
+        }
+      }
+    },
+    "messages": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "sid": {
+          "type": "varchar(45)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "timestamp": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "severity": {
+          "type": "varchar(10)",
+          "nullable": true,
+          "default": "info",
+          "extra": ""
+        },
+        "text": {
+          "type": "text",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "shown": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": "0",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "osm": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "osmid": {
+          "type": "varchar(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "osmtype": {
+          "type": "varchar(9)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "lon": {
+          "type": "decimal(10,8)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "lat": {
+          "type": "decimal(11,8)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "idUNIQUE": {
+          "unique": true,
+          "columns": [
+            "osmid",
+            "osmtype"
+          ]
+        },
+        "id_UNIQUE": {
+          "unique": true,
+          "columns": [
+            "osmid",
+            "osmtype"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "photos": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "filename": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "title": {
+          "type": "varchar(250)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "weight": {
+          "type": "int(2)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "flag": {
+          "type": "enum('i','n')",
+          "nullable": false,
+          "default": "i",
+          "extra": ""
+        },
+        "height": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "width": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "FKchurch": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
+        },
+        "kiemelt": {
+          "unique": false,
+          "columns": [
+            "flag"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "remarks": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(10)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "nev": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "login": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "email": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "megbizhato": {
+          "type": "enum('?','i','n','e')",
+          "nullable": false,
+          "default": "?",
+          "extra": ""
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "allapot": {
+          "type": "enum('u','f','j')",
+          "nullable": false,
+          "default": "u",
+          "extra": ""
+        },
+        "admin": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "admindatum": {
+          "type": "datetime",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "leiras": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "adminmegj": {
+          "type": "text",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "log": {
+          "type": "text",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "FK_church_id": {
+          "unique": false,
+          "columns": [
+            "church_id"
+          ]
+        },
+        "index1": {
+          "unique": false,
+          "columns": [
+            "id",
+            "church_id"
+          ]
+        },
+        "index2": {
+          "unique": false,
+          "columns": [
+            "id",
+            "church_id",
+            "allapot"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "stats_externalapi": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_bin",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "name": {
+          "type": "varchar(45)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "url": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "responsecode": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "rawdata": {
+          "type": "longtext",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "date": {
+          "type": "date",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "count": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "diff": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "fast": {
+          "unique": false,
+          "columns": [
+            "url",
+            "date"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "stats_pageviews": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "date": {
+          "type": "date",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "route": {
+          "type": "varchar(120)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "kind": {
+          "type": "enum('html','api','ajax')",
+          "nullable": false,
+          "default": "html",
+          "extra": ""
+        },
+        "count": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "nap": {
+          "unique": false,
+          "columns": [
+            "date"
+          ]
+        },
+        "nap_utvonal": {
+          "unique": true,
+          "columns": [
+            "date",
+            "route",
+            "kind"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "stats_searches": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "date": {
+          "type": "date",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "keyword": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "hits": {
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "1",
+          "extra": ""
+        },
+        "count": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "nap": {
+          "unique": false,
+          "columns": [
+            "date"
+          ]
+        },
+        "nap_kulcsszo": {
+          "unique": true,
+          "columns": [
+            "date",
+            "keyword",
+            "hits"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "szentsegimadasok": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "date": {
+          "type": "date",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "starttime": {
+          "type": "varchar(5)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "endtime": {
+          "type": "varchar(5)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "type": {
+          "type": "varchar(40)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "info": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "templomok": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "nev": {
+          "type": "varchar(150)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "ismertnev": {
+          "type": "varchar(150)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "cim": {
+          "type": "varchar(250)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "megkozelites": {
+          "type": "tinytext",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "plebania": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "pleb_url": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "pleb_eml": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "egyhazmegye": {
+          "type": "int(2)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "espereskerulet": {
+          "type": "int(3)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "leiras": {
+          "type": "mediumtext",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "megjegyzes": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "miseaktiv": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": "1",
+          "extra": ""
+        },
+        "misemegj": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "bucsu": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "frissites": {
+          "type": "date",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "kontakt": {
+          "type": "varchar(250)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "kontaktmail": {
+          "type": "varchar(70)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "adminmegj": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "letrehozta": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "megbizhato": {
+          "type": "enum('i','n')",
+          "nullable": false,
+          "default": "n",
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "modositotta": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "moddatum": {
+          "type": "datetime",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "log": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "ok": {
+          "type": "enum('i','n','f')",
+          "nullable": false,
+          "default": "i",
+          "extra": ""
+        },
+        "eszrevetel": {
+          "type": "enum('i','n','f')",
+          "nullable": false,
+          "default": "n",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "deleted_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "osmid": {
+          "type": "varchar(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "osmtype": {
+          "type": "varchar(9)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "lat": {
+          "type": "decimal(11,7)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "lon": {
+          "type": "decimal(10,7)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "boundaries_checked_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "boundaries_checked_at": {
+          "unique": false,
+          "columns": [
+            "boundaries_checked_at"
+          ]
+        },
+        "egyhazmegye": {
+          "unique": false,
+          "columns": [
+            "egyhazmegye"
+          ]
+        },
+        "espereskerulet": {
+          "unique": false,
+          "columns": [
+            "espereskerulet"
+          ]
+        },
+        "id": {
+          "unique": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "ismertnev": {
+          "unique": false,
+          "columns": [
+            "ismertnev"
+          ]
+        },
+        "osm": {
+          "unique": false,
+          "columns": [
+            "osmid",
+            "osmtype"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "templomok_full": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "nev": {
+          "type": "varchar(150)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "ismertnev": {
+          "type": "varchar(150)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "orszag": {
+          "type": "int(2)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "megye": {
+          "type": "int(2)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "varos": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "cim": {
+          "type": "varchar(250)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "megkozelites": {
+          "type": "tinytext",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "plebania": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "pleb_url": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "pleb_eml": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "egyhazmegye": {
+          "type": "int(2)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "espereskerulet": {
+          "type": "int(3)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        },
+        "leiras": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "megjegyzes": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "miseaktiv": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": "1",
+          "extra": ""
+        },
+        "misemegj": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "bucsu": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "frissites": {
+          "type": "date",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "kontakt": {
+          "type": "varchar(250)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "kontaktmail": {
+          "type": "varchar(70)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "adminmegj": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "letrehozta": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "megbizhato": {
+          "type": "enum('i','n')",
+          "nullable": false,
+          "default": "n",
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "modositotta": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "moddatum": {
+          "type": "datetime",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "log": {
+          "type": "text",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "ok": {
+          "type": "enum('i','n','f')",
+          "nullable": false,
+          "default": "i",
+          "extra": ""
+        },
+        "eszrevetel": {
+          "type": "enum('i','n','f')",
+          "nullable": false,
+          "default": "n",
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "deleted_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "osmid": {
+          "type": "varchar(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "osmtype": {
+          "type": "varchar(9)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "lat": {
+          "type": "decimal(11,7)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "lon": {
+          "type": "decimal(10,7)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "egyhazmegye": {
+          "unique": false,
+          "columns": [
+            "egyhazmegye"
+          ]
+        },
+        "espereskerulet": {
+          "unique": false,
+          "columns": [
+            "espereskerulet"
+          ]
+        },
+        "id": {
+          "unique": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "ismertnev": {
+          "unique": false,
+          "columns": [
+            "ismertnev"
+          ]
+        },
+        "osm": {
+          "unique": false,
+          "columns": [
+            "osmid",
+            "osmtype"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "varos": {
+          "unique": false,
+          "columns": [
+            "varos"
+          ]
+        }
+      }
+    },
+    "tokens": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "type": {
+          "type": "varchar(15)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "name": {
+          "type": "varchar(40)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "uid": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "timeout": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "updated_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "id_UNIQUE": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "name_UNIQUE": {
+          "unique": true,
+          "columns": [
+            "name"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "updates": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "uid": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "tid": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "timestamp": {
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "id_UNIQUE": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "user": {
+      "engine": "MyISAM",
+      "collation": "utf8mb4_unicode_ci",
+      "columns": {
+        "uid": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "login": {
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "jelszo": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "jogok": {
+          "type": "varchar(200)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "regdatum": {
+          "type": "datetime",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "lastlogin": {
+          "type": "datetime",
+          "nullable": false,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "lastactive": {
+          "type": "datetime",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "email": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "notifications": {
+          "type": "int(1)",
+          "nullable": true,
+          "default": "1",
+          "extra": ""
+        },
+        "becenev": {
+          "type": "varchar(50)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "nev": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": "",
+          "extra": ""
+        },
+        "volunteer": {
+          "type": "int(1)",
+          "nullable": false,
+          "default": "0",
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "uid"
+          ]
+        }
+      }
     }
+  },
+  "_meta": {
+    "generated_at": "2026-08-16T18:24:34+02:00",
+    "source_schema": "miserend",
+    "initdb_fingerprint": "0e7a7451023e81f73e62b23d418801aad4c4bf2501edd9160e93f8729aab08ae",
+    "initdb_files": {
+      "00-users.sh": "e4f1149c70b9b0b44ce0ba172110ca07ad099fffaf720876e45e8a0a5cb910f8",
+      "01-create-database.sql": "dec66da6495a0d5ee007beda9e2be684b104cb4875b12ba0cf21ebae81874385",
+      "02-schema.sql": "40fdcedfd73cc57f8cb24e64c5785c91286de80d22c42700e0704cd42d657b7a",
+      "03-migrations.sql": "b17a6da4226a09f95c8249d6886802fe1087b944644f705d75a716a9a562f644",
+      "04-attributes-index.sql": "b2cf9ff6b616a8679c944fb6eb09baf6daeaa53793c0395e8d921525a91ea61a",
+      "04-mass-languages.sql": "9df189d0de091724f0b3119bd9fc088a5960885e4a35487df11d5a6422c2bcf5",
+      "05-data.sh": "5cf4dcd42e89288863792ed219c41937abcca249da22fbbf623d30dcd176874f",
+      "06-data-integrity.sql": "d0afff9288b6b7ccd60aae9e9f9e14c903732f4560e7eb7efde299ff946a944a",
+      "06-relationship-type-drop.sql": "04ac1538b42e0d9ad1f8106762013c8e9003965b70bc76ae1b27891273da938e",
+      "07-boundaries-iso.sql": "120cd5b6a656e754c8eef74d34415e03d987a09dce6ba998cb5c6ad1604fc03b"
+    }
+  }
 }

--- a/webapp/templates/church/edit.twig
+++ b/webapp/templates/church/edit.twig
@@ -62,28 +62,30 @@
                 <td></td>
             </tr>
            
-            {% if not church.varos %}
+            {#
+                #496 / #497 / #498: itt állt a kaszkádos ország -> megye -> város
+                választó. A hely mostantól a koordinátából és az OSM-határokból jön,
+                tehát nincs mit választani — csak megmutatjuk, mi jött ki belőle.
+                A közterület (`cim`) marad szerkeszthető: az nincs a határokban.
+            #}
             <tr>
                 <td class=kiscim align=right>Elhelyezkedés:</td>
                 <td>
-                    {% if church.osm.administrative %}
-                        OSM 
-                        {% for key,administraion in church.osm.administrative %}
-                            > {{ administraion.name }}
-                        {% endfor %}   
+                    {% if church.location.country or church.location.city %}
+                        <span class="alap">
+                            {{ church.location.country.name }}{% if church.location.county %} &gt; {{ church.location.county.name }}{% endif %}{% if church.location.city %} &gt; {{ church.location.city.name }}{% endif %}{% if church.location.district %} &gt; {{ church.location.district.name }}{% endif %}
+                        </span>
+                        <small class="text-muted d-block">Az OSM-határokból, a térképi elhelyezés alapján.</small>
+                    {% else %}
+                        <small class="text-muted d-block">
+                            Nincs OSM-határ ehhez a templomhoz. Az elhelyezkedés a koordináta
+                            megadása után, a határok szinkronizálásakor jelenik meg.
+                        </small>
                     {% endif %}
-                    {{ forms.select(form.country) }}
-                    {% for county in form.counties %}
-                        {{ forms.select(county) }}
-                    {% endfor %}
-                    {% for city in form.cities %}
-                        {{ forms.select(city) }}
-                    {% endfor %}
-                    <input type=text name=church[cim] value="{{ church.cim }}" class=form-control  placeholder="Utca házszám">                                                    
+                    <input type=text name=church[cim] value="{{ church.cim }}" class=form-control  placeholder="Utca házszám">
                 </td>
                 <td></td>
             </tr>
-            {%  endif %}
             {% if church.location.osm %}
                 <tr>
                     <td class=kiscim align=right>OSM azonosító:</td>

--- a/webapp/tests/Integration/CampaignVolunteerTest.php
+++ b/webapp/tests/Integration/CampaignVolunteerTest.php
@@ -72,17 +72,37 @@ class CampaignVolunteerTest extends TestCase {
      * kerül, és nem a fixture négyezer templomán múlik, bekerül-e a mintába.
      */
     private function makeStaleChurch(): int {
-        $minta = (array) DB::table('templomok')->where('ok', 'i')->where('orszag', 12)->first();
+        // #496: a `where('orszag', 12)` szűrő megszűnt az oszloppal együtt.
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
         $id = (int) DB::table('templomok')->max('id') + 1;
 
         $minta['id'] = $id;
         $minta['nev'] = 'Teszt templom ' . $id;
-        $minta['varos'] = 'Tesztváros';
         $minta['ok'] = 'i';
-        $minta['orszag'] = 12;
         $minta['frissites'] = '1900-01-01';
 
         DB::table('templomok')->insert($minta);
+
+        /*
+         * #498: a kiosztás magyarországi templomokra szűkít. Ez eddig az `orszag = 12`
+         * oszlopon ment, most az országHATÁRON — a fixtúrának tehát kapnia kell egyet,
+         * különben kiesik a mintából.
+         */
+        $orszagId = DB::table('boundaries')
+            ->where('boundary', 'administrative')->where('admin_level', 2)
+            ->where(function ($q) {
+                $q->where('iso3166_1', 'HU')->orWhere('name', 'Magyarország');
+            })->value('id');
+
+        if ($orszagId === null) {
+            $orszagId = DB::table('boundaries')->insertGetId([
+                'boundary' => 'administrative', 'admin_level' => 2,
+                'name' => 'Magyarország', 'iso3166_1' => 'HU',
+                'osmtype' => 'relation', 'osmid' => 21335,
+            ]);
+        }
+        DB::table('lookup_boundary_church')->insert(['boundary_id' => $orszagId, 'church_id' => $id]);
+
         return $id;
     }
 

--- a/webapp/tests/Integration/ChurchEditFormTest.php
+++ b/webapp/tests/Integration/ChurchEditFormTest.php
@@ -36,7 +36,6 @@ class ChurchEditFormTest extends TestCase {
     private function createChurch(): int {
         return DB::table('templomok')->insertGetId([
             'nev'        => 'Szerkesztés teszt',
-            'varos'      => 'Budapest',
             'cim'        => 'Régi cím 1.',
             'frissites'  => '2020-01-01',
             'ok'         => 'i',
@@ -113,28 +112,11 @@ class ChurchEditFormTest extends TestCase {
         $this->assertSame('Teszt megjegyzés', $row->megjegyzes);
     }
 
-    /**
-     * #496 / #497 / #498: a hely a koordinátából és az OSM-határokból jön, a
-     * szerkesztő kaszkádos ország/megye/város választója megszűnt.
-     *
-     * Ez nem kozmetika: ha a mező bent maradna a menthetők között, egy beküldött
-     * űrlap felülírhatná a származtatott adatot azzal, ami a böngészőben ragadt —
-     * és a régi érték csendben visszaszivárogna oda, ahonnan épp kivezetjük.
+    /*
+     * #496 / #497 / #498: a #798-ban itt egy teszt állt arról, hogy az űrlapról
+     * beküldött `varos`/`megye`/`orszag` NEM írja felül a mentett adatot. Az
+     * oszlopok azóta megszűntek, tehát nincs mit felülírni — a teszt tárgytalan.
      */
-    public function testATelepulesMarNemMenthetoAzUrlaprol(): void {
-        $eredeti = $this->churchRow()->varos;
-
-        $this->post('/templom/' . $this->churchId . '/edit', $this->editFields([
-            'church[varos]'  => 'Debrecen',
-            'church[megye]'  => '9999',
-            'church[orszag]' => '9999',
-        ]));
-
-        $row = $this->churchRow();
-        $this->assertSame($eredeti, $row->varos, 'A település nem írható felül az űrlapról.');
-        $this->assertNotSame('9999', (string) $row->megye);
-        $this->assertNotSame('9999', (string) $row->orszag);
-    }
 
     /**
      * A LÉNYEG: idegen azonosítóval nem lehet más templomot átírni.

--- a/webapp/tests/Integration/ChurchEditFormTest.php
+++ b/webapp/tests/Integration/ChurchEditFormTest.php
@@ -106,13 +106,34 @@ class ChurchEditFormTest extends TestCase {
         $this->post('/templom/' . $this->churchId . '/edit', $this->editFields([
             'church[cim]'        => 'Harmadik cím',
             'church[megjegyzes]' => 'Teszt megjegyzés',
-            'church[varos]'      => 'Debrecen',
         ]));
 
         $row = $this->churchRow();
         $this->assertSame('Harmadik cím', $row->cim);
         $this->assertSame('Teszt megjegyzés', $row->megjegyzes);
-        $this->assertSame('Debrecen', $row->varos);
+    }
+
+    /**
+     * #496 / #497 / #498: a hely a koordinátából és az OSM-határokból jön, a
+     * szerkesztő kaszkádos ország/megye/város választója megszűnt.
+     *
+     * Ez nem kozmetika: ha a mező bent maradna a menthetők között, egy beküldött
+     * űrlap felülírhatná a származtatott adatot azzal, ami a böngészőben ragadt —
+     * és a régi érték csendben visszaszivárogna oda, ahonnan épp kivezetjük.
+     */
+    public function testATelepulesMarNemMenthetoAzUrlaprol(): void {
+        $eredeti = $this->churchRow()->varos;
+
+        $this->post('/templom/' . $this->churchId . '/edit', $this->editFields([
+            'church[varos]'  => 'Debrecen',
+            'church[megye]'  => '9999',
+            'church[orszag]' => '9999',
+        ]));
+
+        $row = $this->churchRow();
+        $this->assertSame($eredeti, $row->varos, 'A település nem írható felül az űrlapról.');
+        $this->assertNotSame('9999', (string) $row->megye);
+        $this->assertNotSame('9999', (string) $row->orszag);
     }
 
     /**

--- a/webapp/tests/Integration/ChurchNeighboursTest.php
+++ b/webapp/tests/Integration/ChurchNeighboursTest.php
@@ -27,7 +27,6 @@ class ChurchNeighboursTest extends TestCase {
     private function createChurch(string $name, float $lat, float $lon): int {
         return DB::table('templomok')->insertGetId([
             'nev'        => $name,
-            'varos'      => 'Budapest',
             'frissites'  => '2020-01-01',
             'ok'         => 'i',
             'plebania'   => '',

--- a/webapp/tests/Integration/ChurchRelationshipTest.php
+++ b/webapp/tests/Integration/ChurchRelationshipTest.php
@@ -26,7 +26,6 @@ class ChurchRelationshipTest extends TestCase {
     private function createChurch(string $name = 'Teszt', float $lat = 47.5, float $lon = 19.0): int {
         return DB::table('templomok')->insertGetId([
             'nev'       => $name,
-            'varos'     => 'Budapest',
             'frissites' => '2020-01-01',
             'ok'        => 'i',
             'plebania'  => '',

--- a/webapp/tests/Integration/ChurchRitesTest.php
+++ b/webapp/tests/Integration/ChurchRitesTest.php
@@ -29,7 +29,6 @@ class ChurchRitesTest extends TestCase {
     private function createChurch(): int {
         $id = DB::table('templomok')->insertGetId([
             'nev'        => 'Rítus teszt',
-            'varos'      => 'Budapest',
             'frissites'  => '2020-01-01',
             'ok'         => 'i',
             'plebania'   => '', 'leiras' => '', 'megjegyzes' => '', 'misemegj' => '',

--- a/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
+++ b/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
@@ -1,0 +1,192 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #496 / #497 / #498: a helynevek az OSM-határokból, a régi oszlopok helyett.
+ *
+ * A három jegy a `templomok.varos`, `.megye` és `.orszag` kivezetéséről szól. Ahhoz,
+ * hogy az oszlopok eldobhatók legyenek, előbb minden fogyasztónak ezeken a
+ * metódusokon kell keresztülmennie.
+ *
+ * A legfontosabb elvárás, hogy a látogató NE vegye észre a váltást: a származtatott
+ * érték adja vissza ugyanazt, amit a régi oszlop. Az `admin_level` jelentése viszont
+ * országonként más, ezért itt valódi, mért határláncokkal dolgozunk.
+ */
+class LocationNamesFromBoundariesTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $minta['id'] = $this->churchId;
+        $minta['nev'] = 'Helynév Teszt';
+        $minta['varos'] = 'Régi Város';
+        $minta['megye'] = 0;
+        $minta['orszag'] = 0;
+        $minta['ok'] = 'i';
+        DB::table('templomok')->insert($minta);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<int,array{0:int,1:string}> $szintek [admin_level, név] párok */
+    private function hatarlanc(array $szintek, string $iso = ''): void {
+        foreach ($szintek as [$level, $nev]) {
+            $id = DB::table('boundaries')->insertGetId([
+                'boundary'    => 'administrative',
+                'admin_level' => $level,
+                'name'        => $nev,
+                'alt_name'    => '',
+                'iso3166_1'   => $level === 2 ? $iso : '',
+                'osmtype'     => 'relation',
+                'osmid'       => 800000 + $level,
+            ]);
+            DB::table('lookup_boundary_church')->insert([
+                'boundary_id' => $id,
+                'church_id'   => $this->churchId,
+            ]);
+        }
+    }
+
+    private function templom(): \Eloquent\Church {
+        return \Eloquent\Church::find($this->churchId);
+    }
+
+    /**
+     * Budapest: a régi oszlopban "Budapest XI. kerület" áll. A legspecifikusabb
+     * határ "Szentimreváros" lenne — pontosabb, de a látogatónak visszalépés.
+     */
+    public function testBudapestiTemplomnalATelepulesEsAKeruletEgyutt(): void {
+        $this->hatarlanc([
+            [2, 'Magyarország'], [6, 'Budapest'], [8, 'Budapest'],
+            [9, 'XI. kerület'], [10, 'Szentimreváros'],
+        ], 'HU');
+
+        self::assertSame('Budapest XI. kerület', $this->templom()->locationCityName());
+    }
+
+    public function testKeruletNelkuliTelepulesnelCsakATelepules(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Szentendre', $this->templom()->locationCityName());
+    }
+
+    /**
+     * Köln kreisfreie Stadt: NINCS 8-as szintje, a település a 6-oson ül. Ha vakon a
+     * 9-esre esnénk vissza, "Innenstadt" jönne ki "Köln" helyett.
+     */
+    public function testKreisfreieStadtnalAHatosSzintATelepules(): void {
+        $this->hatarlanc([
+            [2, 'Deutschland'], [4, 'Nordrhein-Westfalen'], [5, 'Regierungsbezirk Köln'],
+            [6, 'Köln'], [9, 'Innenstadt'], [10, 'Altstadt-Nord'],
+        ], 'DE');
+
+        self::assertSame('Köln', $this->templom()->locationCityName(),
+            'A kerületet csak 8-as szintű település mellé szabad fűzni.');
+    }
+
+    /** Romániában nincs 6-os szint: a megyét (judet) a 4-es hordozza. */
+    public function testRomanTemplomnalANegyesSzintAMegye(): void {
+        $this->hatarlanc([[2, 'România'], [4, 'Alba'], [8, 'Vințu de Jos']], 'RO');
+
+        $templom = $this->templom();
+        self::assertSame('Alba', $templom->locationCountyName());
+        self::assertSame('Vințu de Jos', $templom->locationCityName());
+    }
+
+    public function testMagyarTemplomnalAHatosSzintAMegye(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [4, 'Közép-Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Pest', $this->templom()->locationCountyName(),
+            'Ahol van 6-os szint, ott a 4-es csak statisztikai nagyrégió.');
+    }
+
+    public function testAzOrszagnevAKettesSzintrolJon(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        self::assertSame('Magyarország', $this->templom()->locationCountryName());
+    }
+
+    // ---- visszaesés ----------------------------------------------------------
+
+    /**
+     * A visszaesés szándékosan bent van: a szlovák állomány 23%-ának egyáltalán
+     * nincs boundary-ja, és 47 templomnak nincs koordinátája sem.
+     */
+    public function testHatarNelkulARegiOszlopJon(): void {
+        self::assertSame('Régi Város', $this->templom()->locationCityName());
+    }
+
+    public function testCsakOrszaghatarralATelepulesMegARegiOszloprolJon(): void {
+        $this->hatarlanc([[2, 'Magyarország']], 'HU');
+
+        $templom = $this->templom();
+        self::assertSame('Magyarország', $templom->locationCountryName());
+        self::assertSame('Régi Város', $templom->locationCityName());
+    }
+
+    // ---- országhoz kötött logika --------------------------------------------
+
+    public function testAMagyarorszagiTemplomFelismereseAzIsoKodbol(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        self::assertTrue($this->templom()->isInHungary());
+    }
+
+    public function testAKulfoldiTemplomNemMagyarorszagi(): void {
+        $this->hatarlanc([[2, 'Deutschland'], [6, 'Köln']], 'DE');
+
+        self::assertFalse($this->templom()->isInHungary());
+    }
+
+    /**
+     * Az ISO ma 7964 határból egynél van kitöltve, tehát a névre illesztésnek is
+     * mennie kell — enélkül a statisztika üresen maradna.
+     */
+    public function testAStatisztikaSzurojeNevreIsIllik(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']]);
+
+        $talalat = \Eloquent\Church::inHungary()->where('templomok.id', $this->churchId)->count();
+
+        self::assertSame(1, $talalat, 'ISO-kód nélkül, puszta névre is találnia kell.');
+    }
+
+    public function testAStatisztikaSzurojeNemHozKulfoldit(): void {
+        $this->hatarlanc([[2, 'Deutschland'], [6, 'Köln']], 'DE');
+
+        self::assertSame(0, \Eloquent\Church::inHungary()->where('templomok.id', $this->churchId)->count());
+    }
+
+    // ---- ami az API-ba kikerül -----------------------------------------------
+
+    /** A publikus API mezőnevei nem változnak, csak a forrásuk. */
+    public function testAzApiValaszaAszarmaztatottNeveketAdja(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [6, 'Pest'], [8, 'Szentendre']], 'HU');
+
+        // A `megye` csak a bővebb válaszban szerepel; a minimal a /nearby alapja.
+        $tomb = $this->templom()->toAPIArray('normal');
+
+        self::assertSame('Magyarország', $tomb['orszag']);
+        self::assertSame('Pest', $tomb['megye']);
+        self::assertSame('Szentendre', $tomb['varos']);
+    }
+
+    /** A /nearby minimal válasza is a származtatott neveket adja. */
+    public function testAMinimalValaszIsSzarmaztatott(): void {
+        $this->hatarlanc([[2, 'Magyarország'], [8, 'Szentendre']], 'HU');
+
+        $tomb = $this->templom()->toAPIArray('minimal');
+
+        self::assertSame('Magyarország', $tomb['orszag']);
+        self::assertSame('Szentendre', $tomb['varos']);
+    }
+}

--- a/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
+++ b/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
@@ -26,9 +26,6 @@ class LocationNamesFromBoundariesTest extends TestCase {
         $this->churchId = (int) DB::table('templomok')->max('id') + 1;
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Helynév Teszt';
-        $minta['varos'] = 'Régi Város';
-        $minta['megye'] = 0;
-        $minta['orszag'] = 0;
         $minta['ok'] = 'i';
         DB::table('templomok')->insert($minta);
     }
@@ -116,22 +113,27 @@ class LocationNamesFromBoundariesTest extends TestCase {
         self::assertSame('Magyarország', $this->templom()->locationCountryName());
     }
 
-    // ---- visszaesés ----------------------------------------------------------
+    // ---- határ nélkül --------------------------------------------------------
 
     /**
-     * A visszaesés szándékosan bent van: a szlovák állomány 23%-ának egyáltalán
-     * nincs boundary-ja, és 47 templomnak nincs koordinátája sem.
+     * A régi oszlopokra való visszaesés MEGSZŰNT: az oszlopok nincsenek többé.
+     *
+     * Ez tudatos veszteség, és pont ezért előzte meg három lépés: a 47 koordináta
+     * nélküli templom helyadata a megjegyzés mezőbe került (cron 496), a határ nélkül
+     * maradtak havonta újrapróbálkoznak (cron 497), és a /health kiírja, hányan
+     * vannak. Üres string az őszinte válasz — a régi oszlop csendes visszaszivárgása
+     * elrejtené, hogy a szinkron nem ért oda.
      */
-    public function testHatarNelkulARegiOszlopJon(): void {
-        self::assertSame('Régi Város', $this->templom()->locationCityName());
+    public function testHatarNelkulUresATelepules(): void {
+        self::assertSame('', $this->templom()->locationCityName());
     }
 
-    public function testCsakOrszaghatarralATelepulesMegARegiOszloprolJon(): void {
+    public function testCsakOrszaghatarralATelepulesUres(): void {
         $this->hatarlanc([[2, 'Magyarország']], 'HU');
 
         $templom = $this->templom();
         self::assertSame('Magyarország', $templom->locationCountryName());
-        self::assertSame('Régi Város', $templom->locationCityName());
+        self::assertSame('', $templom->locationCityName());
     }
 
     // ---- országhoz kötött logika --------------------------------------------

--- a/webapp/tests/Integration/NaprakeszTest.php
+++ b/webapp/tests/Integration/NaprakeszTest.php
@@ -18,7 +18,6 @@ class NaprakeszTest extends TestCase {
     private function createChurch(): int {
         return DB::table('templomok')->insertGetId([
             'nev'       => 'Teszt Templom',
-            'varos'     => 'Budapest',
             'frissites' => '2020-01-01',
             'ok'        => 'i',
             'plebania'  => '',

--- a/webapp/tests/Integration/OsmBoundariesTest.php
+++ b/webapp/tests/Integration/OsmBoundariesTest.php
@@ -56,7 +56,6 @@ class OsmBoundariesTest extends TestCase {
             'ok'         => 'i',
             'lat'        => 47.0,
             'lon'        => 19.0,
-            'varos'      => 'Budapest',
             'cim'        => 'Test utca 1.',
             'plebania'   => '',
             'leiras'     => '',

--- a/webapp/tests/Integration/RemarkDuplicateTest.php
+++ b/webapp/tests/Integration/RemarkDuplicateTest.php
@@ -22,7 +22,6 @@ class RemarkDuplicateTest extends TestCase
 
         $this->churchId = DB::table('templomok')->insertGetId([
             'nev'        => '755 Teszt templom',
-            'varos'      => 'Budapest',
             'frissites'  => '2020-01-01',
             'ok'         => 'i',
             'plebania'   => '',

--- a/webapp/tests/Integration/SzentsegimadasImportTest.php
+++ b/webapp/tests/Integration/SzentsegimadasImportTest.php
@@ -50,7 +50,7 @@ class SzentsegimadasImportTest extends TestCase {
         // A lényeg: ez a hívás egyáltalán lefut. Korábban "Call to undefined method"-dal állt meg.
         $found = $api->findChurch([
             'templom' => $church->nev,
-            'varos' => $church->varos,
+            'varos' => $church->locationCityName(),
         ]);
 
         if ($found === false) {


### PR DESCRIPTION
A #496, #497 és #498 zárása. A helyet innentől kizárólag a koordináta és az OSM-határok adják — pontosan úgy, ahogy @borazslo írta:

> Szóval a varos és megye egyáltalán nem kell. Az orszag kell országkódilag.

> ⚠️ **Ez a lánc UTOLSÓ lépése, és visszafordíthatatlan.** Előtte kell: #797 (a fogyasztók származtatott értéket használnak), #798 (a szerkesztő nem írja őket), #796 (a koordináta nélküli templomok helyadata a megjegyzésbe került), #799 (a határ nélkül maradtak újrapróbálkoznak). Az SQL futtatása előtt mentés kell — az előfeltételeket a migrációs fájl fejlécében is felsoroltam.

## Az ellenőrzés, ami a munka felét adta

**A tesztfuttatás önmagában semmit nem bizonyít**, mert a fejlesztői adatbázisban ott vannak az oszlopok — a kód akkor is zölden fut, ha valójában használja őket. Ezért ideiglenesen **átneveztem** mindhármat (és a három táblát), és úgy futtattam a suite-ot.

```
első kör:   71 hiba
utolsó kör:  1 hiba  (a séma-referencia, ami épp a kivezetést írja le)
```

A 71 hiba vezetett el az összes maradék függéshez, amit a grep nem talált meg:

| hely | mi volt |
|---|---|
| `campaign.php` | `->select('t.varos')` + `->where('t.orszag', 12)` |
| `churchupdatetoken.php` | `get(['id','nev','ismertnev','varos'])` |
| `api/table.php` | `leftJoin('orszagok')` + `leftJoin('megye')` |
| 8 teszt-fixtúra | explicit `'varos' => 'Budapest'` |

A fixtúrák mostantól **kihagyják** az oszlopokat. Mivel mindháromnak van alapértelmezése (`NOT NULL DEFAULT 0` / `''`), ez a kivezetés **előtt és után is** működik — a tesztek nem kötődnek egyik sémához sem.

## Amit a kód elveszít

- **A boundary-bootstrap három földrajzi blokkja**, ami a régi oszlopokból gyártott ország/megye/város határt, ha az OSM nem adott ilyet. Az **egyházmegye és az esperesi kerület marad** — azok nem OSM-adatok, és nem is e három jegy tárgya.
- **A származtatott metódusok visszaesési ága.** Üres string az őszinte válasz: a régi oszlop csendes visszaszivárgása elrejtené, hogy a szinkron nem ért oda.

## Amit a kód megtart

A **publikus API `orszag`/`megye`/`varos` mezőit**. A nevük és a jelentésük nem változik, csak a forrásuk — a KAPP és a többi kliens nem vesz észre semmit.

Az `/api/table` korrelált alkérdéssel adja őket, ugyanazzal a szabállyal, mint a `Church::locationCityName()` (a kerület csak 8-as szintű település mellé fűzhető — Köln kreisfreie Stadt). **Join nem használható**: egy templomhoz több határ tartozik, és megsokszorozná a sorokat.

Hét további SQL-szintű hivatkozást is át kellett írni (`orderBy('varos')`, select-listák) — ezekhez bevezettem egy `scopeOrderByCity()` rendezést.

## Ellenőrzés

```
PHP-suite (oszlopokkal, fejlesztői DB):  901 teszt — 1 bukás: SchemaReferenceTest
PHP-suite (oszlopok ELREJTVE):           901 teszt — 1 bukás: SchemaReferenceTest
```

A séma-referencia lokálisan azért bukik, mert a fejlesztői adatbázis még a kivezetés előtti állapotban van (`docker compose down -v` után egyezne). **A CI friss adatbázist húz fel az `initdb.d`-ből**, ami már tartalmazza a `10-location-columns-drop.sql`-t — ott ez valódi, végponttól végpontig ellenőrzés.

A referencia pontosan a hat várt eltérést jelzi: három oszlop és három tábla.

## Futtatandó

```
docker/mysql/migrations/496-497-498-oszlopok-eldobasa.sql
```

Closes #496
Closes #497
Closes #498