### PR TITLE
Egy teszt ne tilthassa le az összes templomot

### DIFF
--- a/webapp/tests/Integration/OsmBoundariesTest.php
+++ b/webapp/tests/Integration/OsmBoundariesTest.php
@@ -15,6 +15,9 @@ use Illuminate\Database\Capsule\Manager as DB;
  */
 class OsmBoundariesTest extends TestCase {
 
+    /** @var array<int,int> a setUp előtt aktív templomok azonosítói */
+    private array $eredetilegAktiv = [];
+
     /** @var int ID of the primary test church inserted in setUp */
     private int $testChurchId;
 
@@ -32,6 +35,16 @@ class OsmBoundariesTest extends TestCase {
         // őket. Ezért ok='n'-re állítjuk: a checkBoundaries ELSŐ szűrője where('ok','i'),
         // így a seed teljesen kiesik. Csak a lentebb beszúrt (ok='i') fixture-ök maradnak.
         // A tranzakció a tearDown-ban visszagördül, a seed érintetlen marad.
+        //
+        // …ELVILEG. MySQL/MariaDB alatt a DDL IMPLICIT COMMITOT okoz: ha a futás során
+        // bárhol lefut egy ALTER/CREATE, a nyitott tranzakció csendben lezárul, és a
+        // tearDown rollBack()-je már nem csinál semmit. Ilyenkor ez a WHERE nélküli
+        // tömeges UPDATE a teljes seedet letiltva hagyja — 5050 templom tűnik el a
+        // fejlesztői adatbázisból, hiba és jelzés nélkül. Pontosan ez történt velem.
+        //
+        // Ezért feljegyezzük, kik voltak aktívak, és a tearDown vissza is állítja őket,
+        // ha a visszagördülés elmaradt.
+        $this->eredetilegAktiv = DB::table('templomok')->where('ok', 'i')->pluck('id')->all();
         DB::table('templomok')->update(['ok' => 'n']);
 
         $this->testChurchId = $this->insertChurch([
@@ -45,6 +58,22 @@ class OsmBoundariesTest extends TestCase {
 
     protected function tearDown(): void {
         DB::rollBack();
+
+        /*
+         * Biztonsági háló a fenti WHERE nélküli UPDATE alá. Ha a rollBack() megtette a
+         * dolgát, ez a lekérdezés nem talál semmit, és nem is ír. Ha viszont a
+         * tranzakció egy implicit commit miatt már lezárult, itt állítjuk helyre a
+         * seedet — a fejlesztő ne azzal szembesüljön, hogy üres lett a kereső.
+         */
+        $hianyzo = array_values(array_diff(
+            $this->eredetilegAktiv,
+            DB::table('templomok')->where('ok', 'i')->pluck('id')->all()
+        ));
+
+        if ($hianyzo !== []) {
+            DB::table('templomok')->whereIn('id', $hianyzo)->update(['ok' => 'i']);
+        }
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
Az `OsmBoundariesTest` a seedet **WHERE nélküli tömeges UPDATE-tel** teszi láthatatlanná, és a visszaállítást a tranzakció visszagördülésére bízza:

```php
// A tranzakció a tearDown-ban visszagördül, a seed érintetlen marad.
DB::table('templomok')->update(['ok' => 'n']);
```

**Elvileg.** MySQL/MariaDB alatt viszont a **DDL implicit commitot okoz**: ha a futás során bárhol lefut egy `ALTER`/`CREATE`, a nyitott tranzakció csendben lezárul, és a `rollBack()` már nem csinál semmit. Ilyenkor a teljes seed letiltva marad — **5050 templom tűnik el a fejlesztői adatbázisból, hiba és jelzés nélkül.**

## Nem elmélet

Pont ez történt velem munka közben. A kereső üres lett, a búcsú-statisztikáim értelmetlen számokat adtak (1540 helyett 17), és percekbe telt, mire kiderült, hogy **nem a kódom rossz, hanem az adatbázis**. A seedből kellett visszatöltenem.

A csúnya ebben az, hogy semmi nem jelez: a tesztek zölden lefutnak, a rollback „megtörténik", és a kár csak később, máshol derül ki.

## A javítás

Feljegyzem, kik voltak aktívak a `setUp` előtt, és a `tearDown` visszaállítja őket, ha a visszagördülés elmaradt. Ha a `rollBack()` megtette a dolgát, a háló nem talál semmit és nem ír.

Magát a tömeges UPDATE-et **nem veszem el**: a tesztnek szüksége van rá, hogy a `checkBoundaries()` ne a seedet szedje fel a fixtúrák helyett — ezt a komment részletesen indokolja is.

```
PHP-suite: zöld, a teszt után 5050 aktív templom (mint előtte)
```