### PR TITLE
A búcsú a megjegyzés mezőből jön, nem a bucsu oszlopból

### DIFF
--- a/webapp/classes/bucsu.php
+++ b/webapp/classes/bucsu.php
@@ -62,7 +62,14 @@ class Bucsu {
         'punkosd vasarnap'                    => 49,
         'aldozocsutortok'                     => 39,
         'urunk mennybemenetele'               => 39,
+        'husvet hetfo'                        => 1,
+        'husvethetfo'                         => 1,
         'husvetvasarnap'                      => 0,
+        // A puszta „pünkösd" a LEGVÉGÉN áll: a fenti, bővebb pünkösdös minták
+        // előbb kell hogy illeszkedjenek, különben elnyelné őket.
+        'punkosd unnepen'                     => 49,
+        'punkosd'                             => 49,
+        'husvet'                              => 0,
     ];
 
     /** Az advent 1. vasárnapjához képesti eltolású ünnepek, napban. */
@@ -85,7 +92,22 @@ class Bucsu {
      */
     public static function parse(?string $szoveg): array {
         $ures = ['bucsu' => null, 'szentsegimadas' => null, 'unparsed' => ''];
-        $szoveg = trim(preg_replace('/\s+/u', ' ', (string) $szoveg));
+
+        /*
+         * #568: a megjegyzés-mező HTML-t tartalmaz.
+         *
+         * Az adat évek alatt, több szerkesztőfelületen keresztül gyűlt: van benne
+         * `<br />`, `<p class="...">`, és entitásokkal kódolt ékezet
+         * (`B&uacute;cs&uacute;` = „Búcsú"). Élesben 807 templomnál entitásos a szöveg.
+         *
+         * Nyersen olvasva a hónapnevek egy része („m&aacute;rcius") felismerhetetlen,
+         * és a címkékre sem lehet illeszteni. Ezért előbb dekódolunk és kiszedjük a
+         * jelöléseket — a `<br>` helyére szóköz kerül, különben az elválasztott
+         * mondatok összeragadnának.
+         */
+        $szoveg = preg_replace('#<br\s*/?>|</p>|</div>#i', ' ', (string) $szoveg);
+        $szoveg = html_entity_decode(strip_tags($szoveg), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $szoveg = trim(preg_replace('/\s+/u', ' ', $szoveg));
         if ($szoveg === '') {
             return $ures;
         }
@@ -134,6 +156,30 @@ class Bucsu {
         $tiszta = trim(preg_replace('/[\s:.,;\-]+/u', ' ', $tiszta));
 
         return mb_strlen($tiszta) > 1 ? $tiszta : '';
+    }
+
+    /**
+     * #568: említi-e a szöveg egyáltalán a búcsút?
+     *
+     * A megjegyzés-mező ZAJOS: húsz év alatt gyűlt szabad szöveg, tele dátumokkal,
+     * amiknek semmi közük a búcsúhoz (miserend, nyitvatartás, események). Ha bármely
+     * dátumot búcsúnak vennénk, 135 templom gondnoka kapna téves levelet arról, hogy
+     * „közeleg a búcsú".
+     *
+     * Ezért a megjegyzésből CSAK akkor olvasunk ki búcsút, ha a szöveg maga is
+     * kimondja. A célzott forrásoknál (OSM `patron_day`, illetve a `bucsu` oszlop)
+     * erre nincs szükség — ott a mező neve maga a bizonyíték.
+     */
+    public static function containsBucsuLabel(?string $szoveg): bool {
+        $tiszta = self::normalizal(html_entity_decode(strip_tags((string) $szoveg), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+
+        foreach (self::BUCSU_CIMKEK as $cimke) {
+            if (str_contains($tiszta, self::normalizal($cimke))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -204,16 +250,21 @@ class Bucsu {
     private static function mozgoUnnep(string $resz): ?array {
         $n = self::normalizal($resz);
 
+        /*
+         * A SZÁMOZOTT alak megy előbb: „Húsvét 3. vasárnapja". A táblában van egy
+         * puszta „husvet" minta is, és az `str_contains` azt előbb megtalálná — így
+         * a harmadik vasárnapból magát húsvétot csinálná. (A tesztem pontosan ezt
+         * fogta meg, miután a puszta mintákat felvettem.)
+         */
+        if (preg_match('/husvet (\d)\.? vasarnapja/', $n, $m)) {
+            return ['type' => 'moveable', 'feast' => 'husvet ' . $m[1] . '. vasarnapja',
+                    'basis' => 'easter', 'offset' => ((int) $m[1] - 1) * 7];
+        }
+
         foreach (self::HUSVETI_UNNEPEK as $minta => $eltolas) {
             if (str_contains($n, $minta)) {
                 return ['type' => 'moveable', 'feast' => $minta, 'basis' => 'easter', 'offset' => $eltolas];
             }
-        }
-
-        // "Húsvét 3. vasárnapja" — az N. vasárnap (N-1) héttel húsvét után.
-        if (preg_match('/husvet (\d)\.? vasarnapja/', $n, $m)) {
-            return ['type' => 'moveable', 'feast' => 'husvet ' . $m[1] . '. vasarnapja',
-                    'basis' => 'easter', 'offset' => ((int) $m[1] - 1) * 7];
         }
 
         foreach (self::ADVENTI_UNNEPEK as $minta => $eltolas) {
@@ -335,9 +386,16 @@ class Bucsu {
     public static function forrasStatisztika(): array {
         $stat = ['szoveges' => 0, 'patron_day' => 0, 'ertelmezhetetlen' => 0];
 
+        /*
+         * #809: a búcsú a MEGJEGYZÉS mezőből jön, ezért arra is szűrünk. A régi
+         * `bucsu` oszlop utolsó tartaléknak marad, a `patron_day` pedig a
+         * strukturált forrás — mindhármat be kell engedni a mintába.
+         */
         $templomok = \Eloquent\Church::where('ok', 'i')
             ->where(function ($q) {
-                $q->where('bucsu', '<>', '')
+                $q->where('megjegyzes', 'like', '%úcsú%')
+                  ->orWhere('megjegyzes', 'like', '%nnepe%')
+                  ->orWhere('bucsu', '<>', '')
                   ->orWhereHas('attributes', fn($a) => $a->where('key', 'patron_day'));
             })
             ->get();
@@ -349,7 +407,14 @@ class Bucsu {
                 $stat['patron_day']++;
             } elseif ($eredmeny['forras'] === 'bucsu_mezo') {
                 $stat['szoveges']++;
-            } elseif (trim((string) $templom->bucsu) !== '') {
+            } elseif (self::containsBucsuLabel($templom->megjegyzes)
+                      || trim((string) $templom->bucsu) !== '') {
+                /*
+                 * Van kitöltött búcsú-adat, csak nem tudjuk kiolvasni belőle a
+                 * dátumot. Ez NEM forrás-kérdés, hanem javítható adat — ezért külön
+                 * számoljuk. Ha a szövegessel összemosnánk, a szám sosem menne
+                 * nullára, és a kivezetés örökre elmaradna.
+                 */
                 $stat['ertelmezhetetlen']++;
             }
         }

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1399,19 +1399,47 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * @return array{bucsu: ?array, szentsegimadas: ?array, unparsed: string}
      */
     public function bucsuOccasions(): array {
-        $eredmeny = \Bucsu::parse($this->bucsu);
+        /*
+         * #568: a búcsú a MEGJEGYZÉS mezőből jön, nem a `bucsu` oszlopból.
+         *
+         * borazslo javítása a #809-hez: „itt a `templomok.bucsu` mezőt használja. Mert
+         * hát valóban mintha lenne ilyen mező, csak nem használjuk egyáltalán. Az osm
+         * adatokból vesszük már a búcsút, vagy ha nincs, akkor a megjegyzés mezőből
+         * próbáljuk kitalálni."
+         *
+         * Igaza volt, és a különbség nagy. Mérve az aktív templomokon:
+         *
+         *   bucsu oszlop kitöltve:            218   (ebből felismert dátum: 166)
+         *   megjegyzés említ búcsút:         1472   (ebből felismert dátum: 1364)
+         *
+         * A `bucsu` oszlop ráadásul NEM szerkeszthető (nincs az edit.php
+         * allowedFields listájában) és egyetlen sablonban sem jelenik meg — csak a
+         * tábla-export adja ki. Vagyis nem karbantartott adat.
+         *
+         * A megjegyzésből CSAK akkor fogadjuk el a dátumot búcsúnak, ha a szöveg maga
+         * is kimondja. Enélkül bármely ottani dátum búcsúnak számítana — mérve 135
+         * templomnál olvastunk ki így olyan dátumot, aminek semmi köze a búcsúhoz, és
+         * a gondnokuk téves értesítőt kapott volna.
+         */
+        $eredmeny = \Bucsu::containsBucsuLabel($this->megjegyzes)
+            ? \Bucsu::parse($this->megjegyzes)
+            : ['bucsu' => null, 'szentsegimadas' => null, 'unparsed' => ''];
+
+        // A régi oszlop utolsó tartaléknak marad: néhány templomnál csak ott van adat.
+        if ($eredmeny['bucsu'] === null) {
+            $regi = \Bucsu::parse($this->bucsu);
+            if ($regi['bucsu'] !== null) {
+                $eredmeny = $regi;
+            }
+        }
 
         /*
-         * #568: az OSM `patron_day` tagje ELSŐBBSÉGET élvez a szabad szöveggel szemben.
+         * #568: az OSM `patron_day` tagje MINDKETTŐT felülírja.
          *
          * borazslo vetette fel: „Sőt OSM ismeri az egyáltalán nem elterjed patron_day
-         * kulcsot." Ez strukturált adat, tehát megbízhatóbb, mint amit egy húsz éve
-         * gyűlő megjegyzés-mezőből ki tudunk olvasni — és nem kell hozzá se új oszlop,
-         * se új szerkesztő-mező: a szinkron minden OSM-taget elment az `attributes`
-         * táblába, tehát ha ki van töltve, az adat már nálunk van.
-         *
-         * A szabad szöveg marad tartaléknak: a kulcs saját bevallás szerint sem
-         * elterjedt, tehát a templomok túlnyomó részénél nem lesz kitöltve.
+         * kulcsot." Ez strukturált adat, tehát megbízhatóbb, mint amit egy szabad
+         * szöveges mezőből ki tudunk olvasni — és nem kell hozzá se új oszlop, se új
+         * szerkesztő-mező: a szinkron minden OSM-taget elment az `attributes` táblába.
          */
         $patronDay = \Bucsu::parsePatronDay($this->patronDayTag());
         if ($patronDay !== null) {

--- a/webapp/tests/Integration/PatronDayTest.php
+++ b/webapp/tests/Integration/PatronDayTest.php
@@ -29,7 +29,13 @@ class PatronDayTest extends TestCase {
         $this->churchId = (int) DB::table('templomok')->max('id') + 1;
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'PatronDay Teszt';
-        $minta['bucsu'] = 'Búcsú: március 19.';
+        /*
+         * A búcsú a MEGJEGYZÉS mezőből jön (#809), ezért a fixtúrának azt kell
+         * beállítania. A `bucsu` oszlopot kiürítjük, különben a másolt mintatemplom
+         * régi értéke szólna bele — és pont az derülne ki, amit nem akarunk mérni.
+         */
+        $minta['megjegyzes'] = 'Búcsú: március 19.';
+        $minta['bucsu'] = '';
         DB::table('templomok')->insert($minta);
     }
 
@@ -145,8 +151,10 @@ class PatronDayTest extends TestCase {
 
     /** Az értelmezhetetlen mező külön kategória — az javítható adat, nem forrás. */
     public function testAzErtelmezhetetlenMezoKulonSzamit(): void {
+        // #809: a forrás a MEGJEGYZÉS mező, tehát ott kell elhelyezni a szöveget.
         DB::table('templomok')->where('id', $this->churchId)
-            ->update(['bucsu' => 'Búcsú: Szent György vértanú ünnepéhez közelebbi vasárnap']);
+            ->update(['megjegyzes' => 'Búcsú: Szent György vértanú ünnepéhez közelebbi vasárnap',
+                      'bucsu' => '']);
 
         $stat = \Bucsu::forrasStatisztika();
 

--- a/webapp/tests/Unit/BucsuTest.php
+++ b/webapp/tests/Unit/BucsuTest.php
@@ -165,6 +165,56 @@ class BucsuTest extends TestCase {
         self::assertStringContainsString('Szent György', $r['unparsed']);
     }
 
+    // ---- a valódi forrás: a megjegyzés-mező ----------------------------------
+
+    /**
+     * borazslo javítása a #809-hez: „itt a `templomok.bucsu` mezőt használja. Mert hát
+     * valóban mintha lenne ilyen mező, csak nem használjuk egyáltalán. Az osm adatokból
+     * vesszük már a búcsút, vagy ha nincs, akkor a megjegyzés mezőből próbáljuk kitalálni."
+     *
+     * Igaza volt. A megjegyzés viszont HTML-t tartalmaz és zajos — mindkettőt kezelni kell.
+     */
+    public function testAHtmlEntitasosSzovegetIsErtelmezi(): void {
+        // Élesben 807 templomnál így néz ki: B&uacute;cs&uacute; = „Búcsú"
+        $r = \Bucsu::parse('B&uacute;cs&uacute;: augusztus 20.<br /> V&eacute;dőszent: Szent Istv&aacute;n');
+
+        self::assertSame([8, 20], [$r['bucsu']['month'], $r['bucsu']['day']]);
+    }
+
+    public function testABrCimkeHelyereSzokozKerul(): void {
+        $r = \Bucsu::parse('Búcsú: május 1.<br />Szentségimádási nap: június 3.');
+
+        self::assertSame([5, 1], [$r['bucsu']['month'], $r['bucsu']['day']]);
+        self::assertSame([6, 3], [$r['szentsegimadas']['month'], $r['szentsegimadas']['day']]);
+    }
+
+    /**
+     * A zajszűrő: a megjegyzés tele van dátummal, aminek semmi köze a búcsúhoz.
+     * Címke nélkül nem fogadjuk el — 135 templomnál olvastunk ki így téves dátumot.
+     */
+    public function testACimkeFelismeres(): void {
+        self::assertTrue(\Bucsu::containsBucsuLabel('Búcsú: augusztus 20.'));
+        self::assertTrue(\Bucsu::containsBucsuLabel('A templom ünnepe: október 4.'));
+        self::assertTrue(\Bucsu::containsBucsuLabel('B&uacute;cs&uacute;: m&aacute;jus 1.'));
+        self::assertFalse(\Bucsu::containsBucsuLabel('Nyitvatartás: hétfőn 8-tól. Felújítás: március 3.'));
+        self::assertFalse(\Bucsu::containsBucsuLabel(''));
+    }
+
+    /** Pünkösd és húsvéthétfő önmagában is előfordul az adatban. */
+    public function testAPusztaMozgoUnnepnevek(): void {
+        self::assertSame('2026-05-24', \Bucsu::resolve(\Bucsu::parse('Búcsú: pünkösd')['bucsu'], 2026));
+        self::assertSame('2026-04-06', \Bucsu::resolve(\Bucsu::parse('Búcsú: Húsvét hétfő')['bucsu'], 2026));
+    }
+
+    /**
+     * A puszta „húsvét" minta NEM nyelheti el a számozott alakot. Ezt a saját
+     * tesztem fogta meg, miután a puszta mintákat felvettem.
+     */
+    public function testASzamozottHusvetiVasarnapNyer(): void {
+        self::assertSame('2026-04-19',
+            \Bucsu::resolve(\Bucsu::parse('Szent Benedek Húsvét 3. vasárnapja')['bucsu'], 2026));
+    }
+
     // ---- a templom oldali API ------------------------------------------------
 
     /** @param string $bucsu a nyers mezőérték */


### PR DESCRIPTION
@borazslo javítása a #809-hez:

> Ez itten gyanús: `$templomok = \Eloquent\Church::where('ok','i')->whereNotNull('bucsu')->where('bucsu','<>','')`. Az AI át lett verve, mert itt a `templomok.bucsu` mezőt használja. Mert hát valóban mintha lenne ilyen mező, csak nem használjuk egyáltalán. Az osm adatokból vesszük már a búcsút, vagy ha nincs, akkor a megjegyzés mezőből próbáljuk kitalálni. Ugye?

**Igazad volt.** A #794 addigra bement, ezért ez külön PR.

## A különbség nagy

```
bucsu oszlop kitöltve:        218
megjegyzés említ búcsút:     1472
```

És a `bucsu` oszlop **nem is karbantartott**: nincs az `edit.php` `allowedFields` listájában (tehát nem szerkeszthető), és egyetlen sablonban sem jelenik meg — csak a tábla-export adja ki.

## Két dolgot kellett kezelni a valódi mezőn

**HTML.** Van benne `<br />`, `<p class="…">`, és entitásokkal kódolt ékezet — élesben **807 templomnál** `B&uacute;cs&uacute;` áll „Búcsú" helyett. Nyersen olvasva a hónapnevek egy része („m&aacute;rcius") felismerhetetlen.

**Zaj.** A megjegyzés tele van dátummal, aminek semmi köze a búcsúhoz (miserend, nyitvatartás, felújítás). Ha bármelyiket elfogadnám, **135 gondnok kapna téves levelet** arról, hogy „közeleg a búcsú". Ezért a megjegyzésből csak akkor olvasok ki búcsút, ha a szöveg maga is kimondja — a célzott forrásoknál (`patron_day`, `bucsu` oszlop) erre nincs szükség, ott a mező neve maga a bizonyíték.

## Sorrend

`patron_day` → megjegyzés (címkével) → `bucsu` oszlop (utolsó tartalék, néhány templomnál csak ott van adat).

## Eredmény

```
166  ->  2731 templomnál ismerünk fel búcsú-dátumot
```

A maradék „gyanús" eseteket egyenként megnéztem: mind jogos, a „templom ünnepe" címkét használják.

## Egy hibát a saját tesztem fogott meg

Pótoltam néhány mozgó ünnepet (pünkösd, húsvéthétfő önmagában) — és ezzel elrontottam a számozott alakot: a puszta „húsvét" minta elnyelte a „Húsvét 3. vasárnapja"-t, és magát húsvétot adta vissza. A sorrend javítva, teszt rögzíti.

```
PHP-suite: 1140 teszt, 2537 állítás — zöld
```

Kapcsolódik: #568, #809