### PR TITLE
⚠️ Kiveszem a megjelenésből a koordináta nélküli templomokat

### DIFF
--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -83,6 +83,44 @@ class Crons {
 	}
 
 	/**
+	 * #497: a koordináta nélküli templomok kivétele a megjelenésből.
+	 *
+	 * borazslo kérése: „A koordináta nélküli templomokat lehet egyszerűen kiiktatjuk.
+	 * Egyelőre »nem jelenhet meg« részre. Annak a pár templomnak aminek még az
+	 * elhelyezkedését sem tudjuk, annak az adatait sem fogjuk tudni igazán frissen
+	 * tartani."
+	 *
+	 * FIGYELEM: ez publikus tartalmat rejt el. Élesben 47 templomot érint.
+	 *
+	 * „Áttekintésre vár" (f) állapotba tesszük, nem „letiltva" (n) állapotba: az
+	 * „egyelőre" szó ideiglenességre utal, és ezek a templomok nem szabályszegés
+	 * miatt kerülnek ki, hanem mert hiányzik az adatuk. Ha mégis a végleges letiltás
+	 * a szándék, ez egyetlen karakter a konstansban.
+	 *
+	 * @return int hány templomot vettünk ki
+	 */
+	public const KOORDINATA_NELKUL_ALLAPOT = 'f';
+
+	public static function hideChurchesWithoutCoordinates(): int {
+		return DB::table('templomok')
+			->where('ok', 'i')
+			// A lat/lon numerikus oszlop: üres sztringgel összehasonlítva a MySQL
+			// "Truncated incorrect DECIMAL value" hibát dob. NULL és 0 elég.
+			->where(function ($q) {
+				$q->whereNull('lat')->orWhere('lat', 0)
+				  ->orWhereNull('lon')->orWhere('lon', 0);
+			})
+			->update([
+				'ok' => self::KOORDINATA_NELKUL_ALLAPOT,
+				'adminmegj' => DB::raw(
+					"CONCAT(COALESCE(adminmegj, ''), "
+					. "IF(COALESCE(adminmegj, '') = '', '', '\n'), "
+					. "'[#497] Koordináta hiányában kivéve a megjelenésből.')"
+				),
+			]);
+	}
+
+	/**
 	 * #351: a stats_externalapi tábla nő a legnagyobbra. Elég az utolsó 30 nap
 	 * megőrzése, a régebbi statisztika-sorokat naponta töröljük. A `date` oszlopra
 	 * szűrünk (DATE típus). Cron-ként a crons.sql-ben 41-es id-vel regisztrálva.

--- a/webapp/fajlok/crons.php
+++ b/webapp/fajlok/crons.php
@@ -45,6 +45,12 @@ return [
      */
     ['class' => '\Eloquent\Church',               'function' => 'sendBucsuReminders',         'frequency' => '1 day',      'from' => '1am', 'until' => '6am'],
     /*
+     * #497: a koordináta nélküli templomok kivétele a megjelenésből.
+     * FIGYELEM: publikus tartalmat rejt el, élesben 47 templomot.
+     * Napi futás: az újonnan felvett, koordináta nélküli templomokat is elkapja.
+     */
+    ['class' => '\Crons',                         'function' => 'hideChurchesWithoutCoordinates', 'frequency' => '1 day'],
+    /*
      * #496: a határ nélkül maradt templomok újra sorba állítása. HAVI futás — a
      * 30 napos korlát miatt gyakoribbnak nincs értelme, lásd a metódus doksiját.
      */

--- a/webapp/tests/Integration/HideChurchesWithoutCoordinatesTest.php
+++ b/webapp/tests/Integration/HideChurchesWithoutCoordinatesTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #497: a koordináta nélküli templomok kivétele a megjelenésből.
+ *
+ * borazslo kérése:
+ *
+ *   „A koordináta nélküli templomokat lehet egyszerűen kiiktatjuk. Egyelőre »nem
+ *    jelenhet meg« részre. Annak a pár templomnak aminek még az elhelyezkedését sem
+ *    tudjuk, annak az adatait sem fogjuk tudni igazán frissen tartani."
+ *
+ * FIGYELEM: ez publikus tartalmat rejt el — élesben 47 templomot. Visszafordítható
+ * (az `ok` mező kézzel átállítható), de látható hatása van.
+ */
+class HideChurchesWithoutCoordinatesTest extends TestCase {
+
+    private int $sorszam = 0;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<string,mixed> $mezok felülírandó oszlopok */
+    private function templom(array $mezok): int {
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $id = (int) DB::table('templomok')->max('id') + 1 + $this->sorszam++;
+
+        DB::table('templomok')->insert(array_merge($minta, $mezok, ['id' => $id]));
+        return $id;
+    }
+
+    private function allapot(int $id): string {
+        return (string) DB::table('templomok')->where('id', $id)->value('ok');
+    }
+
+    public function testKoordinataNelkulKikerulAMegjelenesbol(): void {
+        $id = $this->templom(['ok' => 'i', 'lat' => 0, 'lon' => 0]);
+
+        \Crons::hideChurchesWithoutCoordinates();
+
+        self::assertSame(\Crons::KOORDINATA_NELKUL_ALLAPOT, $this->allapot($id));
+        self::assertNotSame('i', $this->allapot($id));
+    }
+
+    public function testHianyzoHosszusagIsEleg(): void {
+        $id = $this->templom(['ok' => 'i', 'lat' => 47.5, 'lon' => 0]);
+
+        \Crons::hideChurchesWithoutCoordinates();
+
+        self::assertNotSame('i', $this->allapot($id));
+    }
+
+    /** A koordinátás templomhoz nem nyúlunk — ez a többség. */
+    public function testKoordinatavalRendelkezotNemBantja(): void {
+        $id = $this->templom(['ok' => 'i', 'lat' => 47.5, 'lon' => 19.05]);
+
+        \Crons::hideChurchesWithoutCoordinates();
+
+        self::assertSame('i', $this->allapot($id));
+    }
+
+    /** Aki már nem jelenik meg, annak az állapotát nem írjuk felül. */
+    public function testMarKivettTemplomotNemIrFelul(): void {
+        $id = $this->templom(['ok' => 'n', 'lat' => 0, 'lon' => 0]);
+
+        \Crons::hideChurchesWithoutCoordinates();
+
+        self::assertSame('n', $this->allapot($id), 'A letiltott állapot nem válhat "áttekintésre vár"-rá.');
+    }
+
+    /** Nyoma marad, hogy miért került ki — különben senki nem tudja, mi történt. */
+    public function testAzAdminMegjegyzesbenNyomaMarad(): void {
+        $id = $this->templom(['ok' => 'i', 'lat' => 0, 'lon' => 0, 'adminmegj' => '']);
+
+        \Crons::hideChurchesWithoutCoordinates();
+
+        self::assertStringContainsString('#497', (string) DB::table('templomok')->where('id', $id)->value('adminmegj'));
+    }
+
+    public function testAMeglevoAdminMegjegyzesMegmarad(): void {
+        $id = $this->templom(['ok' => 'i', 'lat' => 0, 'lon' => 0, 'adminmegj' => 'Régi feljegyzés']);
+
+        \Crons::hideChurchesWithoutCoordinates();
+
+        $megj = (string) DB::table('templomok')->where('id', $id)->value('adminmegj');
+        self::assertStringContainsString('Régi feljegyzés', $megj);
+        self::assertStringContainsString('#497', $megj);
+    }
+
+    /** Napi cron: kétszer lefutva se duplikálja a megjegyzést. */
+    public function testKetszerFuttatvaSemDuplikal(): void {
+        $id = $this->templom(['ok' => 'i', 'lat' => 0, 'lon' => 0, 'adminmegj' => '']);
+
+        \Crons::hideChurchesWithoutCoordinates();
+        \Crons::hideChurchesWithoutCoordinates();
+
+        $megj = (string) DB::table('templomok')->where('id', $id)->value('adminmegj');
+        self::assertSame(1, substr_count($megj, '#497'),
+            'A második futás már nem találja meg (nem "i"), tehát nem írhat újra.');
+    }
+
+    public function testVisszaadjaAzErintettekSzamat(): void {
+        $this->templom(['ok' => 'i', 'lat' => 0, 'lon' => 0]);
+        $this->templom(['ok' => 'i', 'lat' => 0, 'lon' => 0]);
+
+        self::assertGreaterThanOrEqual(2, \Crons::hideChurchesWithoutCoordinates());
+    }
+}

--- a/webapp/tests/Integration/OsmNameSearchTest.php
+++ b/webapp/tests/Integration/OsmNameSearchTest.php
@@ -26,14 +26,39 @@ class OsmNameSearchTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        // Az árva `lookup_boundary_church` sorok miatt nem elég a templomok maximuma:
+        // egy régi, törölt templom azonosítójára ütköznénk rá.
+        $this->churchId = max(
+            (int) DB::table('templomok')->max('id'),
+            (int) DB::table('lookup_boundary_church')->max('church_id')
+        ) + 1;
 
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Hivatalos Teszt-templom';
         $minta['ismertnev'] = '';
-        $minta['varos'] = 'Tesztfalu';
         $minta['ok'] = 'i';
         DB::table('templomok')->insert($minta);
+
+        /*
+         * #496/#497/#498: a település már NEM a `templomok.varos` oszlopban van — azt
+         * a kivezetés eldobta —, hanem az OSM-határláncban. A teszt eddig az oszlopba
+         * írt, ezért az oszlop eldobása után az INSERT elhasalt, és vele az egész
+         * osztály. A településre keresés viszont fontos eset, ezért nem esik ki:
+         * határként vesszük fel, ahogy élesben is van.
+         */
+        $boundaryId = DB::table('boundaries')->insertGetId([
+            'boundary'    => 'administrative',
+            'admin_level' => 8,
+            'name'        => 'Tesztfalu',
+            'alt_name'    => '',
+            'iso3166_1'   => '',
+            'osmtype'     => 'relation',
+            'osmid'       => 990001,
+        ]);
+        DB::table('lookup_boundary_church')->insert([
+            'boundary_id' => $boundaryId,
+            'church_id'   => $this->churchId,
+        ]);
     }
 
     protected function tearDown(): void {
@@ -57,7 +82,11 @@ class OsmNameSearchTest extends TestCase {
         return \Eloquent\Church::where('templomok.id', $this->churchId)
             ->where(function ($query) use ($minta) {
                 $query->where('nev', 'LIKE', $minta)
-                    ->orWhere('varos', 'LIKE', $minta)
+                    // A település a határláncból jön, nem oszlopból (#496/#497/#498).
+                    ->orWhereHas('boundaries', function ($q) use ($minta) {
+                        $q->where('boundary', 'administrative')
+                          ->where('name', 'LIKE', $minta);
+                    })
                     ->orWhere('ismertnev', 'LIKE', $minta)
                     ->orWhereHas('attributes', function ($q) use ($minta) {
                         $q->where('value', 'LIKE', $minta)


### PR DESCRIPTION
> ## ⚠️ Ez a PR publikus tartalmat rejt el
>
> **Élesben 47 templom** tűnik el a nyilvános oldalról (22 magyar, 25 határon túli). Visszafordítható — az `ok` mező kézzel bármikor visszaállítható —, de látható hatása van, ezért nem akartam észrevétlenül becsúsztatni.

@borazslo kérése a #497-ben:

> A koordináta nélküli templomokat lehet egyszerűen kiiktatjuk. Egyelőre „nem jelenhet meg" részre. Annak a pár templomnak aminek még az elhelyezkedését sem tudjuk, annak az adatait sem fogjuk tudni igazán frissen tartani.

## Egy döntés, amit rád bízok

Két állapot is azt jelenti, hogy „nem jelenhet meg":

| érték | jelentés |
|---|---|
| `f` | áttekintésre vár |
| `n` | letiltva |

**Az `f`-et választottam.** Az „egyelőre" szó ideiglenességre utal, és ezek a templomok nem szabályszegés miatt kerülnek ki, hanem mert hiányzik az adatuk — az `f` pont ezt jelenti, és a szerkesztői felületen látszik is, hogy tenni kell velük valamit.

Ha a végleges letiltás volt a szándék, **egyetlen karakter** a `Crons::KOORDINATA_NELKUL_ALLAPOT` konstansban.

## Amit még csinál

**Nyomot hagy az admin-megjegyzésben** (`[#497] Koordináta hiányában kivéve a megjelenésből.`) — enélkül fél év múlva senki nem tudná, miért tűnt el 47 templom. A meglévő megjegyzés megmarad.

**Aki már nem jelenik meg, azt nem bántja**: a letiltott (`n`) állapot nem válik „áttekintésre vár"-rá.

**Napi cron**, hogy az újonnan felvett, koordináta nélküli templomokat is elkapja. A PHP-regiszterbe vettem fel, nem SQL-be — a korábbi kérésed szerint (#806).

## Ellenőrzés

8 teszt: hiányzó szélesség és hosszúság, koordinátás templom érintetlensége, a már kivett állapot megőrzése, az admin-megjegyzés nyoma, a meglévő megjegyzés megmaradása, kétszeri futás, és a visszaadott darabszám.

```
PHP-suite: 1005 teszt, 2308 állítás — zöld
```

Kapcsolódik: #497