### PR TITLE
Zöldre viszem a mastert: a keresőteszt még az eldobott varos oszlopba írt

### DIFF
--- a/webapp/tests/Integration/OsmNameSearchTest.php
+++ b/webapp/tests/Integration/OsmNameSearchTest.php
@@ -26,14 +26,39 @@ class OsmNameSearchTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        // Az árva `lookup_boundary_church` sorok miatt nem elég a templomok maximuma:
+        // egy régi, törölt templom azonosítójára ütköznénk rá.
+        $this->churchId = max(
+            (int) DB::table('templomok')->max('id'),
+            (int) DB::table('lookup_boundary_church')->max('church_id')
+        ) + 1;
 
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Hivatalos Teszt-templom';
         $minta['ismertnev'] = '';
-        $minta['varos'] = 'Tesztfalu';
         $minta['ok'] = 'i';
         DB::table('templomok')->insert($minta);
+
+        /*
+         * #496/#497/#498: a település már NEM a `templomok.varos` oszlopban van — azt
+         * a kivezetés eldobta —, hanem az OSM-határláncban. A teszt eddig az oszlopba
+         * írt, ezért az oszlop eldobása után az INSERT elhasalt, és vele az egész
+         * osztály. A településre keresés viszont fontos eset, ezért nem esik ki:
+         * határként vesszük fel, ahogy élesben is van.
+         */
+        $boundaryId = DB::table('boundaries')->insertGetId([
+            'boundary'    => 'administrative',
+            'admin_level' => 8,
+            'name'        => 'Tesztfalu',
+            'alt_name'    => '',
+            'iso3166_1'   => '',
+            'osmtype'     => 'relation',
+            'osmid'       => 990001,
+        ]);
+        DB::table('lookup_boundary_church')->insert([
+            'boundary_id' => $boundaryId,
+            'church_id'   => $this->churchId,
+        ]);
     }
 
     protected function tearDown(): void {
@@ -57,7 +82,11 @@ class OsmNameSearchTest extends TestCase {
         return \Eloquent\Church::where('templomok.id', $this->churchId)
             ->where(function ($query) use ($minta) {
                 $query->where('nev', 'LIKE', $minta)
-                    ->orWhere('varos', 'LIKE', $minta)
+                    // A település a határláncból jön, nem oszlopból (#496/#497/#498).
+                    ->orWhereHas('boundaries', function ($q) use ($minta) {
+                        $q->where('boundary', 'administrative')
+                          ->where('name', 'LIKE', $minta);
+                    })
                     ->orWhere('ismertnev', 'LIKE', $minta)
                     ->orWhereHas('attributes', function ($q) use ($minta) {
                         $q->where('value', 'LIKE', $minta)


### PR DESCRIPTION
**A master PHPUnit-ja most piros, és emiatt minden nyitott PR is az.**

Az ok: a helyoszlopok kivezetése eldobta a `templomok.varos` oszlopot, de az `OsmNameSearchTest` `setUp`-ja továbbra is abba írt:

```
Column not found: 1054 Unknown column 'varos' in 'INSERT INTO'
```

Az INSERT elhasal, és vele az osztály **mind a tíz tesztje**. Amelyik PR nem hozza magával a javítást, az ettől piros lesz — akkor is, ha a saját változásával minden rendben.

**Mit csináltam.** A településre keresés fontos eset (a látogató a falura keres, nem a titulusra), ezért nem ejtettem ki a tesztet. Ehelyett a település oda került, ahol élesben is van: **az OSM-határláncba**. A lekérdezés is a határra illeszt, nem oszlopra — tehát most azt méri, ami a valóság.

Egy mellékes javítás is kellett: az azonosítót a `lookup_boundary_church` maximumára is figyelve választom. Vannak benne árva sorok régen törölt templomokhoz, és a puszta `max(templomok.id)+1` ezekre ütközne rá.

Ez a PR **semmi mást nem tartalmaz** — szándékosan, hogy azonnal mehessen, és a többi PR-ről lekerüljön a piros.