### PR TITLE
A kerület névváltozatait a kereső oldja fel

### DIFF
--- a/webapp/classes/html/ajax/autocompletecombined.php
+++ b/webapp/classes/html/ajax/autocompletecombined.php
@@ -22,6 +22,77 @@ use Illuminate\Database\Capsule\Manager as DB;
  */
 class AutocompleteCombined extends Ajax {
 
+    /** Az arab -> római átváltás a budapesti kerületekhez (1-23). */
+    private const ROMAI = [
+        1 => 'I', 2 => 'II', 3 => 'III', 4 => 'IV', 5 => 'V', 6 => 'VI', 7 => 'VII',
+        8 => 'VIII', 9 => 'IX', 10 => 'X', 11 => 'XI', 12 => 'XII', 13 => 'XIII',
+        14 => 'XIV', 15 => 'XV', 16 => 'XVI', 17 => 'XVII', 18 => 'XVIII', 19 => 'XIX',
+        20 => 'XX', 21 => 'XXI', 22 => 'XXII', 23 => 'XXIII',
+    ];
+
+    /**
+     * #497: további keresési minták a budapesti kerület-változatokból.
+     *
+     * Az OSM-ben a kerület neve „II. kerület" — a látogatók viszont sokféleképpen
+     * írják: „Budapest, II. kerület", „2. kerület", „II ker", „Budapest 2 ker".
+     * borazslo kérése az volt, hogy ezt a KERESŐ oldja fel, ne az adatbázis.
+     *
+     * Csak akkor csinálunk bármit, ha a szövegben tényleg kerület-hivatkozás van;
+     * egyébként üres tömböt adunk, és a hívó a sima részlet-keresést használja.
+     *
+     * @param string $szoveg a beírt szöveg
+     * @return array<int,string> LIKE-minták (üres, ha nem kerület-jellegű a szöveg)
+     */
+    public static function keruletVariansok(string $szoveg): array {
+        $tiszta = trim(mb_strtolower($szoveg));
+
+        // A "budapest" előtag és az utána álló vessző elhagyható.
+        $tiszta = preg_replace('/^budapest\s*,?\s*/u', '', $tiszta);
+
+        // "ker", "ker." -> "kerület"; a szó végi rövidítést is elfogadjuk.
+        $tiszta = preg_replace('/\bker\.?$/u', 'kerület', $tiszta);
+        $tiszta = preg_replace('/\bker\.?\s/u', 'kerület ', $tiszta);
+
+        /*
+         * A "kerület" szó CSAK a római számnál hagyható el. A puszta arab szám
+         * ("11") lehet irányítószám-részlet, házszám vagy bármi — abból nem
+         * következtetünk kerületre.
+         */
+        $romaiMinta = '/^([ivx]+)\s*\.?\s*(kerület)?$/u';
+        $arabMinta = '/^([0-9]{1,2})\s*\.?\s*kerület$/u';
+        if (!preg_match($romaiMinta, trim($tiszta), $m) && !preg_match($arabMinta, trim($tiszta), $m)) {
+            return [];
+        }
+
+        $szam = $m[1];
+        if (ctype_digit($szam)) {
+            $index = (int) $szam;
+            if (!isset(self::ROMAI[$index])) {
+                return [];
+            }
+            $romai = self::ROMAI[$index];
+        } else {
+            $romai = mb_strtoupper($szam);
+            if (!in_array($romai, self::ROMAI, true)) {
+                return [];
+            }
+        }
+
+        // A tárolt alak "II. kerület"; a % azért kell, mert a régi, oszlopokból
+        // gyártott boundary-k neve "Budapest II. kerület".
+        /*
+         * SZÓHATÁRRA illesztünk, nem sima részletre. A `%II. kerület%` a XII.-t és a
+         * XXII.-t is megfogná, mert azok tartalmazzák a "II. kerület" részletet —
+         * így egyetlen kerület keresésére húsz találat jött.
+         *
+         * Három alak kell: pontos egyezés, szó eleji, és a szövegben szóköz után
+         * álló (a régi, oszlopokból gyártott boundary-k neve "Budapest II. kerület").
+         */
+        $nev = $romai . '. kerület';
+
+        return [$nev, $nev . '%', '% ' . $nev . '%'];
+    }
+
     public $format = "json";
     public $content;
 
@@ -67,9 +138,24 @@ class AutocompleteCombined extends Ajax {
          * a XI.-é "Újbuda". Ezekre ma nulla találat jön, pedig a látogatók így hívják
          * őket.
          */
-        $boundaryQuery = \Eloquent\Boundary::where(function ($q) use ($text) {
-                $q->where('name', 'like', '%' . $text . '%')
-                  ->orWhere('alt_name', 'like', '%' . $text . '%');
+        /*
+         * #497: a budapesti kerületek névváltozatai.
+         *
+         * borazslo: „a keresőbe a rendes nevét kell írni, hogy »II. kerület« nem pedig,
+         * hogy »Budapest, II. kerület« vagy »2. kerület«, stb. De szerintem ezt nem
+         * adatbázis féle szinten kéne kezelni, hanem a kereső autocomplete részében
+         * lehetne varázsolni, nem?"
+         *
+         * Pontosan ezt csinálja a `keruletVariansok()`: a beírt szövegből további
+         * keresési mintákat gyárt, az adatbázisban tárolt neveket nem bántjuk.
+         */
+        $mintak = array_merge(['%' . $text . '%'], self::keruletVariansok($text));
+
+        $boundaryQuery = \Eloquent\Boundary::where(function ($q) use ($mintak) {
+                foreach ($mintak as $minta) {
+                    $q->orWhere('name', 'like', $minta)
+                      ->orWhere('alt_name', 'like', $minta);
+                }
             })
             ->where(function ($q) {
                 $q->whereNull('denomination')

--- a/webapp/tests/Unit/KeruletVariansokTest.php
+++ b/webapp/tests/Unit/KeruletVariansokTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #497: a budapesti kerületek névváltozatai a keresőben.
+ *
+ * borazslo:
+ *
+ *   „a keresőbe a rendes nevét kell írni, hogy »II. kerület« nem pedig, hogy
+ *    »Budapest, II. kerület« vagy »2. kerület«, stb. De szerintem ezt nem adatbázis
+ *    féle szinten kéne kezelni, hanem a kereső autocomplete részében lehetne
+ *    varázsolni, nem?"
+ *
+ * Pontosan ez történik: a beírt szövegből további keresési mintákat gyártunk, az
+ * adatbázisban tárolt neveket nem bántjuk.
+ */
+class KeruletVariansokTest extends TestCase {
+
+    /** @return array<int,string> */
+    private function variansok(string $szoveg): array {
+        return \Html\Ajax\Autocompletecombined::keruletVariansok($szoveg);
+    }
+
+    private function elsoNev(string $szoveg): ?string {
+        $v = $this->variansok($szoveg);
+        return $v[0] ?? null;
+    }
+
+    public function testABudapestElotagElhagyhato(): void {
+        self::assertSame('II. kerület', $this->elsoNev('Budapest, II. kerület'));
+        self::assertSame('II. kerület', $this->elsoNev('Budapest II. kerület'));
+    }
+
+    public function testAzArabSzamRomaivaValik(): void {
+        self::assertSame('II. kerület', $this->elsoNev('2. kerület'));
+        self::assertSame('XI. kerület', $this->elsoNev('11. kerület'));
+        self::assertSame('XXIII. kerület', $this->elsoNev('23. kerület'));
+    }
+
+    public function testAPontElhagyhato(): void {
+        self::assertSame('II. kerület', $this->elsoNev('2 kerület'));
+        self::assertSame('II. kerület', $this->elsoNev('II kerület'));
+    }
+
+    public function testAKerRovidites(): void {
+        self::assertSame('II. kerület', $this->elsoNev('II. ker'));
+        self::assertSame('II. kerület', $this->elsoNev('ii. ker.'));
+    }
+
+    public function testARomaiSzamOnmagabanIsEleg(): void {
+        self::assertSame('XI. kerület', $this->elsoNev('XI'));
+    }
+
+    /**
+     * A puszta arab szám NEM elég: lehet irányítószám-részlet, házszám vagy bármi.
+     * Ha ebből kerületre következtetnénk, minden „11"-re a XI. kerületet ajánlanánk.
+     */
+    public function testAPusztaArabSzamNemKerulet(): void {
+        self::assertSame([], $this->variansok('11'));
+        self::assertSame([], $this->variansok('2'));
+    }
+
+    public function testNemLetezoKeruletnelNincsVariant(): void {
+        self::assertSame([], $this->variansok('99. kerület'));
+        self::assertSame([], $this->variansok('0. kerület'));
+    }
+
+    public function testHelynevreNemAdVariant(): void {
+        self::assertSame([], $this->variansok('Szentendre'));
+        self::assertSame([], $this->variansok('kerület'));
+    }
+
+    /**
+     * SZÓHATÁRRA kell illeszteni: a `%II. kerület%` a XII.-t és a XXII.-t is
+     * megfogná, mert azok tartalmazzák a „II. kerület" részletet — egyetlen kerület
+     * keresésére húsz találat jött.
+     */
+    public function testAMintakSzohatarraIllenek(): void {
+        $mintak = $this->variansok('II. kerület');
+
+        self::assertContains('II. kerület', $mintak, 'a pontos egyezésnek benne kell lennie');
+        foreach ($mintak as $minta) {
+            self::assertStringNotContainsString('%II. kerület%', $minta,
+                'a mindkét oldalon nyitott minta a XII.-t és XXII.-t is megfogná');
+        }
+    }
+
+    /** A régi, oszlopokból gyártott boundary neve „Budapest II. kerület". */
+    public function testASzokozUtaniAlakotIsKeresi(): void {
+        self::assertContains('% II. kerület%', $this->variansok('II. kerület'));
+    }
+}


### PR DESCRIPTION
@borazslo a #497-ben:

> Budapesti kerületek esetén: létezik a városrész, ezért maguk a templomok megtalálhatóak kerületek szerint is, de a keresőbe a rendes nevét kell írni, hogy „II. kerület" nem pedig, hogy „Budapest, II. kerület" vagy „2. kerület", stb. De szerintem ezt nem adatbázis féle szinten kéne kezelni, hanem a kereső autocomplete részében lehetne varázsolni, nem?

De, pontosan ott. A beírt szövegből további keresési mintákat gyártok — a tárolt neveket nem bántom.

> Épül a #793-ra (a boundary `alt_name`-es keresésére).

## Felismert alakok

```
Budapest, II. kerület  ->  II. kerület
Budapest II. kerület   ->  II. kerület
2. kerület             ->  II. kerület
2 kerület              ->  II. kerület
II kerület             ->  II. kerület
II. ker                ->  II. kerület
ii. ker.               ->  II. kerület
XI                     ->  XI. kerület
```

## Két hibát menet közben fogtam meg

**A sima `%II. kerület%` minta a XII.-t és a XXII.-t is megfogja**, mert azok tartalmazzák részletként — egyetlen kerület keresésére húsz találat jött (XIII., XXIII., XVII. …). Ezért szóhatárra illesztek: pontos egyezés, szó eleji, és szóköz utáni alak (a régi, oszlopokból gyártott boundary neve „Budapest II. kerület").

**A puszta arab szám nem elég.** A „11" lehet irányítószám-részlet, házszám vagy bármi — abból nem következtetek kerületre. A „kerület" szó csak római számnál hagyható el, ott egyértelmű.

Mérve, javítás után:

| beírt szöveg | találat |
|---|---|
| Budapest, II. kerület | II. kerület, Budapest II. kerület |
| 2. kerület | ugyanaz |
| XII. kerület | XII. kerület, Budapest XII. kerület |
| 11 | — |
| Szentendre | — |

## Ellenőrzés

10 teszt: a Budapest-előtag, az arab→római váltás, a pont elhagyása, a „ker" rövidítés, a római szám önmagában, a puszta arab szám elutasítása, a nem létező kerület, a helynév, és a szóhatárra illesztés mindkét iránya.

```
PHP-suite: 903 teszt, 2109 állítás — zöld
```

Kapcsolódik: #497