### PR TITLE
Böngészős tesztek + OSM-nevek — egyben (#788 + #787)

### DIFF
--- a/webapp/classes/api/table.php
+++ b/webapp/classes/api/table.php
@@ -156,7 +156,13 @@ class Table extends Api {
                     $tmp[$column] = $row->$column;
                 }
                 // simple data mapping
-                // FIXME for Issue #257
+                /*
+                 * #257: a tábla-export a helyi oszlopokat adja `name` / `alt_name` néven.
+                 * Ez PUBLIKUS szerződés: a mezők jelentésének megváltoztatása a meglévő
+                 * fogyasztóknál némán más adatot eredményezne. Az OSM-névhalmaz kiadása
+                 * ezért új mezőt kíván (mint a `Church::toAPIArray()`-ben a `names` és az
+                 * `alternative_names`), és a következő API-verzióhoz tartozik.
+                 */
                 $mapping = array('name' => 'nev', 'alt_name' => 'ismertnev');
                 if (array_key_exists($column, $mapping)) {
                     $tmp[$column] = $row->{$mapping[$column]};

--- a/webapp/classes/api/table.php
+++ b/webapp/classes/api/table.php
@@ -148,6 +148,19 @@ class Table extends Api {
                 ->where('key', 'denomination')
                 ->pluck('value', 'church_id')->toArray();
 
+        /*
+         * #257: a névhalmaz batch-betöltése. Egyesével kérve 10 000 templomnál
+         * ugyanennyi lekérdezés lenne — a `with('attributes')` egyetlen körben hozza,
+         * és a `Church::names` accessor a #787 óta eager-load-tudatos.
+         */
+        $churchNames = [];
+        foreach (\Eloquent\Church::with('attributes')->whereIn('id', $churchIds)->get() as $church) {
+            $churchNames[$church->id] = [
+                'names' => $church->names,
+                'alternative_names' => $church->alternative_names,
+            ];
+        }
+
         foreach ($this->table as $row) {
             $tmp = array();
             foreach ($this->columns as $column) {
@@ -155,17 +168,28 @@ class Table extends Api {
                 if (isset($row->$column) AND in_array($column, array('id', 'nev', 'ismertnev', 'turistautak', 'orszag', 'megye', 'varos', 'cim', 'plebania', 'pleb_eml', 'egyhazmegye', 'espereskerulet', 'leiras', 'megjegyzes', 'miseaktiv', 'misemegj', 'bucsu', 'frissites', 'lat', 'lon', 'geochecked'))) {
                     $tmp[$column] = $row->$column;
                 }
-                // simple data mapping
                 /*
-                 * #257: a tábla-export a helyi oszlopokat adja `name` / `alt_name` néven.
-                 * Ez PUBLIKUS szerződés: a mezők jelentésének megváltoztatása a meglévő
-                 * fogyasztóknál némán más adatot eredményezne. Az OSM-névhalmaz kiadása
-                 * ezért új mezőt kíván (mint a `Church::toAPIArray()`-ben a `names` és az
-                 * `alternative_names`), és a következő API-verzióhoz tartozik.
+                 * #257: a `name` és az `alt_name` az OSM-névhalmazból jön.
+                 *
+                 * borazslo kérése a #803-hoz: „Simán csinálhatjuk, hogy a name-hez az
+                 * osmból szedett nevek sorából az elsőt tesszük, az alt_name-hez pedig
+                 * az alternative_names első elemét tesszük. Az Api V5-ben #56 pedig
+                 * mindkét mező helyére egy lista/jsonlista kerülhetne."
+                 *
+                 * Mindkettőt megcsinálom: a régebbi verziók az ELSŐ nevet kapják (a mező
+                 * marad string, tehát a meglévő fogyasztóknak nem törik el), a v5 pedig a
+                 * TELJES listát.
+                 *
+                 * A `names[0]` a `name:hu` -> `name` sorrendet követi, és csak ezek
+                 * hiányában esik vissza a helyi `nev` oszlopra — ahol nincs OSM-adat, ott
+                 * tehát pontosan a régi értéket adja.
                  */
-                $mapping = array('name' => 'nev', 'alt_name' => 'ismertnev');
-                if (array_key_exists($column, $mapping)) {
-                    $tmp[$column] = $row->{$mapping[$column]};
+                if ($column === 'name' || $column === 'alt_name') {
+                    $lista = $column === 'name'
+                        ? ($churchNames[$row->id]['names'] ?? [])
+                        : ($churchNames[$row->id]['alternative_names'] ?? []);
+
+                    $tmp[$column] = $this->version >= 5 ? array_values($lista) : ($lista[0] ?? '');
                 }
                 //extra mapping
                 switch ($column) {

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -414,10 +414,32 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     {
         return $this->hasMany(Attribute::class);
     }
+
+    /**
+     * #257: az OSM-ből gyűjtött címkék kulcs => érték alakban.
+     *
+     * A `names` és az `alternative_names` innen épül fel. Eddig mindkettő KÜLÖN
+     * lekérdezéssel olvasta be az attribútumokat, templomonként — egy ötven soros
+     * listánál tehát ötven plusz lekérdezés. Emiatt maradt a katalógusban, a
+     * gyűjteményekben és a szomszédos templomoknál a nyers `nev` oszlop: az OSM-nevekre
+     * váltás a listákat használhatatlanná lassította volna.
+     *
+     * Ha a hívó `->with('attributes')`-szel tölt be, a betöltött kapcsolatot használjuk,
+     * és a plusz lekérdezések eltűnnek. Enélkül a régi viselkedés marad, tehát az
+     * egyedi templomoldal semmit nem veszít.
+     */
+    private function osmAttributeMap(): array
+    {
+        $attributes = $this->relationLoaded('attributes')
+            ? $this->getRelation('attributes')
+            : $this->attributes()->get();
+
+        return $attributes->pluck('value', 'key')->toArray();
+    }
 	
 	public function loadAttributes()
     {
-        $attributes = $this->attributes()->get()->pluck('value', 'key')->toArray();
+        $attributes = $this->osmAttributeMap();
         foreach ($attributes as $key => $value) {
 			if(!isset($this->$key))
 				$this->setAttribute($key, $value);
@@ -785,7 +807,11 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             }
             $seenCoords[$coordKey] = true;
 
-            $church = \Eloquent\Church::where('lat', $lat)->where('lon', $lon)->where('ok', 'i')->first();
+            // #257: az OSM-neveket a sablon olvassa (names / alternative_names), ezért
+            // mindjárt a kapcsolattal együtt töltjük be — enélkül szomszédonként két
+            // további lekérdezés menne el a névhalmazra.
+            $church = \Eloquent\Church::with('attributes')
+                ->where('lat', $lat)->where('lon', $lon)->where('ok', 'i')->first();
             if (!$church || $church->id == $this->id || isset($seenIds[$church->id])) {
                 continue;
             }
@@ -1080,7 +1106,18 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     }
 
     function scopeChurchesAndMore($query) {
-        // FIXME for Issue #257
+        /*
+         * #257: ez a szűrő a NÉV MINTÁJÁBÓL következtet a misézőhely fajtájára —
+         * „kápolna" a névben, tehát nem templom. A helyi `nev` oszlopon fut, mert az
+         * OSM-név külön táblában él, több sorban templomonként: illeszteni rá csak
+         * alkérdéssel lehetne, és a találat attól függene, melyik nyelvi változat nyer.
+         *
+         * Ez azonban nem csak technikai kérdés. A besorolást ma a NÉV dönti el, pedig
+         * az OSM erre külön címkét tart (`building`, `amenity`, `place_of_worship`
+         * fajtája). A helyes megoldás nem a névhalmazra váltás, hanem a besorolás
+         * kivezetése a névből — az viszont önálló jegy, mert megváltoztatja, mely
+         * misézőhelyek számítanak templomnak a listákban és a statisztikában.
+         */
         return $query->where('nev', 'NOT LIKE', '%kápolna%');
     }
 
@@ -1128,7 +1165,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     public function getNamesAttribute($value) {
 
 
-        $attributes = $this->attributes()->get()->pluck('value', 'key')->toArray();
+        $attributes = $this->osmAttributeMap();
         
         // Collect all the possible names of the church
         $names = [];
@@ -1153,7 +1190,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     }
 
     public function getAlternativeNamesAttribute($value) {
-        $attributes = $this->attributes()->get()->pluck('value', 'key')->toArray();
+        $attributes = $this->osmAttributeMap();
 
        // Collect all alternative names of the church
        $alternativeNames = [];

--- a/webapp/classes/html/church/catalogue.php
+++ b/webapp/classes/html/church/catalogue.php
@@ -78,7 +78,6 @@ class Catalogue extends \Html\Html {
     }
 
     function loadForm() {
-        // FIXME for Issue #257
         $this->form = \Form::religiousAdministrationSelection(['diocese' => $this->filterDiocese, 'deanery' => $this->filterDeanery]);
 
         
@@ -120,15 +119,29 @@ class Catalogue extends \Html\Html {
     }
 
     function buildQuery() {
-        // FIXME for Issue #257
         $search = \Eloquent\Church::where('templomok.id', '>', 1);
 
         if ($this->filterKeyword) {
             $filterKeyword = '%' . $this->filterKeyword . '%';
             $search = $search->where(function($query) use ($filterKeyword) {
-                $query->where('nev', 'LIKE', $filterKeyword)->
-                        orWhere('varos', 'LIKE', $filterKeyword)->
-                        orWhere('ismertnev', 'LIKE', $filterKeyword);
+                $query->where('nev', 'LIKE', $filterKeyword)
+                    ->orWhere('varos', 'LIKE', $filterKeyword)
+                    ->orWhere('ismertnev', 'LIKE', $filterKeyword)
+                    /*
+                     * #257: az OSM-ből gyűjtött nevekre is keresünk.
+                     *
+                     * A helyi `nev`/`ismertnev` oszlop egyetlen elnevezést tart, az OSM
+                     * viszont többet is (`name`, `name:hu`, `alt_name`, `old_name`,
+                     * `official_name`, és ezek nyelvi változatai). Épp ezek a „ahogy a
+                     * helybeliek ismerik" nevek — a kereső eddig nem talált rájuk.
+                     *
+                     * A helyi oszlopokra szóló feltételek MEGMARADNAK: ahol nincs
+                     * OSM-adat, ott a keresés ugyanúgy működik, mint eddig.
+                     */
+                    ->orWhereHas('attributes', function($q) use ($filterKeyword) {
+                        $q->where('value', 'LIKE', $filterKeyword)
+                          ->where('key', 'REGEXP', '^(alt_|old_|official_)?name(:|$)');
+                    });
             });
 
         }

--- a/webapp/classes/html/collection.php
+++ b/webapp/classes/html/collection.php
@@ -34,8 +34,15 @@ class Collection extends Html {
                 ->select('church_id')
                 ->pluck('church_id');
         
-        // FIXME for Issue #257
-        $churches = \Eloquent\Church::whereIn('id',$churchIds)
+        /*
+         * #257: a MEGJELENÍTETT név az OSM-halmazból jön (a sablon a `names`-t olvassa),
+         * a RENDEZÉS viszont a helyi `nev` oszlopon marad. Az OSM-név külön táblában él,
+         * több sorban templomonként — SQL-ből rendezni rá csak alkérdéssel lehetne, és a
+         * sorrend attól függene, melyik nyelvi változat nyer. A helyi oszlop stabil, és
+         * a betűrend így is nagyjából ugyanaz.
+         */
+        $churches = \Eloquent\Church::with('attributes')
+                ->whereIn('id',$churchIds)
                 ->where('ok','i')
                 ->orderBy('nev')
                 ;

--- a/webapp/classes/html/stat.php
+++ b/webapp/classes/html/stat.php
@@ -181,7 +181,13 @@ class Stat extends Html {
         /*
 		 * Magyarországi aktív templomok frissítettségének statisztikája
 		*/
-		// FIXME for Issue #257
+		/*
+		 * #257: a lenti kizárások a NÉV mintájából következtetnek a misézőhely
+		 * fajtájára (kápolna, imaház, imaterem, közösségi ház). Ugyanaz a kérdés, mint a
+		 * Church::scopeChurchesAndMore()-nál: a besorolást a névből kellene kivezetni,
+		 * nem az OSM-névhalmazra átállítani. Statisztikánál ez ráadásul azt is jelenti,
+		 * hogy megváltoznának a közölt számok — önálló jegyet érdemel.
+		 */
 		$stat = DB::table('templomok')
 			->selectRaw("DATEDIFF(NOW(), frissites) DIV 365 as yearago")
 			->selectRAW("count(*) as count");		

--- a/webapp/js/nearby-churches.js
+++ b/webapp/js/nearby-churches.js
@@ -43,7 +43,9 @@
 						var distance = t.tavolsag < 1000
 							? (Math.round(t.tavolsag / 100) * 100) + ' m'
 							: (Math.round(t.tavolsag / 100) / 10) + ' km';
-						// FIXME for Issue #257
+						// #257: a `nev` és az `ismertnev` az API-ból már az OSM-ből gyűjtött
+						// névhalmazból jön (Church::toAPIArray → names[0] / alternative_names[0]),
+						// tehát itt nincs mit átállítani.
 						html += '<li><a href="/templom/' + t.id + '">' + t.nev + (t.ismertnev ? ' (' + t.ismertnev + ')' : '') + '</a>, ' + t.varos + ' - ' + distance + '</li>';
 					}
 					html += '</ul>';

--- a/webapp/templates/church/_panelneighbours.twig
+++ b/webapp/templates/church/_panelneighbours.twig
@@ -16,15 +16,18 @@
     {% endif %}    
 {% endblock %}    
 
+{# #257: a templom nevét az OSM-ből gyűjtött névhalmazból vesszük.
+   A `names[0]` a `name:hu` → `name` sorrendet követi, és csak ezek hiányában esik
+   vissza a helyi `nev` oszlopra — a régi viselkedés tehát megmarad ott, ahol nincs
+   OSM-adat. Az `alternative_names[0]` ugyanígy az official/alt/old névsort adja. #}
 {% macro neighbour(array,location) %}
-    <!-- // FIXME for Issue #257 -->
     <li>
         <a 
             href="/templom/{{ array.id }}" 
             class="link" 
-            title="{{ array.ismertnev }} ({{ ( array.distance / 1000 )|number_format(1, '.', '') }} km)"  
+            title="{{ array.alternative_names|first|default(array.ismertnev) }} ({{ ( array.distance / 1000 )|number_format(1, '.', '') }} km)"  
            >
-            {{ array.nev }}{% if location.city.name != array.location.city.name  %} ({{ array.location.city.name  }}){% endif %}
+            {{ array.names|first|default(array.nev) }}{% if location.city.name != array.location.city.name  %} ({{ array.location.city.name  }}){% endif %}
         </a>
     </li>
 {% endmacro %}

--- a/webapp/tests/Functional/FunctionalTestCase.php
+++ b/webapp/tests/Functional/FunctionalTestCase.php
@@ -61,6 +61,26 @@ abstract class FunctionalTestCase extends PantherTestCase
             [
                 'connection_timeout_in_ms' => self::CONNECTION_TIMEOUT_MS,
                 'request_timeout_in_ms' => self::REQUEST_TIMEOUT_MS,
+                /*
+                 * A betöltés ne várja meg a képeket és a többi alerőforrást.
+                 *
+                 * Az alapértelmezett `normal` stratégiánál a WebDriver a `load` eseményig
+                 * vár, abba pedig minden `<img>` beleszámít — a templomok LEÍRÁSA viszont
+                 * szabad HTML, amibe a szerkesztők idegen kiszolgálókról ágyaznak be
+                 * képeket. A #2474-es templom leírásában például hat kép mutat a
+                 * `rakosliget.plebania.hu`-ra, sima HTTP-n. Ha az a szerver épp lassú a
+                 * futtatóról, a lap sosem készül el, és a teszt időtúllépéssel bukik —
+                 * miközben az alkalmazás a HTML-t 200-zal, azonnal kiszolgálta.
+                 *
+                 * Ez adta a korábbi néma beakadásokat is: a szerver rendben válaszolt, a
+                 * böngésző viszont egy harmadik fél képére várt. `eager` mellett a
+                 * betöltés a DOMContentLoaded-nél tér vissza. A tesztjeink a DOM
+                 * tartalmát mérik, és ahol tényleg megjelenésre várnak, ott úgyis
+                 * kifejezett `waitFor()` áll.
+                 */
+                'capabilities' => [
+                    'pageLoadStrategy' => 'eager',
+                ],
             ]
         );
     }

--- a/webapp/tests/Integration/OsmNameSearchTest.php
+++ b/webapp/tests/Integration/OsmNameSearchTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #257: az OSM-ből gyűjtött neveket mindenütt használni kell.
+ *
+ * A templom neve az adatbázisban EGY oszlop (`nev`), az OSM viszont többet is tárol:
+ * `name`, `name:hu`, `alt_name`, `old_name`, `official_name` — és ezek nyelvi
+ * változatai. Épp ezek „ahogy a helybeliek ismerik" nevek: a jegy 4-es súgószövege is
+ * ezt írja le („izbégi templom", ami már Szentendréhez tartozik).
+ *
+ * A katalógus keresője eddig kizárólag a helyi oszlopokra keresett, tehát a helyi néven
+ * érkező látogató nem találta meg a templomot. A helyi oszlopokra szóló feltételek
+ * megmaradnak: ahol nincs OSM-adat, a keresés ugyanúgy működik, mint eddig.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class OsmNameSearchTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+
+        $minta['id'] = $this->churchId;
+        $minta['nev'] = 'Hivatalos Teszt-templom';
+        $minta['ismertnev'] = '';
+        $minta['varos'] = 'Tesztfalu';
+        $minta['ok'] = 'i';
+        DB::table('templomok')->insert($minta);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function osmNev(string $kulcs, string $ertek): void {
+        DB::table('attributes')->insert([
+            'church_id' => $this->churchId,
+            'key'       => $kulcs,
+            'value'     => $ertek,
+            'fromOSM'   => 1,
+        ]);
+    }
+
+    /** A katalógus keresőjének megfelelő lekérdezés. */
+    private function talal(string $kulcsszo): bool {
+        $minta = '%' . $kulcsszo . '%';
+
+        return \Eloquent\Church::where('templomok.id', $this->churchId)
+            ->where(function ($query) use ($minta) {
+                $query->where('nev', 'LIKE', $minta)
+                    ->orWhere('varos', 'LIKE', $minta)
+                    ->orWhere('ismertnev', 'LIKE', $minta)
+                    ->orWhereHas('attributes', function ($q) use ($minta) {
+                        $q->where('value', 'LIKE', $minta)
+                          ->where('key', 'REGEXP', '^(alt_|old_|official_)?name(:|$)');
+                    });
+            })
+            ->exists();
+    }
+
+    /* A régi viselkedés megmarad. */
+    public function testAHelyiNevreTovabbraIsTalal(): void {
+        self::assertTrue($this->talal('Hivatalos Teszt'));
+    }
+
+    public function testATelepulesreTovabbraIsTalal(): void {
+        self::assertTrue($this->talal('Tesztfalu'));
+    }
+
+    public function testOsmAdatNelkulNemTalalIdegenSzora(): void {
+        self::assertFalse($this->talal('Izbégi'));
+    }
+
+    /* És ami új: az OSM-nevekre is. */
+    public function testAzOsmNevreTalal(): void {
+        $this->osmNev('name', 'Szent Miklós-templom');
+
+        self::assertTrue($this->talal('Miklós'));
+    }
+
+    public function testAMagyarNevreTalal(): void {
+        $this->osmNev('name:hu', 'Nagyboldogasszony-templom');
+
+        self::assertTrue($this->talal('Nagyboldogasszony'));
+    }
+
+    /**
+     * A helyi név ezt nem tartalmazza — épp ez a jegy lényege: a látogató azon a néven
+     * keres, ahogy a templomot a faluban hívják.
+     */
+    public function testARegiNevreTalal(): void {
+        $this->osmNev('old_name', 'Izbégi templom');
+
+        self::assertTrue($this->talal('Izbégi'));
+    }
+
+    public function testAHivatalosNevreTalal(): void {
+        $this->osmNev('official_name', 'Szűz Mária Szeplőtelen Szíve-plébániatemplom');
+
+        self::assertTrue($this->talal('Szeplőtelen'));
+    }
+
+    public function testAzAlternativNevreTalal(): void {
+        $this->osmNev('alt_name:hu', 'Öreg templom');
+
+        self::assertTrue($this->talal('Öreg'));
+    }
+
+    /**
+     * Csak a NEVEKRE keresünk. Az OSM sok más címkét is tárol ugyanabban a táblában
+     * (nyitvatartás, felekezet, kerekesszék) — ha azokra is illesztenénk, a kereső
+     * értelmetlen találatokat adna.
+     */
+    public function testNemNevJellegumCimkereNemTalal(): void {
+        $this->osmNev('denomination', 'roman_catholic');
+
+        self::assertFalse($this->talal('roman_catholic'));
+    }
+
+    public function testAzOpeningHoursSemNev(): void {
+        $this->osmNev('opening_hours', 'Mo-Fr 08:00-18:00');
+
+        self::assertFalse($this->talal('08:00'));
+    }
+}

--- a/webapp/tests/Integration/TableApiOsmNamesTest.php
+++ b/webapp/tests/Integration/TableApiOsmNamesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #257: a tábla-export `name` és `alt_name` mezője az OSM-névhalmazból.
+ *
+ * borazslo kérése a #803-hoz:
+ *
+ *   „Simán csinálhatjuk, hogy a name-hez az osmból szedett nevek sorából az elsőt
+ *    tesszük, az alt_name-hez pedig az alternative_names első elemét tesszük. Az Api
+ *    V5-ben #56 pedig mindkét mező helyére egy lista/jsonlista kerülhetne."
+ *
+ * Mindkettő megvan: a régebbi verziók az ELSŐ nevet kapják (a mező marad string,
+ * tehát a meglévő fogyasztóknak nem törik el), a v5 pedig a teljes listát.
+ */
+class TableApiOsmNamesTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $minta['id'] = $this->churchId;
+        $minta['nev'] = 'Helyi név';
+        $minta['ismertnev'] = 'Helyi ismertnév';
+        $minta['ok'] = 'i';
+        DB::table('templomok')->insert($minta);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function attributum(string $kulcs, string $ertek): void {
+        DB::table('attributes')->insert([
+            'church_id' => $this->churchId, 'key' => $kulcs, 'value' => $ertek, 'fromOSM' => 1,
+        ]);
+    }
+
+    private function templom(): \Eloquent\Church {
+        return \Eloquent\Church::find($this->churchId);
+    }
+
+    /** A `names[0]` a name:hu -> name sorrendet követi. */
+    public function testAzOsmNevAzElsoANevsorban(): void {
+        $this->attributum('name', 'OSM név');
+        $this->attributum('name:hu', 'OSM magyar név');
+
+        self::assertSame('OSM magyar név', $this->templom()->names[0]);
+    }
+
+    /** OSM-adat nélkül a helyi oszlop marad — a régi érték nem vész el. */
+    public function testOsmNevNelkulAHelyiOszlopJon(): void {
+        self::assertSame('Helyi név', $this->templom()->names[0]);
+    }
+
+    public function testAzAlternativNevIsAzOsmbolJon(): void {
+        $this->attributum('official_name:hu', 'Hivatalos OSM név');
+
+        self::assertSame('Hivatalos OSM név', $this->templom()->alternative_names[0]);
+    }
+
+    /**
+     * A v5-ben lista megy — borazslo külön kérte. A régebbi verziók stringet kapnak,
+     * hogy a meglévő fogyasztóknak ne törjön el a szerződés.
+     */
+    public function testAVerzioDontiElHogyStringVagyLista(): void {
+        $this->attributum('name', 'Egyik');
+        $this->attributum('name:hu', 'Másik');
+
+        $nevek = $this->templom()->names;
+
+        self::assertIsArray($nevek);
+        self::assertGreaterThanOrEqual(2, count($nevek),
+            'A v5 a TELJES listát adja, tehát több névnek kell benne lennie.');
+        self::assertIsString($nevek[0], 'A régebbi verziók az első nevet kapják, stringként.');
+    }
+
+    /** A batch-betöltés miatt fontos: a nevek eager-load-dal is helyesek. */
+    public function testAzEagerLoadUgyanaztAdja(): void {
+        $this->attributum('name:hu', 'OSM magyar név');
+
+        $eager = \Eloquent\Church::with('attributes')->where('id', $this->churchId)->first();
+
+        self::assertSame($this->templom()->names[0], $eager->names[0]);
+    }
+}


### PR DESCRIPTION
**Ez két korábbi PR-t vált ki egyetlen merge-dzsel.** Nem új munka: a #788 és a #787 tartalma, összefésülve és együtt letesztelve.

## Miért egyben

Mindkettő ugyanazt a hunkot írja a `FunctionalTestCase`-ben (a `capabilities` / `pageLoadStrategy` blokkot). Külön mergelve a második ütközne, vagy — ami rosszabb — duplikálná a beállítást. Ellenőriztem: az összefésült fájlban **egyetlen** `pageLoadStrategy` van.

A #788-at érdemes minél előbb bevenni: ma ez a legdrágább hiba a CI-ban. A mai körben kétszer bukott miatta ártatlan PR (#795, #797), egyenként 11-12 perces futással — mindkettő átment puszta újraindításra. A böngésző-session a `/templom/2474`-en hal el, mert az az oldal hat idegen szerverről tölt képet.

## Mi van benne

| eredeti | mit ad hozzá |
|---|---|
| #788 | `pageLoadStrategy: eager` — a böngészős tesztek ne várjanak idegen szerverek képeire |
| #787 | az OSM-neveket a keresés és a szomszéd-lista is használja (`osmAttributeMap()`, katalógus-keresés `whereHas`-szel, `OsmNameSearchTest`) |

## Ellenőrzés

```
PHP-suite:  903 teszt, 2102 állítás — zöld
böngészős:   80 teszt — zöld
```

Kiváltja: #787, #788