### PR TITLE
Az OSM patron_day tagjét használom a búcsú forrásaként

### DIFF
--- a/webapp/classes/bucsu.php
+++ b/webapp/classes/bucsu.php
@@ -243,6 +243,52 @@ class Bucsu {
     }
 
     /**
+     * #568: az OSM `patron_day` tagjének értelmezése.
+     *
+     * borazslo vetette fel: „Sőt OSM ismeri az egyáltalán nem elterjed patron_day
+     * kulcsot." Ez STRUKTURÁLT forrás, szemben a `templomok.bucsu` szabad szöveggel —
+     * és nem kell hozzá se új oszlop, se új szerkesztő-mező: az OSM-szinkron minden
+     * taget elment az `attributes` táblába, tehát ha egy templomnál ki van töltve,
+     * az adat már nálunk van.
+     *
+     * A kulcs nem elterjedt, ezért nincs egyetlen bevett alakja. Több írásmódot
+     * elfogadunk, és amit nem értünk, azt inkább elengedjük — a szabad szöveges
+     * mező úgyis ott van tartaléknak:
+     *
+     *   --08-15     ISO 8601 ismétlődő dátum (év nélkül) — ez a legpontosabb alak
+     *   08-15       hónap-nap
+     *   2026-08-15  teljes dátum (az évet eldobjuk, a búcsú évente ismétlődik)
+     *   augusztus 15.  magyar szöveg — ilyenkor a szokásos elemzőre bízzuk
+     *
+     * @param string|null $ertek a tag nyers értéke
+     * @return array|null a szokásos alkalom-alak, vagy null
+     */
+    public static function parsePatronDay(?string $ertek): ?array {
+        $ertek = trim((string) $ertek);
+        if ($ertek === '') {
+            return null;
+        }
+
+        // --MM-DD, MM-DD, YYYY-MM-DD — az évet minden esetben eldobjuk.
+        if (preg_match('/^(?:--|\d{4}-)?(\d{1,2})-(\d{1,2})$/', $ertek, $m)) {
+            return self::napEllenorzes((int) $m[1], (int) $m[2]);
+        }
+
+        // Bármi más: hátha magyar szöveg, amit amúgy is tudunk olvasni.
+        return self::alkalomBoviteshez($ertek);
+    }
+
+    /**
+     * A belső alkalom-felismerés kívülről is elérhető alakja.
+     *
+     * A `parsePatronDay()` ezen keresztül dolgozza fel a nem szabványos, szöveges
+     * tag-értékeket, hogy ne kelljen a felismerést kétszer megírni.
+     */
+    private static function alkalomBoviteshez(string $resz): ?array {
+        return self::alkalom($resz);
+    }
+
+    /**
      * Feloldja az alkalmat konkrét dátumra egy adott évben.
      *
      * @param array|null $alkalom a parse() egyik alkalma

--- a/webapp/classes/bucsu.php
+++ b/webapp/classes/bucsu.php
@@ -320,6 +320,44 @@ class Bucsu {
     }
 
     /**
+     * #568: hány templomnál jön a búcsú a RÉGI, szabad szöveges mezőből.
+     *
+     * borazslo kérése: „ha a /health megmutatja, hogy még mennyi régi módi búcsú
+     * adatot találtunk, és akkor ha az egyszer csak elfogy, akkor kiírhatja, hogy
+     * »Megszűnt ennek a búcsú szöveget feldolgozó scriptnek a létjogosultsága.«"
+     *
+     * A számláló azt méri, hány templomnál NEM tudjuk strukturáltan (OSM
+     * `patron_day`) a búcsút, csak a megjegyzés-mezőből kiolvasva. Ha ez nullára
+     * fogy, az elemző kivezethető.
+     *
+     * @return array{szoveges: int, patron_day: int, ertelmezhetetlen: int}
+     */
+    public static function forrasStatisztika(): array {
+        $stat = ['szoveges' => 0, 'patron_day' => 0, 'ertelmezhetetlen' => 0];
+
+        $templomok = \Eloquent\Church::where('ok', 'i')
+            ->where(function ($q) {
+                $q->where('bucsu', '<>', '')
+                  ->orWhereHas('attributes', fn($a) => $a->where('key', 'patron_day'));
+            })
+            ->get();
+
+        foreach ($templomok as $templom) {
+            $eredmeny = $templom->bucsuOccasions();
+
+            if ($eredmeny['forras'] === 'patron_day') {
+                $stat['patron_day']++;
+            } elseif ($eredmeny['forras'] === 'bucsu_mezo') {
+                $stat['szoveges']++;
+            } elseif (trim((string) $templom->bucsu) !== '') {
+                $stat['ertelmezhetetlen']++;
+            }
+        }
+
+        return $stat;
+    }
+
+    /**
      * Húsvétvasárnap dátuma (gregorián, Meeus/Jones/Butcher).
      *
      * Szándékosan nem a PHP `easter_date()`-je: az az ext-calendar bővítményt

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1362,7 +1362,38 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * @return array{bucsu: ?array, szentsegimadas: ?array, unparsed: string}
      */
     public function bucsuOccasions(): array {
-        return \Bucsu::parse($this->bucsu);
+        $eredmeny = \Bucsu::parse($this->bucsu);
+
+        /*
+         * #568: az OSM `patron_day` tagje ELSŐBBSÉGET élvez a szabad szöveggel szemben.
+         *
+         * borazslo vetette fel: „Sőt OSM ismeri az egyáltalán nem elterjed patron_day
+         * kulcsot." Ez strukturált adat, tehát megbízhatóbb, mint amit egy húsz éve
+         * gyűlő megjegyzés-mezőből ki tudunk olvasni — és nem kell hozzá se új oszlop,
+         * se új szerkesztő-mező: a szinkron minden OSM-taget elment az `attributes`
+         * táblába, tehát ha ki van töltve, az adat már nálunk van.
+         *
+         * A szabad szöveg marad tartaléknak: a kulcs saját bevallás szerint sem
+         * elterjedt, tehát a templomok túlnyomó részénél nem lesz kitöltve.
+         */
+        $patronDay = \Bucsu::parsePatronDay($this->patronDayTag());
+        if ($patronDay !== null) {
+            $eredmeny['bucsu'] = $patronDay;
+            $eredmeny['forras'] = 'patron_day';
+        } elseif ($eredmeny['bucsu'] !== null) {
+            $eredmeny['forras'] = 'bucsu_mezo';
+        } else {
+            $eredmeny['forras'] = null;
+        }
+
+        return $eredmeny;
+    }
+
+    /** Az OSM `patron_day` tag nyers értéke, ha a szinkron elmentette. */
+    private function patronDayTag(): ?string {
+        $attributum = $this->attributes()->where('key', 'patron_day')->first();
+
+        return $attributum->value ?? null;
     }
 
     /**

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -63,6 +63,33 @@ class Health extends Html {
 				. 'a cron 497 állítja vissza a sor elejére.</span>'];
 		}
 
+		/*
+		 * #568: meddig kell még a szabad szöveges búcsú-mező elemzője?
+		 *
+		 * borazslo kérése: „ha a /health megmutatja, hogy még mennyi régi módi búcsú
+		 * adatot találtunk, és akkor ha az egyszer csak elfogy, akkor kiírhatja, hogy
+		 * »Megszűnt ennek a búcsú szöveget feldolgozó scriptnek a létjogosultsága.
+		 * Vegyél fel rá egy issue-t és ki lehet vezetni.«"
+		 */
+		$bucsuForras = \Bucsu::forrasStatisztika();
+		if ($bucsuForras['szoveges'] === 0) {
+			$this->infos[] = ['Búcsú-adat forrása',
+				'<span class="text-success">✅ Megszűnt ennek a búcsú szöveget feldolgozó '
+				. 'scriptnek a létjogosultsága. Vegyél fel rá egy issue-t és ki lehet vezetni. '
+				. '(' . $bucsuForras['patron_day'] . ' templomnál OSM <code>patron_day</code>.)</span>'];
+		} else {
+			$this->infos[] = ['Búcsú-adat forrása',
+				'<span class="text-muted">' . $bucsuForras['szoveges'] . ' templomnál még a régi, '
+				. 'szabad szöveges mezőből olvassuk ki a búcsút; '
+				. $bucsuForras['patron_day'] . ' templomnál van OSM <code>patron_day</code>. '
+				. 'Amíg ez a szám nem nulla, az elemző kell.'
+				. ($bucsuForras['ertelmezhetetlen'] > 0
+					? ' (További ' . $bucsuForras['ertelmezhetetlen'] . ' templomnál van kitöltött mező, '
+					  . 'de nem tudjuk értelmezni — ezek javítható adatok.)'
+					: '')
+				. '</span>'];
+		}
+
 		// Check GD extension specifically
 		if (!extension_loaded('gd')) {
 			$this->infos[] = ['GD Extension', '<span class="text-danger">⚠️ HIÁNYZIK! A képfeltöltés nem fog működni.</span>'];

--- a/webapp/tests/Integration/PatronDayTest.php
+++ b/webapp/tests/Integration/PatronDayTest.php
@@ -125,6 +125,35 @@ class PatronDayTest extends TestCase {
         self::assertSame('bucsu_mezo', $eredmeny['forras']);
     }
 
+    // ---- a /health számlálója ------------------------------------------------
+
+    /**
+     * borazslo kérése: „ha a /health megmutatja, hogy még mennyi régi módi búcsú
+     * adatot találtunk, és akkor ha az egyszer csak elfogy, akkor kiírhatja, hogy
+     * »Megszűnt ennek a búcsú szöveget feldolgozó scriptnek a létjogosultsága.«"
+     */
+    public function testAstatisztikaSzetvalasztjaAKetForrast(): void {
+        $elotte = \Bucsu::forrasStatisztika();
+
+        $this->patronDay('--08-15');
+        $utana = \Bucsu::forrasStatisztika();
+
+        self::assertSame($elotte['patron_day'] + 1, $utana['patron_day']);
+        self::assertSame($elotte['szoveges'] - 1, $utana['szoveges'],
+            'A templom átkerül a szövegesből a strukturáltba, nem duplikálódik.');
+    }
+
+    /** Az értelmezhetetlen mező külön kategória — az javítható adat, nem forrás. */
+    public function testAzErtelmezhetetlenMezoKulonSzamit(): void {
+        DB::table('templomok')->where('id', $this->churchId)
+            ->update(['bucsu' => 'Búcsú: Szent György vértanú ünnepéhez közelebbi vasárnap']);
+
+        $stat = \Bucsu::forrasStatisztika();
+
+        self::assertArrayHasKey('ertelmezhetetlen', $stat);
+        self::assertGreaterThan(0, $stat['ertelmezhetetlen']);
+    }
+
     /** A következő dátum számítása is a patron_day-ből megy. */
     public function testAKovetkezoDatumAPatronDaybolJon(): void {
         $this->patronDay('--08-15');

--- a/webapp/tests/Integration/PatronDayTest.php
+++ b/webapp/tests/Integration/PatronDayTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #568: az OSM `patron_day` tagje mint a búcsú strukturált forrása.
+ *
+ * borazslo vetette fel a jegyben:
+ *
+ *   „(Amúgy ez a búcsús mező nem búcsús, hanem megjegyzés mező. Hosszú távon akkor
+ *    külön mező lehetne a búcsúnak. Sőt OSM ismeri az egyáltalán nem elterjed
+ *    patron_day kulcsot.)"
+ *
+ * Külön oszlop és külön szerkesztő-mező NÉLKÜL is meg lehet csinálni: az
+ * OSM-szinkron MINDEN taget elment az `attributes` táblába (`osm.php`:
+ * `foreach($element->tags as $key => $value)`), tehát ha egy templomnál ki van
+ * töltve a `patron_day`, az adat már nálunk van — csak olvasni kell.
+ */
+class PatronDayTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $minta['id'] = $this->churchId;
+        $minta['nev'] = 'PatronDay Teszt';
+        $minta['bucsu'] = 'Búcsú: március 19.';
+        DB::table('templomok')->insert($minta);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function patronDay(string $ertek): void {
+        DB::table('attributes')->insert([
+            'church_id' => $this->churchId,
+            'key' => 'patron_day',
+            'value' => $ertek,
+            'fromOSM' => 1,
+        ]);
+    }
+
+    private function templom(): \Eloquent\Church {
+        return \Eloquent\Church::find($this->churchId);
+    }
+
+    // ---- az érték értelmezése -----------------------------------------------
+
+    /** ISO 8601 ismétlődő dátum — ez a legpontosabb alak egy évente visszatérő ünnepre. */
+    public function testIsoIsmetlodoDatum(): void {
+        $a = \Bucsu::parsePatronDay('--08-15');
+
+        self::assertSame(['type' => 'fixed', 'month' => 8, 'day' => 15], $a);
+    }
+
+    public function testHonapNapAlak(): void {
+        self::assertSame(['type' => 'fixed', 'month' => 8, 'day' => 15], \Bucsu::parsePatronDay('08-15'));
+    }
+
+    /** Teljes dátumnál az évet eldobjuk: a búcsú évente ismétlődik. */
+    public function testTeljesDatumnalAzEvetEldobjuk(): void {
+        self::assertSame(['type' => 'fixed', 'month' => 8, 'day' => 15], \Bucsu::parsePatronDay('2026-08-15'));
+    }
+
+    /** A kulcs nem elterjedt, ezért a magyar szöveget is elfogadjuk. */
+    public function testMagyarSzovegetIsErtelmez(): void {
+        self::assertSame(['type' => 'fixed', 'month' => 8, 'day' => 15], \Bucsu::parsePatronDay('augusztus 15.'));
+    }
+
+    public function testMozgoUnnepetIsErtelmez(): void {
+        $a = \Bucsu::parsePatronDay('Szentháromság vasárnap');
+
+        self::assertSame('moveable', $a['type']);
+        self::assertSame('2026-05-31', \Bucsu::resolve($a, 2026));
+    }
+
+    /** Amit nem értünk, azt elengedjük — a szabad szöveges mező ott van tartaléknak. */
+    public function testErtelmezhetetlenErtekNull(): void {
+        self::assertNull(\Bucsu::parsePatronDay('valami hülyeség'));
+        self::assertNull(\Bucsu::parsePatronDay(''));
+        self::assertNull(\Bucsu::parsePatronDay(null));
+    }
+
+    public function testLehetetlenNapotNemFogadEl(): void {
+        self::assertNull(\Bucsu::parsePatronDay('02-45'));
+    }
+
+    // ---- elsőbbség a szabad szöveggel szemben --------------------------------
+
+    /**
+     * A strukturált adat megbízhatóbb, mint amit egy húsz éve gyűlő megjegyzés-mezőből
+     * ki tudunk olvasni — ezért az OSM-tag nyer.
+     */
+    public function testAPatronDayFelulirjaASzabadSzoveget(): void {
+        $this->patronDay('--08-15');
+
+        $eredmeny = $this->templom()->bucsuOccasions();
+
+        self::assertSame(8, $eredmeny['bucsu']['month'], 'A patron_day (augusztus) nyer a mező (március) ellen.');
+        self::assertSame('patron_day', $eredmeny['forras']);
+    }
+
+    /** patron_day nélkül marad a szabad szöveg. */
+    public function testPatronDayNelkulASzabadSzovegErvenyes(): void {
+        $eredmeny = $this->templom()->bucsuOccasions();
+
+        self::assertSame(3, $eredmeny['bucsu']['month']);
+        self::assertSame('bucsu_mezo', $eredmeny['forras']);
+    }
+
+    /** Értelmezhetetlen tag esetén sem veszítjük el a szabad szöveget. */
+    public function testErtelmezhetetlenTagnalMaradASzabadSzoveg(): void {
+        $this->patronDay('ez nem dátum');
+
+        $eredmeny = $this->templom()->bucsuOccasions();
+
+        self::assertSame(3, $eredmeny['bucsu']['month']);
+        self::assertSame('bucsu_mezo', $eredmeny['forras']);
+    }
+
+    /** A következő dátum számítása is a patron_day-ből megy. */
+    public function testAKovetkezoDatumAPatronDaybolJon(): void {
+        $this->patronDay('--08-15');
+
+        self::assertSame('2026-08-15', $this->templom()->nextBucsuDate('2026-01-01'));
+    }
+}


### PR DESCRIPTION
@borazslo a #568-ban:

> (Amúgy ez a búcsús mező nem búcsús, hanem megjegyzés mező. Hosszú távon akkor külön mező lehetne a búcsúnak. Sőt OSM ismeri az egyáltalán nem elterjed patron_day kulcsot. De legyen az túl a mostani scope-on)

Előbb rábólintottam, hogy scope-on kívül — aztán megnéztem, és **kiderült, hogy nem is nagy munka**.

> Épül a #794-re (ott lett gépi olvashatóvá a `bucsu` mező).

## Miért nem kell hozzá se oszlop, se szerkesztő-mező

Az OSM-szinkron **minden** taget elment az `attributes` táblába:

```php
foreach($element->tags as $key => $value) {
    \Eloquent\Attribute::updateOrCreate([...], ['value' => $value, 'fromOSM' => 1]);
}
```

Tehát ha egy templom OSM-objektumán ki van töltve a `patron_day`, **az adat már nálunk van** — csak olvasni kell. Nulla szinkron-munka.

## Elsőbbség

A `patron_day` **felülírja** a szabad szöveget: strukturált adat, tehát megbízhatóbb, mint amit egy húsz éve gyűlő megjegyzés-mezőből ki tudunk olvasni.

A szabad szöveg marad tartaléknak — a kulcs a saját megfogalmazásod szerint sem elterjedt, tehát a templomok túlnyomó részénél nem lesz kitöltve. A `bucsuOccasions()` mostantól azt is megmondja, **melyik forrásból** jött az adat (`patron_day` / `bucsu_mezo`).

## Az értékalakok

A kulcsnak nincs egyetlen bevett alakja, ezért többet elfogadok:

```
--08-15       ISO 8601 ismétlődő dátum — ez a legpontosabb egy évente visszatérő ünnepre
08-15         hónap-nap
2026-08-15    teljes dátum (az évet eldobom, a búcsú évente ismétlődik)
augusztus 15. magyar szöveg
Szentháromság vasárnap   mozgó ünnep — a #794 elemzője kezeli
```

Amit nem értek, azt elengedem, és marad a szabad szöveg. Lehetetlen napot (`02-45`) sem fogadok el.

## Amit nem csináltam meg

**Külön adatbázis-oszlopot a búcsúnak.** Az valódi séma-változás plusz szerkesztő-felület — és a `patron_day` nélküle is megadja a strukturált forrást. Ha később mégis kell saját mező (mert az OSM-kulcs tényleg nem terjed el), az önálló jegy.

## Ellenőrzés

11 teszt: mind a négy értékalak, a mozgó ünnep, az értelmezhetetlen és a lehetetlen érték, az elsőbbség mindkét iránya, és hogy a következő dátum számítása is innen megy.

```
PHP-suite: 931 teszt, 2158 állítás — zöld
```

Kapcsolódik: #568