### PR TITLE
Az alkalom kaphat saját helyszínt, ha nem a templomban van

### DIFF
--- a/calendar/public/i18n/hu.json
+++ b/calendar/public/i18n/hu.json
@@ -53,6 +53,8 @@
   "LATITUDE": "Szélesség",
   "LONGITUDE": "Hosszúság",
   "DIFFERENT_LOCATION_HINT": "A koordinátát a térképről vagy az OpenStreetMap-ből másolhatod. Mindkét mező kell, különben a mise a templomban marad.",
+  "DIFFERENT_LOCATION_BADGE": "Nem a templomban: {{place}}",
+  "DIFFERENT_LOCATION_SHOW_ON_MAP": "Megnyitás az OpenStreetMap-en",
   "RECURRENCE": "Ismétlődés",
   "PERIOD": "Időszak",
   "MANUAL_EXPERIOD": "Kézzel kivett időszakok",

--- a/calendar/public/i18n/hu.json
+++ b/calendar/public/i18n/hu.json
@@ -48,7 +48,11 @@
   "OTHER_SETTINGS": "Tulajdonságok",
   "ADVANCED_SETTINGS": "Speciális",
   "COMMENT": "Megjegyzés",
-
+  "DIFFERENT_LOCATION": "Eltérő helyszín (nem a templomban)",
+  "LOCATION_NAME": "Helyszín megnevezése",
+  "LATITUDE": "Szélesség",
+  "LONGITUDE": "Hosszúság",
+  "DIFFERENT_LOCATION_HINT": "A koordinátát a térképről vagy az OpenStreetMap-ből másolhatod. Mindkét mező kell, különben a mise a templomban marad.",
   "RECURRENCE": "Ismétlődés",
   "PERIOD": "Időszak",
   "MANUAL_EXPERIOD": "Kézzel kivett időszakok",
@@ -77,7 +81,6 @@
   "DURATION_EXTENDED_DAYS": "nap",
   "TITLE": "Liturgia neve",
   "RITE": "Rítus",
-
   "CANCEL": "Mégsem",
   "SAVE": "Mentés",
   "SEND_TO_APPROVE": "Javaslat beküldése",
@@ -92,18 +95,26 @@
   "DELETE_PERIOD": "Időszak eseményeinek törlése",
   "DELETE_PERIOD_TITLE": "Időszak eseményeinek törlése",
   "DELETE_PERIOD_WARNING": "Valóban törölni szeretnéd az időszak összesen {{count}} eseményét? A törlés vissza nem vonható, de az átalakított miserend mentéséig nem kerül rögzítésre az adatbázisban.",
-  "COPY_PERIOD": "Időszak másolása",
+  "COPY_PERIOD": "Másolás új időszakra",
   "COPY_PERIOD_INFO": "Az időszak összesen {{count}} eseménye kerül lemásolásra az új időszakra.",
   "PERIODS": {
+    "YEAR_EDITOR_TITLE": "Időszakok beállítása",
+    "YEAR_EDITOR_HINT": "Azokat az időszakokat lehet itt beállítani, amik évenként eltérő időpontokban vannak, és nem egy másik időszaktól függenek. Amennyiben olyan időszakról van szó, ami átnyúlik egy adott naptári éven, akkor mindig a kezdeti időpontja szerint kell kezelni. Generálni a már mentett adatokkal lehet. Amíg nincs egy generálás sem, addig a naptárban nem jelennek meg az események, még az időszak nélküliek sem.",
     "START_DATE": "Kezdete",
     "END_DATE": "Vége",
-    "NO_PERIOD": "Nincs időszak"
+    "SAVE": "Mentés",
+    "GENERATE": "Generálás",
+    "NO_PERIOD": "Időszak nélkül",
+    "OLDER_MASSES_EXPANDABLE": "Vannak még régebbi misék is. Kattints ide a kibontáshoz",
+    "OLDER_EXCEPTION_DATES_SHOW": "Régebbiek megjelenítése",
+    "OLDER_EXCEPTION_DATES_HIDE": "Régebbiek elrejtése",
+    "EXCEPTION_AUTO": "Automatikusan kizárva a {{periodName}} időszakból.",
+    "EXCEPTION_MANUAL": "Kézzel beállítva, hogy a {{periodName}} időszakban ne jelenjen meg.",
+    "EXCEPTION_DATE": "Ismétlődő esemény kézzel törölve erről erről a napról."
   },
-
   "ROMAN_CATHOLIC": "Római katolikus",
   "GREEK_CATHOLIC": "Görögkatolikus",
   "TRADITIONAL": "Régi rítusú szentmise",
-
   "MASS_TITLE": {
     "HOLY_MASS": "Szentmise",
     "LITURGY_OF_THE_WORD": "Igeliturgia",
@@ -125,20 +136,17 @@
     "TRADITIONAL_GOOD_FRIDAY_LITURGY": "Nagypénteki szertartás (régi rítusú)",
     "TRADITIONAL_EASTER_VIGIL": "Húsvét vigíliája (régi rítusú)"
   },
-
   "MASS_TITLE_CATEGORY": {
     "MASS": "Mise(félék)",
     "ADORATION": "Szentségimádások",
     "CONFESSION": "Gyóntatások",
     "OTHER": "Egyéb imaalkalmak"
   },
-
   "MASS_FILTER": {
     "TITLE": "Kategória szűrés",
     "SELECT_ALL": "Összes kijelölése",
     "DESELECT_ALL": "Kijelölések törlése"
   },
-
   "MASS_TYPES": "Jellemzők",
   "FAMILY": "Családos/mocorgós",
   "STUDENT": "Diák",
@@ -147,7 +155,6 @@
   "ORGAN": "Orgonás",
   "SINGER": "Énekes",
   "SILENT": "Csendes",
-
   "LANGUAGES": {
     "cu": "ószláv",
     "en": "angol",
@@ -169,22 +176,20 @@
     "tl": "tagalog/filippínó",
     "ua": "ukrán"
   },
-
   "MONTHS": {
-    "1" : "január",
-    "2" : "február",
-    "3" : "március",
-    "4" : "április",
-    "5" : "május",
-    "6" : "június",
-    "7" : "július",
-    "8" : "augusztus",
-    "9" : "szeptember",
-    "10" : "október",
-    "11" : "november",
-    "12" : "december"
+    "1": "január",
+    "2": "február",
+    "3": "március",
+    "4": "április",
+    "5": "május",
+    "6": "június",
+    "7": "július",
+    "8": "augusztus",
+    "9": "szeptember",
+    "10": "október",
+    "11": "november",
+    "12": "december"
   },
-
   "EVENT_VIEWER": {
     "EQUAL_TIMEZONE": "Az Önével azonos időzónában.",
     "DIFFERENT_TIMEZONE": "Figyelem! A kezdési idő más időzónában ({{eventTimeZone}}) lett megadva, mint az öné ({{localTimeZone}})!",
@@ -200,7 +205,6 @@
     "IMPORTED_NOT_EDITABLE": "Ez a liturgia külső naptárból származik, ezért itt nem szerkeszthető. A módosítást a külső naptárban kell elvégezni, a napi szinkron átveszi.",
     "IMPORTED_BADGE": "külső naptárból"
   },
-
   "RRULE": {
     "NO_RECURRENCE": "Egyszeri alkalom",
     "ON": {
@@ -217,7 +221,6 @@
     }
   },
   "SEPARATOR_AND": " és ",
-
   "SUGGESTION": {
     "SELECTED_PACKAGE": "Kiválasztott csomag",
     "STATES": {
@@ -240,7 +243,7 @@
     "HEADER": {
       "PREV": "Előző",
       "NEXT": "Következő",
-      "LIST" : "Lista",
+      "LIST": "Lista",
       "TODAY": "Ma",
       "DAY": "Nap",
       "WEEK": "Hét",
@@ -251,28 +254,10 @@
     "APPROVE": "Jóváhagy",
     "REJECT": "Elutasít"
   },
-
-  "PERIODS": {
-    "YEAR_EDITOR_TITLE": "Időszakok beállítása",
-    "YEAR_EDITOR_HINT": "Azokat az időszakokat lehet itt beállítani, amik évenként eltérő időpontokban vannak, és nem egy másik időszaktól függenek. Amennyiben olyan időszakról van szó, ami átnyúlik egy adott naptári éven, akkor mindig a kezdeti időpontja szerint kell kezelni. Generálni a már mentett adatokkal lehet. Amíg nincs egy generálás sem, addig a naptárban nem jelennek meg az események, még az időszak nélküliek sem.",
-    "START_DATE": "Kezdete",
-    "END_DATE": "Vége",
-    "SAVE": "Mentés",
-    "GENERATE": "Generálás",
-    "NO_PERIOD": "Időszak nélkül",
-    "OLDER_MASSES_EXPANDABLE": "Vannak még régebbi misék is. Kattints ide a kibontáshoz",
-    "OLDER_EXCEPTION_DATES_SHOW": "Régebbiek megjelenítése",
-    "OLDER_EXCEPTION_DATES_HIDE": "Régebbiek elrejtése",
-    "EXCEPTION_AUTO": "Automatikusan kizárva a {{periodName}} időszakból.",
-    "EXCEPTION_MANUAL": "Kézzel beállítva, hogy a {{periodName}} időszakban ne jelenjen meg.",
-    "EXCEPTION_DATE": "Ismétlődő esemény kézzel törölve erről erről a napról."
-  },
-
   "SIMPLE_EVENT": {
     "MORE_SETTINGS": "További beállítások",
     "SAVE": "Mentés"
   },
-
   "ERRORS": {
     "REQUIRED_PERIOD": "Meg kell adni, hogy melyik időszakban ismétlődik.",
     "REQUIRED_DAY": "Meg kell adni, hogy melyik napon van.",
@@ -281,19 +266,14 @@
     "REQUIRED_CHRISTMAS_DAY": "Meg kell adni, hogy mely napon van a liturgia.",
     "REQUIRED_START_TIME": "Meg kell adni a liturgia időpontját."
   },
-
-
   "MASS_DETAILS_DATETIME": "A liturgia időpontja és ismétlődései",
   "OTHER_SETTINGS_DETAILS": "A liturgia egyéb tulajdonságai",
-
-  "COPY_PERIOD": "Másolás új időszakra",
   "COPY_PERIOD_DIALOG": {
     "TITLE": "Másolás az időszakra",
     "CURRENT_PERIOD": "Jelenlegi időszak",
     "TARGET_PERIOD": "Cél időszak",
     "SELECTED_TARGET": "Kiválasztott cél időszak"
   },
-
   "BOUNDARY": {
     "region": "régió",
     "statistical": "statisztika",
@@ -307,22 +287,20 @@
     "wine_growing_area": "borvidék",
     "police": "rendőrség"
   },
-
   "SCHEDULE_OUTDATED_MESSAGE_YEARS": "éve nem volt frissítve a miserend.",
   "SCHEDULE_OUTDATED_MESSAGE_MONTHS": "hónapja nem volt frissítve a miserend.",
   "SCHEDULE_OUTDATED_MESSAGE_SUFFIX": "Kérlek frissítsd az adatokat. Ha így jó ahogy van, kattints ide:",
   "SCHEDULE_MARK_AS_CURRENT": "A miserend így pontos",
-
   "CHURCH_RANK": {
-    "parish":           "plébánia",
-    "auxiliary":  "oldallagosan ellátott plébánia",
-    "filial":    "fília",
-    "rectoral":        "templomigazgatóság",
-    "unknown":          "ismeretlen"
+    "parish": "plébánia",
+    "auxiliary": "oldallagosan ellátott plébánia",
+    "filial": "fília",
+    "rectoral": "templomigazgatóság",
+    "unknown": "ismeretlen"
   },
   "CHURCH_RELATIONSHIP_TYPE": {
-    "subordinate":               "alá-fölé rendelt",
-    "associated":                "mellérendelt",
+    "subordinate": "alá-fölé rendelt",
+    "associated": "mellérendelt",
     "territorially_independent": "területileg ott van, de lényegében független"
   }
 }

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.html
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.html
@@ -334,6 +334,39 @@
         <textarea matInput [(ngModel)]="data.event.comment"></textarea>
       </mat-form-field>
 
+      <!--
+        #431: eltérő helyszín. A használati eset: „Röszke plébánia biciklitúrát
+        szervez időnként, és van mise valami random pusztai helyen."
+
+        A mise a plébániáé marad, csak máshol tartják — ezért az alkalomhoz kötjük a
+        helyet, nem új misézőhelyhez. Alapból rejtve: a misék túlnyomó többsége a
+        templomban van, és nem akarjuk minden szerkesztőnek az arcába tolni.
+      -->
+      <div class="eltero-helyszin">
+        <mat-checkbox [(ngModel)]="elteroHelyszin" (change)="onElteroHelyszinValtozott()">
+          {{ 'DIFFERENT_LOCATION' | translate }}
+        </mat-checkbox>
+
+        @if (elteroHelyszin) {
+          <div class="helyszin-mezok">
+            <mat-form-field>
+              <mat-label>{{ 'LOCATION_NAME' | translate }}</mat-label>
+              <input matInput [(ngModel)]="data.event.locationName"
+                     placeholder="pl. Röszkei puszta, kereszt">
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>{{ 'LATITUDE' | translate }}</mat-label>
+              <input matInput type="number" step="0.0000001" [(ngModel)]="data.event.locationLat">
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>{{ 'LONGITUDE' | translate }}</mat-label>
+              <input matInput type="number" step="0.0000001" [(ngModel)]="data.event.locationLon">
+            </mat-form-field>
+            <small class="hint">{{ 'DIFFERENT_LOCATION_HINT' | translate }}</small>
+          </div>
+        }
+      </div>
+
     </mat-expansion-panel>
   </mat-accordion>
 

--- a/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
+++ b/calendar/src/app/components/add-full-event-dialog/add-full-event-dialog.component.ts
@@ -18,6 +18,7 @@ import {PeriodService} from '../../services/period.service';
 import {AsyncPipe, TitleCasePipe, CommonModule} from '@angular/common';
 import {map, Observable, of, startWith} from 'rxjs';
 import {MatSelectModule} from '@angular/material/select';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {recurrences, Renum} from '../../enum/recurrence';
 import {TranslatePipe, TranslateService} from '@ngx-translate/core';
 import {Rite, RiteMassTypes} from '../../enum/rites';
@@ -57,6 +58,7 @@ import {ChristmasDay} from "../../enum/christmas-day";
     AsyncPipe,
     ReactiveFormsModule,
     MatSelectModule,
+    MatCheckboxModule,
     TranslatePipe,
     TitleCasePipe,
     MatExpansionModule,
@@ -79,6 +81,29 @@ export class AddFullEventDialogComponent {
   // értéke periodId-kből álló tömb, ami a Mass.manualExperiod-be megy mentéskor
   // (KÜLÖN az automatikusan számolt experiod-tól, hogy az automatikák ne töröljék).
   experiodCtr = new FormControl<number[]>(this.data.event.manualExperiod ?? []);
+
+  /**
+   * #431: eltérő helyszín kapcsoló.
+   *
+   * Nyitáskor abból derül ki, hogy be van-e kapcsolva, hogy van-e már koordináta —
+   * így a meglévő alkalmak szerkesztésekor magától kinyílik a blokk.
+   */
+  elteroHelyszin = this.data.event.locationLat != null && this.data.event.locationLon != null;
+
+  /**
+   * Kikapcsoláskor TÖRÖLJÜK a mezőket.
+   *
+   * Enélkül a kikapcsolt jelölő mellett is elmenne a koordináta, és a mise némán egy
+   * régi, elfelejtett helyszínen maradna — pont az a fajta hiba, amit senki nem néz
+   * meg, mert a felületen már nem is látszik.
+   */
+  onElteroHelyszinValtozott(): void {
+    if (!this.elteroHelyszin) {
+      this.data.event.locationLat = null;
+      this.data.event.locationLon = null;
+      this.data.event.locationName = null;
+    }
+  }
 
   // #454: Új dátum hozzáadásához használt ideiglenes változó
   public newExceptionDate: Date | null = null;

--- a/calendar/src/app/components/church-calendar/church-calendar.component.css
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.css
@@ -244,3 +244,34 @@
   vertical-align: middle;
   cursor: help;
 }
+
+/* #431: az alkalom saját helyszíne — jel a naptárban és a mise-listában.
+   A színt szándékosan nem a szöveghez igazítom: pont az a lényeg, hogy KIÜSSÖN. */
+/* ::ng-deep, mert a heti/havi nézetbe a FullCalendar NYERS HTML-ként teszi be az
+   ikont — azon nincs `_ngcontent` bélyeg, tehát a scoped szabály nem fogná meg.
+   Ugyanez a technika, mint a fenti `.fc-timegrid-event .type-icon`-nál. */
+::ng-deep .mcal-location-icon {
+  color: #b8500a;
+  font-size: 18px;
+  height: 18px;
+  width: 18px;
+  vertical-align: middle;
+}
+.mcal-location-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 6px;
+  color: #b8500a;
+  text-decoration: none;
+  cursor: pointer;
+}
+.mcal-location-badge:hover { text-decoration: underline; }
+/* A listás nézetben a NÉV is kifér; a szűk rácsokban csak az ikon marad. */
+.mcal-location-name {
+  font-size: 0.85em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 14em;
+}

--- a/calendar/src/app/components/church-calendar/church-calendar.component.html
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.html
@@ -80,7 +80,7 @@
 
 <!-- Template used to render FullCalendar list items via Angular bindings.
      Context variables provided from component: timeText, title, lang, types, comment -->
-<ng-template #eventListTemplate let-timeText="timeText" let-title="title" let-lang="lang" let-types="types" let-comment="comment">
+<ng-template #eventListTemplate let-timeText="timeText" let-title="title" let-lang="lang" let-types="types" let-comment="comment" let-ownLocation="ownLocation">
   <div class="fc-list-item-container d-flex align-items-center" style="gap:6px;">
     <span class="fc-list-item-time" *ngIf="timeText">{{ timeText }}</span>
     <div class="fc-list-item-main d-flex align-items-center" style="gap:6px;">
@@ -99,8 +99,17 @@
         </ng-container>
       </ng-container>
 
-      <ng-container *ngIf="comment">          
+      <ng-container *ngIf="comment">
           <span class="material-icons" title="{{ comment }}" style="margin-left:6px; height:18px; font-size:18px; vertical-align:top;">info</span>
+      </ng-container>
+
+      <!-- #431: az alkalom saját helyszíne. A listás nézetben a NÉV is kifér, nem csak
+           az ikon — ez a leginkább olvasásra való nézet. -->
+      <ng-container *ngIf="ownLocation">
+        <span class="mcal-location-badge" [matTooltip]="'DIFFERENT_LOCATION_BADGE' | translate:{place: ownLocation}">
+          <span class="material-icons" style="height:18px; font-size:18px; vertical-align:top;">place</span>
+          <span class="mcal-location-name">{{ ownLocation }}</span>
+        </span>
       </ng-container>
     </div>
   </div>
@@ -272,6 +281,12 @@
                       <img class="type-icon" style="height:18px; margin-left:6px" [matTooltip]="(('LANGUAGES.' + l) | translate) + ' nyelvű'" [src]="'/cal_images/flags/' + l.toLowerCase() + '.svg'" [alt]="(('LANGUAGES.' + l) | translate) + ' nyelvű'" />
                     </ng-container>
                   </ng-container>
+
+                  <!-- #431: saját helyszín — a hivatkozás az OpenStreetMap-re visz. -->
+                  <a *ngIf="m.ownLocation" class="mcal-location-badge" [href]="m.ownLocationUrl" target="_blank" rel="noopener"
+                     [matTooltip]="('DIFFERENT_LOCATION_BADGE' | translate:{place: m.ownLocation}) + ' — ' + ('DIFFERENT_LOCATION_SHOW_ON_MAP' | translate)">
+                    <mat-icon class="mcal-location-icon">place</mat-icon>
+                  </a>
                 </td>
                 <td style="padding:10px">
                   <div *ngIf="(m.experiodNames && m.experiodNames.length) || m.exdate || m.exDates" class="text-muted small">
@@ -358,6 +373,12 @@
                     <img class="type-icon" style="height:18px; margin-left:6px" [matTooltip]="(('LANGUAGES.' + l) | translate) + ' nyelvű'" [src]="'/cal_images/flags/' + l.toLowerCase() + '.svg'" [alt]="(('LANGUAGES.' + l) | translate) + ' nyelvű'" />
                   </ng-container>
                 </ng-container>
+
+                <!-- #431: saját helyszín — a hivatkozás az OpenStreetMap-re visz. -->
+                <a *ngIf="m.ownLocation" class="mcal-location-badge" [href]="m.ownLocationUrl" target="_blank" rel="noopener"
+                   [matTooltip]="('DIFFERENT_LOCATION_BADGE' | translate:{place: m.ownLocation}) + ' — ' + ('DIFFERENT_LOCATION_SHOW_ON_MAP' | translate)">
+                  <mat-icon class="mcal-location-icon">place</mat-icon>
+                </a>
               </td>
               <td style="padding:10px">
                 <div *ngIf="(m.experiodNames && m.experiodNames.length) || m.exdate || m.exDates" class="text-muted small">

--- a/calendar/src/app/components/church-calendar/church-calendar.component.ts
+++ b/calendar/src/app/components/church-calendar/church-calendar.component.ts
@@ -1993,6 +1993,13 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
         if (mass && mass.comment) comment = mass.comment;
       }
 
+      /*
+       * #431: az alkalom saját helyszíne. borazslo kérése, hogy a listás, heti és havi
+       * nézetben is LÁTSZÓDJON, ha a mise nem a templomban van — enélkül a szabadtéri
+       * alkalom ugyanúgy néz ki, mint a templomi, és a hívő rossz helyre megy.
+       */
+      const ownLocation = MassUtil.hasOwnLocation(mass) ? MassUtil.locationLabel(mass) : null;
+
       const flagMap: Record<string, string> = { hu: '🇭🇺', en: '🇬🇧', de: '🇩🇪', sk: '🇸🇰', ro: '🇷🇴' };
 
       let flagHtml = '';
@@ -2025,12 +2032,20 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
         commentHtml = `<span class="material-icons" title="${escaped}" style="height:22px; font-size:22px; vertical-align:middle;">info</span>`;
       }
 
+      // #431: helyszín-jel. Ugyanaz a ligatúra-technika, mint a megjegyzésnél: nyers
+      // HTML-ben az Angular direktívák (matTooltip) nem futnak le, marad a `title`.
+      let locationHtml = '';
+      if (ownLocation) {
+        const cimke = this.translateService.instant('DIFFERENT_LOCATION_BADGE', {place: ownLocation});
+        locationHtml = `<span class="material-icons mcal-location-icon" title="${escapeAttr(cimke)}" style="height:18px; font-size:18px; vertical-align:top;">place</span>`;
+      }
+
       // For list views build a list-style row (with optional flag)
       if (isListView) {
         // Render the Angular template into DOM nodes and serialize to HTML so translation pipes
         // and other Angular bindings work.
         if (this.eventListTemplateRef && this.eventListTemplateContainer) {
-          const ctx = { timeText: info.timeText || '', title: info.event.title || '', lang: lang, types: types, comment: comment };
+          const ctx = { timeText: info.timeText || '', title: info.event.title || '', lang: lang, types: types, comment: comment, ownLocation: ownLocation };
           const view: EmbeddedViewRef<any> = this.eventListTemplateContainer.createEmbeddedView(this.eventListTemplateRef, ctx);
           view.detectChanges();
           // serialize root nodes
@@ -2080,7 +2095,15 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
           (lang && this.languagesOf(lang).some(l => this.shouldShowFlag(l))) ||
           (Array.isArray(types) && types.length > 0) ||
           !!comment;
-        return { html: shouldShowDetails ? `${monthHtml} ${detailsHtml}` : monthHtml };
+        /*
+         * #431: a helyszín-jel a havi nézetben is KIÜL, nem az `info` mögé bújik.
+         *
+         * A többi ikon (zászló, típus, megjegyzés) itt szándékosan összecsuklik egy
+         * „további információ" jelbe, mert a havi rács szűk. A helyszín viszont nem
+         * árnyalat: aki nem veszi észre, rossz helyre megy. Ezért kap saját jelet.
+         */
+        const monthTail = `${locationHtml}${shouldShowDetails ? ' ' + detailsHtml : ''}`;
+        return { html: monthTail !== '' ? `${monthHtml} ${monthTail}` : monthHtml };
       }
 
       // #358: az ikonok az IDŐ sorába kerülnek, nem a cím mellé.
@@ -2091,7 +2114,7 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
       // levágtuk őket, egyszerűen eltűntek. Az idő („18:00") viszont rövid — ott
       // elférnek mellette, és a cím kap egy saját, teljes sort.
       const combinedHtml =
-        `<span class="mcal-event-head">${timeHtml}${flagHtml}${typesHtml}${commentHtml}</span>`
+        `<span class="mcal-event-head">${timeHtml}${flagHtml}${typesHtml}${commentHtml}${locationHtml}</span>`
         + `<span class="fc-event-title-wrap">${titleHtml}</span>`;
       return { html: combinedHtml };
     } catch (e) {
@@ -2365,6 +2388,10 @@ export class ChurchCalendarComponent implements OnInit, AfterViewInit, OnChanges
         flag: flag,
         types: m.types ? m.types : [],
         comment: m.comment,
+        // #431: az alkalom saját helyszíne — a mise-listában is látszania kell, hogy
+        // a szerkesztő egy pillantásból lássa, melyik alkalom nincs a templomban.
+        ownLocation: MassUtil.hasOwnLocation(m) ? MassUtil.locationLabel(m) : null,
+        ownLocationUrl: MassUtil.hasOwnLocation(m) ? MassUtil.locationOsmUrl(m) : null,
         // #592: külső naptárból importált liturgia — a listában jelöljük, és nem szerkeszthető.
         imported: !!m.imported,
         // #428: a mise-listában az auto + kézi kizárt időszakok UNIÓJA jelenjen meg

--- a/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.css
+++ b/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.css
@@ -63,3 +63,18 @@ button[mat-flat-button] {
   font-size: 0.9rem;
   padding: 0 8px;
 }
+
+/* #431: az alkalom saját helyszíne a felugró nézetben. */
+.own-location {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  color: #b8500a;
+}
+.own-location .mcal-location-icon {
+  font-size: 20px;
+  height: 20px;
+  width: 20px;
+}
+.own-location a { font-size: 0.9rem; }

--- a/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.html
+++ b/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.html
@@ -65,6 +65,22 @@
       }
     </p>
 
+    <!--
+      #431: ha az alkalom nem a templomban van, azt itt is ki KELL írni.
+      A fejlécben a templom neve áll — enélkül a felugró ablak azt állítaná, hogy a
+      szabadtéri mise a templomban lesz. A hivatkozás az OpenStreetMap-re visz, a
+      koordinátára kitett jelölővel (borazslo kérése).
+    -->
+    @if (ownLocation) {
+      <p class="own-location">
+        <mat-icon class="mcal-location-icon">place</mat-icon>
+        <span>{{ ownLocation }}</span>
+        <a [href]="ownLocationUrl" target="_blank" rel="noopener">
+          {{ 'DIFFERENT_LOCATION_SHOW_ON_MAP' | translate }}
+        </a>
+      </p>
+    }
+
     @if (data.mass.comment && data.mass.comment.length > 0) {
       <p class="comment">
         {{ data.mass.comment }}

--- a/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.ts
+++ b/calendar/src/app/components/event-viewer-dialog/event-viewer-dialog.component.ts
@@ -56,6 +56,17 @@ export class EventViewerDialogComponent {
   readonly data = inject<EventViewerDialogData>(MAT_DIALOG_DATA);
 
   public readonly start = DateTimeUtil.getReadableDateTime(this.data.start);
+
+  /**
+   * #431: az alkalom saját helyszíne, ha nem a templomban van.
+   *
+   * `null`, amíg nincs mindkét koordináta — a fejlécben ilyenkor a templom neve áll,
+   * és az a helyes.
+   */
+  public readonly ownLocation: string | null =
+    MassUtil.hasOwnLocation(this.data.mass) ? MassUtil.locationLabel(this.data.mass) : null;
+  public readonly ownLocationUrl: string | null =
+    MassUtil.hasOwnLocation(this.data.mass) ? MassUtil.locationOsmUrl(this.data.mass) : null;
   // User must confirm editing via the confirmation dialog before edit/delete controls are shown
   public confirmedEdit: boolean = false;
 

--- a/calendar/src/app/components/mass-row/mass-row.component.html
+++ b/calendar/src/app/components/mass-row/mass-row.component.html
@@ -36,6 +36,10 @@
     @if (mass.comment && mass.comment.length > 0){
       <span class="event-row-comment"> megjegyzés: {{mass.comment}};</span>
     }
+    <!-- #431: az ÚJ és TÖRÖLT miséknél is látni kell, ha nem a templomban van. -->
+    @if (mass.ownLocation && mass.ownLocation.length > 0){
+      <span> helyszín: {{mass.ownLocation}};</span>
+    }
     <span>)</span>
   </div>
 }

--- a/calendar/src/app/components/masses-diff/masses-diff.component.html
+++ b/calendar/src/app/components/masses-diff/masses-diff.component.html
@@ -72,6 +72,14 @@
       <span> => </span>
       <span>{{newMass.comment}}</span>
     }
+    <!-- #431: a helyszín változása. „A templomban" a hiányzó érték olvasható alakja:
+         üres cella mellett nem derülne ki, hogy a mise VISSZAKERÜLT a templomba. -->
+    @if (origMass.ownLocation != newMass.ownLocation) {
+      <span>Helyszín:</span>
+      <span>{{ origMass.ownLocation || 'a templomban' }}</span>
+      <span> => </span>
+      <span>{{ newMass.ownLocation || 'a templomban' }}</span>
+    }
     @if (experiodChanged) {
       <span>Kizárt periódus(ok):</span>
       <span>{{origMass.experiod}}</span>

--- a/calendar/src/app/components/masses-diff/masses-diff.component.spec.ts
+++ b/calendar/src/app/components/masses-diff/masses-diff.component.spec.ts
@@ -91,4 +91,43 @@ describe('MassesDiffComponent', () => {
 
     expect(component.experiodChanged).toBeTrue();
   });
+
+  // ---- #431: helyszín-változás ------------------------------------------------
+
+  /**
+   * borazslo kérése: a „Javasolt változások" összefoglalóban a módosított miséknél
+   * jelenjen meg a helyszín is. Az üres érték olvasható alakja „a templomban" —
+   * üres cella mellett nem derülne ki, hogy a mise VISSZAKERÜLT a templomba.
+   */
+  function helyszinSor(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('a helyszín felvételét megmutatja', () => {
+    component.origMass = mise();
+    component.newMass = {...mise(), ownLocation: 'Röszkei puszta'};
+
+    fixture.detectChanges();
+
+    expect(helyszinSor()).toContain('Helyszín:');
+    expect(helyszinSor()).toContain('Röszkei puszta');
+  });
+
+  it('a templomba visszakerülést is megmutatja', () => {
+    component.origMass = {...mise(), ownLocation: 'Röszkei puszta'};
+    component.newMass = mise();
+
+    fixture.detectChanges();
+
+    expect(helyszinSor()).toContain('a templomban');
+  });
+
+  it('változatlan helyszínnél nem ír ki semmit', () => {
+    component.origMass = {...mise(), ownLocation: 'Röszkei puszta'};
+    component.newMass = {...mise(), ownLocation: 'Röszkei puszta'};
+
+    fixture.detectChanges();
+
+    expect(helyszinSor()).not.toContain('Helyszín:');
+  });
 });

--- a/calendar/src/app/components/suggestions/suggestions.component.ts
+++ b/calendar/src/app/components/suggestions/suggestions.component.ts
@@ -447,6 +447,8 @@ export class SuggestionsComponent implements OnInit {
       ...(rite && rite.length > 0 && {rite: rite}),
       ...(duration && duration.length > 0 && {duration: duration}),
       ...(mass.comment && mass.comment.length > 0 && {comment: mass.comment}),
+      // #431: ha az alkalom nem a templomban van, azt a javaslatban is látni kell.
+      ...(MassUtil.hasOwnLocation(mass) && {ownLocation: MassUtil.locationLabel(mass)}),
       // #334: a mise több nyelvű is lehet ("sk,la") — mindegyiket külön fordítjuk,
       // különben a `LANGUAGES.sk,la` kulcs fordítás nélkül, nyersen jelenne meg.
       lang: MassUtil.languageCodes(mass.lang)

--- a/calendar/src/app/model/dialog-event.ts
+++ b/calendar/src/app/model/dialog-event.ts
@@ -31,4 +31,12 @@ export interface DialogEvent {
   experiod?: number[] | null;
   // #428: a felhasználó által kézzel beállított kivétel-időszakok
   manualExperiod?: number[] | null;
+
+  /**
+   * #431: az alkalom saját helyszíne, ha nem a templomban van.
+   * Üresen hagyva a mise a templomban marad.
+   */
+  locationLat?: number | null;
+  locationLon?: number | null;
+  locationName?: string | null;
 }

--- a/calendar/src/app/model/mass.ts
+++ b/calendar/src/app/model/mass.ts
@@ -94,6 +94,20 @@ export interface Mass {
   comment?: string | null;
 
   /**
+   * #431: az alkalom SAJÁT helyszíne, ha nem a templomban van.
+   *
+   * A használati eset: „Röszke plébánia biciklitúrát szervez időnként, és van mise
+   * valami random pusztai helyen." A helyet ezért az ALKALOMHOZ kötjük, nem új
+   * misézőhelyhez — így a mise a szervező plébániáé marad, és nem keletkezik minden
+   * szabadtéri alkalomból egy örökre ottmaradó pont a térképen.
+   *
+   * Mindhárom mező opcionális; ha nincs koordináta, a mise a templomban van.
+   */
+  locationLat?: number | null;
+  locationLon?: number | null;
+  locationName?: string | null;
+
+  /**
    * #592: külső naptárból (iCalendar) importált liturgia. Ezeket a napi szinkron
    * teljes cserével írja újra, ezért itt nem szerkeszthetők — a szerkesztő
    * felajánlás helyett magyarázatot mutat. A backend származtatja, nem tárolt mező.

--- a/calendar/src/app/model/readable-mass.ts
+++ b/calendar/src/app/model/readable-mass.ts
@@ -16,4 +16,10 @@ export interface ReadableMass {
   lang: string;
   comment?: string;
   experiod?: string[];
+  /**
+   * #431: az alkalom saját helyszíne, olvasható alakban („Röszkei puszta" vagy a
+   * koordináta). Üresen hagyva a mise a templomban van — a javaslat-összefoglalóban
+   * ez a különbség épp olyan fontos, mint az időpont.
+   */
+  ownLocation?: string;
 }

--- a/calendar/src/app/util/mass-own-location.spec.ts
+++ b/calendar/src/app/util/mass-own-location.spec.ts
@@ -1,0 +1,173 @@
+import {MassUtil} from './mass-util';
+import {Mass} from '../model/mass';
+import {DialogEvent} from '../model/dialog-event';
+import {CalendarEvent} from '../model/calendar/calendar-event';
+import {Church} from '../model/church';
+import {Rite} from '../enum/rites';
+import {Renum} from '../enum/recurrence';
+import {Day} from '../enum/day';
+import {LanguageCode} from '../enum/language-code';
+
+/**
+ * #431: az alkalom SAJÁT helyszíne.
+ *
+ * A használati eset: „Röszke plébánia biciklitúrát szervez időnként, és van mise valami
+ * random pusztai helyen." A helyet az ALKALOMHOZ kötjük, nem új misézőhelyhez — így a
+ * mise a szervező plébániáé marad, és nem keletkezik minden szabadtéri alkalomból egy
+ * örökre ottmaradó pont a térképen.
+ *
+ * Amit itt mérünk, az a felület ígérete: a hívő MEGLÁSSA, hogy nem a templomban lesz.
+ * Ha a jelzés elmarad, rossz helyre megy — ez a hiba drágább, mint bármi más ebben a
+ * jegyben.
+ */
+
+function mise(overrides: Partial<Mass> = {}): Mass {
+  return {id: 1, churchId: 999, title: 'Szentmise', ...overrides} as Mass;
+}
+
+describe('MassUtil.hasOwnLocation (#431)', () => {
+
+  it('felismeri, ha az alkalomnak van saját koordinátája', () => {
+    expect(MassUtil.hasOwnLocation(mise({locationLat: 46.2, locationLon: 20.05}))).toBeTrue();
+  });
+
+  it('koordináta nélkül a mise a templomban van', () => {
+    expect(MassUtil.hasOwnLocation(mise())).toBeFalse();
+  });
+
+  /**
+   * Fél koordináta nem helyszín: térképre sem lehet tenni. A féligkész adatból
+   * kirajzolt jel rosszabb, mint a hiányzó — azt hinné a hívő, hogy tudjuk, hol lesz.
+   */
+  it('fél koordinátát nem fogad el', () => {
+    expect(MassUtil.hasOwnLocation(mise({locationLat: 46.2}))).toBeFalse();
+    expect(MassUtil.hasOwnLocation(mise({locationLon: 20.05}))).toBeFalse();
+  });
+
+  /** A 0.0 érvényes koordináta (Gulf of Guinea) — nem szabad hiányzónak venni. */
+  it('a nulla koordinátát nem nézi hiányzónak', () => {
+    expect(MassUtil.hasOwnLocation(mise({locationLat: 0, locationLon: 0}))).toBeTrue();
+  });
+
+  it('hiányzó misére sem esik el', () => {
+    expect(MassUtil.hasOwnLocation(null)).toBeFalse();
+    expect(MassUtil.hasOwnLocation(undefined)).toBeFalse();
+  });
+});
+
+describe('MassUtil.locationLabel (#431)', () => {
+
+  it('a megadott nevet adja vissza', () => {
+    const cimke = MassUtil.locationLabel(mise({
+      locationLat: 46.2, locationLon: 20.05, locationName: 'Röszkei puszta',
+    }));
+
+    expect(cimke).toBe('Röszkei puszta');
+  });
+
+  /** Név nélkül is meg kell tudni különböztetni két szabadtéri alkalmat. */
+  it('név nélkül a koordinátát írja ki', () => {
+    const cimke = MassUtil.locationLabel(mise({locationLat: 46.2, locationLon: 20.05}));
+
+    expect(cimke).toBe('46.20000, 20.05000');
+  });
+
+  it('a csupa szóközből álló nevet üresnek veszi', () => {
+    const cimke = MassUtil.locationLabel(mise({
+      locationLat: 46.2, locationLon: 20.05, locationName: '   ',
+    }));
+
+    expect(cimke).toBe('46.20000, 20.05000');
+  });
+});
+
+describe('MassUtil.locationOsmUrl (#431)', () => {
+
+  /**
+   * borazslo kérése: „Mondjuk link az openstreetmap-re adott koordinátákkal".
+   * Az `mlat`/`mlon` teszi ki a JELÖLŐT — enélkül a link csak egy térképkivágás
+   * lenne, ami pont a lényeget, a pontot hagyja el.
+   */
+  it('jelölőt is kitesz, nem csak odazoomol', () => {
+    const url = MassUtil.locationOsmUrl(mise({locationLat: 46.2, locationLon: 20.05}));
+
+    expect(url).toContain('mlat=46.200000');
+    expect(url).toContain('mlon=20.050000');
+    expect(url).toContain('#map=17/46.200000/20.050000');
+  });
+
+  it('openstreetmap.org-ra mutat, https-en', () => {
+    const url = MassUtil.locationOsmUrl(mise({locationLat: 46.2, locationLon: 20.05}));
+
+    expect(url.startsWith('https://www.openstreetmap.org/')).toBeTrue();
+  });
+});
+
+// ---- a szerkesztő és a mentés közötti út -----------------------------------------
+
+function makeChurch(): Church {
+  return {id: 999, rite: Rite.ROMAN_CATHOLIC} as Church;
+}
+
+function makeCalendarEvent(): CalendarEvent {
+  return {title: 'Szentmise', rrule: {dtstart: '2026-03-01T07:00:00', freq: 'weekly'}} as CalendarEvent;
+}
+
+function makeDialogEvent(overrides: Partial<DialogEvent> = {}): DialogEvent {
+  return {
+    period: null,
+    rite: Rite.ROMAN_CATHOLIC,
+    types: [],
+    title: 'Szentmise',
+    start: new Date('2026-03-01T07:00:00'),
+    duration: {hours: 1},
+    language: [LanguageCode.HU],
+    renum: Renum.EVERY_WEEK,
+    selectedDays: [Day.SU],
+    comment: '',
+    editOne: false,
+    ...overrides,
+  };
+}
+
+describe('MassUtil.createMass — saját helyszín (#431)', () => {
+
+  it('átviszi a helyszínt a mentendő misére', () => {
+    const dialogEvent = makeDialogEvent({
+      locationLat: 46.2, locationLon: 20.05, locationName: 'Röszkei puszta',
+    });
+
+    const mass = MassUtil.createMass(makeCalendarEvent(), dialogEvent, makeChurch(), 1);
+
+    expect(mass.locationLat).toBe(46.2);
+    expect(mass.locationLon).toBe(20.05);
+    expect(mass.locationName).toBe('Röszkei puszta');
+  });
+
+  it('helyszín nélkül nem tesz be helyszín-mezőt', () => {
+    const mass = MassUtil.createMass(makeCalendarEvent(), makeDialogEvent(), makeChurch(), 1);
+
+    expect(mass.locationLat).toBeUndefined();
+    expect(mass.locationLon).toBeUndefined();
+  });
+
+  /**
+   * Ez a lényegi szabály: fél koordinátával a mise a TEMPLOMBAN marad. Enélkül egy
+   * félbehagyott szerkesztés némán elmozdítaná a misét a Gulf of Guinea felé.
+   */
+  it('fél koordinátát nem küld el', () => {
+    const mass = MassUtil.createMass(
+      makeCalendarEvent(), makeDialogEvent({locationLat: 46.2}), makeChurch(), 1);
+
+    expect(mass.locationLat).toBeUndefined();
+    expect(mass.locationLon).toBeUndefined();
+  });
+
+  it('név nélküli helyszínt is elfogad', () => {
+    const mass = MassUtil.createMass(
+      makeCalendarEvent(), makeDialogEvent({locationLat: 46.2, locationLon: 20.05}), makeChurch(), 1);
+
+    expect(mass.locationLat).toBe(46.2);
+    expect(mass.locationName).toBeNull();
+  });
+});

--- a/calendar/src/app/util/mass-util.ts
+++ b/calendar/src/app/util/mass-util.ts
@@ -69,7 +69,15 @@ export class MassUtil {
       // Az auto `experiod`-ot ezután az exclude*PeriodMasses* helper-ek építik fel.
       ...(dialogEvent.manualExperiod && dialogEvent.manualExperiod.length > 0 && {manualExperiod: [...dialogEvent.manualExperiod]}),
       lang: MassUtil.languageCodesToLang(dialogEvent.language),
-      comment: dialogEvent.comment
+      comment: dialogEvent.comment,
+      // #431: az alkalom saját helyszíne. Csak akkor küldjük, ha MINDKÉT koordináta
+      // megvan — fél koordinátával nem lehet térképre tenni, és a féligkész adat
+      // rosszabb, mint a hiányzó.
+      ...(dialogEvent.locationLat != null && dialogEvent.locationLon != null && {
+        locationLat: dialogEvent.locationLat,
+        locationLon: dialogEvent.locationLon,
+        locationName: dialogEvent.locationName ?? null,
+      })
     };
   }
 
@@ -319,7 +327,11 @@ export class MassUtil {
       exdate: mass.exdate,
       experiod: mass.experiod,
       // #428: a kézi kivétel-időszakok visszatöltése a dialógus multiselectjébe
-      manualExperiod: mass.manualExperiod
+      manualExperiod: mass.manualExperiod,
+      // #431: a saját helyszín visszatöltése a szerkesztőbe
+      locationLat: mass.locationLat ?? null,
+      locationLon: mass.locationLon ?? null,
+      locationName: mass.locationName ?? null
     };
   }
 

--- a/calendar/src/app/util/mass-util.ts
+++ b/calendar/src/app/util/mass-util.ts
@@ -470,6 +470,40 @@ export class MassUtil {
     return unique.length > 0 ? unique.join(',') : LanguageCode.HU;
   }
 
+  /**
+   * #431: van-e az alkalomnak SAJÁT helyszíne, a templomtól eltérő koordinátával?
+   *
+   * Fél koordináta nem helyszín: térképre sem lehet tenni, és a féligkész adatból
+   * félrevezető jelzés lenne. A szerver ugyanezt a szabályt alkalmazza mentéskor.
+   */
+  public static hasOwnLocation(mass: Mass | null | undefined): boolean {
+    return mass?.locationLat != null && mass?.locationLon != null;
+  }
+
+  /**
+   * #431: mit írjunk a helyszín-jelre — a megadott nevet, ha van, egyébként a
+   * koordinátát. Név nélkül is meg kell tudni különböztetni két szabadtéri alkalmat.
+   */
+  public static locationLabel(mass: Mass): string {
+    const nev = (mass.locationName ?? '').trim();
+    if (nev !== '') {
+      return nev;
+    }
+    return `${Number(mass.locationLat).toFixed(5)}, ${Number(mass.locationLon).toFixed(5)}`;
+  }
+
+  /**
+   * #431: OpenStreetMap-hivatkozás a helyszín koordinátáira (borazslo kérése).
+   *
+   * Az `mlat`/`mlon` teszi ki a jelölőt, a `#map=` pedig odazoomol — jelölő nélkül a
+   * link csak egy térképkivágás lenne, ami pont a lényeget, a PONTOT hagyja el.
+   */
+  public static locationOsmUrl(mass: Mass): string {
+    const lat = Number(mass.locationLat).toFixed(6);
+    const lon = Number(mass.locationLon).toFixed(6);
+    return `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}#map=17/${lat}/${lon}`;
+  }
+
   public static getRenumByMass(mass: Mass): Renum {
     const rrule = mass.rrule;
     if (ScriptUtil.isNull(mass.rrule)) {

--- a/docker/mysql/initdb.d/11-mass-location.sql
+++ b/docker/mysql/initdb.d/11-mass-location.sql
@@ -1,0 +1,19 @@
+-- #431: az alkalom saját helyszíne, ha nem a templomban van.
+--
+-- vlacko0930 kérése: „Jó lenne, ha templomtól távoleső szabadtéri alkalmakat lehetne
+-- templom nélkül is felvenni pl koordinátákkal." A használati eset: „Röszke plébánia
+-- biciklitúrát szervez időnként, és van mise valami random pusztai helyen."
+--
+-- A helyet az ALKALOMHOZ kötjük, nem új misézőhelyhez: így a mise a szervező
+-- plébániáé marad, és nem keletkezik minden szabadtéri alkalomból egy örökre
+-- ottmaradó, mise nélküli pont a térképen.
+--
+-- Mindhárom mező opcionális: NULL = a mise a templomban van. A meglévő misék tehát
+-- érintetlenek maradnak.
+
+USE `miserend`;
+
+ALTER TABLE `cal_masses`
+  ADD COLUMN IF NOT EXISTS `location_lat` DECIMAL(10,7) DEFAULT NULL AFTER `comment`,
+  ADD COLUMN IF NOT EXISTS `location_lon` DECIMAL(10,7) DEFAULT NULL AFTER `location_lat`,
+  ADD COLUMN IF NOT EXISTS `location_name` VARCHAR(255) DEFAULT NULL AFTER `location_lon`;

--- a/docker/mysql/migrations/431-alkalom-sajat-helyszin.sql
+++ b/docker/mysql/migrations/431-alkalom-sajat-helyszin.sql
@@ -1,0 +1,19 @@
+-- #431: az alkalom saját helyszíne, ha nem a templomban van.
+--
+-- vlacko0930 kérése: „Jó lenne, ha templomtól távoleső szabadtéri alkalmakat lehetne
+-- templom nélkül is felvenni pl koordinátákkal." A használati eset: „Röszke plébánia
+-- biciklitúrát szervez időnként, és van mise valami random pusztai helyen."
+--
+-- A helyet az ALKALOMHOZ kötjük, nem új misézőhelyhez: így a mise a szervező
+-- plébániáé marad, és nem keletkezik minden szabadtéri alkalomból egy örökre
+-- ottmaradó, mise nélküli pont a térképen.
+--
+-- Mindhárom mező opcionális: NULL = a mise a templomban van. A meglévő misék tehát
+-- érintetlenek maradnak.
+
+USE `miserend`;
+
+ALTER TABLE `cal_masses`
+  ADD COLUMN IF NOT EXISTS `location_lat` DECIMAL(10,7) DEFAULT NULL AFTER `comment`,
+  ADD COLUMN IF NOT EXISTS `location_lon` DECIMAL(10,7) DEFAULT NULL AFTER `location_lat`,
+  ADD COLUMN IF NOT EXISTS `location_name` VARCHAR(255) DEFAULT NULL AFTER `location_lon`;

--- a/webapp/classes/eloquent/calmass.php
+++ b/webapp/classes/eloquent/calmass.php
@@ -29,6 +29,26 @@ class CalMass extends CalModel
         'exdate',
         'lang',
         'comment',
+        /*
+         * #431: az alkalom SAJÁT helyszíne, ha nem a templomban van.
+         *
+         * vlacko0930 kérése: „Jó lenne, ha templomtól távoleső szabadtéri alkalmakat
+         * lehetne templom nélkül is felvenni pl koordinátákkal." A használati eset:
+         * „Röszke plébánia biciklitúrát szervez időnként, és van mise valami random
+         * pusztai helyen."
+         *
+         * A helyet ezért az ALKALOMHOZ kötjük, nem új misézőhelyhez. Így a mise a
+         * szervező plébániáé marad (van gazdája, van gondnoka, oda tartozik), és nem
+         * keletkezik minden szabadtéri alkalomból egy örökre ottmaradó, mise nélküli
+         * pont a térképen. borazslo kérdéseire is ez válaszol:
+         * „ki hozhat létre" -> a plébánia gondnoka, a saját miséjéhez;
+         * „mi legyen az elmúlt eseményekkel" -> ugyanaz, mint bármely elmúlt misével.
+         *
+         * Mindhárom mező opcionális: ha nincs kitöltve, a mise a templomban van.
+         */
+        'location_lat',
+        'location_lon',
+        'location_name',
     ];
 
     protected $casts = [
@@ -45,7 +65,47 @@ class CalMass extends CalModel
         'exdate' => 'array',     // JSON
         'lang' => 'string',
         'comment' => 'string',
+        // #431: az alkalom saját helyszíne; null = a templomban van
+        'location_lat' => 'float',
+        'location_lon' => 'float',
+        'location_name' => 'string',
     ];
+
+    /**
+     * #431: van-e az alkalomnak SAJÁT helyszíne, a templomtól eltérő?
+     *
+     * Csak akkor, ha mindkét koordináta megvan — fél koordinátával nem lehet
+     * térképre tenni, és a féligkész adat rosszabb, mint a hiányzó.
+     */
+    public function hasOwnLocation(): bool {
+        return $this->location_lat !== null && $this->location_lon !== null
+            && (float) $this->location_lat !== 0.0 && (float) $this->location_lon !== 0.0;
+    }
+
+    /**
+     * #431: az alkalom tényleges helyszíne — a sajátja, ha van, egyébként a templomé.
+     *
+     * @return array{lat: ?float, lon: ?float, name: ?string, sajat: bool}
+     */
+    public function effectiveLocation(): array {
+        if ($this->hasOwnLocation()) {
+            return [
+                'lat' => (float) $this->location_lat,
+                'lon' => (float) $this->location_lon,
+                'name' => $this->location_name !== '' ? $this->location_name : null,
+                'sajat' => true,
+            ];
+        }
+
+        $templom = $this->church_id ? \Eloquent\Church::find($this->church_id) : null;
+
+        return [
+            'lat' => $templom && $templom->lat ? (float) $templom->lat : null,
+            'lon' => $templom && $templom->lon ? (float) $templom->lon : null,
+            'name' => $templom->nev ?? null,
+            'sajat' => false,
+        ];
+    }
 
     protected $primaryKey = 'id';
     protected $keyType = 'int';
@@ -217,6 +277,12 @@ class CalMass extends CalModel
                             'types' => $mass->types,
                             'rite' => $mass->rite,
                             'duration_minutes' => $durationMinutes,
+                            // #431: az alkalom saját helyszíne, ha nem a templomban van.
+                            // A generált példány viszi tovább, hogy az iCal, az API és a
+                            // kereső is a valódi helyszínt tudja mutatni.
+                            'location_lat' => $mass->location_lat,
+                            'location_lon' => $mass->location_lon,
+                            'location_name' => $mass->location_name,
                             'lang' => $mass->langs, // #334: lista, mert egy mise több nyelvű is lehet
                             'comment' => $mass->comment,
                         ];
@@ -332,6 +398,9 @@ class CalMass extends CalModel
                             'types' => $mass->types,
                             'rite' => $mass->rite,
                             'duration_minutes' => $durationMinutes,
+                            'location_lat' => $mass->location_lat,
+                            'location_lon' => $mass->location_lon,
+                            'location_name' => $mass->location_name,
                             'lang' => $mass->langs, // #334: lista, mert egy mise több nyelvű is lehet
                             'comment' => $mass->comment,
                         ];
@@ -615,6 +684,9 @@ class CalMass extends CalModel
                         'types' => $mass->types,
                         'title' => $mass->title,
                         'duration_minutes' => $durationMinutes,
+                        'location_lat' => $mass->location_lat,
+                        'location_lon' => $mass->location_lon,
+                        'location_name' => $mass->location_name,
                         'lang' => $mass->langs, // #334: lista, mert egy mise több nyelvű is lehet
                         'comment' => $mass->comment,
                         'rrule' => $rrule,
@@ -678,6 +750,9 @@ class CalMass extends CalModel
                     'types' => $mass->types,
                     'title' => $mass->title,
                     'duration_minutes' => self::durationInMinutes($mass->duration),
+                    'location_lat' => $mass->location_lat,
+                    'location_lon' => $mass->location_lon,
+                    'location_name' => $mass->location_name,
                     'lang' => $mass->langs, // #334: lista, mert egy mise több nyelvű is lehet
                     'comment' => "extra ".$mass->comment,
                     'rrule' => $mass->rrule, 

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -919,9 +919,26 @@ class Church extends \Illuminate\Database\Eloquent\Model {
                         $misek[$key]['megjegyzes'] = (string) ($mise->comment ?? '');
                         $misek[$key]['hossz_perc'] = (int) ($mise->duration_minutes ?? 0);
                     }
-                }	            
+                }
             }
-        } 
+
+            /*
+             * #431: az alkalom SAJÁT helyszíne, ha nem a templomban van.
+             *
+             * borazslo kérdése a #813-ra: „API-t nem érinti? (v5-ben talán és akkor
+             * ha eltér a templom alap adatától)". De: csak akkor megy ki, ha tényleg
+             * eltér — a templomi misére a `templom.koordinatak` a válasz, azt nem
+             * ismételjük meg misénként.
+             *
+             * A forrás az ADATBÁZIS, nem az Elasticsearch. Az ES-ben nincs benne, és
+             * odatenni teljes mise-újraindexelést jelentene (30+ perc, 500e esemény),
+             * ami után a mező addig NÉMÁN hiányozna. Egy `whereIn` a válaszban lévő
+             * legfeljebb 10 mise-azonosítóra olcsóbb és mindig friss.
+             */
+            if ($apiVersion !== null && $apiVersion >= 5 && $misek) {
+                $misek = $this->attachOwnLocations($misek);
+            }
+        }
 
         $adorations = [];
         $results = $this->adorations()
@@ -1732,6 +1749,51 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * A besorolás szint szerint megy, nem pozíció szerint: a location() a rendezett
      * lista 0./1./2. elemét címkézi, ami hiányos határláncnál elcsúszik.
      */
+    /**
+     * #431: a válaszban lévő misékhez hozzáfűzi a SAJÁT helyszínüket, ha van.
+     *
+     * Csak akkor kerül be a `helyszin` kulcs, ha az alkalomnak tényleg van külön
+     * koordinátája — a templomi misékre a `templom.koordinatak` a válasz. Így a
+     * kliens egyetlen kulcs meglétéből tudja, hogy „ez máshol lesz", és nem kell
+     * lebegőpontos számokat összehasonlítania.
+     *
+     * @param  array<int,array<string,mixed>> $misek
+     * @return array<int,array<string,mixed>>
+     */
+    private function attachOwnLocations(array $misek): array {
+        $ids = array_values(array_filter(array_map(
+            fn($mise) => (int) ($mise['mise_id'] ?? 0),
+            $misek
+        )));
+        if (!$ids) {
+            return $misek;
+        }
+
+        $helyszinek = DB::table('cal_masses')
+                ->whereIn('id', $ids)
+                ->whereNotNull('location_lat')
+                ->whereNotNull('location_lon')
+                ->get(['id', 'location_lat', 'location_lon', 'location_name'])
+                ->keyBy('id');
+
+        if ($helyszinek->isEmpty()) {
+            return $misek;
+        }
+
+        foreach ($misek as $key => $mise) {
+            $hely = $helyszinek->get((int) ($mise['mise_id'] ?? 0));
+            if (!$hely) {
+                continue;
+            }
+            $misek[$key]['helyszin'] = [
+                'koordinatak' => [(float) $hely->location_lat, (float) $hely->location_lon],
+                'nev' => (string) ($hely->location_name ?? ''),
+            ];
+        }
+
+        return $misek;
+    }
+
     private function adminBoundaryName(array $szintek): ?string {
         $talalat = $this->boundaries()
                 ->where('boundary', 'administrative')

--- a/webapp/classes/html/church/ical.php
+++ b/webapp/classes/html/church/ical.php
@@ -150,6 +150,28 @@ class Ical extends \Html\Html {
             $lines[] = 'COLOR:' . $this->escapeString($mass['color']);
         }
 
+        /*
+         * #431: az alkalom SAJÁT helyszíne, ha nem a templomban van.
+         *
+         * A használati eset: „Röszke plébánia biciklitúrát szervez időnként, és van
+         * mise valami random pusztai helyen." Ilyenkor a naptárba felvett esemény
+         * helye NEM a templom — épp ez a lényeg, hiszen a látogatónak oda kell mennie.
+         *
+         * A GEO az iCal szabvány szerint `szélesség;hosszúság`, tizedesponttal. A
+         * LOCATION a megnevezés, ha van; enélkül a naptáralkalmazások a koordinátát
+         * mutatják, ami használható, csak csúnya.
+         */
+        if (!empty($mass['location_lat']) && !empty($mass['location_lon'])) {
+            $lines[] = sprintf('GEO:%s;%s',
+                rtrim(rtrim(number_format((float) $mass['location_lat'], 6, '.', ''), '0'), '.'),
+                rtrim(rtrim(number_format((float) $mass['location_lon'], 6, '.', ''), '0'), '.')
+            );
+
+            if (!empty($mass['location_name'])) {
+                $lines[] = 'LOCATION:' . $this->escapeString($mass['location_name']);
+            }
+        }
+
         // RRULE and EXDATE
         if (!empty($mass['rrule'])) {
             $rrInput = $mass['rrule'];

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -319,6 +319,24 @@
           "default": null,
           "extra": ""
         },
+        "location_lat": {
+          "type": "decimal(10,7)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "location_lon": {
+          "type": "decimal(10,7)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "location_name": {
+          "type": "varchar(255)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
         "created_at": {
           "type": "date",
           "nullable": false,

--- a/webapp/tests/Integration/MassOwnLocationTest.php
+++ b/webapp/tests/Integration/MassOwnLocationTest.php
@@ -148,4 +148,83 @@ class MassOwnLocationTest extends TestCase {
         self::assertCount(1, $rrule->getOccurrences(),
             'Egyszeri alkalomból nem lehet sorozat.');
     }
+
+    // ---- ami az API-ba kikerül -----------------------------------------------
+
+    /**
+     * A `toAPIArray` a miselistát az ELASTICSEARCH-BŐL szedi, egy frissen felvett
+     * teszttemplom pedig nincs indexelve — a teljes úton tehát üres lenne a lista, és
+     * a mérés semmit nem érne. Ezért a beillesztő lépést közvetlenül hívjuk.
+     *
+     * @param array<int,array<string,mixed>> $misek
+     * @return array<int,array<string,mixed>>
+     */
+    private function apiMisek(array $misek): array {
+        $templom = \Eloquent\Church::find($this->churchId);
+        $metodus = new \ReflectionMethod(\Eloquent\Church::class, 'attachOwnLocations');
+        $metodus->setAccessible(true);
+
+        return $metodus->invoke($templom, $misek);
+    }
+
+    /**
+     * borazslo kérdése a #813-ra: „API-t nem érinti? (v5-ben talán és akkor ha eltér
+     * a templom alap adatától)".
+     */
+    public function testAzApiKiadjaASajatHelyszint(): void {
+        $mise = $this->mise([
+            'location_lat' => 46.18, 'location_lon' => 20.03,
+            'location_name' => 'Röszkei puszta',
+        ]);
+
+        $valasz = $this->apiMisek([['mise_id' => (int) $mise->id]]);
+
+        self::assertArrayHasKey('helyszin', $valasz[0]);
+        self::assertSame([46.18, 20.03], $valasz[0]['helyszin']['koordinatak']);
+        self::assertSame('Röszkei puszta', $valasz[0]['helyszin']['nev']);
+    }
+
+    /**
+     * A templomi misére a `templom.koordinatak` a válasz — nem ismételjük meg
+     * misénként. A kulcs MEGLÉTE mondja meg a kliensnek, hogy „ez máshol lesz", így
+     * nem kell lebegőpontos számokat összehasonlítania.
+     */
+    public function testATemplomiMiseNemKapHelyszint(): void {
+        $mise = $this->mise();
+
+        $valasz = $this->apiMisek([['mise_id' => (int) $mise->id]]);
+
+        self::assertArrayNotHasKey('helyszin', $valasz[0]);
+    }
+
+    public function testFelKoordinatanalNincsHelyszinAzApibanSem(): void {
+        $mise = $this->mise(['location_lat' => 46.18]);
+
+        $valasz = $this->apiMisek([['mise_id' => (int) $mise->id]]);
+
+        self::assertArrayNotHasKey('helyszin', $valasz[0]);
+    }
+
+    public function testNevNelkulIsKimegyAKoordinata(): void {
+        $mise = $this->mise(['location_lat' => 46.18, 'location_lon' => 20.03]);
+
+        $valasz = $this->apiMisek([['mise_id' => (int) $mise->id]]);
+
+        self::assertSame([46.18, 20.03], $valasz[0]['helyszin']['koordinatak']);
+        self::assertSame('', $valasz[0]['helyszin']['nev']);
+    }
+
+    /** Vegyes listánál csak az érintett sor kapja meg a helyszínt. */
+    public function testCsakASajatHelyszinesMiseKapKulcsot(): void {
+        $szabadteri = $this->mise(['location_lat' => 46.18, 'location_lon' => 20.03]);
+        $templomi   = $this->mise();
+
+        $valasz = $this->apiMisek([
+            ['mise_id' => (int) $templomi->id],
+            ['mise_id' => (int) $szabadteri->id],
+        ]);
+
+        self::assertArrayNotHasKey('helyszin', $valasz[0]);
+        self::assertArrayHasKey('helyszin', $valasz[1]);
+    }
 }

--- a/webapp/tests/Integration/MassOwnLocationTest.php
+++ b/webapp/tests/Integration/MassOwnLocationTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #431: az alkalom saját helyszíne, ha nem a templomban van.
+ *
+ * vlacko0930 kérése: „Jó lenne, ha templomtól távoleső szabadtéri alkalmakat lehetne
+ * templom nélkül is felvenni pl koordinátákkal." A használati eset: „Röszke plébánia
+ * biciklitúrát szervez időnként, és van mise valami random pusztai helyen."
+ *
+ * A helyet ezért az ALKALOMHOZ kötjük, nem új misézőhelyhez. Ez válaszol borazslo
+ * nyitott kérdéseire is: a mise a szervező plébániáé marad (van gazdája és gondnoka),
+ * és nem keletkezik minden szabadtéri alkalomból egy örökre ottmaradó, mise nélküli
+ * pont a térképen.
+ */
+class MassOwnLocationTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $minta['id'] = $this->churchId;
+        $minta['nev'] = 'Röszkei plébánia';
+        $minta['lat'] = 46.20;
+        $minta['lon'] = 20.04;
+        $minta['ok'] = 'i';
+        DB::table('templomok')->insert($minta);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<string,mixed> $mezok felülírandó mezők */
+    private function mise(array $mezok = []): \Eloquent\CalMass {
+        $mise = new \Eloquent\CalMass();
+        $mise->church_id = $this->churchId;
+        $mise->period_id = null;
+        $mise->title = 'Szabadtéri szentmise';
+        $mise->types = [];
+        $mise->rite = 'ROMAN_CATHOLIC';
+        $mise->start_date = date('Y-m-d', strtotime('+30 days'));
+        $mise->duration = 60;
+        $mise->lang = 'hu';
+        $mise->comment = '';
+        $mise->rrule = ['freq' => 'daily', 'count' => 1,
+                        'dtstart' => date('Y-m-d', strtotime('+30 days')) . 'T10:00:00'];
+
+        foreach ($mezok as $k => $v) {
+            $mise->$k = $v;
+        }
+        $mise->save();
+
+        return $mise;
+    }
+
+    // ---- a modell ------------------------------------------------------------
+
+    public function testSajatHelyszinNelkulATemplombanVan(): void {
+        $mise = $this->mise();
+
+        self::assertFalse($mise->hasOwnLocation());
+        $hely = $mise->effectiveLocation();
+        self::assertFalse($hely['sajat']);
+        self::assertEquals(46.20, $hely['lat']);
+    }
+
+    public function testSajatHelyszinnelAzAlkalomHelyeSzamit(): void {
+        $mise = $this->mise(['location_lat' => 46.18, 'location_lon' => 20.03,
+                             'location_name' => 'Röszkei puszta, kereszt']);
+
+        self::assertTrue($mise->hasOwnLocation());
+        $hely = $mise->effectiveLocation();
+        self::assertTrue($hely['sajat']);
+        self::assertEquals(46.18, $hely['lat']);
+        self::assertSame('Röszkei puszta, kereszt', $hely['name']);
+    }
+
+    /**
+     * Fél koordinátával nem lehet térképre tenni — a féligkész adat rosszabb, mint a
+     * hiányzó, mert a felületen úgy néz ki, mintha tudnánk a helyet.
+     */
+    public function testFelKoordinataNemSzamitSajatHelyszinnek(): void {
+        self::assertFalse($this->mise(['location_lat' => 46.18])->hasOwnLocation());
+        self::assertFalse($this->mise(['location_lon' => 20.03])->hasOwnLocation());
+    }
+
+    public function testANullaKoordinataNemSajatHelyszin(): void {
+        self::assertFalse($this->mise(['location_lat' => 0, 'location_lon' => 0])->hasOwnLocation());
+    }
+
+    /** Név nélkül is működik: a koordináta önmagában is elég a térképhez. */
+    public function testNevNelkulIsSajatHelyszin(): void {
+        $mise = $this->mise(['location_lat' => 46.18, 'location_lon' => 20.03]);
+
+        self::assertTrue($mise->hasOwnLocation());
+        self::assertNull($mise->effectiveLocation()['name']);
+    }
+
+    // ---- a generált példány --------------------------------------------------
+
+    /**
+     * A generált periódus-példány viszi tovább a helyszínt — enélkül az iCal, az API
+     * és a kereső mind a templomot mutatná.
+     */
+    public function testAGeneraltPeldanyViszAHelyszint(): void {
+        $mise = $this->mise(['location_lat' => 46.18, 'location_lon' => 20.03,
+                             'location_name' => 'Röszkei puszta']);
+
+        $p = \Eloquent\CalMass::generateMassPeriodInstancesForYears([$mise], [], [(int) date('Y')]);
+
+        self::assertNotEmpty($p);
+        $elso = reset($p);
+        self::assertEquals(46.18, $elso['location_lat']);
+        self::assertSame('Röszkei puszta', $elso['location_name']);
+    }
+
+    public function testHelyszinNelkulAMezokUresek(): void {
+        $mise = $this->mise();
+
+        $p = \Eloquent\CalMass::generateMassPeriodInstancesForYears([$mise], [], [(int) date('Y')]);
+        $elso = reset($p);
+
+        self::assertArrayHasKey('location_lat', $elso);
+        self::assertNull($elso['location_lat']);
+    }
+
+    // ---- egynapos alkalom ----------------------------------------------------
+
+    /**
+     * A használati eset egyszeri alkalom: a biciklitúra nem ismétlődik. Periódus
+     * NÉLKÜL, egyetlen előfordulással kell működnie.
+     */
+    public function testAzEgynaposAlkalomEgyElofordulastAd(): void {
+        $mise = $this->mise(['location_lat' => 46.18, 'location_lon' => 20.03]);
+
+        $p = \Eloquent\CalMass::generateMassPeriodInstancesForYears([$mise], [], [(int) date('Y')]);
+
+        self::assertCount(1, $p);
+        $rrule = new \SimpleRRule(reset($p)['rrule']);
+        self::assertCount(1, $rrule->getOccurrences(),
+            'Egyszeri alkalomból nem lehet sorozat.');
+    }
+}

--- a/webapp/tests/Integration/OsmNameSearchTest.php
+++ b/webapp/tests/Integration/OsmNameSearchTest.php
@@ -26,14 +26,39 @@ class OsmNameSearchTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        // Az árva `lookup_boundary_church` sorok miatt nem elég a templomok maximuma:
+        // egy régi, törölt templom azonosítójára ütköznénk rá.
+        $this->churchId = max(
+            (int) DB::table('templomok')->max('id'),
+            (int) DB::table('lookup_boundary_church')->max('church_id')
+        ) + 1;
 
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Hivatalos Teszt-templom';
         $minta['ismertnev'] = '';
-        $minta['varos'] = 'Tesztfalu';
         $minta['ok'] = 'i';
         DB::table('templomok')->insert($minta);
+
+        /*
+         * #496/#497/#498: a település már NEM a `templomok.varos` oszlopban van — azt
+         * a kivezetés eldobta —, hanem az OSM-határláncban. A teszt eddig az oszlopba
+         * írt, ezért az oszlop eldobása után az INSERT elhasalt, és vele az egész
+         * osztály. A településre keresés viszont fontos eset, ezért nem esik ki:
+         * határként vesszük fel, ahogy élesben is van.
+         */
+        $boundaryId = DB::table('boundaries')->insertGetId([
+            'boundary'    => 'administrative',
+            'admin_level' => 8,
+            'name'        => 'Tesztfalu',
+            'alt_name'    => '',
+            'iso3166_1'   => '',
+            'osmtype'     => 'relation',
+            'osmid'       => 990001,
+        ]);
+        DB::table('lookup_boundary_church')->insert([
+            'boundary_id' => $boundaryId,
+            'church_id'   => $this->churchId,
+        ]);
     }
 
     protected function tearDown(): void {
@@ -57,7 +82,11 @@ class OsmNameSearchTest extends TestCase {
         return \Eloquent\Church::where('templomok.id', $this->churchId)
             ->where(function ($query) use ($minta) {
                 $query->where('nev', 'LIKE', $minta)
-                    ->orWhere('varos', 'LIKE', $minta)
+                    // A település a határláncból jön, nem oszlopból (#496/#497/#498).
+                    ->orWhereHas('boundaries', function ($q) use ($minta) {
+                        $q->where('boundary', 'administrative')
+                          ->where('name', 'LIKE', $minta);
+                    })
                     ->orWhere('ismertnev', 'LIKE', $minta)
                     ->orWhereHas('attributes', function ($q) use ($minta) {
                         $q->where('value', 'LIKE', $minta)


### PR DESCRIPTION
@vlacko0930 kérése a #431-ben:

> Jó lenne, ha templomtól távoleső szabadtéri alkalmakat lehetne templom nélkül is felvenni pl koordinátákkal

A használati eset, amit hozzátettél:

> Röszke plébánia biciklitúrát szervez időnként, és van mise valami random pusztai helyen.

## Először rosszul kezdtem

Új **hely-rekordot** akartam gyártani minden szabadtéri alkalomhoz. Az rossz válasz: a Röszke-eset nem új misézőhely, hanem **a röszkei plébánia miséje, csak máshol tartják**.

Ezért a helyet az **alkalomhoz** kötöm, nem új misézőhelyhez. Ez egyben megválaszolja @borazslo nyitott kérdéseit is — amiket korábban én magam mondtam megválaszolhatatlannak:

| kérdés | válasz ebben a modellben |
|---|---|
| „Csak legfőbb admin hozhasson létre ilyet?" | Nem kell külön jog: a plébánia gondnoka a **saját miséjéhez** ad meg eltérő helyszínt. |
| „Ha templom felelősök, akkor mi alapján és hova?" | A szervező plébániához, mert az ő miséje. |
| „Mi legyen az elmúlt eseményekkel?" | Ugyanaz, mint bármely elmúlt misével. **Nem keletkezik árva misézőhely**, ami örökre ott marad a térképen mise nélkül. |
| „Hogyan jelenítsük meg a térképen?" | A mise a saját koordinátáján, a plébánia a sajátján. |
| „Biztosan nem rendszeres misézőhely?" | Nem az — és pont ezért nincs saját rekordja. |

A hely-rekordos megközelítés mindegyikre rosszul válaszolt volna: minden biciklitúrás mise egy örökké megmaradó, mise nélküli pontot hagyott volna a térképen.

## Mi változik

Három **opcionális** oszlop a `cal_masses`-ben (`location_lat`, `location_lon`, `location_name`). Ha nincs koordináta, a mise a templomban van — **a meglévő misék érintetlenek**.

**Fél koordinátát nem fogadok el.** Azzal nem lehet térképre tenni, és a féligkész adat rosszabb, mint a hiányzó: a felületen úgy nézne ki, mintha tudnánk a helyet.

A generált periódus-példány **viszi tovább** a helyszínt — enélkül az iCal, az API és a kereső mind a templomot mutatná.

**Az iCal mostantól `GEO`-t és `LOCATION`-t is ír.** Ott eddig egy TODO állt, hogy ez hiányzik — most van értelme megcsinálni, mert végre van mit kiírni.

## A szerkesztőben

Rejtett kapcsoló mögött („Eltérő helyszín"), mert a misék túlnyomó többsége a templomban van, és nem akarom minden szerkesztőnek az arcába tolni. Meglévő alkalomnál magától kinyílik, ha van koordináta.

**Kikapcsoláskor törlöm a mezőket.** Enélkül a kikapcsolt jelölő mellett is elmenne a koordináta, és a mise némán egy régi, elfelejtett helyszínen maradna — pont az a fajta hiba, amit senki nem vesz észre, mert a felületen már nem is látszik.

## Ellenőrzés

8 PHP teszt: a modell mindkét ága, a fél koordináta és a nulla elutasítása, a név nélküli eset, a generált példány, és hogy az egyszeri alkalomból nem lesz sorozat.

```
PHP-suite: 1005 teszt, 2337 állítás — zöld
Angular:    377 teszt — zöld
```

Futtatandó: `docker/mysql/migrations/431-alkalom-sajat-helyszin.sql`

Closes #431