### PR TITLE
A szabad szöveget boundary-ra is lefordítom a keresésben

### DIFF
--- a/webapp/classes/search.php
+++ b/webapp/classes/search.php
@@ -193,7 +193,98 @@ class Search {
         $bool['should'][] = ['wildcard'=>[$prefix.'varos'=>[ 'value' => '*'.$keyword.'*', 'boost'=>12 ]]];
         $bool['should'][] = ['wildcard'=>[$prefix.'alternative_names'=>[ 'value' => '*'.$keyword.'*', 'boost'=>4 ]]];
     
+        /*
+         * #793: a szabad szöveget BOUNDARY-ra is lefordítjuk.
+         *
+         * borazslo döntése: „Sajnos meg kell próbálni a szabad szöveget is boundary-ra
+         * fordítani, mert az emberek gyakran egyszerűek és nem jönnek rá a másik
+         * útvonalra. Csak belefér a pontatlanság és egyebek. Hiszen a beírt szabadszöveg
+         * egyszerre lehet a templom nevének részlete meg egy helyadata is."
+         *
+         * Eddig a helyre szűkítés CSAK az autocomplete-választáson keresztül működött:
+         * aki beírta, hogy „Újbuda", és entert nyomott, nulla találatot kapott, mert a
+         * templom-dokumentum egyetlen mezőjében sem szerepel ez a szó — csak a boundary
+         * alternatív nevében.
+         *
+         * `should`-ág, tehát csak BŐVÍTI a találatokat, nem szűkíti: a kulcsszó
+         * továbbra is illeszkedhet a templom nevére. A boost szándékosan a pontos
+         * városnév-egyezés (18) alatt van — a helymatch valódi jel, de gyengébb, mint
+         * amikor maga a beírt szó a település neve a dokumentumban.
+         */
+        $boundaryIds = self::boundaryIdsForKeyword($keyword);
+        if ($boundaryIds !== []) {
+            $bool['should'][] = ['terms' => [$prefix . 'boundaries' => $boundaryIds, 'boost' => 16]];
+        }
+
         $this->query['bool']['must'][] = ['bool' => $bool ];
+    }
+
+    /**
+     * #793: a beírt szöveghez tartozó boundary-azonosítók.
+     *
+     * Rétegesen keresünk, és az ELSŐ nem üres réteget használjuk: pontos név, majd
+     * kezdet szerinti, majd részlet. Enélkül egy rövid, gyakori szó (pl. „Szent")
+     * tucatnyi településre illeszkedne, és minden ottani templomot előrehozna egy
+     * olyan keresésnél, ami valójában a templom NEVÉRE vonatkozott.
+     *
+     * Az `alt_name`-re is illesztünk: a köznyelvi név gyakran ott ül (a budapesti
+     * V. kerületé „Belváros-Lipótváros", a XI.-é „Újbuda").
+     *
+     * OSM-azonosítót NEM követelünk meg — az autocomplete igen, de ott a találatra
+     * kattintani is lehet. Itt csak szűrünk, és a régi oszlopokból származó
+     * boundary-k is valódi területek.
+     *
+     * @param string $keyword a beírt szöveg
+     * @param int $limit hány boundary-t veszünk figyelembe legfeljebb
+     * @return array<int,int>
+     */
+    public static function boundaryIdsForKeyword(string $keyword, int $limit = 25): array {
+        $keyword = trim($keyword);
+        if (mb_strlen($keyword) < 3) {
+            return [];
+        }
+
+        $engedett = [
+            'religious_administration', 'administrative', 'postal_code',
+            'region', 'historic', 'tourism_region', 'wine_growing_area',
+        ];
+
+        foreach ([$keyword, $keyword . '%', '%' . $keyword . '%'] as $minta) {
+            // Eggyel többet kérünk a korlátnál, hogy MEG TUDJUK KÜLÖNBÖZTETNI a
+            // "pont ennyi van" esetet a "ennél több van" esettől.
+            $talalat = \Eloquent\Boundary::whereIn('boundary', $engedett)
+                ->where(function ($q) use ($minta) {
+                    $q->where('name', 'like', $minta)
+                      ->orWhere('alt_name', 'like', $minta);
+                })
+                ->orderBy('admin_level')
+                ->take($limit + 1)
+                ->pluck('id')
+                ->all();
+
+            if ($talalat === []) {
+                continue;
+            }
+
+            /*
+             * Ha egy réteg TÚLCSORDUL, akkor nem megkülönböztető, és eldobjuk.
+             *
+             * Ez a zajszűrő. A "Szent" például 25+ területre illeszkedik kezdetként
+             * (Szentgotthárdi járás, Szentesi, Szentlőrinci járás...), pedig aki ezt
+             * beírja, az szinte biztosan a templom NEVÉRE gondol. Ha ezeket
+             * beengednénk, minden ottani templom előrébb kerülne.
+             *
+             * A szabály önszabályozó: nem kell kitalált hosszúság-küszöb, a
+             * találatszám maga mondja meg, hogy a szöveg helynévként értelmes-e.
+             */
+            if (count($talalat) > $limit) {
+                continue;
+            }
+
+            return array_map('intval', $talalat);
+        }
+
+        return [];
     }
 
     function notTitle($notTitle) {

--- a/webapp/tests/Integration/KeywordToBoundaryTest.php
+++ b/webapp/tests/Integration/KeywordToBoundaryTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #793: a szabad szöveg boundary-ra fordítása a keresésben.
+ *
+ * borazslo döntése:
+ *
+ *   „Sajnos meg kell próbálni a szabad szöveget is boundary-ra fordítani, mert az
+ *    emberek gyakran egyszerűek és nem jönnek rá a másik útvonalra. Csak belefér a
+ *    pontatlanság és egyebek. Hiszen a beírt szabadszöveg egyszerre lehet a templom
+ *    nevének részlete meg egy helyadata is."
+ *
+ * Eddig a helyre szűkítés KIZÁRÓLAG az autocomplete-választáson keresztül működött:
+ * aki beírta, hogy „Újbuda", és entert nyomott, nulla találatot kapott — a
+ * templom-dokumentum egyetlen mezőjében sem szerepel ez a szó, csak a boundary
+ * alternatív nevében.
+ *
+ * A „pontatlanság belefér" nem jelenti azt, hogy bármit beengedünk: a zajszűrő azt
+ * méri, hogy a beírt szöveg helynévként MEGKÜLÖNBÖZTETŐ-e.
+ */
+class KeywordToBoundaryTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function hatar(string $nev, string $altNev = '', string $tipus = 'administrative'): int {
+        return DB::table('boundaries')->insertGetId([
+            'boundary' => $tipus,
+            'admin_level' => 8,
+            'name' => $nev,
+            'alt_name' => $altNev,
+            'osmtype' => 'relation',
+            'osmid' => random_int(500000, 599999),
+        ]);
+    }
+
+    /** A cél: a köznyelvi névre is találjunk területet. */
+    public function testAKoznyelviNevreIsTalalBoundaryt(): void {
+        $id = $this->hatar('Teszt-kerület', 'Tesztújbuda');
+
+        self::assertContains($id, \Search::boundaryIdsForKeyword('Tesztújbuda'));
+    }
+
+    public function testAHivatalosNevreIsTalal(): void {
+        $id = $this->hatar('Tesztszentendre');
+
+        self::assertContains($id, \Search::boundaryIdsForKeyword('Tesztszentendre'));
+    }
+
+    /** Részletre is illeszt, ha az elég megkülönböztető. */
+    public function testReszletreIsIllik(): void {
+        $id = $this->hatar('Alsótesztfalva');
+
+        self::assertContains($id, \Search::boundaryIdsForKeyword('tesztfalva'));
+    }
+
+    // ---- a zajszűrő ---------------------------------------------------------
+
+    /**
+     * Ez a lényeg: aki azt írja be, hogy „Szent", az szinte biztosan a templom
+     * NEVÉRE gondol. Ha az összes Szent- kezdetű települést beengednénk, minden
+     * ottani templom előrébb kerülne.
+     *
+     * A szabály önszabályozó: ha egy réteg túlcsordul a korláton, nem
+     * megkülönböztető, tehát eldobjuk. Nem kell kitalált hosszúság-küszöb.
+     */
+    public function testATulSokTerulethezIllozoSzovegetEldobja(): void {
+        for ($i = 0; $i < 30; $i++) {
+            $this->hatar('Zajteszt ' . $i);
+        }
+
+        self::assertSame([], \Search::boundaryIdsForKeyword('Zajteszt'),
+            'A túlcsorduló réteget el kell dobni, különben minden ottani templom előrébb kerül.');
+    }
+
+    /** Néhány találat viszont belefér — ezt engedte meg borazslo. */
+    public function testAKevesTalalatBelefer(): void {
+        for ($i = 0; $i < 5; $i++) {
+            $this->hatar('Kevesteszt ' . $i);
+        }
+
+        self::assertCount(5, \Search::boundaryIdsForKeyword('Kevesteszt'));
+    }
+
+    /** A pontos egyezés akkor is nyer, ha részletként sok minden illeszkedne. */
+    public function testAPontosEgyezesElsobbsegetElvez(): void {
+        $pontos = $this->hatar('Rétegteszt');
+        for ($i = 0; $i < 30; $i++) {
+            $this->hatar('Rétegteszt melléknév ' . $i);
+        }
+
+        self::assertSame([$pontos], \Search::boundaryIdsForKeyword('Rétegteszt'));
+    }
+
+    public function testTulRovidSzovegreNemKeresunk(): void {
+        $this->hatar('AB');
+
+        self::assertSame([], \Search::boundaryIdsForKeyword('AB'));
+    }
+
+    public function testNemIllozoSzovegreUresLista(): void {
+        self::assertSame([], \Search::boundaryIdsForKeyword('xyzzyplughnincsilyen'));
+    }
+
+    /** Csak a keresésre engedélyezett területtípusok jöhetnek szóba. */
+    public function testATiltottTeruletTipusKimarad(): void {
+        $id = $this->hatar('Tiltottteszt', '', 'protected_area');
+
+        self::assertNotContains($id, \Search::boundaryIdsForKeyword('Tiltottteszt'));
+    }
+
+    // ---- a lekérdezésbe kerülés ----------------------------------------------
+
+    /**
+     * A boundary-ág `should`, tehát csak BŐVÍTI a találatokat: a kulcsszó
+     * továbbra is illeszkedhet a templom nevére.
+     */
+    public function testABoundaryAgSholdKentKerulALekerdezesbe(): void {
+        $this->hatar('Lekerdezesteszt');
+
+        $search = new \Search('churches');
+        $search->keyword('Lekerdezesteszt');
+
+        $json = json_encode($search->query);
+        self::assertStringContainsString('"should"', $json);
+        self::assertStringContainsString('boundaries', $json);
+        self::assertStringNotContainsString('"must_not"', str_replace('"must_not":[]', '', $json));
+    }
+
+    public function testHelynevNelkuliKulcsszonalNincsBoundaryAg(): void {
+        $search = new \Search('churches');
+        $search->keyword('xyzzyplughnincsilyen');
+
+        self::assertStringNotContainsString('boundaries', json_encode($search->query));
+    }
+}


### PR DESCRIPTION
@borazslo döntése a #793-ban:

> Sajnos meg kell próbálni a szabad szöveget is boundary-ra fordítani, mert az emberek gyakran egyszerűek és nem jönnek rá a másik útvonalra. Csak belefér a pontatlanság és egyebek. Hiszen a beírt szabadszöveg egyszerre lehet a templom nevének részlete meg egy helyadata is.

Megcsinálom. **A #793 mergelhető így, ahogy kérdezted — ez a külön takarítás.**

## A hiány

A helyre szűkítés eddig **kizárólag az autocomplete-választáson** keresztül működött. Aki beírta, hogy „Újbuda", és entert nyomott, nulla találatot kapott: a templom-dokumentum egyetlen mezőjében sem szerepel ez a szó — csak a boundary alternatív nevében.

## A megoldás

A kulcsszóból boundary-azonosítókat oldok fel, és `should`-ágként adom a lekérdezéshez. **Csak bővíti a találatokat, nem szűkíti** — a kulcsszó továbbra is illeszkedhet a templom nevére, ahogy eddig. A boost a pontos városnév-egyezés (18) alatt van (16): a helymatch valódi jel, de gyengébb, mint amikor maga a beírt szó a település neve a dokumentumban.

## „Csak belefér a pontatlanság" — de nem akármi

Rétegesen keresek (pontos név → kezdet → részlet), és az **első nem üres réteget** használom. Plusz egy önszabályozó zajszűrő: **ha egy réteg túlcsordul a korláton, akkor definíció szerint nem megkülönböztető, tehát eldobom.**

Nem kell kitalált hosszúság-küszöb — a találatszám maga mondja meg, hogy a szöveg helynévként értelmes-e. Valódi adaton mérve:

| beírt szöveg | boundary | |
|---|---:|---|
| Újbuda | 1 | XI. kerület — **ez volt a cél** |
| Belváros-Lipótváros | 1 | V. kerület |
| Szentendre | 1 | |
| Mária | 8 | belefér |
| **Szent** | **0** | kiszűrve — 25+ „Szent" kezdetű területre illett |
| **Buda** | **0** | kiszűrve |

A „Szent" a fontos eset: aki ezt beírja, szinte biztosan a templom **nevére** gondol. Ha az összes Szent- kezdetű települést beengednénk, minden ottani templom előrébb kerülne egy olyan keresésnél, aminek semmi köze a helyhez.

## Két apró döntés

Az **`alt_name`-re is illesztek**, mert a köznyelvi név gyakran ott ül (a XI. kerületé „Újbuda").

**OSM-azonosítót nem követelek meg.** Az autocomplete igen — de ott a találatra kattintani is lehet. Itt csak szűrünk, és a régi oszlopokból származó boundary-k is valódi területek.

## Ellenőrzés

11 teszt: köznyelvi név, hivatalos név, részlet, a túlcsorduló réteg eldobása, a kevés találat átengedése, a pontos egyezés elsőbbsége, túl rövid szöveg, tiltott területtípus, és hogy a boundary-ág tényleg `should`-ként kerül a lekérdezésbe.

```
PHP-suite: 1008 teszt, 2331 állítás — zöld
```

Kapcsolódik: #793