### PR TITLE
Naptár: jogok, plébánia-család, többtemplomos javaslat — egyben (#779 + #780 + #782)

### DIFF
--- a/calendar/src/app/app.routes.ts
+++ b/calendar/src/app/app.routes.ts
@@ -12,6 +12,17 @@ export const routes: Routes = [
   { path: 'templom/:id/editschedule', component: EditScheduleComponent },
   { path: 'templom/:id/javaslatok', component: SuggestionsComponent },
   { path: 'templom/:id', component: ChurchComponent },
+  /*
+   * #830: a plébánia-család közös miserendje saját útvonalon.
+   *
+   * Ugyanaz a komponens, mint a `templom/:id` — a család módot a ChurchComponent az
+   * ÚTVONALBÓL ismeri fel, nem query-paraméterből. Enélkül a `/plebania/:id` csak
+   * átirányítás lehetne a `?csalad=1`-re, és a szép URL rögtön el is tűnne a
+   * címsorból, amint betölt a lap.
+   *
+   * A `?csalad=1` továbbra is működik: a régi linkek nem törnek el.
+   */
+  { path: 'plebania/:id', component: ChurchComponent },
   { path: 'periodyeareditor', component: PeriodYearEditorComponent },
   { path: '', component: SearchComponent },
 ];

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.css
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.css
@@ -103,3 +103,11 @@
  flex-direction: column;
  gap: 1em;
 }
+
+/* #506: a templomválasztó a dialógus TELJES szélességét kapja.
+   A `mat-form-field` alapból inline-block, fix szélességgel — borazslo emiatt látta
+   „csak egy oszlopban". A dialógus első döntése ne szoruljon fél sorba. */
+.church-selector {
+  display: block;
+  width: 100%;
+}

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.html
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.html
@@ -14,12 +14,14 @@
 </div>
 <mat-dialog-content class="mat-typography">
 
+  <!-- #506: a templomválasztó a dialógus TELJES szélességét kapja (borazslo kérése).
+       Ez a legelső döntés a szerkesztésben — nem szabad egy fél oszlopba szorulnia. -->
   @if (hasChurchChoice) {
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="church-selector">
       <mat-label>Melyik templomban?</mat-label>
       <mat-select [ngModel]="data.event.churchId ?? churches[0].id" (ngModelChange)="onChurchChange($event)">
         @for (church of churches; track church.id) {
-          <mat-option [value]="church.id">{{ church.name }}</mat-option>
+          <mat-option [value]="church.id">{{ churchLabel(church) }}</mat-option>
         }
       </mat-select>
     </mat-form-field>

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.html
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.html
@@ -14,6 +14,17 @@
 </div>
 <mat-dialog-content class="mat-typography">
 
+  @if (hasChurchChoice) {
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Melyik templomban?</mat-label>
+      <mat-select [ngModel]="data.event.churchId ?? churches[0].id" (ngModelChange)="onChurchChange($event)">
+        @for (church of churches; track church.id) {
+          <mat-option [value]="church.id">{{ church.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  }
+
   <mat-accordion class="example-headers-align" multi>
     <mat-expansion-panel expanded>
       <mat-expansion-panel-header>

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -23,6 +23,7 @@ import {recurrences, Renum} from '../../enum/recurrence';
 import {TranslatePipe, TranslateService} from '@ngx-translate/core';
 import {Rite, RiteMassTypes} from '../../enum/rites';
 import {MassUtil} from '../../util/mass-util';
+import {ChurchFamilyMember} from '../../model/church';
 import {LanguageCode} from '../../enum/language-code';
 import {DialogResponse} from '../../enum/dialog-response';
 import {MatExpansionModule} from '@angular/material/expansion';
@@ -125,6 +126,14 @@ export class AddFullEventDialogComponent {
 
   public onChurchChange(churchId: number): void {
     this.data.event.churchId = churchId;
+  }
+
+  /**
+   * #506: mindig „település, templomnév" — a naptár rövidítő szabálya itt NEM jó.
+   * A választó döntési pont: ha félreértjük, a mise rossz templomhoz íródik.
+   */
+  public churchLabel(tag: ChurchFamilyMember): string {
+    return MassUtil.familySelectorLabel(tag);
   }
 
   public singleEvent: boolean = this.data.event.renum === Renum.NONE;

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -108,6 +108,25 @@ export class AddFullEventDialogComponent {
   // #454: Új dátum hozzáadásához használt ideiglenes változó
   public newExceptionDate: Date | null = null;
 
+  /**
+   * #506: melyik templomhoz tartozzon az esemény.
+   *
+   * Csak akkor jelenik meg, ha tényleg van miből választani — a plébániának vannak
+   * fíliái, és többhöz is van írásjogunk. Egy templomnál a választó felesleges zaj,
+   * és a dialógus ugyanúgy néz ki, mint eddig.
+   */
+  public get churches() {
+    return this.data.churches ?? [];
+  }
+
+  public get hasChurchChoice(): boolean {
+    return this.churches.length > 1;
+  }
+
+  public onChurchChange(churchId: number): void {
+    this.data.event.churchId = churchId;
+  }
+
   public singleEvent: boolean = this.data.event.renum === Renum.NONE;
   public specialPeriodType?: SpecialType | null = null;
 

--- a/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.css
+++ b/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.css
@@ -10,3 +10,10 @@
 .mat-mdc-card-actions {
   justify-content: end;
 }
+
+/* #506: a templomválasztó teljes szélességben — lásd a teljes szerkesztőt. */
+.simple-church {
+  display: block;
+  width: 100%;
+  margin-top: 0.5em;
+}

--- a/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.html
+++ b/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.html
@@ -10,6 +10,16 @@
       <mat-icon fontSet="material-symbols-outlined" class="icon">calendar_clock</mat-icon>
       <span>{{ dateTime }}</span>
     </div>
+    @if (hasChurchChoice) {
+      <mat-form-field class="simple-church" appearance="outline">
+        <mat-label>Melyik templomban?</mat-label>
+        <mat-select [ngModel]="churchId" (ngModelChange)="onChurchChange($event)">
+          @for (church of churches; track church.id) {
+            <mat-option [value]="church.id">{{ church.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
   </mat-card-content>
   <mat-card-actions>
     <button mat-flat-button (click)="onMoreDetails()">{{ 'SIMPLE_EVENT.MORE_SETTINGS' | translate }}</button>

--- a/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.html
+++ b/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.html
@@ -15,7 +15,7 @@
         <mat-label>Melyik templomban?</mat-label>
         <mat-select [ngModel]="churchId" (ngModelChange)="onChurchChange($event)">
           @for (church of churches; track church.id) {
-            <mat-option [value]="church.id">{{ church.name }}</mat-option>
+            <mat-option [value]="church.id">{{ churchLabel(church) }}</mat-option>
           }
         </mat-select>
       </mat-form-field>

--- a/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.ts
+++ b/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.ts
@@ -7,6 +7,9 @@ import {MAT_DIALOG_DATA, MatDialogClose, MatDialogRef} from '@angular/material/d
 import {DateTimeUtil} from '../../util/date-time-util';
 import {DialogResponse} from '../../enum/dialog-response';
 import {TranslatePipe} from '@ngx-translate/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatSelectModule} from '@angular/material/select';
+import {FormsModule} from '@angular/forms';
 
 @Component({
   selector: 'app-add-simple-event-dialog',
@@ -15,7 +18,10 @@ import {TranslatePipe} from '@ngx-translate/core';
     MatCardModule,
     MatButtonModule,
     TranslatePipe,
-    MatDialogClose
+    MatDialogClose,
+    MatFormFieldModule,
+    MatSelectModule,
+    FormsModule
   ],
   templateUrl: './add-simple-event-dialog.component.html',
   styleUrls: ['../../../styles.scss', './add-simple-event-dialog.component.css']
@@ -27,9 +33,34 @@ export class AddSimpleEventDialogComponent {
   readonly dateTime: string;
   readonly title: string;
 
+  /**
+   * #506: melyik templomhoz kerüljön az esemény.
+   *
+   * Csak akkor jelenik meg, ha tényleg van miből választani (a plébániának vannak
+   * fíliái, és többhöz is van írásjogunk). Egy templomnál a választó felesleges zaj.
+   *
+   * A választást a `data` objektumba írjuk vissza, mert a dialógus szerződése egy
+   * enum-válasz — azt nem akartam megváltoztatni a meglévő hívók miatt.
+   */
+  churchId?: number;
+
   constructor() {
     this.dateTime = DateTimeUtil.getDateTimeString(this.data.dateTime);
     this.title = this.data.title;
+    this.churchId = this.data.selectedChurchId;
+  }
+
+  get churches() {
+    return this.data.churches ?? [];
+  }
+
+  get hasChurchChoice(): boolean {
+    return this.churches.length > 1;
+  }
+
+  onChurchChange(churchId: number): void {
+    this.churchId = churchId;
+    this.data.selectedChurchId = churchId;
   }
 
   onSaveSimple(): void {

--- a/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.ts
+++ b/calendar/src/app/components/add-simple-event-dialog/add-simple-event-dialog.component.ts
@@ -10,6 +10,8 @@ import {TranslatePipe} from '@ngx-translate/core';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatSelectModule} from '@angular/material/select';
 import {FormsModule} from '@angular/forms';
+import {MassUtil} from '../../util/mass-util';
+import {ChurchFamilyMember} from '../../model/church';
 
 @Component({
   selector: 'app-add-simple-event-dialog',
@@ -61,6 +63,14 @@ export class AddSimpleEventDialogComponent {
   onChurchChange(churchId: number): void {
     this.churchId = churchId;
     this.data.selectedChurchId = churchId;
+  }
+
+  /**
+   * #506: mindig „település, templomnév" — a naptár rövidítő szabálya itt NEM jó.
+   * A választó döntési pont: ha félreértjük, a mise rossz templomhoz íródik.
+   */
+  churchLabel(tag: ChurchFamilyMember): string {
+    return MassUtil.familySelectorLabel(tag);
   }
 
   onSaveSimple(): void {

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -147,6 +147,19 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       if (mass.churchId) {
         ids.add(mass.churchId);
       }
+      /*
+       * #506: az EREDETI templom is érintett, ha a mise átkerült máshova.
+       *
+       * borazslo: „ha a teljes ismétlődő sorozatot módosítottam egyik templomból a
+       * másikra, akkor csak egy helyen jelent meg a módosítási javaslat." A forrás
+       * gondnoka így nem is értesült arról, hogy egy misét elvisznek tőle — pedig ez
+       * az ő miserendjét változtatja meg. (Egyetlen alkalomnál azért működött, mert
+       * ott a forráson keletkezik egy kivétel-dátum, tehát ő is változik.)
+       */
+      const eredeti = mass.id != null ? this.masses.get(mass.id) : undefined;
+      if (eredeti?.churchId) {
+        ids.add(eredeti.churchId);
+      }
     }
     for (const id of deleted) {
       const mass = this.masses.get(id) ?? this.changes.get(id);
@@ -179,7 +192,15 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       return this.currentChurch!;
     }
 
-    const tag = this.writableFamily().find(t => t.id === churchId);
+    /*
+     * #506: a TELJES családban keresünk, nem csak az írhatókban.
+     *
+     * Ha csak az írhatókat néznénk, egy nem írható templom miséje mentéskor némán a
+     * szerkesztett templomhoz került volna — vagyis a jogosultság hiánya ADATMOZGÁSSÁ
+     * fordult volna át. A szerver templomonként ellenőriz: jobb, ha a mentés
+     * elutasításra kerül, mint ha rossz helyre sikerülne.
+     */
+    const tag = this.family.find(t => t.id === churchId);
     if (!tag) {
       return this.currentChurch!;
     }

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -63,6 +63,10 @@ import {CompressionResult, WeekCompressionUtil, WeekEvent} from '../../util/week
 export interface SimpleDialogData {
   dateTime: Date;
   title: string;
+  /** #506: a választható (írható) templomok — család módon kívül üres. */
+  churches?: ChurchFamilyMember[];
+  /** A dialógus ebbe írja vissza a választást. */
+  selectedChurchId?: number;
 }
 
 export interface EventViewerDialogData {
@@ -88,6 +92,8 @@ export interface DialogData {
   // templomnak van már „illeszthető" rendszeres miserendje (pl. tanítási idő).
   existingPeriodIds?: number[];
   country?: string;
+  /** #506: a választható (írható) templomok — család módon kívül üres. */
+  churches?: ChurchFamilyMember[];
 }
 
 @Component({
@@ -122,6 +128,65 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
    * Így a naptárban csak az idegen esemény kap templomnevet a címe elé; a sajátjaink
    * ugyanúgy néznek ki, mint eddig.
    */
+  /**
+   * #506: az ÍRHATÓ családtagok — köztük a saját templom is.
+   *
+   * A felület csak ezeket kínálja fel: értelmetlen olyan templomot választhatóvá tenni,
+   * amit a szerver úgyis visszautasítana. Család módon kívül üres, tehát nincs választó.
+   */
+  /**
+   * #506: mely templomokat érinti ez a mentés?
+   *
+   * A mentendő mise a saját `churchId`-jét hozza; a törlendőét a betöltött adatból
+   * nézzük meg. A szerkesztett templom mindig benne van, mert a kérés oda megy.
+   */
+  private affectedChurchIds(changed: Mass[], deleted: number[]): number[] {
+    const ids = new Set<number>([this.currentChurch!.id]);
+
+    for (const mass of changed) {
+      if (mass.churchId) {
+        ids.add(mass.churchId);
+      }
+    }
+    for (const id of deleted) {
+      const mass = this.masses.get(id) ?? this.changes.get(id);
+      if (mass?.churchId) {
+        ids.add(mass.churchId);
+      }
+    }
+
+    return Array.from(ids);
+  }
+
+  public writableFamily(): ChurchFamilyMember[] {
+    return this.family.filter(tag => tag.writable);
+  }
+
+  /** Van-e egyáltalán miből választani? Egy templomnál a választó felesleges zaj. */
+  public hasChurchChoice(): boolean {
+    return this.writableFamily().length > 1;
+  }
+
+  /**
+   * Az a templom, amelyikhez az ÚJ esemény kerül.
+   *
+   * Alapból a szerkesztett templom — ez a mai viselkedés. Család módban a dialógusban
+   * választott templom, a saját rítusával: egy görögkatolikus fília miséje ne kapjon
+   * római rítust csak azért, mert a plébánia felől nyitottuk meg.
+   */
+  private targetChurch(churchId?: number): Church {
+    if (!churchId || churchId === this.currentChurch!.id) {
+      return this.currentChurch!;
+    }
+
+    const tag = this.writableFamily().find(t => t.id === churchId);
+    if (!tag) {
+      return this.currentChurch!;
+    }
+
+    return {...this.currentChurch!, id: tag.id, name: tag.name, rite: tag.rite};
+  }
+
   private otherChurchNames(): Map<number, string> {
     const nevek = new Map<number, string>();
     for (const tag of this.family) {
@@ -887,27 +952,36 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       return;
     }
 
-    const dialogRef = this.dialog.open(AddSimpleEventDialogComponent, {
-      data: {dateTime: this.selectedDate, title: MassUtil.getSimpleTitle4Church(this.currentChurch!)}
-    });
+    // #506: a választható templomokat és az alapértelmezést a dialógus adatában adjuk át.
+    // A dialógus ugyanebbe az objektumba írja vissza a választást — így a meglévő,
+    // enumot visszaadó szerződés nem változik.
+    const simpleData: SimpleDialogData = {
+      dateTime: this.selectedDate,
+      title: MassUtil.getSimpleTitle4Church(this.currentChurch!),
+      churches: this.writableFamily(),
+      selectedChurchId: this.currentChurch!.id,
+    };
+
+    const dialogRef = this.dialog.open(AddSimpleEventDialogComponent, {data: simpleData});
 
     dialogRef.afterClosed().subscribe(result => {
       if (result === DialogResponse.SAVE_SIMPLE) {
-        this.saveSimpleEvent();
+        this.saveSimpleEvent(simpleData.selectedChurchId);
       } else if(result === DialogResponse.MORE_DETAILS) {
         this.dialogEvent = CalendarUtil.generateDialogEvent(this.currentChurch, this.translateService, this.selectedDate);
+        this.dialogEvent.churchId = simpleData.selectedChurchId;
         this.openFullDialog('ADD_NEW_MASS', this.selectedDate);
       }
     });
   }
 
-  private saveSimpleEvent() {
+  private saveSimpleEvent(churchId?: number) {
     if (this.selectedDate === undefined) {
       return;
     }
 
     const newMassId = MassUtil.generateTmpMassId();
-    const simpleMass: Mass = MassUtil.createSimpleMassByDate(this.selectedDate, this.currentChurch!, newMassId, this.translateService);
+    const simpleMass: Mass = MassUtil.createSimpleMassByDate(this.selectedDate, this.targetChurch(churchId), newMassId, this.translateService);
 
     this.changes.set(simpleMass.id!, simpleMass);
 
@@ -940,7 +1014,9 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
     }
 
     const dialogRef = this.dialog.open(AddFullEventDialogComponent, {
-      data: {title: title, event: this.dialogEvent, existingPeriodIds: existingPeriodIds, country: this.currentChurch.country}
+      // #506: a választható (írható) templomok. Család módon kívül üres, tehát a
+      // dialógus ugyanúgy néz ki, mint eddig.
+      data: {title: title, event: this.dialogEvent, existingPeriodIds: existingPeriodIds, country: this.currentChurch.country, churches: this.writableFamily()}
     });
 
     dialogRef.afterClosed().subscribe(result => {
@@ -957,7 +1033,7 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
           const newSingleMass: Mass = MassUtil.createMass(
             MassUtil.createEventByType(this.dialogEvent, newMassId, undefined, this.translateService),
             this.dialogEvent,
-            this.currentChurch!,
+            this.targetChurch(this.dialogEvent.churchId),
             newMassId
           );
 
@@ -992,7 +1068,7 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
           const periodWeight = this.dialogEvent.period?.weight;
           const specialPeriodType = this.periodService.getSpecialPeriodType(periodId);
           const calendarEvent: CalendarEvent = MassUtil.createEventByType(this.dialogEvent, newMassId, specialPeriodType, this.translateService);
-          const mass: Mass = MassUtil.createMass(calendarEvent, this.dialogEvent, this.currentChurch!, newMassId);
+          const mass: Mass = MassUtil.createMass(calendarEvent, this.dialogEvent, this.targetChurch(this.dialogEvent.churchId), newMassId);
 
           // #352: ha a felhasználó csak rányomott egy meglévő mise módosítására és semmit nem
           // változtatott, ne tegyük változási javaslattá - nem küldünk fantom javaslatot, és
@@ -1049,6 +1125,7 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
     const proceedWithSave = () => {
       this.spinnerService.show();
       const changesArray = Array.from(this.changes.values());
+      const erintettTemplomok = this.affectedChurchIds(changesArray, this.deletedMasses);
       this.eventService.saveChanges(this.currentChurch!.id, changesArray, this.deletedMasses).subscribe(masses => {
       this.changes.clear();
       this.deletedMasses = [];
@@ -1059,7 +1136,12 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       //TODO: EZT MAJD HÁTTÉRBEN
       const currentYear = new Date().getFullYear();
       const years: number[] = [currentYear - 1, currentYear, currentYear + 1];
-      this.searchService.generateMasses(years, this.currentChurch!.id).subscribe();
+      // #506: MINDEN érintett templom indexét újra kell generálni, nem csak a
+      // szerkesztettét — család módban a fília miserendje is most változott, és
+      // enélkül a keresőben a régi maradna.
+      for (const churchId of erintettTemplomok) {
+        this.searchService.generateMasses(years, churchId).subscribe();
+      }
       });
     };
 

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -1193,13 +1193,25 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
     }
 
     this.eventService.sendToApprove(this.currentChurch!.id, suggestionPackage).subscribe(
-      res => {
+      (res: any) => {
         this.changes.clear();
         this.deletedMasses = [];
         this.deletedDates.clear();
         this.reLoadCalendar();
+
+        /*
+         * #781: a szerver templomonként külön csomagot készít, mert a jóváhagyás is
+         * templomonként történik. Ha több lett, mondjuk meg — a beküldő egyetlen
+         * műveletet élt meg, de több gondnok fogja látni, és jó tudnia, hogy a fília
+         * javaslata is elment.
+         */
+        const csomagok: number = Array.isArray(res?.packages) ? res.packages.length : 1;
+        const uzenet: string = csomagok > 1
+          ? `Javaslatod sikeresen beküldve, ${csomagok} templomhoz. Amint jóváhagyják, megjelenik a naptárban.`
+          : 'Javaslatod sikeresen beküldve! Amint jóváhagyják, megjelenik a naptárban.';
+
         this.dialog.open(AddMessageDialogComponent, {
-          data: {message: "Javaslatod sikeresen beküldve! Amint jóváhagyják, megjelenik a naptárban.", decision: false}
+          data: {message: uzenet, decision: false}
         });
       },
       error => {

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -187,15 +187,20 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
     return {...this.currentChurch!, id: tag.id, name: tag.name, rite: tag.rite};
   }
 
+  /**
+   * #506: mi álljon a rokon templomok eseményei előtt a naptárban.
+   *
+   * A szabályt a `MassUtil.familyCalendarLabels` tartja — borazslo kérésére a
+   * település neve az elsődleges, és csak ott jön hozzá a templomnév, ahol egy
+   * településen több érintett misézőhely van.
+   */
   private otherChurchNames(): Map<number, string> {
-    const nevek = new Map<number, string>();
-    for (const tag of this.family) {
-      if (tag.isCurrent) {
-        continue;
-      }
-      nevek.set(tag.id, tag.name);
-    }
-    return nevek;
+    return MassUtil.familyCalendarLabels(this.family);
+  }
+
+  /** #506: a „Melyik templomban?" választó felirata — mindig település + templomnév. */
+  public churchSelectorLabel(tag: ChurchFamilyMember): string {
+    return MassUtil.familySelectorLabel(tag);
   }
 
   // Szűrő komponens megjelenítése - kikapcsolt javaslatok oldalon

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -23,7 +23,7 @@ import {AddSimpleEventDialogComponent} from '../add-simple-event-dialog/add-simp
 import {MassUtil} from '../../util/mass-util';
 import {Mass} from '../../model/mass';
 import {CalendarEvent} from '../../model/calendar/calendar-event';
-import {Church} from '../../model/church';
+import {Church, ChurchFamilyMember} from '../../model/church';
 import {SensorEvent} from '../../model/sensor-event';
 import {LiturgicalDay} from '../../model/liturgical-day';
 import {TranslatePipe, TranslateService} from '@ngx-translate/core';
@@ -106,8 +106,32 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
   @Input() changes: Map<number, Mass> = new Map();
   @Input() deletedMasses: number[] = [];
   @Input() deletedDates: Map<number, string[]> = new Map();
+
   @Input() changedMasses: number[] = [];
   @Input() sensorEvents: SensorEvent[] = [];
+
+  /**
+   * #506: a plébánia és fíliái. Üres marad az egy-templomos szerkesztőben, tehát a
+   * mostani viselkedés semmiben nem változik.
+   */
+  @Input() family: ChurchFamilyMember[] = [];
+
+  /**
+   * A ROKON templomok neve azonosító szerint — a saját templom szándékosan kimarad.
+   *
+   * Így a naptárban csak az idegen esemény kap templomnevet a címe elé; a sajátjaink
+   * ugyanúgy néznek ki, mint eddig.
+   */
+  private otherChurchNames(): Map<number, string> {
+    const nevek = new Map<number, string>();
+    for (const tag of this.family) {
+      if (tag.isCurrent) {
+        continue;
+      }
+      nevek.set(tag.id, tag.name);
+    }
+    return nevek;
+  }
 
   // Szűrő komponens megjelenítése - kikapcsolt javaslatok oldalon
   showFilterComponent: boolean = true;
@@ -273,7 +297,8 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
               this.changedMasses,
               this.deletedMasses,
               this.deletedDates,
-              this.translateService
+              this.translateService,
+              this.otherChurchNames()
             );
             
             // Add sensor events to the calendar
@@ -327,7 +352,8 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       [], // changedMasses is empty since we're generating from combined set
       [], // deletedMasses is empty since we've already removed them
       this.deletedDates,
-      this.translateService
+      this.translateService,
+      this.otherChurchNames()
     );
 
     // Add sensor events to the calendar

--- a/calendar/src/app/components/church-calendar/church-target-selection.spec.ts
+++ b/calendar/src/app/components/church-calendar/church-target-selection.spec.ts
@@ -1,0 +1,121 @@
+import {Church, ChurchFamilyMember} from '../../model/church';
+import {Mass} from '../../model/mass';
+import {Rite} from '../../enum/rites';
+import {MassUtil} from '../../util/mass-util';
+
+/**
+ * #506 „B": az ÚJ esemény ahhoz a templomhoz kerüljön, amelyiket a felhasználó
+ * választotta — és a saját rítusával.
+ *
+ * A választó csak akkor jelenhet meg, ha tényleg van miből választani: a plébániának
+ * vannak fíliái, és többhöz is van írásjogunk. Egy templomnál felesleges zaj, két
+ * kattintással több munka.
+ *
+ * A rítus azért fontos, mert templomonként más lehet (görögkatolikus fília római
+ * plébánia alatt), és az új mise alapértelmezett címét és rítusát ez adja. Ha a
+ * választott templom helyett a megnyitottét használnánk, a fília miséje csendben rossz
+ * rítust kapna.
+ *
+ * A komponens megfelelő metódusai privátak/beágyazottak, ezért itt a logikájukat
+ * emeljük ki — a lényeg a szabály rögzítése.
+ */
+describe('#506 — új esemény céltemploma', () => {
+
+  const tag = (id: number, name: string, rite: Rite, writable: boolean, isCurrent = false): ChurchFamilyMember =>
+    ({id, name, city: 'Teszt', rite, writable, isCurrent, masses: []});
+
+  const plebania = {id: 1, name: 'Plébánia', rite: Rite.ROMAN_CATHOLIC} as Church;
+
+  /** A komponens `targetChurch()`-ének megfelelő szabály. */
+  const celTemplom = (family: ChurchFamilyMember[], current: Church, churchId?: number): Church => {
+    const irhato = family.filter(t => t.writable);
+    if (!churchId || churchId === current.id) {
+      return current;
+    }
+    const valasztott = irhato.find(t => t.id === churchId);
+    if (!valasztott) {
+      return current;
+    }
+    return {...current, id: valasztott.id, name: valasztott.name, rite: valasztott.rite};
+  };
+
+  it('választás nélkül a megnyitott templom marad', () => {
+    const cel = celTemplom([], plebania, undefined);
+
+    expect(cel.id).toBe(1);
+    expect(cel.rite).toBe(Rite.ROMAN_CATHOLIC);
+  });
+
+  it('a választott fília azonosítóját és rítusát kapja az esemény', () => {
+    const family = [
+      tag(1, 'Plébánia', Rite.ROMAN_CATHOLIC, true, true),
+      tag(2, 'Görög fília', Rite.GREEK_CATHOLIC, true),
+    ];
+
+    const cel = celTemplom(family, plebania, 2);
+
+    expect(cel.id).toBe(2);
+    expect(cel.name).toBe('Görög fília');
+    expect(cel.rite).toBe(Rite.GREEK_CATHOLIC);
+  });
+
+  /**
+   * Ez a védelem: ha valahogy mégis nem írható templom azonosítója érkezik, NEM oda
+   * írunk. A szerver úgyis visszautasítaná, de a felület se csináljon rosszat.
+   */
+  it('nem írható templomra nem esik a választás', () => {
+    const family = [
+      tag(1, 'Plébánia', Rite.ROMAN_CATHOLIC, true, true),
+      tag(3, 'Idegen', Rite.ROMAN_CATHOLIC, false),
+    ];
+
+    const cel = celTemplom(family, plebania, 3);
+
+    expect(cel.id).toBe(1);
+  });
+
+  it('ismeretlen azonosítónál a megnyitott templom marad', () => {
+    const family = [tag(1, 'Plébánia', Rite.ROMAN_CATHOLIC, true, true)];
+
+    expect(celTemplom(family, plebania, 999).id).toBe(1);
+  });
+
+  it('a létrehozott mise a céltemplom azonosítóját viseli', () => {
+    const family = [
+      tag(1, 'Plébánia', Rite.ROMAN_CATHOLIC, true, true),
+      tag(2, 'Fília', Rite.ROMAN_CATHOLIC, true),
+    ];
+    const cel = celTemplom(family, plebania, 2);
+
+    const mise: Mass = MassUtil.createSimpleMassByDate(
+      new Date('2026-08-16T09:00:00'), cel, -1,
+      {instant: (kulcs: string) => kulcs} as any
+    );
+
+    expect(mise.churchId).toBe(2);
+  });
+});
+
+/**
+ * A választó megjelenésének szabálya: csak akkor, ha egynél több írható templom van.
+ */
+describe('#506 — mikor jelenjen meg a templomválasztó', () => {
+
+  const tag = (id: number, writable: boolean): ChurchFamilyMember =>
+    ({id, name: 'T' + id, city: '', rite: Rite.ROMAN_CATHOLIC, writable, isCurrent: false, masses: []});
+
+  const vanValasztas = (family: ChurchFamilyMember[]): boolean =>
+    family.filter(t => t.writable).length > 1;
+
+  it('család nélkül nincs választó', () => {
+    expect(vanValasztas([])).toBeFalse();
+  });
+
+  it('egyetlen írható templomnál nincs választó', () => {
+    expect(vanValasztas([tag(1, true), tag(2, false), tag(3, false)])).toBeFalse();
+  });
+
+  it('két írható templomnál van választó', () => {
+    expect(vanValasztas([tag(1, true), tag(2, true)])).toBeTrue();
+  });
+});

--- a/calendar/src/app/components/church/church.component.family.spec.ts
+++ b/calendar/src/app/components/church/church.component.family.spec.ts
@@ -1,0 +1,143 @@
+import {Mass} from '../../model/mass';
+import {Church, ChurchFamilyMember} from '../../model/church';
+import {MassUtil} from '../../util/mass-util';
+import {Rite} from '../../enum/rites';
+
+/**
+ * #506: a plébánia és fíliái egy naptárban.
+ *
+ * Két állítást mérünk, és mindkettő a biztonságról szól:
+ *
+ *  1. A rokon templom miséje MEGTARTJA a saját `churchId`-jét. Ezen múlik minden: a
+ *     mentés ezzel megy vissza, és a szerver ez alapján dönti el, van-e rá jogunk.
+ *     Ha a betöltés elvesztené, a fília miséje a plébániához íródna.
+ *
+ *  2. Az egy-templomos szerkesztő semmiben nem változik: család nélkül ugyanaz a
+ *     mise-halmaz és ugyanaz a cím, mint eddig.
+ */
+describe('ChurchComponent — család módú betöltés', () => {
+
+  const mise = (id: number, churchId: number, title = 'Szentmise'): Mass => ({
+    id,
+    churchId,
+    title,
+    rite: Rite.ROMAN_CATHOLIC,
+  } as Mass);
+
+  const csaladtag = (id: number, name: string, isCurrent: boolean, masses: Mass[]): ChurchFamilyMember => ({
+    id, name, city: 'Teszt', writable: true, isCurrent, masses,
+  });
+
+  /** A komponens privát összefésülőjének megfelelő, kiemelt logika. */
+  const osszefesul = (church: Church): Map<number, Mass> => {
+    const osszes: Mass[] = [...church.masses];
+    for (const tag of church.family ?? []) {
+      if (tag.isCurrent) {
+        continue;
+      }
+      osszes.push(...tag.masses);
+    }
+    return new Map(osszes.map(e => [e.id!, e]));
+  };
+
+  it('család nélkül csak a saját misék jönnek', () => {
+    const church = {id: 1, masses: [mise(10, 1), mise(11, 1)]} as Church;
+
+    const masses = osszefesul(church);
+
+    expect(masses.size).toBe(2);
+    expect(Array.from(masses.values()).every(m => m.churchId === 1)).toBeTrue();
+  });
+
+  it('család módban a fíliák miséi is bekerülnek', () => {
+    const church = {
+      id: 1,
+      masses: [mise(10, 1)],
+      family: [
+        csaladtag(1, 'Plébánia', true, [mise(10, 1)]),
+        csaladtag(2, 'Fília', false, [mise(20, 2), mise(21, 2)]),
+      ],
+    } as Church;
+
+    const masses = osszefesul(church);
+
+    expect(masses.size).toBe(3);
+  });
+
+  it('a saját miséket nem duplázzuk', () => {
+    const church = {
+      id: 1,
+      masses: [mise(10, 1)],
+      family: [csaladtag(1, 'Plébánia', true, [mise(10, 1)])],
+    } as Church;
+
+    expect(osszefesul(church).size).toBe(1);
+  });
+
+  it('a fília miséje megtartja a saját templom-azonosítóját', () => {
+    const church = {
+      id: 1,
+      masses: [mise(10, 1)],
+      family: [
+        csaladtag(1, 'Plébánia', true, [mise(10, 1)]),
+        csaladtag(2, 'Fília', false, [mise(20, 2)]),
+      ],
+    } as Church;
+
+    const masses = osszefesul(church);
+
+    expect(masses.get(20)!.churchId).toBe(2);
+    expect(masses.get(10)!.churchId).toBe(1);
+  });
+});
+
+/**
+ * A naptárban látszania kell, melyik esemény melyik templomé — különben a szerkesztő
+ * összekeveri őket, és a felhasználó azt hiszi, a sajátját írja át.
+ */
+describe('MassUtil — rokon templomok jelölése a naptárban', () => {
+
+  const periods: any[] = [];
+  const mise = (id: number, churchId: number): Mass => ({
+    id,
+    churchId,
+    title: 'Szentmise',
+    rite: Rite.ROMAN_CATHOLIC,
+    startDate: '2026-01-04T09:00:00',
+  } as Mass);
+
+  it('név nélkül a cím változatlan marad', () => {
+    const events = MassUtil.createCalendarEvents(
+      [mise(10, 1)], periods, [], [], new Map(), undefined
+    );
+
+    events.forEach(e => expect(e.title).toBe('Szentmise'));
+  });
+
+  it('a rokon templom eseménye elé kerül a templom neve', () => {
+    const nevek = new Map<number, string>([[2, 'Fília']]);
+
+    const events = MassUtil.createCalendarEvents(
+      [mise(20, 2)], periods, [], [], new Map(), undefined, nevek
+    );
+
+    events.forEach(e => {
+      expect(e.title).toBe('Fília — Szentmise');
+      expect(e.extendedProps.churchId).toBe(2);
+      expect(e.extendedProps.churchName).toBe('Fília');
+    });
+  });
+
+  it('a saját templom eseménye jelöletlen marad', () => {
+    const nevek = new Map<number, string>([[2, 'Fília']]);
+
+    const events = MassUtil.createCalendarEvents(
+      [mise(10, 1)], periods, [], [], new Map(), undefined, nevek
+    );
+
+    events.forEach(e => {
+      expect(e.title).toBe('Szentmise');
+      expect(e.extendedProps.churchId).toBeUndefined();
+    });
+  });
+});

--- a/calendar/src/app/components/church/church.component.family.spec.ts
+++ b/calendar/src/app/components/church/church.component.family.spec.ts
@@ -25,7 +25,7 @@ describe('ChurchComponent — család módú betöltés', () => {
   } as Mass);
 
   const csaladtag = (id: number, name: string, isCurrent: boolean, masses: Mass[]): ChurchFamilyMember => ({
-    id, name, city: 'Teszt', writable: true, isCurrent, masses,
+    id, name, city: 'Teszt', rite: Rite.ROMAN_CATHOLIC, writable: true, isCurrent, masses,
   });
 
   /** A komponens privát összefésülőjének megfelelő, kiemelt logika. */

--- a/calendar/src/app/components/church/church.component.html
+++ b/calendar/src/app/components/church/church.component.html
@@ -6,6 +6,7 @@
       [currentChurch]="currentChurch!"
       [masses]="masses"
       [sensorEvents]="sensorEvents"
+      [family]="family"
     >
     </app-church-calendar>
   </ng-container>

--- a/calendar/src/app/components/church/church.component.ts
+++ b/calendar/src/app/components/church/church.component.ts
@@ -1,7 +1,7 @@
 import {Component, HostListener, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ChurchCalendarComponent} from '../church-calendar/church-calendar.component';
-import {Church} from '../../model/church';
+import {Church, ChurchFamilyMember} from '../../model/church';
 import {Mass} from '../../model/mass';
 import {SensorEvent} from '../../model/sensor-event';
 import {ActivatedRoute} from '@angular/router';
@@ -25,6 +25,14 @@ export class ChurchComponent implements OnInit {
   public sensorEvents: SensorEvent[] = [];
   public loadError: string | null = null;
 
+  /**
+   * #506: a plébánia és fíliái, ha az útvonalon `?csalad=1` szerepel.
+   *
+   * Külön kérni kell, nem alapértelmezés: a szerkesztő így ugyanúgy viselkedik, mint
+   * eddig, amíg valaki tudatosan nem családban akar dolgozni.
+   */
+  public family: ChurchFamilyMember[] = [];
+
   @ViewChild('churchCalendar') churchCalendar!: ChurchCalendarComponent;
 
   constructor(
@@ -41,12 +49,15 @@ export class ChurchComponent implements OnInit {
 
   private initEvents() {
     const churchId: number = +this.activatedRoute.snapshot.params['id'];
-    this.eventService.getChurch(churchId).subscribe({
+    const familyMode: boolean = this.activatedRoute.snapshot.queryParamMap.get('csalad') === '1';
+
+    this.eventService.getChurch(churchId, familyMode).subscribe({
       next: (church: Church) => {
         console.log('[ChurchComponent] Church data loaded:', church);
         console.log('[ChurchComponent] Sensor events count:', church.eventsFromSensor?.length || 0);
         this.currentChurch = church;
-        this.masses = new Map(church.masses.map(e => [e.id!, e]));
+        this.family = church.family ?? [];
+        this.masses = this.collectMasses(church);
         this.sensorEvents = church.eventsFromSensor || [];
         console.log('[ChurchComponent] sensorEvents set to:', this.sensorEvents);
         this.loadError = null;
@@ -58,12 +69,33 @@ export class ChurchComponent implements OnInit {
         // Show a concise, user-friendly error message. Keep dataLoaded true so template can render the message.
         this.loadError = 'Nem sikerült betölteni a templom adatait, mert az adatszolgáltató oldal nem elérhető. Elnézést kérünk.';
         this.currentChurch = undefined;
+        this.family = [];
         this.masses = new Map();
         this.sensorEvents = [];
         this.dataLoaded = true;
         this.spinnerService.hide();
       }
     });
+  }
+
+  /**
+   * A saját és — család módban — a rokon templomok miséi egy naptárban.
+   *
+   * Minden mise hordozza a saját `churchId`-jét, és a mentés azzal megy vissza, tehát a
+   * rokon templom miséje a SAJÁT templomához íródik. A szerver misénként ellenőrzi a
+   * jogosultságot, így a felület tévedése sem tud rossz helyre írni.
+   */
+  private collectMasses(church: Church): Map<number, Mass> {
+    const osszes: Mass[] = [...church.masses];
+
+    for (const tag of church.family ?? []) {
+      if (tag.isCurrent) {
+        continue; // a saját miséi már benne vannak
+      }
+      osszes.push(...tag.masses);
+    }
+
+    return new Map(osszes.map(e => [e.id!, e]));
   }
 
   @HostListener('window:beforeunload', ['$event'])

--- a/calendar/src/app/components/church/church.component.ts
+++ b/calendar/src/app/components/church/church.component.ts
@@ -47,9 +47,33 @@ export class ChurchComponent implements OnInit {
     this.initEvents();
   }
 
+  /**
+   * #830: család módban vagyunk?
+   *
+   * Kétféleképpen kerülhetünk ide: a `?csalad=1` paraméterrel (ez volt az első
+   * megoldás, és a régi linkek miatt marad), vagy a `/plebania/:id` útvonalon —
+   * borazslo kérésére, mert a paraméter nem osztható meg jól és nem is beszédes.
+   *
+   * Az útvonalat SZÁNDÉKOSAN a teljes címből nézzük, nem az Angular útvonal-mintából:
+   * a naptár egy PHP-lapba ágyazva fut, és így akkor is helyesen dönt, ha a
+   * beágyazás miatt a router csak részleges címet lát.
+   *
+   * @param csaladParam a `?csalad` paraméter értéke (vagy `null`)
+   * @param utvonal a böngésző címsorának útvonal-része
+   */
+  public static isFamilyRoute(csaladParam: string | null, utvonal: string): boolean {
+    if (csaladParam === '1') {
+      return true;
+    }
+    return /(^|\/)plebania\/[0-9]+(\/|$)/.test(utvonal ?? '');
+  }
+
   private initEvents() {
     const churchId: number = +this.activatedRoute.snapshot.params['id'];
-    const familyMode: boolean = this.activatedRoute.snapshot.queryParamMap.get('csalad') === '1';
+    const familyMode: boolean = ChurchComponent.isFamilyRoute(
+      this.activatedRoute.snapshot.queryParamMap.get('csalad'),
+      window.location.pathname
+    );
 
     this.eventService.getChurch(churchId, familyMode).subscribe({
       next: (church: Church) => {

--- a/calendar/src/app/components/church/family-route.spec.ts
+++ b/calendar/src/app/components/church/family-route.spec.ts
@@ -1,0 +1,74 @@
+import {ChurchComponent} from './church.component';
+
+/**
+ * #830: mikor mutassa a naptár a család miserendjét?
+ *
+ * borazslo kérése a #804-hez: a `?csalad=1` helyett legyen saját, beszédes útvonal
+ * („kéne egy szó hogy miserend.hu/[valami ügyes szó]/:id"). A paraméteres alak
+ * viszont NEM tűnhet el: a #804 óta kiküldött linkek és könyvjelzők nem törhetnek el.
+ *
+ * Ez a döntés tiszta függvény, ezért komponens-példány nélkül mérhető — a naptár
+ * összeszerelése (FullCalendar, dialógusok, szolgáltatások) semmit nem tenne hozzá.
+ */
+describe('ChurchComponent.isFamilyRoute (#830)', () => {
+
+  describe('a régi, paraméteres alak', () => {
+
+    it('a ?csalad=1 továbbra is család mód', () => {
+      expect(ChurchComponent.isFamilyRoute('1', '/templom/2172')).toBeTrue();
+    });
+
+    it('más érték nem az', () => {
+      expect(ChurchComponent.isFamilyRoute('0', '/templom/2172')).toBeFalse();
+      expect(ChurchComponent.isFamilyRoute('igen', '/templom/2172')).toBeFalse();
+    });
+
+    it('paraméter nélkül a templom-oldal marad egytemplomos', () => {
+      expect(ChurchComponent.isFamilyRoute(null, '/templom/2172')).toBeFalse();
+    });
+  });
+
+  describe('az új útvonal', () => {
+
+    it('a /plebania/:id család mód paraméter nélkül is', () => {
+      expect(ChurchComponent.isFamilyRoute(null, '/plebania/2172')).toBeTrue();
+    });
+
+    /**
+     * A naptár egy PHP-lapba ágyazva fut, ezért a teljes címet nézzük — a beágyazás
+     * miatt a router csak részleges útvonalat láthat.
+     */
+    it('előtaggal együtt is felismeri', () => {
+      expect(ChurchComponent.isFamilyRoute(null, '/valami/plebania/2172')).toBeTrue();
+    });
+
+    it('záró perjellel is', () => {
+      expect(ChurchComponent.isFamilyRoute(null, '/plebania/2172/')).toBeTrue();
+    });
+  });
+
+  describe('amit NEM szabad félreértenie', () => {
+
+    /**
+     * A „plebania" szó a templom nevében vagy a leírásban is előfordulhat — csak
+     * akkor számít, ha ÚTVONAL-szakasz, és szám követi.
+     */
+    it('a szövegben előforduló szó nem elég', () => {
+      expect(ChurchComponent.isFamilyRoute(null, '/templom/2172/plebaniatortenet')).toBeFalse();
+    });
+
+    it('azonosító nélkül nem család mód', () => {
+      expect(ChurchComponent.isFamilyRoute(null, '/plebania')).toBeFalse();
+      expect(ChurchComponent.isFamilyRoute(null, '/plebania/')).toBeFalse();
+    });
+
+    it('nem szám azonosítóra sem', () => {
+      expect(ChurchComponent.isFamilyRoute(null, '/plebania/valami')).toBeFalse();
+    });
+
+    it('üres útvonalon sem esik el', () => {
+      expect(ChurchComponent.isFamilyRoute(null, '')).toBeFalse();
+      expect(ChurchComponent.isFamilyRoute(null, null as any)).toBeFalse();
+    });
+  });
+});

--- a/calendar/src/app/event.service.ts
+++ b/calendar/src/app/event.service.ts
@@ -18,8 +18,15 @@ export class EventService {
 
   constructor(private http: HttpClient, private snackBarService: MatSnackBarService) {}
 
-  getChurch(churchId: number): Observable<Church> {
-    return this.http.get<Church>(environment.apiUrl+'church/'+churchId).pipe(
+  /**
+   * #506: `withFamily` esetén a plébánia és a fíliái is jönnek, a miséikkel együtt.
+   *
+   * Alapértelmezésben KIKAPCSOLVA, hogy az egy-templomos betöltés kérése és válasza
+   * változatlan maradjon.
+   */
+  getChurch(churchId: number, withFamily: boolean = false): Observable<Church> {
+    const url = environment.apiUrl + 'church/' + churchId + (withFamily ? '?family=1' : '');
+    return this.http.get<Church>(url).pipe(
       catchError(error => {
         console.error('[EventService] Hiba a templom adatainak betöltésekor:', error);
         this.snackBarService.error('Nem sikerült a templom adatait betölteni.');

--- a/calendar/src/app/model/calendar/extended-props.ts
+++ b/calendar/src/app/model/calendar/extended-props.ts
@@ -8,5 +8,14 @@ export interface ExtendedProps {
   recentModifiedDates?: string[];
   massTitleCategory?: MassTitleCategory;
 
+  /**
+   * #506: család módban melyik templomé ez az esemény.
+   *
+   * Csak a ROKON templomok eseményein van kitöltve — a saját templom eseményein nem,
+   * hogy az egy-templomos szerkesztő adata változatlan maradjon.
+   */
+  churchId?: number;
+  churchName?: string;
+
   //Ha a naptárba akarunk majd megjeleníteni infókat, azt ide érdemes felvenni.
 }

--- a/calendar/src/app/model/church.ts
+++ b/calendar/src/app/model/church.ts
@@ -2,6 +2,23 @@ import {Mass} from './mass';
 import {Rite} from '../enum/rites';
 import {SensorEvent} from './sensor-event';
 
+/**
+ * #506: a templom „családja" — a plébánia és a fíliái.
+ *
+ * A szerver a `?family=1` kérésre adja vissza. Minden családtag benne van, mert a
+ * miserend nyilvános adat és a plébánia rendjét együtt látni akkor is hasznos, ha nem
+ * mindegyikhez van jogod; hogy melyikbe LEHET írni, azt a `writable` mondja meg. A
+ * mentés a szerveren úgyis templomonként ellenőrzi a jogosultságot.
+ */
+export interface ChurchFamilyMember {
+  id: number;
+  name: string;
+  city: string;
+  writable: boolean;
+  isCurrent: boolean;
+  masses: Mass[];
+}
+
 export interface Church {
   id: number;
   name: string;
@@ -10,4 +27,5 @@ export interface Church {
   masses: Mass[];
   eventsFromSensor?: SensorEvent[];
   country?: string;
+  family?: ChurchFamilyMember[];
 }

--- a/calendar/src/app/model/church.ts
+++ b/calendar/src/app/model/church.ts
@@ -14,6 +14,8 @@ export interface ChurchFamilyMember {
   id: number;
   name: string;
   city: string;
+  /** A rítus templomonként más lehet (görögkatolikus fília római plébánia alatt). */
+  rite: Rite;
   writable: boolean;
   isCurrent: boolean;
   masses: Mass[];

--- a/calendar/src/app/model/dialog-event.ts
+++ b/calendar/src/app/model/dialog-event.ts
@@ -10,6 +10,13 @@ import {EasterDay} from "../enum/easter-day";
 
 export interface DialogEvent {
   /**
+   * #506: melyik templomhoz tartozzon az esemény.
+   *
+   * Csak család módban van kitöltve; enélkül a szerkesztő a saját templomát használja,
+   * tehát az egy-templomos működés változatlan.
+   */
+  churchId?: number;
+  /**
    * Az esemény periódusa (liturgikus időszaka).
    * Ha van, ez határozza meg a kezdeti és a végdátumot, melyben ismétlődik az esemény.
    */

--- a/calendar/src/app/util/church-target.spec.ts
+++ b/calendar/src/app/util/church-target.spec.ts
@@ -1,0 +1,60 @@
+import {MassUtil} from './mass-util';
+import {Mass} from '../model/mass';
+
+/**
+ * #506: melyik templomhoz kerül a mise a szerkesztés után?
+ *
+ * borazslo jelentése a /templom/2172?csalad=1 oldalról:
+ *
+ *   „Módosítani kívánom a babarszőlősi vasárnapi 8-as misét, akkor kattingatok és
+ *    megjelenik a select hogy »Melyik templomban?«. de ott »Bicsérd« szerepel, nem a
+ *    helyes templom."
+ *
+ * Az ok: a `massToDialogEvent` nem adta vissza a mise saját templomát, tehát a
+ * választó a lista ELSŐ elemére esett vissza — és mentéskor a mise NÉMÁN odakerült.
+ * Család módban ez adatvesztés: a fília miséje a plébániához íródott volna át.
+ *
+ * A hiba csak akkor látszik, ha valaki figyeli a legördülőt. Ezért mérjük itt.
+ */
+describe('MassUtil.massToDialogEvent — templom-hovatartozás (#506)', () => {
+
+  function mise(churchId: number, extra: Partial<Mass> = {}): Mass {
+    return {
+      id: 42,
+      churchId,
+      title: 'Szentmise',
+      rite: 'ROMAN_CATHOLIC',
+      startDate: '2026-03-01T08:00:00',
+      lang: 'hu',
+      ...extra,
+    } as Mass;
+  }
+
+  it('visszaadja a mise saját templomát', () => {
+    expect(MassUtil.massToDialogEvent(mise(2173)).churchId).toBe(2173);
+  });
+
+  /**
+   * Ez a lényeg: a szerkesztő a `churchId ?? churches[0].id` alakot használja, tehát
+   * ha itt `undefined` jön vissza, a mise a lista első templomához kerül.
+   */
+  it('nem hagyja üresen — különben a lista első templomához kerülne a mise', () => {
+    expect(MassUtil.massToDialogEvent(mise(2173)).churchId).toBeDefined();
+  });
+
+  /** Egyetlen alkalom szerkesztésekor is a mise saját temploma az alapértelmezés. */
+  it('egyetlen alkalom szerkesztésénél is megmarad', () => {
+    const esemeny = MassUtil.massToDialogEventEditOne(mise(2173), new Date('2026-03-08T08:00:00'));
+
+    expect(esemeny.churchId).toBe(2173);
+    expect(esemeny.editOne).toBeTrue();
+  });
+
+  /**
+   * A másolás új misét hoz létre a forrás adataiból. A templomot innen is örökölnie
+   * kell, különben a másolat a lista első templomához kerülne.
+   */
+  it('a másoláshoz készült dialógus is a forrás templomát hozza', () => {
+    expect(MassUtil.massToDialogEvent(mise(2173, {periodId: 5})).churchId).toBe(2173);
+  });
+});

--- a/calendar/src/app/util/family-labels.spec.ts
+++ b/calendar/src/app/util/family-labels.spec.ts
@@ -1,0 +1,127 @@
+import {MassUtil} from './mass-util';
+import {ChurchFamilyMember} from '../model/church';
+import {Rite} from '../enum/rites';
+
+/**
+ * #506: mi álljon a rokon templomok eseményei előtt a naptárban.
+ *
+ * borazslo szabálya: „gyakran jobb a település nevét kiírni mint a templomét". Igaza
+ * van — egy plébánia fíliái jellemzően különböző falvakban vannak, és a hívőnek a falu
+ * mond valamit, nem a titulus („Nagyboldogasszony"-ból tíz is van a megyében).
+ *
+ * De ha KÉT misézőhely is ugyanabban a faluban van, a falunév már nem különböztet meg —
+ * ilyenkor kell a templomnév is. Ez a fájl pontosan ezt a négy esetet méri.
+ */
+
+function tag(overrides: Partial<ChurchFamilyMember> = {}): ChurchFamilyMember {
+  return {
+    id: 1,
+    name: 'Szent Kereszt',
+    city: 'Röszke',
+    rite: Rite.ROMAN_CATHOLIC,
+    writable: true,
+    isCurrent: false,
+    masses: [],
+    ...overrides,
+  };
+}
+
+describe('MassUtil.familyCalendarLabels (#506)', () => {
+
+  /** A szerkesztett templom eseményei ugyanúgy néznek ki, mint az egy-templomos nézetben. */
+  it('a szerkesztett templom nem kap előtagot', () => {
+    const cimkek = MassUtil.familyCalendarLabels([
+      tag({id: 1, isCurrent: true}),
+      tag({id: 2, name: 'Szent Anna', city: 'Domaszék'}),
+    ]);
+
+    expect(cimkek.has(1)).toBeFalse();
+  });
+
+  it('azonos településen a templom nevét írja ki', () => {
+    const cimkek = MassUtil.familyCalendarLabels([
+      tag({id: 1, name: 'Szent Kereszt', city: 'Szeged', isCurrent: true}),
+      tag({id: 2, name: 'Szent Anna', city: 'Szeged'}),
+    ]);
+
+    expect(cimkek.get(2)).toBe('Szent Anna');
+  });
+
+  it('másik településen — ahol csak egy érintett hely van — a település nevét írja ki', () => {
+    const cimkek = MassUtil.familyCalendarLabels([
+      tag({id: 1, city: 'Szeged', isCurrent: true}),
+      tag({id: 2, name: 'Szent Anna', city: 'Domaszék'}),
+    ]);
+
+    expect(cimkek.get(2)).toBe('Domaszék');
+  });
+
+  /**
+   * Ez a szabály lényege: két domaszéki misézőhelynél a puszta „Domaszék" két
+   * különböző eseményt jelölne ugyanúgy — a hívő nem tudná, melyikre menjen.
+   */
+  it('másik településen — ahol több érintett hely van — település és templomnév is kell', () => {
+    const cimkek = MassUtil.familyCalendarLabels([
+      tag({id: 1, city: 'Szeged', isCurrent: true}),
+      tag({id: 2, name: 'Szent Anna', city: 'Domaszék'}),
+      tag({id: 3, name: 'Kápolna', city: 'Domaszék'}),
+    ]);
+
+    expect(cimkek.get(2)).toBe('Domaszék, Szent Anna');
+    expect(cimkek.get(3)).toBe('Domaszék, Kápolna');
+  });
+
+  /**
+   * A számolás az ÉRINTETT helyekre megy: a település többi temploma nincs a
+   * naptárban, tehát nincs mitől megkülönböztetni.
+   */
+  it('a saját település nem duzzasztja fel a másik település számlálóját', () => {
+    const cimkek = MassUtil.familyCalendarLabels([
+      tag({id: 1, name: 'Szent Kereszt', city: 'Szeged', isCurrent: true}),
+      tag({id: 2, name: 'Szent Anna', city: 'Szeged'}),
+      tag({id: 3, name: 'Kápolna', city: 'Domaszék'}),
+    ]);
+
+    expect(cimkek.get(3)).toBe('Domaszék');
+  });
+
+  /**
+   * A szlovák állomány 23%-ának nincs határlánca, tehát a település ÜRES lehet.
+   * Ilyenkor a templomnév az egyetlen fogódzó — üres előtag nem elfogadható.
+   */
+  it('település nélkül a templom nevét írja ki', () => {
+    const cimkek = MassUtil.familyCalendarLabels([
+      tag({id: 1, city: 'Szeged', isCurrent: true}),
+      tag({id: 2, name: 'Szent Anna', city: ''}),
+    ]);
+
+    expect(cimkek.get(2)).toBe('Szent Anna');
+  });
+
+  it('egy-templomos szerkesztőben nincs egyetlen címke sem', () => {
+    expect(MassUtil.familyCalendarLabels([]).size).toBe(0);
+    expect(MassUtil.familyCalendarLabels([tag({isCurrent: true})]).size).toBe(0);
+  });
+});
+
+describe('MassUtil.familySelectorLabel (#506)', () => {
+
+  /**
+   * A választó DÖNTÉSI pont: ha félreértjük, a mise rossz templomhoz íródik. Ezért itt
+   * nem a naptár rövidítő szabálya megy — mindig kiírjuk mindkettőt.
+   */
+  it('mindig település és templomnév', () => {
+    expect(MassUtil.familySelectorLabel(tag({name: 'Szent Anna', city: 'Domaszék'})))
+      .toBe('Domaszék, Szent Anna');
+  });
+
+  it('a szerkesztett templomot sem rövidíti', () => {
+    expect(MassUtil.familySelectorLabel(tag({name: 'Szent Kereszt', city: 'Szeged', isCurrent: true})))
+      .toBe('Szeged, Szent Kereszt');
+  });
+
+  it('település nélkül csak a templomnév marad', () => {
+    expect(MassUtil.familySelectorLabel(tag({name: 'Szent Anna', city: ''})))
+      .toBe('Szent Anna');
+  });
+});

--- a/calendar/src/app/util/mass-util.ts
+++ b/calendar/src/app/util/mass-util.ts
@@ -172,10 +172,26 @@ export class MassUtil {
     return calEvents;
   }
 
-  public static createCalendarEvents(masses: Mass[], periods: GeneratedPeriod[], changes: number[], deletedMasses: number[], deletedDates:Map<number, string[]>, translate?: TranslateService): CalendarEvent[] {
+  /**
+   * #506: `otherChurchNames` a rokon templomok neve — család módban ebből derül ki a
+   * naptárban, melyik esemény melyik templomé.
+   *
+   * A saját templom miséin SEMMI nem változik: a térkép csak a rokon templomokat
+   * tartalmazza, tehát az egy-templomos szerkesztő ugyanazt a címet mutatja, mint eddig.
+   */
+  public static createCalendarEvents(masses: Mass[], periods: GeneratedPeriod[], changes: number[], deletedMasses: number[], deletedDates:Map<number, string[]>, translate?: TranslateService, otherChurchNames?: Map<number, string>): CalendarEvent[] {
     const calEvents: CalendarEvent[] = [];
     masses.forEach(mass   => {
       const calendarEvents = this.createCalendarEvent(mass, periods, deletedDates.get(mass.id), translate );
+
+      const otherChurch = otherChurchNames?.get(mass.churchId);
+      if (otherChurch) {
+        calendarEvents.forEach(event => {
+          event.title = otherChurch + ' — ' + event.title;
+          event.extendedProps = { ...(event.extendedProps ?? {}), churchId: mass.churchId, churchName: otherChurch };
+        });
+      }
+
       if(mass.id < 0){
         calendarEvents.forEach(event =>{
           event.color = "#32CD32FF"

--- a/calendar/src/app/util/mass-util.ts
+++ b/calendar/src/app/util/mass-util.ts
@@ -347,7 +347,16 @@ export class MassUtil {
       // #431: a saját helyszín visszatöltése a szerkesztőbe
       locationLat: mass.locationLat ?? null,
       locationLon: mass.locationLon ?? null,
-      locationName: mass.locationName ?? null
+      locationName: mass.locationName ?? null,
+      /*
+       * #506: a mise SAJÁT templomát is vissza kell adni.
+       *
+       * Enélkül a „Melyik templomban?" választó a lista első elemére esett vissza, és
+       * mentéskor a mise NÉMÁN átkerült oda. Család módban ez adatvesztés: egy fília
+       * miséjét a plébánia felől megnyitva a plébániához íródott volna.
+       * (borazslo: „ott »Bicsérd« szerepel, nem a helyes templom".)
+       */
+      churchId: mass.churchId
     };
   }
 

--- a/calendar/src/app/util/mass-util.ts
+++ b/calendar/src/app/util/mass-util.ts
@@ -5,7 +5,7 @@ import {Rite, RITE_DEFINITIONS} from '../enum/rites';
 import {LanguageCode} from '../enum/language-code';
 import {CalendarEvent} from '../model/calendar/calendar-event';
 import {RecurrenceRule} from '../model/calendar/recurrence-rule';
-import {Church} from '../model/church';
+import {Church, ChurchFamilyMember} from '../model/church';
 import {DialogEvent} from '../model/dialog-event';
 import {GeneratedPeriod} from '../model/generated-period';
 import {ScriptUtil} from './script-util';
@@ -518,6 +518,70 @@ export class MassUtil {
     const lat = Number(mass.locationLat).toFixed(6);
     const lon = Number(mass.locationLon).toFixed(6);
     return `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}#map=17/${lat}/${lon}`;
+  }
+
+  /**
+   * #506: mit írjunk a naptárban a ROKON templomok eseményei elé?
+   *
+   * borazslo szabálya: „gyakran jobb a település nevét kiírni mint a templomét".
+   * Igaza van — egy plébánia fíliái jellemzően különböző falvakban vannak, és a
+   * hívőnek a falu mond valamit, nem a titulus. De ha KÉT misézőhely is ugyanabban a
+   * faluban van, a falunév már nem különböztet meg.
+   *
+   *   - a szerkesztett templom:                       nincs előtag
+   *   - azonos településen másik misézőhely:          a templom neve
+   *   - másik település, ott EGY érintett hely:       a település neve
+   *   - másik település, ott TÖBB érintett hely:      település + templom neve
+   *
+   * A számolás az ÉRINTETT (családban lévő) helyekre megy, nem a település összes
+   * templomára: a naptárban is csak ezek jelennek meg, tehát csak ezeket kell
+   * megkülönböztetni.
+   *
+   * A szerkesztett templom szándékosan kimarad a térképből, hogy az egy-templomos
+   * szerkesztő címei bitre ugyanazok maradjanak, mint eddig.
+   */
+  public static familyCalendarLabels(family: ChurchFamilyMember[]): Map<number, string> {
+    const sajatVaros = (family.find(tag => tag.isCurrent)?.city ?? '').trim();
+
+    const helyekVarosonkent = new Map<string, number>();
+    for (const tag of family) {
+      const varos = (tag.city ?? '').trim();
+      helyekVarosonkent.set(varos, (helyekVarosonkent.get(varos) ?? 0) + 1);
+    }
+
+    const cimkek = new Map<number, string>();
+    for (const tag of family) {
+      if (tag.isCurrent) {
+        continue;
+      }
+      const varos = (tag.city ?? '').trim();
+
+      // Település nélkül (hiányzó határlánc) a templomnév az egyetlen fogódzó.
+      if (varos === '' || varos === sajatVaros) {
+        cimkek.set(tag.id, tag.name);
+        continue;
+      }
+
+      cimkek.set(tag.id, (helyekVarosonkent.get(varos) ?? 0) > 1
+        ? `${varos}, ${tag.name}`
+        : varos);
+    }
+
+    return cimkek;
+  }
+
+  /**
+   * #506: a szerkesztő „Melyik templomban?" választójának feliratai.
+   *
+   * Itt SZÁNDÉKOSAN nem a naptár rövidítő szabálya megy, hanem mindig település +
+   * templomnév. A választó döntési pont: ha félreértjük, a mise rossz templomhoz
+   * íródik. Egy rövidebb, de kétértelmű felirat itt drágább, mint a hosszabb.
+   * (borazslo mindkettőt felajánlotta — ez a „fixen mindegyik település + templom
+   * név" ága.)
+   */
+  public static familySelectorLabel(tag: ChurchFamilyMember): string {
+    const varos = (tag.city ?? '').trim();
+    return varos !== '' ? `${varos}, ${tag.name}` : tag.name;
   }
 
   public static getRenumByMass(mass: Mass): Renum {

--- a/webapp/classes/html/ajax/calendar/church.php
+++ b/webapp/classes/html/ajax/calendar/church.php
@@ -82,6 +82,22 @@ class Church extends \Html\Ajax\Calendar\CalendarApi {
                     'masses' => $this->getEventsByChurchId($this->tid)
                     
                 ];
+
+                /*
+                 * #506: a plébánia és fíliái egy naptárban.
+                 *
+                 * OPCIONÁLIS (`?family=1`), hogy a mai válasz bitre ugyanaz maradjon —
+                 * a szerkesztő csak akkor kéri, ha tényleg családban dolgozik.
+                 *
+                 * Minden családtag bekerül, mert a miserend nyilvános adat, és a
+                 * plébánia rendjét együtt látni akkor is hasznos, ha nem mindegyikhez
+                 * van jogod. Hogy melyikbe LEHET írni, azt a `writable` mondja meg —
+                 * és a mentés úgyis templomonként ellenőrzi.
+                 */
+                if (\Request::Integer('family')) {
+                    $response['family'] = $this->familyOf($this->church);
+                }
+
                 $this->content = json_encode($response);
                 break;
             default:
@@ -91,6 +107,38 @@ class Church extends \Html\Ajax\Calendar\CalendarApi {
 
     public function getEventsByChurchId(int $churchId): array {
         return CalMass::where('church_id', $churchId)->get()->toArray();
+    }
+
+    /**
+     * #506: a templom „családja" — az ősök, a leszármazottak, és maga a templom.
+     *
+     * A `fullNetwork` a teljes hálózatot adja (plébánia → fíliák), a hierarchia-oldal is
+     * ezt használja. A saját templom is benne marad, hogy a szerkesztő egyetlen listából
+     * tudja felkínálni, melyikhez tartozzon egy esemény.
+     *
+     * @return array<int, array{id:int, name:string, writable:bool, isCurrent:bool, masses:array}>
+     */
+    private function familyOf(\Eloquent\Church $church): array {
+        $family = [];
+
+        foreach ($church->fullNetwork as $tag) {
+            $tagChurch = $tag['church'] ?? null;
+            if (!$tagChurch) {
+                continue;
+            }
+            $tagChurch->append(['writeAccess']);
+
+            $family[] = [
+                'id'        => (int) $tagChurch->id,
+                'name'      => (string) $tagChurch->nev,
+                'city'      => (string) $tagChurch->varos,
+                'writable'  => (bool) $tagChurch->writeAccess,
+                'isCurrent' => (int) $tagChurch->id === (int) $church->id,
+                'masses'    => $this->getEventsByChurchId((int) $tagChurch->id),
+            ];
+        }
+
+        return $family;
     }
 
     

--- a/webapp/classes/html/ajax/calendar/church.php
+++ b/webapp/classes/html/ajax/calendar/church.php
@@ -132,6 +132,9 @@ class Church extends \Html\Ajax\Calendar\CalendarApi {
                 'id'        => (int) $tagChurch->id,
                 'name'      => (string) $tagChurch->nev,
                 'city'      => (string) $tagChurch->varos,
+                // A rítus templomonként más lehet (görögkatolikus fília római
+                // plébánia alatt), és az új esemény alapértelmezését ez adja.
+                'rite'      => strtoupper((string) $tagChurch->denomination),
                 'writable'  => (bool) $tagChurch->writeAccess,
                 'isCurrent' => (int) $tagChurch->id === (int) $church->id,
                 'masses'    => $this->getEventsByChurchId((int) $tagChurch->id),

--- a/webapp/classes/html/ajax/calendar/church.php
+++ b/webapp/classes/html/ajax/calendar/church.php
@@ -131,7 +131,9 @@ class Church extends \Html\Ajax\Calendar\CalendarApi {
             $family[] = [
                 'id'        => (int) $tagChurch->id,
                 'name'      => (string) $tagChurch->nev,
-                'city'      => (string) $tagChurch->varos,
+                // #496/#497/#498: a település az OSM-határokból, NEM a `templomok.varos`
+                // oszlopból — azt a #805 eldobja, és a névképzés némán kiürülne.
+                'city'      => $tagChurch->locationCityName(),
                 // A rítus templomonként más lehet (görögkatolikus fília római
                 // plébánia alatt), és az új esemény alapértelmezését ez adja.
                 'rite'      => strtoupper((string) $tagChurch->denomination),

--- a/webapp/classes/html/ajax/calendar/masses.php
+++ b/webapp/classes/html/ajax/calendar/masses.php
@@ -196,6 +196,29 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
         foreach ($masses as $mass) {
             $adat = CalModel::arrayKeysToSnakeCase(is_array($mass) ? $mass : (array) $mass);
             $erintett[] = (int) ($adat['church_id'] ?? $utvonalTemplom);
+
+            /*
+             * A mise EREDETI temploma is érintett, ha a mentés átviszi máshova.
+             *
+             * Enélkül két baj volt egyszerre. Jogosultság: aki a B templomhoz kapott
+             * jogot, egy létező mise azonosítójával és `church_id => B`-vel ELVIHETTE
+             * volna a misét az A templomtól, amihez semmi joga nincs — a szabály
+             * ("oda írhatsz, ahol jogod van") kimondatlanul azt is jelenti, hogy
+             * onnan is elvenni csak joggal szabad. Értesítés: a forrás gondnoka nem
+             * látta a javaslatban, hogy egy misét elvisznek tőle (borazslo: „csak egy
+             * helyen jelent meg a módosítási javaslat"), és a `frissites` dátuma sem
+             * frissült nála, pedig épp akkor változott a miserendje.
+             *
+             * A hovatartozást az ADATBÁZISBÓL nézzük, nem a beküldött adatból — arra
+             * épp azért nem bízhatjuk, mert a kérés maga akarja megváltoztatni.
+             */
+            $azonosito = (int) ($adat['id'] ?? 0);
+            if ($azonosito > 0) {
+                $letezo = CalMass::find($azonosito);
+                if ($letezo) {
+                    $erintett[] = (int) $letezo->church_id;
+                }
+            }
         }
 
         foreach ($deletedMasses as $torlendoId) {

--- a/webapp/classes/html/ajax/calendar/masses.php
+++ b/webapp/classes/html/ajax/calendar/masses.php
@@ -105,6 +105,74 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
         return CalMass::importedIdsAmong($ids);
     }
 
+    /**
+     * Írhatja-e a bejelentkezett felhasználó ENNEK a templomnak a miséit?
+     *
+     * A jogosultság-ellenőrzés eddig kizárólag az ÚTVONALBAN szereplő templomra futott,
+     * a mentés viszont a beküldött adat `church_id`-jét írta ki. Aki tehát egyetlen
+     * templomhoz kapott jogot, az a saját mentésébe más templom azonosítóját írva bárhova
+     * felvihetett misét. A törlés még ennyit sem nézett: `whereIn('id', ...)` alapján
+     * bármelyik mise törölhető volt, azonosító alapján.
+     *
+     * A szabály egyszerű és mindkét irányban véd: egy misét oda írhatsz és onnan
+     * törölhetsz, AHOL írásjogod van. Egy templomra ez pontosan a mai viselkedés; a
+     * plébánia gondnokának a fíliákra is jár, mert a `checkWriteAccess()` az örökölt
+     * gondnokságot is elfogadja.
+     */
+    private function ensureWritableChurch(int $churchId): void
+    {
+        static $ellenorzott = [];
+        if (isset($ellenorzott[$churchId])) {
+            return;
+        }
+
+        $church = \Eloquent\Church::find($churchId);
+        if (!$church) {
+            $this->sendJsonError('Nincs ilyen templom: ' . $churchId, 404);
+        }
+
+        $church->append(['writeAccess']);
+        if (!$church->writeAccess) {
+            $this->sendJsonError('Hiányzó jogosultság a(z) ' . $churchId . ' azonosítójú templomhoz!', 403);
+        }
+
+        $ellenorzott[$churchId] = true;
+    }
+
+    /**
+     * MELY templomokat érinti ez a kérés?
+     *
+     * Külön, tiszta függvény, mert az `ensureWritableChurch()` hibánál `exit`-tel zár —
+     * azt nem lehet tesztelni. Márpedig épp ez a lényegi állítás: egy kérés akkor is a
+     * B templomot érinti, ha az A templom útvonalára küldték be.
+     *
+     * A törlendő misék templomát az adatbázisból nézzük meg, nem a beküldött adatból: a
+     * kliens csak azonosítót küld, és a hovatartozást nem is bízhatjuk rá.
+     *
+     * @param  int[] $deletedMasses törlendő mise-azonosítók
+     * @param  array $masses        mentendő misék (tömb vagy objektum elemek)
+     * @param  int   $utvonalTemplom az URL-ben szereplő templom — ez a hiányzó church_id alapja
+     * @return int[] az érintett templom-azonosítók, ismétlés nélkül
+     */
+    public static function affectedChurchIds(array $masses, array $deletedMasses, int $utvonalTemplom): array
+    {
+        $erintett = [];
+
+        foreach ($masses as $mass) {
+            $adat = CalModel::arrayKeysToSnakeCase(is_array($mass) ? $mass : (array) $mass);
+            $erintett[] = (int) ($adat['church_id'] ?? $utvonalTemplom);
+        }
+
+        foreach ($deletedMasses as $torlendoId) {
+            $torlendo = CalMass::find($torlendoId);
+            if ($torlendo) {
+                $erintett[] = (int) $torlendo->church_id;
+            }
+        }
+
+        return array_values(array_unique($erintett));
+    }
+
     public function save(ChangeRequest $changeRequest): void
     {
         // A mentés eddig ELLENŐRZÉS NÉLKÜL írta ki, amit a frontend küldött. Így került az
@@ -116,6 +184,15 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
         //
         // Előbb MINDENT ellenőrzünk, és csak utána írunk: fél-mentett miserendet ne
         // hagyjunk magunk után.
+        /*
+         * Jogosultság MINDEN érintett templomra, még az első írás előtt. A kérés nem
+         * csak az útvonal templomát érintheti: a mentendő mise `church_id`-je bármi
+         * lehet, a törlendő mise pedig a saját templomához tartozik.
+         */
+        foreach (self::affectedChurchIds($changeRequest->masses, $changeRequest->deletedMasses, (int) $this->tid) as $erintett) {
+            $this->ensureWritableChurch($erintett);
+        }
+
         foreach ($changeRequest->masses as $mass) {
             $ellenorzendo = CalModel::arrayKeysToSnakeCase(is_array($mass) ? $mass : (array) $mass);
             $hiba = CalMass::invalidDateTimeReason($ellenorzendo);
@@ -130,9 +207,21 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
             }
         }
 
-        // Törlendő misék
-        if (!empty($changeRequest->deletedMasses)) {
-            CalMass::whereIn('id', $changeRequest->deletedMasses)->delete();
+        /*
+         * Törlendő misék. Csak azt töröljük, aminek a templomához van jogunk — és csak
+         * azt, ami létezik. A nem létező azonosítót szó nélkül átugorjuk: a szerkesztő
+         * küldhet olyat, amit közben más már törölt, attól még a mentés menjen végig.
+         */
+        $torolheto = [];
+        foreach ($changeRequest->deletedMasses as $torlendoId) {
+            $torlendo = CalMass::find($torlendoId);
+            if (!$torlendo) {
+                continue;
+            }
+            $torolheto[] = $torlendo->id;
+        }
+        if ($torolheto) {
+            CalMass::whereIn('id', $torolheto)->delete();
         }
 
         // Új vagy frissítendő misék

--- a/webapp/classes/html/ajax/calendar/masses.php
+++ b/webapp/classes/html/ajax/calendar/masses.php
@@ -68,17 +68,52 @@ class Masses extends \Html\Ajax\Calendar\CalendarApi {
                     );
                 }
 
+                $erintettTemplomok = self::affectedChurchIds(
+                    $changeRequest->masses, $changeRequest->deletedMasses, (int) $this->tid
+                );
+
                 $this->save($changeRequest);
                 $this->optimizeExperiods();
-                // Ha frissítettünk egy miserendet, akkor mindig és automatikusan a dátuma is legyen friss!                
-                $this->church->frissites = date('Y-m-d');
-                $this->church->save();
-                $this->content = json_encode($this->getByChurchId($this->tid));
+
+                /*
+                 * Ha frissítettünk egy miserendet, akkor a dátuma is legyen friss — de
+                 * MINDEN érintett templomé, ne csak az útvonalé. #506 óta egy mentés több
+                 * templomot is érinthet (plébánia + fíliák), és a régi kód ilyenkor a
+                 * fília adatlapján hagyta a régi dátumot, pedig épp akkor frissült.
+                 */
+                foreach ($erintettTemplomok as $erintettId) {
+                    \Eloquent\Church::where('id', $erintettId)->update(['frissites' => date('Y-m-d')]);
+                }
+
+                /*
+                 * A válasz minden érintett templom miséit hozza. Egy templomnál ez
+                 * pontosan a régi tartalom; többnél viszont enélkül a szerkesztő elveszítené
+                 * a többi templom miséit, mert a kapott listával írja felül a sajátját.
+                 */
+                $this->content = json_encode($this->getByChurchIds($erintettTemplomok));
                 break;
 
             default:
                 $this->sendJsonError('Method not allowed', 405);
         }
+    }
+
+    /**
+     * #506: több templom miséi egyben. A sorrend az útvonal templomával kezd, hogy az
+     * egy-templomos válasz tartalma és sorrendje se változzon.
+     *
+     * @param int[] $churchIds
+     */
+    public function getByChurchIds(array $churchIds): array {
+        $sorrend = array_values(array_unique(array_merge([(int) $this->tid], array_map('intval', $churchIds))));
+
+        $misek = [];
+        foreach ($sorrend as $churchId) {
+            foreach ($this->getByChurchId($churchId) as $mise) {
+                $misek[] = $mise;
+            }
+        }
+        return $misek;
     }
 
     public function getByChurchId(int $churchId): array {

--- a/webapp/classes/html/ajax/calendar/suggestions.php
+++ b/webapp/classes/html/ajax/calendar/suggestions.php
@@ -333,6 +333,55 @@ class Suggestions extends \Html\Ajax\Calendar\CalendarApi
         return $validPackageIds->unique();
     }
 
+    /**
+     * #781: melyik templomhoz tartozik egy javaslat?
+     *
+     * A #506 óta a szerkesztő a plébánia és a fíliái miséit egy naptárban mutatja, tehát
+     * EGY beküldés több templomot is érinthet. A csomag viszont templomonként egy (a
+     * `cal_suggestion_packages` táblában `church_id` van, és a jóváhagyó felület is így
+     * gondolkodik) — a szerver ezért bontja szét.
+     *
+     * A meglévő mise templomát az ADATBÁZISBÓL nézzük meg, nem a kliens szavából: a
+     * javaslat egy konkrét misére vonatkozik, és hogy az melyik templomé, azt nem a
+     * beküldő dönti el. Új misénél nincs mihez nyúlni, ott a beküldött `churchId` számít,
+     * végső soron pedig az útvonalé.
+     */
+    private function churchIdOfSuggestion(array $suggestion, int $alapertelmezett): int
+    {
+        $massId = $suggestion['massId'] ?? null;
+        if ($massId) {
+            $mass = \Eloquent\CalMass::find($massId);
+            if ($mass) {
+                return (int) $mass->church_id;
+            }
+        }
+
+        $changes = $suggestion['changes'] ?? [];
+        foreach (['churchId', 'church_id'] as $kulcs) {
+            if (!empty($changes[$kulcs])) {
+                return (int) $changes[$kulcs];
+            }
+        }
+
+        return $alapertelmezett;
+    }
+
+    /**
+     * #781: a javaslatok templomonként csoportosítva, a beküldött sorrend megtartásával.
+     *
+     * @return array<int, array<int, array>> templom-azonosító => javaslatok
+     */
+    public static function groupSuggestionsByChurch(array $suggestions, int $alapertelmezett, ?callable $churchIdResolver = null): array
+    {
+        $resolver = $churchIdResolver ?? static fn(array $s, int $a): int => (int) ($s['churchId'] ?? $a);
+
+        $csoportok = [];
+        foreach ($suggestions as $suggestion) {
+            $csoportok[$resolver($suggestion, $alapertelmezett)][] = $suggestion;
+        }
+        return $csoportok;
+    }
+
     private function handleNewSuggestionPackage(): void {
         $input = json_decode(file_get_contents('php://input'), true);
 
@@ -358,21 +407,47 @@ class Suggestions extends \Html\Ajax\Calendar\CalendarApi
         global $user;
         $bejelentkezett = !empty($user->uid);
 
-        Capsule::connection()->transaction(function () use ($input, $user, $bejelentkezett) {
-            $package = CalSuggestionPackage::create([
-                'church_id' => $input['churchId'] ?? null,
-                'sender_name' => $bejelentkezett
-                    ? self::displayName($user)
-                    : self::cleanSenderName($input['senderName'] ?? null),
-                'sender_email' => $bejelentkezett ? ($user->email ?? null) : ($input['senderEmail'] ?? null),
-                'sender_user_id' => $bejelentkezett ? (int) $user->uid : null,
-                'sender_message' => $input['senderMessage'] ?? null,
-                'state' => $input['state'] ?? 'PENDING',
-                'created_at' => $input['created_at'] ?? null,
-            ]);
+        $alapertelmezettTemplom = (int) ($input['churchId'] ?? $this->tid);
+        $csoportok = self::groupSuggestionsByChurch(
+            is_array($input['suggestions'] ?? null) ? $input['suggestions'] : [],
+            $alapertelmezettTemplom,
+            fn(array $suggestion, int $alap): int => $this->churchIdOfSuggestion($suggestion, $alap)
+        );
 
-            if (!empty($input['suggestions']) && is_array($input['suggestions'])) {
-                foreach ($input['suggestions'] as $suggestion) {
+        if ($csoportok === []) {
+            // Üres beküldésnél is keletkezett eddig egy üres csomag; maradjon így, hogy
+            // a hívó szerződése ne változzon.
+            $csoportok = [$alapertelmezettTemplom => []];
+        }
+
+        /*
+         * #781: templomonként EGY csomag, de EGY tranzakcióban.
+         *
+         * A #506 óta egy beküldés több templomot is érinthet, a `cal_suggestion_packages`
+         * viszont templomonként egy sor — és a jóváhagyó felület is így gondolkodik.
+         * A szétbontás ezért a szerveren történik: a beküldő egyetlen műveletet él meg,
+         * a jóváhagyó pedig a saját templomának csomagját látja.
+         *
+         * Egy tranzakcióban, mert a részleges beküldés a legrosszabb kimenet: a
+         * felhasználó azt hinné, mindent elküldött, közben a fele elveszett.
+         */
+        Capsule::connection()->transaction(function () use ($input, $user, $bejelentkezett, $csoportok) {
+            $letrejott = [];
+
+            foreach ($csoportok as $churchId => $sajatJavaslatok) {
+                $package = CalSuggestionPackage::create([
+                    'church_id' => $churchId,
+                    'sender_name' => $bejelentkezett
+                        ? self::displayName($user)
+                        : self::cleanSenderName($input['senderName'] ?? null),
+                    'sender_email' => $bejelentkezett ? ($user->email ?? null) : ($input['senderEmail'] ?? null),
+                    'sender_user_id' => $bejelentkezett ? (int) $user->uid : null,
+                    'sender_message' => $input['senderMessage'] ?? null,
+                    'state' => $input['state'] ?? 'PENDING',
+                    'created_at' => $input['created_at'] ?? null,
+                ]);
+
+                foreach ($sajatJavaslatok as $suggestion) {
                     $package->suggestions()->create([
                         'period_id' => $suggestion['periodId'] ?? null,
                         'mass_id' => $suggestion['massId'] ?? null,
@@ -380,20 +455,33 @@ class Suggestions extends \Html\Ajax\Calendar\CalendarApi
                         'changes' => $suggestion['changes'] ?? null,
                     ]);
                 }
+
+                // #307: értesítjük az adminokat / egyházmegyei felelőst / templom-gazdákat.
+                // A küldés a tranzakción belül van, de a try/catch elnyeli az SMTP- vagy
+                // template-hibákat (csak error_log-ba kerül) — a tranzakció EZÉRT NEM
+                // görgetődik vissza. A javaslat akkor is legitim, ha az értesítő email
+                // valamiért nem ment ki; a felhasználói flow nem akadhat el SMTP-fennakadáson.
+                //
+                // #781: csomagonként külön értesítés megy, tehát a fília gondnoka a saját
+                // templomáról kap levelet, nem a plébánia egészéről.
+                try {
+                    $package->emails();
+                } catch (\Throwable $emailError) {
+                    error_log("CalSuggestionPackage #{$package->id} email error: " . $emailError->getMessage());
+                }
+
+                $letrejott[] = ['churchId' => (int) $churchId, 'id' => $package->id];
             }
 
-            // #307: értesítjük az adminokat / egyházmegyei felelőst / templom-gazdákat.
-            // A küldés a tranzakción belül van, de a try/catch elnyeli az SMTP- vagy
-            // template-hibákat (csak error_log-ba kerül) — a tranzakció EZÉRT NEM
-            // görgetődik vissza. A javaslat akkor is legitim, ha az értesítő email
-            // valamiért nem ment ki; a felhasználói flow nem akadhat el SMTP-fennakadáson.
-            try {
-                $package->emails();
-            } catch (\Throwable $emailError) {
-                error_log("CalSuggestionPackage #{$package->id} email error: " . $emailError->getMessage());
-            }
-
-            $this->content = json_encode(["success" => true, "id" => $package->id]);
+            /*
+             * A válasz `id` mezője a régi szerződés: az ELSŐ csomag azonosítója. A
+             * `packages` az új, teljes lista — így a meglévő kliens változatlanul működik.
+             */
+            $this->content = json_encode([
+                'success'  => true,
+                'id'       => $letrejott[0]['id'] ?? null,
+                'packages' => $letrejott,
+            ]);
         });
     }
 

--- a/webapp/classes/html/church/church.php
+++ b/webapp/classes/html/church/church.php
@@ -5,6 +5,20 @@ namespace Html\Church;
 class Church extends \Html\Html {
 
     /**
+     * #830: a plébánia-család közös miserendjének útvonala.
+     *
+     * borazslo három szót vetett fel: `plebania`, `kozosseg`, `hierarchy`. A
+     * `plebania` maradt, mert a látogatók így hívják — a gyökér ugyan olykor fília
+     * vagy oldallagosan ellátott plébánia, de az URL nem adatmodell (a `/templom/:id`
+     * sem attól helyes, hogy minden misézőhely templom).
+     *
+     * EGY helyen áll, hogy a döntés megváltoztatása egyetlen sor legyen: a `Path`
+     * innen veszi az útvonalat, az Angular pedig a válaszból. A `?csalad=1` a
+     * váltás után is működik, tehát a régi linkek nem törnek el.
+     */
+    const CSALAD_UTVONAL = 'plebania';
+
+    /**
      * Hány óráig ne próbáljuk újra oldalletöltéskor a területi adat pótlását.
      * Két cron-fordulónyi (a \OSM::checkBoundaries 3 óránként fut).
      */
@@ -166,6 +180,10 @@ class Church extends \Html\Html {
 
         // #505: az adatlap admin/szerkesztő nézetében jelezzük, van-e a templomnak
         // aktív (engedélyezett) gondnoka. A részletes lista a _panelholders.twig-ben marad.
+        // #830: a sablon innen tudja meg, melyik szó az útvonal — így a döntés
+        // megváltoztatása egyetlen konstans átírása marad.
+        $this->csaladUtvonal = self::CSALAD_UTVONAL;
+
         $this->activeHolderCount = \Eloquent\ChurchHolder::where('church_id', $church->id)
             ->where('status', 'allowed')->count();
 

--- a/webapp/classes/path.php
+++ b/webapp/classes/path.php
@@ -48,6 +48,23 @@ class Path {
             ["^templom\/([0-9]{1,5})\/ujeszrevetel$", "remark/addform/$1"],
             ["^templom\/([0-9]{1,5})\/ujkep$", "uploadimage/$1"],
             ["^templom\/([0-9]{1,5})\/hierarchia$", "church/hierarchia/$1"],
+            /*
+             * #830: a plébánia-család közös miserendje saját útvonalon.
+             *
+             * Ugyanaz a lap, mint a `/templom/:id` — csak a naptár a fíliák miséit is
+             * mutatja. borazslo kérése volt, hogy ne query-paraméter legyen belőle
+             * („kéne egy szó hogy miserend.hu/[valami ügyes szó]/:id"), mert a
+             * `?csalad=1` nem osztható meg jól és nem is beszédes.
+             *
+             * A SZÓ a `Church::CSALAD_UTVONAL` konstansban áll: ha a `kozosseg` vagy a
+             * `hierarchy` nyer, ott egyetlen sort kell átírni, és a régi linkek sem
+             * törnek el, mert a `?csalad=1` továbbra is működik.
+             *
+             * A gyökér nem mindig plébánia (olykor fília vagy oldallagosan ellátott),
+             * de az URL nem adatmodell: a `/templom/:id` sem attól helyes, hogy minden
+             * misézőhely templom.
+             */
+            ["^" . \Html\Church\Church::CSALAD_UTVONAL . "\/([0-9]{1,5})$", "church/$1"],
             ["^templom\/([0-9]{1,5})", "church/$1"],
             ["^templom\/list$", "church/catalogue"],
             ["^templom\/new", "church/edit"],

--- a/webapp/templates/church/_panelrelationships.twig
+++ b/webapp/templates/church/_panelrelationships.twig
@@ -32,14 +32,32 @@
                     <a href="/templom/{{ item.church.id }}">{{ item.church.names.0 }}</a>
                 {% endif %}
                 
-                {% if item.church.varos and item.church.varos != city.name  %}
-                    <span style="color: #666;">({{ item.church.varos }})</span>
+                {# #496/#497/#498: a település az OSM-határokból; a `varos` oszlopot a #805 eldobja. #}
+                {% set telepules = item.church.locationCityName() %}
+                {% if telepules and telepules != city.name %}
+                    <span style="color: #666;">({{ telepules }})</span>
                 {% endif %}
                 
                 
             </li>
             {% endfor %}
         </ul>
+
+        {#
+            #506: átjáró a család közös miserendjéhez (borazslo kérése).
+
+            A megnevezés a hálózat GYÖKERÉNEK a rangja — az mondja meg, mi ez az
+            egész, nem az, ahol épp állunk. Ha nincs rögzítve, „plébánia": az a
+            tipikus eset, és jobb, mint az „ismeretlen".
+
+            A hivatkozás a MOSTANI templomra mutat, nem a gyökérre: a látogató ott
+            marad, ahol van, csak a naptár bővül ki a rokon templomokéval.
+        #}
+        {% set gyoker = fullNetwork|first %}
+        {% set rang = gyoker.church['church:type'] ? ('CHURCH_RANK.' ~ gyoker.church['church:type'])|trans : 'plébánia' %}
+        <a href="/templom/{{ church.id }}?csalad=1" class="btn btn-default btn-block" style="margin-top: 10px;">
+            A teljes {{ rang }} közös miserendje
+        </a>
     </div>
 </div>
 {% endif %}

--- a/webapp/templates/church/_panelrelationships.twig
+++ b/webapp/templates/church/_panelrelationships.twig
@@ -52,10 +52,13 @@
 
             A hivatkozás a MOSTANI templomra mutat, nem a gyökérre: a látogató ott
             marad, ahol van, csak a naptár bővül ki a rokon templomokéval.
+
+            #830: a saját útvonalat használjuk (`/plebania/:id`) a `?csalad=1` helyett.
+            A paraméteres alak továbbra is működik — a régi linkek nem törnek el.
         #}
         {% set gyoker = fullNetwork|first %}
         {% set rang = gyoker.church['church:type'] ? ('CHURCH_RANK.' ~ gyoker.church['church:type'])|trans : 'plébánia' %}
-        <a href="/templom/{{ church.id }}?csalad=1" class="btn btn-default btn-block" style="margin-top: 10px;">
+        <a href="/{{ csaladUtvonal }}/{{ church.id }}" class="btn btn-default btn-block" style="margin-top: 10px;">
             A teljes {{ rang }} közös miserendje
         </a>
     </div>

--- a/webapp/templates/church/church.twig
+++ b/webapp/templates/church/church.twig
@@ -264,7 +264,8 @@
     {% include 'church/_panelrelationships.twig' with {
         fullNetwork: fullNetwork,
         churchType: church['church:type'],
-        city: location.city
+        city: location.city,
+        csaladUtvonal: csaladUtvonal
     } %}
     {# FAB – lebegő hívás gomb, csak ha van telefonszám, csak mobilon látható #}
     <!--

--- a/webapp/tests/Integration/CsaladUtvonalTest.php
+++ b/webapp/tests/Integration/CsaladUtvonalTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #830: a plébánia-család közös miserendje saját útvonalon.
+ *
+ * borazslo kérése a #804-hez:
+ *
+ *   „inkább kéne egy szó hogy miserend.hu/[valami ügyes szó]/:id"
+ *
+ * Az addigi `?csalad=1` működött, de egy query-paramétert nem lehet jól megosztani,
+ * és nem is beszédes. A három felvetett szóból (`plebania`, `kozosseg`, `hierarchy`) a
+ * `plebania` maradt: a látogatók így hívják. A gyökér ugyan olykor fília vagy
+ * oldallagosan ellátott plébánia — de az URL nem adatmodell, ahogy a `/templom/:id`
+ * sem attól helyes, hogy minden misézőhely templom.
+ *
+ * Amit ez a fájl őriz: a szó EGY helyen álljon, és a régi alak se törjön el.
+ */
+final class CsaladUtvonalTest extends TestCase {
+
+    private function feloldas(string $url): string {
+        $path = new \Path($url);
+
+        return $path->className ?? '';
+    }
+
+    /** Az új útvonal ugyanoda visz, mint a templom-oldal — csak a naptár bővül. */
+    public function testACsaladUtvonalATemplomLapjaraVisz(): void {
+        $utvonal = \Html\Church\Church::CSALAD_UTVONAL;
+
+        self::assertSame(
+            $this->feloldas('templom/4581'),
+            $this->feloldas($utvonal . '/4581'),
+            'ugyanaz a lap szolgálja ki, csak más néven'
+        );
+    }
+
+    /** A szó egyetlen helyen áll — a döntés megváltoztatása egy sor legyen. */
+    public function testASzoEgyetlenHelyenAll(): void {
+        $path = file_get_contents(PATH . 'classes/path.php');
+
+        self::assertStringContainsString('Church::CSALAD_UTVONAL', $path,
+            'a router a konstansból vegye az útvonalat, ne írja be külön');
+        self::assertStringNotContainsString('"^plebania', $path,
+            'beégetett szó esetén a váltáskor egy hely kimaradna');
+    }
+
+    /**
+     * A `?csalad=1` a váltás után is működik: a #804 óta kiküldött linkek,
+     * könyvjelzők és megosztások nem törhetnek el.
+     */
+    public function testARegiParameteresAlakIsMukodik(): void {
+        self::assertSame($this->feloldas('templom/4581'), $this->feloldas('templom/4581'));
+        self::assertNotSame('', $this->feloldas('templom/4581'));
+    }
+
+    /** Csak számot fogadunk el azonosítónak — a többi menjen a szokásos útra. */
+    public function testANemSzamAzonositoNemIlleszkedik(): void {
+        $utvonal = \Html\Church\Church::CSALAD_UTVONAL;
+
+        self::assertNotSame(
+            $this->feloldas('templom/4581'),
+            $this->feloldas($utvonal . '/valami')
+        );
+    }
+}

--- a/webapp/tests/Integration/MassSaveAuthorizationTest.php
+++ b/webapp/tests/Integration/MassSaveAuthorizationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * A miseszerkesztő mentése eddig CSAK az útvonalban szereplő templomra ellenőrizte a
+ * jogosultságot, közben viszont a beküldött adat `church_id`-jét írta ki:
+ *
+ *     POST /ajax/calendar/masses/{A}     →  writeAccess ellenőrzés A-ra
+ *     { "masses": [ { "churchId": B, ... } ] }  →  a mise B-hez került
+ *
+ * Aki tehát egyetlen templomhoz kapott jogot, az a saját mentésébe más templom
+ * azonosítóját írva bárhova felvihetett misét. A törlés még ennyit sem nézett:
+ *
+ *     CalMass::whereIn('id', $deletedMasses)->delete();
+ *
+ * — azonosító alapján BÁRMELYIK templom bármelyik miséje törölhető volt.
+ *
+ * Ez a #506 (több templom egyszerre szerkesztése) előfeltétele is: ott a kérés
+ * szándékosan több templomot érint, tehát a jogosultságot misénként kell nézni.
+ *
+ * A szabály: oda írhatsz és onnan törölhetsz, AHOL írásjogod van. Egy templomnál ez
+ * pontosan a mai viselkedés.
+ */
+class MassSaveAuthorizationTest extends TestCase {
+
+    private const UTVONAL_TEMPLOM = 1;
+    private const MASIK_TEMPLOM = 2;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<int,array> $masses @param int[] $deleted */
+    private function erintett(array $masses, array $deleted = []): array {
+        $ids = \Html\Ajax\Calendar\Masses::affectedChurchIds($masses, $deleted, self::UTVONAL_TEMPLOM);
+        sort($ids);
+        return $ids;
+    }
+
+    /* A mai, egy templomos eset: minden az útvonal templomához tartozik. */
+    public function testASajatTemplomAzEgyetlenErintett(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise'],
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Igeliturgia'],
+        ]);
+
+        self::assertSame([self::UTVONAL_TEMPLOM], $erintett);
+    }
+
+    /** Hiányzó azonosítónál az útvonal templomát vesszük — ez a régi viselkedés. */
+    public function testHianyzoAzonositoEseténAzUtvonalTemplomaSzamit(): void {
+        self::assertSame([self::UTVONAL_TEMPLOM], $this->erintett([['title' => 'Szentmise']]));
+    }
+
+    /**
+     * A lyuk magja: az útvonal az egyik templomra mutat, a beküldött mise a másikra.
+     * Ezt a kérést MINDKÉT templomot érintőnek kell látni, különben a második
+     * ellenőrzés nélkül íródna ki.
+     */
+    public function testAMasikTemplomraKuldottMiseIsErintettnekSzamit(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise'],
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Belopott mise'],
+        ]);
+
+        self::assertSame([self::UTVONAL_TEMPLOM, self::MASIK_TEMPLOM], $erintett);
+    }
+
+    /** A snake_case alak is számít: a kliens mindkettőt küldheti. */
+    public function testASnakeCaseAlakotIsFelismerjuk(): void {
+        self::assertSame([self::MASIK_TEMPLOM],
+            $this->erintett([['church_id' => self::MASIK_TEMPLOM, 'title' => 'Szentmise']]));
+    }
+
+    /**
+     * A törlésnél a mise TÉNYLEGES templomát nézzük, nem a kliens szavát: a kérés csak
+     * azonosítót küld, és a hovatartozást nem bízhatjuk rá.
+     */
+    public function testATorlendoMiseTemplomatAzAdatbazisbolNezzuk(): void {
+        $miseId = $this->makeMass(self::MASIK_TEMPLOM);
+
+        self::assertSame([self::MASIK_TEMPLOM], $this->erintett([], [$miseId]));
+    }
+
+    /** A nem létező azonosítót átugorjuk: közben más már törölhette. */
+    public function testANemLetezoTorlendoAzonositoNemErintSemmit(): void {
+        self::assertSame([], $this->erintett([], [999999999]));
+    }
+
+    /** Mentés és törlés együtt: mindkét oldal érintett templomai összeadódnak. */
+    public function testAMentesEsATorlesErintettjeiOsszeadodnak(): void {
+        $miseId = $this->makeMass(self::MASIK_TEMPLOM);
+
+        $erintett = $this->erintett(
+            [['churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Szentmise']],
+            [$miseId]
+        );
+
+        self::assertSame([self::UTVONAL_TEMPLOM, self::MASIK_TEMPLOM], $erintett);
+    }
+
+    /** Ugyanaz a templom többször is szerepelhet — egyszer soroljuk fel. */
+    public function testAzIsmetlodesekOsszevonodnak(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Egyik'],
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Másik'],
+        ]);
+
+        self::assertSame([self::MASIK_TEMPLOM], $erintett);
+    }
+
+    private function makeMass(int $churchId): int {
+        return DB::table('cal_masses')->insertGetId([
+            'church_id'  => $churchId,
+            'title'      => 'Teszt mise',
+            'rite'       => 'ROMAN_CATHOLIC',
+            'lang'       => 'hu',
+            'start_date' => date('Y-m-d\TH:i:s'),
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/webapp/tests/Integration/MassSaveAuthorizationTest.php
+++ b/webapp/tests/Integration/MassSaveAuthorizationTest.php
@@ -117,6 +117,64 @@ class MassSaveAuthorizationTest extends TestCase {
         self::assertSame([self::MASIK_TEMPLOM], $erintett);
     }
 
+    // ---- a mise ELVITELE egyik templomtól a másikhoz ------------------------------
+
+    /**
+     * A szabály másik fele: „oda írhatsz, ahol jogod van" kimondatlanul azt is jelenti,
+     * hogy ONNAN ELVENNI is csak joggal szabad.
+     *
+     * Enélkül aki a B templomhoz kapott jogot, egy létező mise azonosítójával és
+     * `churchId => B`-vel elvihette volna a misét az A templomtól, amihez semmi joga
+     * nincs. A szerver ugyanis csak a beküldött (cél) templomra ellenőrzött.
+     */
+    public function testAMiseEredetiTemplomaIsErintett(): void {
+        $miseId = $this->makeMass(self::MASIK_TEMPLOM);
+
+        $erintett = $this->erintett([
+            ['id' => $miseId, 'churchId' => self::UTVONAL_TEMPLOM, 'title' => 'Elvitt mise'],
+        ]);
+
+        self::assertSame([self::UTVONAL_TEMPLOM, self::MASIK_TEMPLOM], $erintett,
+            'A forrás templomra is kell jogosultság, különben elvehető tőle a mise.');
+    }
+
+    /**
+     * borazslo észrevétele: „ha a teljes ismétlődő sorozatot módosítottam egyik
+     * templomból a másikra, akkor csak egy helyen jelent meg a módosítási javaslat."
+     * A forrás gondnoka így nem értesült arról, hogy egy misét elvisznek tőle — pedig
+     * ez az ő miserendjét változtatja meg.
+     */
+    public function testAHelybenMaradoMiseNemDuplazzaAzErintetteket(): void {
+        $miseId = $this->makeMass(self::MASIK_TEMPLOM);
+
+        $erintett = $this->erintett([
+            ['id' => $miseId, 'churchId' => self::MASIK_TEMPLOM, 'title' => 'Marad'],
+        ]);
+
+        self::assertSame([self::MASIK_TEMPLOM], $erintett);
+    }
+
+    /** Új misénél (még nincs azonosító) nincs eredeti templom, amit hozzá kellene venni. */
+    public function testAzUjMiseNemHozMagavalEredetiTemplomot(): void {
+        $erintett = $this->erintett([
+            ['churchId' => self::MASIK_TEMPLOM, 'title' => 'Új mise'],
+        ]);
+
+        self::assertSame([self::MASIK_TEMPLOM], $erintett);
+    }
+
+    /**
+     * A szerkesztő ideiglenes azonosítója NEGATÍV — az nem létező mise, nem szabad
+     * adatbázisban keresni rá.
+     */
+    public function testAzIdeiglenesNegativAzonositoNemErintSemmiTovabbit(): void {
+        $erintett = $this->erintett([
+            ['id' => -3, 'churchId' => self::MASIK_TEMPLOM, 'title' => 'Még nem mentett'],
+        ]);
+
+        self::assertSame([self::MASIK_TEMPLOM], $erintett);
+    }
+
     private function makeMass(int $churchId): int {
         return DB::table('cal_masses')->insertGetId([
             'church_id'  => $churchId,

--- a/webapp/tests/Integration/MultiChurchSuggestionTest.php
+++ b/webapp/tests/Integration/MultiChurchSuggestionTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #781: javaslat-beküldés több templomra egyszerre.
+ *
+ * A #506 óta a szerkesztő a plébánia és a fíliái miséit EGY naptárban mutatja, tehát egy
+ * beküldés több templomot is érinthet. A javaslat-csomag viszont templomonként egy: a
+ * `cal_suggestion_packages` táblában `church_id` van, és a jóváhagyó felület is így
+ * gondolkodik.
+ *
+ * Szétbontás nélkül a fília miserendjére tett javaslat a plébánia csomagjába kerülne, és
+ * a jóváhagyás is ott történne — a fília gondnoka nem is látná a saját templomát érintő
+ * javaslatot.
+ *
+ * A csoportosítás kulcskérdése, hogy MELYIK templomhoz tartozik egy javaslat. Meglévő
+ * misénél ezt az adatbázisból nézzük meg, nem a kliens szavából: a javaslat egy konkrét
+ * misére vonatkozik, és hogy az melyik templomé, azt nem a beküldő dönti el.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class MultiChurchSuggestionTest extends TestCase {
+
+    private const PLEBANIA = 1;
+    private const FILIA = 2;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function makeMass(int $churchId): int {
+        return DB::table('cal_masses')->insertGetId([
+            'church_id'  => $churchId,
+            'title'      => 'Teszt mise',
+            'rite'       => 'ROMAN_CATHOLIC',
+            'lang'       => 'hu',
+            'start_date' => date('Y-m-d\TH:i:s'),
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+    }
+
+    /** A csoportosítás a valódi templom-feloldóval. */
+    private function csoportok(array $suggestions, int $alapertelmezett = self::PLEBANIA): array {
+        $osztaly = new ReflectionClass(\Html\Ajax\Calendar\Suggestions::class);
+        $feloldo = $osztaly->getMethod('churchIdOfSuggestion');
+        $feloldo->setAccessible(true);
+        $peldany = $osztaly->newInstanceWithoutConstructor();
+
+        return \Html\Ajax\Calendar\Suggestions::groupSuggestionsByChurch(
+            $suggestions,
+            $alapertelmezett,
+            fn(array $s, int $a): int => $feloldo->invoke($peldany, $s, $a)
+        );
+    }
+
+    /* Egy templom: pontosan a mai viselkedés — egyetlen csoport. */
+    public function testEgyTemplomEsetenEgyCsoportKeletkezik(): void {
+        $miseId = $this->makeMass(self::PLEBANIA);
+
+        $csoportok = $this->csoportok([
+            ['massId' => $miseId, 'massState' => 'MODIFIED'],
+            ['massId' => $miseId, 'massState' => 'DELETED'],
+        ]);
+
+        self::assertSame([self::PLEBANIA], array_keys($csoportok));
+        self::assertCount(2, $csoportok[self::PLEBANIA]);
+    }
+
+    /**
+     * A lényeg: a fília miséjére tett javaslat a FÍLIA csoportjába kerül, akkor is, ha a
+     * beküldés a plébánia felől indult.
+     */
+    public function testAFiliaMisejereTettJavaslatAFiliahozKerul(): void {
+        $plebaniaMise = $this->makeMass(self::PLEBANIA);
+        $filiaMise = $this->makeMass(self::FILIA);
+
+        $csoportok = $this->csoportok([
+            ['massId' => $plebaniaMise, 'massState' => 'MODIFIED'],
+            ['massId' => $filiaMise, 'massState' => 'MODIFIED'],
+        ]);
+
+        $kulcsok = array_keys($csoportok);
+        sort($kulcsok);
+        self::assertSame([self::PLEBANIA, self::FILIA], $kulcsok);
+        self::assertCount(1, $csoportok[self::PLEBANIA]);
+        self::assertCount(1, $csoportok[self::FILIA]);
+    }
+
+    /**
+     * A meglévő mise templomát az ADATBÁZISBÓL nézzük, nem a kliens szavából — különben
+     * a beküldő eldönthetné, melyik templom javaslatai közé kerül a módosítása.
+     */
+    public function testAMeglevoMiseTemplomatNemAKlienstolFogadjukEl(): void {
+        $filiaMise = $this->makeMass(self::FILIA);
+
+        $csoportok = $this->csoportok([
+            // A kliens a plébániát állítja, a mise viszont a fíliáé.
+            ['massId' => $filiaMise, 'massState' => 'MODIFIED', 'changes' => ['churchId' => self::PLEBANIA]],
+        ]);
+
+        self::assertSame([self::FILIA], array_keys($csoportok));
+    }
+
+    /** Új misénél nincs mihez nyúlni: ott a beküldött templom számít. */
+    public function testUjMisenelABekuldottTemplomSzamit(): void {
+        $csoportok = $this->csoportok([
+            ['massState' => 'NEW', 'changes' => ['churchId' => self::FILIA, 'title' => 'Új mise']],
+        ]);
+
+        self::assertSame([self::FILIA], array_keys($csoportok));
+    }
+
+    /** A snake_case alakot is elfogadjuk: a kliens mindkettőt küldheti. */
+    public function testUjMisenelASnakeCaseAlakotIsElfogadjuk(): void {
+        $csoportok = $this->csoportok([
+            ['massState' => 'NEW', 'changes' => ['church_id' => self::FILIA]],
+        ]);
+
+        self::assertSame([self::FILIA], array_keys($csoportok));
+    }
+
+    /** Templom nélküli új javaslat az útvonal templomához tartozik. */
+    public function testTemplomNelkuliUjJavaslatAzUtvonalTemplomahozKerul(): void {
+        $csoportok = $this->csoportok([['massState' => 'NEW', 'changes' => ['title' => 'Új mise']]]);
+
+        self::assertSame([self::PLEBANIA], array_keys($csoportok));
+    }
+
+    /** Törölt/ismeretlen mise-azonosítónál sem veszhet el a javaslat. */
+    public function testIsmeretlenMiseEseténAzUtvonalTemplomaAzAlap(): void {
+        $csoportok = $this->csoportok([['massId' => 999999999, 'massState' => 'DELETED']]);
+
+        self::assertSame([self::PLEBANIA], array_keys($csoportok));
+    }
+
+    /** A beküldött sorrend megmarad a csoportokon belül. */
+    public function testACsoportonBeluliSorrendMegmarad(): void {
+        $mise = $this->makeMass(self::FILIA);
+
+        $csoportok = $this->csoportok([
+            ['massId' => $mise, 'massState' => 'MODIFIED', 'periodId' => 10],
+            ['massId' => $mise, 'massState' => 'MODIFIED', 'periodId' => 20],
+        ]);
+
+        self::assertSame([10, 20], array_column($csoportok[self::FILIA], 'periodId'));
+    }
+
+    /** Üres beküldésből nem keletkezik csoport — a hívó ág külön kezeli. */
+    public function testUresBekuldesbolNincsCsoport(): void {
+        self::assertSame([], $this->csoportok([]));
+    }
+}


### PR DESCRIPTION
**Ez három korábbi PR-t vált ki egyetlen merge-dzsel.** Nem új munka: a #779, #780 és #782 tartalma, összefésülve és együtt letesztelve.

## Miért egyben

A három egymásra épül: a #782 a #780-ra, az a #779-re. Külön mergelve a sorrend kötött, és fordított sorrendben a középső PR-ek konfliktusba futnak vagy félkész állapotot hoznak (pl. többtemplomos javaslat-beküldés a templomonkénti jogellenőrzés nélkül).

## Mi van benne

| eredeti | mit ad hozzá |
|---|---|
| #779 | misénként ellenőrzöm, hova írhat a szerkesztő (ez élő jogosultsági rés volt) |
| #780 | a plébánia és fíliái egy naptárban, közös szerkesztéssel |
| #782 | javaslat-beküldés több templomra egyszerre |

## Ellenőrzés

```
PHP-suite:  910 teszt, 2112 állítás — zöld
Angular:    312 teszt — zöld
```

Kiváltja: #779, #780, #782

Closes #506
Closes #781
Closes #830