### PR TITLE
A v4 marad a kurrensnek hirdetett API-verzió

### DIFF
--- a/webapp/classes/api/api.php
+++ b/webapp/classes/api/api.php
@@ -31,6 +31,21 @@ class Api {
      */
     const LEGUJABB_VERZIO = 5;
 
+    /**
+     * #800: a KURRENSNEK hirdetett verzió — ez nem feltétlenül a legmagasabb.
+     *
+     * borazslo a #778-hoz: „még éppen szerintem az api v4 maradhat a kurrensnek
+     * kikiálltot, mert a v5 sqlite még nagyon változnia kell".
+     *
+     * A két szám SZÁNDÉKOSAN külön: a `LEGUJABB_VERZIO` a validálás felső korlátja
+     * (a v5 kéréseket el kell fogadni), az `AJANLOTT_VERZIO` pedig az, amit a
+     * dokumentáció aktuálisként mutat és amire új klienst építeni javaslunk. Amíg a
+     * v5 sqlite mise-formátuma alakul, a kettő nem eshet egybe.
+     *
+     * Ha a v5 megszilárdul, itt egyetlen szám átírása a teendő.
+     */
+    const AJANLOTT_VERZIO = 4;
+
     public function validateVersionMain() {
         // Laza összehasonlítás: a \Request::IntegerRequired() sztringet ad vissza, és a
         // szigorú változat emiatt a meglévő verziókat is elutasítaná.

--- a/webapp/templates/apidocs.twig
+++ b/webapp/templates/apidocs.twig
@@ -3,15 +3,29 @@
 {% set title = 'API dokumentáció' %}
 {% set columns2 = true %}
 
-{# #56: a verziószám a kódból jön, nem sablonba írva — így az v6-nál nem marad el. #}
-{% set currentVersion = constant('Api\\Api::LEGUJABB_VERZIO') %}
+{# #56: a verziószám a kódból jön, nem sablonba írva — így az v6-nál nem marad el.
+   #800: az AJÁNLOTT verziót mutatjuk, nem a legmagasabbat. A v5 létezik és
+   használható, de a mise-formátuma még alakul, ezért a v4 marad a kurrens. #}
+{% set currentVersion = constant('Api\\Api::AJANLOTT_VERZIO') %}
+{% set newestVersion = constant('Api\\Api::LEGUJABB_VERZIO') %}
 
 {% block content %}
 
-<p>Az aktuális API verzió az <strong>API v{{ currentVersion }}</strong>. Az API v3 és v4 továbbra is támogatott — a v4 válasza változatlan marad. A már nem támogatott API verziók mindenre a „2” szöveges értékkel térnek vissza.</p>
+<p>
+    Az aktuális API verzió az <strong>API v{{ currentVersion }}</strong> — új klienst erre érdemes építeni.
+    A v{{ newestVersion }} már elérhető, de még kísérleti (lásd lentebb).
+    Az API v3 továbbra is támogatott, és a v{{ currentVersion }} válasza változatlan marad.
+    A már nem támogatott API verziók mindenre a „2” szöveges értékkel térnek vissza.
+</p>
 <p>Természetesen https a megfelelő kommunikációs csatorna.</p>
 
-<h4>Mi új az API v5-ben?</h4>
+<h4>Mi új az API v{{ newestVersion }}-ben? <em>(kísérleti)</em></h4>
+<p>
+    A <strong>v{{ newestVersion }}</strong> már használható, de <strong>még nem ez a kurrens verzió</strong>:
+    a miserend sqlite-formátuma még változni fog. Új klienst egyelőre a
+    v{{ currentVersion }}-re érdemes építeni; a v{{ newestVersion }}-öt kipróbálni jó,
+    de számíts rá, hogy a mise-adat szerkezete még alakul.
+</p>
 <p>A v5 <strong>bővítés, nem csere</strong>: minden mező megmarad, ami a v4-ben volt, és mellé jönnek az újak. Így a meglévő kliensek mezőnként állhatnak át.</p>
 <ul>
     <li><strong>Strukturált mise-adat.</strong> A v4-ben a mise két mező volt: <code>idopont</code> és <code>informacio</code> — az utóbbi egy előre összerakott magyar mondat („Római katolikus Szentmise”). Ebből nem lehetett szűrni és fordítani sem. A v5 mellétesz: <code>mise_id</code>, <code>ritus</code>, <code>megnevezes</code>, <code>nyelvek</code>, <code>tipusok</code>, <code>megjegyzes</code>, <code>hossz_perc</code>. Az <code>informacio</code> a v5-ben is megmarad.</li>

--- a/webapp/tests/Unit/ApiRecommendedVersionTest.php
+++ b/webapp/tests/Unit/ApiRecommendedVersionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #800: melyik API-verziót hirdetjük kurrensnek.
+ *
+ * borazslo a #778-hoz:
+ *
+ *   „még éppen szerintem az api v4 maradhat a kurrensnek kikiálltot, mert a v5
+ *    sqlite még nagyon változnia kell"
+ *
+ * A két szám ezért külön él: a `LEGUJABB_VERZIO` a validálás felső korlátja (a v5
+ * kéréseket el KELL fogadni), az `AJANLOTT_VERZIO` pedig az, amit a dokumentáció
+ * aktuálisként mutat. Ez a teszt azt őrzi, hogy a kettő ne csússzon össze
+ * véletlenül — a v5 kikiáltása tudatos döntés legyen, ne egy elfelejtett konstans.
+ */
+class ApiRecommendedVersionTest extends TestCase {
+
+    public function testAzAjanlottVerzioNemLehetMagasabbALegujabbnal(): void {
+        self::assertLessThanOrEqual(\Api\Api::LEGUJABB_VERZIO, \Api\Api::AJANLOTT_VERZIO);
+    }
+
+    /** Amíg a v5 sqlite mise-formátuma alakul, a v4 marad a kurrens. */
+    public function testJelenlegAV4AzAjanlott(): void {
+        self::assertSame(4, \Api\Api::AJANLOTT_VERZIO,
+            'Ha a v5 megszilárdult, ezt a tesztet és a konstanst együtt kell átírni.');
+    }
+
+    /** A v5 kéréseket akkor is el kell fogadni, ha nem az az ajánlott. */
+    public function testAzOtosVerzioTovabbraIsErvenyes(): void {
+        self::assertSame(5, \Api\Api::LEGUJABB_VERZIO);
+    }
+
+    /**
+     * A dokumentáció az AJÁNLOTT verziót mutatja aktuálisként — ez volt borazslo
+     * konkrét kérése.
+     */
+    public function testADokumentacioAzAjanlottVerziotMutatja(): void {
+        $sablon = file_get_contents(PATH . 'templates/apidocs.twig');
+
+        self::assertStringContainsString("Api\\\\Api::AJANLOTT_VERZIO", $sablon);
+        self::assertStringContainsString('kísérleti', $sablon,
+            'A legújabb verziót kísérletiként kell jelölni, amíg nem az az ajánlott.');
+    }
+}


### PR DESCRIPTION
@borazslo a #778-hoz:

> Ez így jó, de még éppen szerintem az api v4 maradhat a kurrensnek kikiálltot, mert a v5 sqlite még nagyon változnia kell: #800

A #778 azóta bement, de **a kérés nem valósult meg benne**. A master ma ezt csinálja:

```twig
{% set currentVersion = constant('Api\Api::LEGUJABB_VERZIO') %}   {# = 5 #}
```

Vagyis a dokumentáció a v5-öt hirdeti aktuálisnak — pont amit kifogásoltál.

## A gond

Egyetlen konstans csinált két dolgot: ő volt a **validálás felső korlátja** (a v5 kéréseket el kell fogadni) **és** a doksi „kurrens" verziója. A kettő most vált el egymástól, mert a v5 már létezik, de még nem ajánlott.

## A megoldás

```php
const LEGUJABB_VERZIO = 5;   // a legmagasabb ELFOGADOTT
const AJANLOTT_VERZIO = 4;   // amit KURRENSKÉNT hirdetünk
```

A dokumentáció mostantól a v4-et mutatja aktuálisként, a v5-öt pedig **kísérletiként** jelöli, kiírva, hogy a mise-formátuma még alakulni fog:

> A **v5** már használható, de **még nem ez a kurrens verzió**: a miserend sqlite-formátuma még változni fog. Új klienst egyelőre a v4-re érdemes építeni.

A v5 kérések természetesen továbbra is érvényesek — csak nem ezt ajánljuk.

Ha a v5 megszilárdul, **egyetlen szám átírása** a teendő.

## Ellenőrzés

4 teszt, köztük egy őr arra, hogy a két szám ne csússzon össze véletlenül — a v5 kikiáltása tudatos döntés legyen, ne egy elfelejtett konstans.

```
PHP-suite: 956 teszt, 2179 állítás — zöld
```

Ellenőriztem a valódi kimenetet is: a `/apidocs` most `API v4</strong>`-et ír, és kétszer szerepel benne a „kísérleti" jelölés.

Kapcsolódik: #778, #800