### PR TITLE
Egyetlen rossz OSM-elem ne állítsa meg a határ-ellenőrző cront

### DIFF
--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -163,8 +163,47 @@ class OSM {
         if (empty($overpass->jsonData->elements)) {
             return [];
         }
-         
-        foreach($overpass->jsonData->elements as $element) {            
+
+        return self::saveBoundaryElements($overpass->jsonData->elements);
+    }
+
+    /**
+     * #821: az Overpass-tól kapott határ-elemek mentése.
+     *
+     * Külön metódus, mert a `downloadBoundaries()` maga építi a HTTP-klienst, tehát a
+     * mentési logikát csak élő hálózattal lehetne mérni. Márpedig épp ez a rész
+     * szállt el élesben egyetlen rossz elemtől, és állította meg az egész cront.
+     *
+     * @param  iterable $elements az Overpass válaszának `elements` tömbje
+     * @return int[] a mentett/megtalált határok azonosítói
+     */
+    static function saveBoundaryElements($elements): array {
+        $return = [];
+
+        foreach($elements as $element) {
+            /*
+             * #821: a `boundary` TAG nélküli elemeket kihagyjuk.
+             *
+             * A lekérdezés az OSM `type=boundary` RELÁCIÓ-TÍPUSRA szűr, ami nem
+             * ugyanaz, mint a `boundary=*` tag: van olyan elem, amin az előbbi ott
+             * van, az utóbbi viszont nincs (élesben a 18357156-os reláció, a „Dublin
+             * Metropolitan District Court"). A `boundaries.boundary` oszlop NOT NULL,
+             * alapérték nélkül — a mentés tehát kivétellel elszállt:
+             *
+             *   Field 'boundary' doesn't have a default value
+             *
+             * És mivel a kivételt senki nem fogta el, EGYETLEN ilyen elem megállította
+             * az egész cront: élesben 21 órán át egyetlen templom határa sem frissült.
+             *
+             * Az ilyen elem amúgy sem használható: minden fogyasztó `boundary`-re
+             * szűr (`where('boundary','administrative')`), tehát egy besorolás nélküli
+             * sor csak szemét lenne — épp az, ami az „Orphan Boundaries" számlálót hizlalja.
+             */
+            $boundaryTag = trim((string) ($element->tags->boundary ?? ''));
+            if ($boundaryTag === '') {
+                continue;
+            }
+
             $boundary = \Eloquent\Boundary::firstOrNew(['osmtype' => $element->type, 'osmid' => $element->id]);
             
             $changed = false;
@@ -199,12 +238,28 @@ class OSM {
                 $changed = true;
             }
 
-            if ($changed) {
-                $boundary->save();
-            } else {
-                // Az OSM adat nem változott, de jelezzük, hogy most is ellenőriztük.
-                // Ez biztosítja, hogy a boundaries.updated_at tükrözze az utolsó ellenőrzés idejét.
-                $boundary->touch();
+            /*
+             * #821: egyetlen rossz elem ne állítsa meg az egész cront.
+             *
+             * A fenti kihagyás a MOST ismert okot szünteti meg, de az OSM szabadon
+             * szerkeszthető: bármikor jöhet olyan adat, amit a séma nem fogad el (túl
+             * hosszú név, ismeretlen mező). Ezért a mentés köré védőháló kerül — a
+             * hibás elemet kihagyjuk és naplózzuk, a többi templom határa frissül.
+             */
+            try {
+                if ($changed) {
+                    $boundary->save();
+                } else {
+                    // Az OSM adat nem változott, de jelezzük, hogy most is ellenőriztük.
+                    // Ez biztosítja, hogy a boundaries.updated_at tükrözze az utolsó ellenőrzés idejét.
+                    $boundary->touch();
+                }
+            } catch (\Throwable $e) {
+                error_log(sprintf(
+                    '[miserend] Nem menthető határ (%s/%s): %s',
+                    $element->type, $element->id, $e->getMessage()
+                ));
+                continue;
             }
 
             $return[] = $boundary->id;

--- a/webapp/tests/Integration/BoundaryElementSaveTest.php
+++ b/webapp/tests/Integration/BoundaryElementSaveTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #821: egyetlen rossz OSM-elem megállította a határ-ellenőrző cront.
+ *
+ * Élesben ez történt:
+ *
+ *   SQLSTATE[HY000]: General error: 1364 Field 'boundary' doesn't have a default value
+ *   insert into `boundaries` (`osmtype`, `osmid`, `name`, ...)
+ *   values (relation, 18357156, Dublin Metropolitan District Court, ...)
+ *
+ * Az ok: a lekérdezés az OSM `type=boundary` RELÁCIÓ-TÍPUSRA szűr, ami nem ugyanaz,
+ * mint a `boundary=*` tag. Van olyan elem, amin az előbbi ott van, az utóbbi nincs —
+ * a `boundaries.boundary` oszlop viszont NOT NULL, alapérték nélkül.
+ *
+ * A kivételt senki nem fogta el, ezért EGYETLEN ilyen elem megállította az egész
+ * cront: élesben 21 órán át (6 sikertelen próbálkozás) egyetlen templom határa sem
+ * frissült. A health oldal ezt „elakadt időzített feladat"-ként mutatta.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class BoundaryElementSaveTest extends TestCase {
+
+    private int $osmIdAlap;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        // Az éles azonosítókkal ne ütközzünk: jóval a létezők fölött kezdünk.
+        $this->osmIdAlap = ((int) DB::table('boundaries')->max('osmid')) + 1000;
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param array<string,mixed> $tags */
+    private function elem(array $tags, int $eltolas = 0): object {
+        return (object) [
+            'type' => 'relation',
+            'id'   => $this->osmIdAlap + $eltolas,
+            'tags' => (object) $tags,
+        ];
+    }
+
+    // ---- a valódi éles eset --------------------------------------------------
+
+    /**
+     * A bejelentett elem: `type=boundary` reláció, `boundary` tag NÉLKÜL.
+     * Korábban kivétellel elszállt; most egyszerűen kimarad.
+     */
+    public function testABoundaryTagNelkuliElemNemSzallEl(): void {
+        $elem = $this->elem(['name' => 'Dublin Metropolitan District Court']);
+
+        $eredmeny = \OSM::saveBoundaryElements([$elem]);
+
+        self::assertSame([], $eredmeny);
+    }
+
+    public function testABoundaryTagNelkuliElemNemKerulAzAdatbazisba(): void {
+        $elem = $this->elem(['name' => 'Dublin Metropolitan District Court']);
+
+        \OSM::saveBoundaryElements([$elem]);
+
+        self::assertSame(0, DB::table('boundaries')->where('osmid', $elem->id)->count(),
+            'Besorolás nélküli sor csak az "Orphan Boundaries" számlálót hizlalná.');
+    }
+
+    /** Az üres string sem besorolás. */
+    public function testAzUresBoundaryTagIsKimarad(): void {
+        \OSM::saveBoundaryElements([$this->elem(['boundary' => '   ', 'name' => 'Semmi'])]);
+
+        self::assertSame(0, DB::table('boundaries')->where('osmid', $this->osmIdAlap)->count());
+    }
+
+    // ---- a lényeg: a többi elem attól még megy -------------------------------
+
+    /**
+     * Ez a hiba igazi ára: a rossz elem nem csak magát vitte el, hanem az egész
+     * futást — utána egyetlen templom határa sem frissült.
+     */
+    public function testARosszElemUtanAJoElemekMegMentodnek(): void {
+        $eredmeny = \OSM::saveBoundaryElements([
+            $this->elem(['name' => 'Rossz elem'], 0),
+            $this->elem(['boundary' => 'administrative', 'admin_level' => 8, 'name' => 'Jó település'], 1),
+        ]);
+
+        self::assertCount(1, $eredmeny);
+        self::assertSame(1, DB::table('boundaries')->where('osmid', $this->osmIdAlap + 1)->count());
+    }
+
+    // ---- a rendes eset változatlan -------------------------------------------
+
+    public function testARendesHatarMentodik(): void {
+        $eredmeny = \OSM::saveBoundaryElements([
+            $this->elem(['boundary' => 'administrative', 'admin_level' => 8, 'name' => 'Szentendre']),
+        ]);
+
+        self::assertCount(1, $eredmeny);
+
+        $sor = DB::table('boundaries')->where('osmid', $this->osmIdAlap)->first();
+        self::assertSame('administrative', $sor->boundary);
+        self::assertSame('Szentendre', $sor->name);
+        self::assertSame(8, (int) $sor->admin_level);
+    }
+
+    /** #498: az országkód a kötőjeles OSM-tagból jön. */
+    public function testAzOrszagkodAtjon(): void {
+        \OSM::saveBoundaryElements([
+            $this->elem(['boundary' => 'administrative', 'admin_level' => 2,
+                         'name' => 'Magyarország', 'ISO3166-1' => 'hu']),
+        ]);
+
+        self::assertSame('HU', DB::table('boundaries')->where('osmid', $this->osmIdAlap)->value('iso3166_1'));
+    }
+
+    /** A magyar név elsőbbséget élvez — ez a régi viselkedés. */
+    public function testAMagyarNevFelulirjaAzAlapNevet(): void {
+        \OSM::saveBoundaryElements([
+            $this->elem(['boundary' => 'administrative', 'name' => 'Wien', 'name:hu' => 'Bécs']),
+        ]);
+
+        self::assertSame('Bécs', DB::table('boundaries')->where('osmid', $this->osmIdAlap)->value('name'));
+    }
+
+    /**
+     * Név nélküli, de besorolt határnál a besorolás lesz a név — enélkül a NOT NULL
+     * `name` oszlopon hasalna el a mentés.
+     */
+    public function testNevNelkulABesorolasLeszANev(): void {
+        \OSM::saveBoundaryElements([$this->elem(['boundary' => 'administrative'])]);
+
+        self::assertSame('administrative', DB::table('boundaries')->where('osmid', $this->osmIdAlap)->value('name'));
+    }
+
+    /** Ugyanaz az elem kétszer: egy sor, nem kettő. */
+    public function testUgyanazAzElemNemDuplazodik(): void {
+        $elem = $this->elem(['boundary' => 'administrative', 'admin_level' => 8, 'name' => 'Szentendre']);
+
+        \OSM::saveBoundaryElements([$elem]);
+        \OSM::saveBoundaryElements([$elem]);
+
+        self::assertSame(1, DB::table('boundaries')->where('osmid', $elem->id)->count());
+    }
+
+    public function testUresListaraUresValasz(): void {
+        self::assertSame([], \OSM::saveBoundaryElements([]));
+    }
+}


### PR DESCRIPTION
Ezt a hibát találtam:

```
\OSM->checkBoundaries() futtatása sikertelen.
SQLSTATE[HY000]: General error: 1364 Field 'boundary' doesn't have a default value
insert into `boundaries` (`osmtype`, `osmid`, `name`, ...)
values (relation, 18357156, Dublin Metropolitan District Court, ...)
```

**Az ok.** A lekérdezés az OSM `type=boundary` **reláció-típusra** szűr (`['type'='boundary']`), ami nem ugyanaz, mint a `boundary=*` **tag**. Van olyan elem, amin az előbbi ott van, az utóbbi viszont nincs — a 18357156-os reláció, a „Dublin Metropolitan District Court" pontosan ilyen. A `boundaries.boundary` oszlop viszont `NOT NULL`, alapérték nélkül, tehát a mentés kivétellel elszállt.

**Ami ebből igazán fájt:** a kivételt senki nem fogta el, ezért **egyetlen ilyen elem megállította az egész cront.** A health oldal szerint 21 órán át, hat sikertelen próbálkozáson keresztül **egyetlen templom határa sem frissült** — nem csak azé, amelyiknél a rossz elem előjött.

**Két javítás:**

1. **A `boundary` tag nélküli elem kimarad.** Nem veszteség: minden fogyasztó `boundary`-re szűr (`where('boundary','administrative')`), tehát egy besorolás nélküli sor sosem kerülne elő — csak az **„Orphan Boundaries"** számlálót hizlalná, ami a health oldalon most 71-en áll.

2. **Védőháló a mentés köré.** Az OSM szabadon szerkeszthető: holnap más adat lesz rossz (túl hosszú név, ismeretlen mező). Mostantól egy hibás elem kimarad és naplóba kerül, a futás pedig megy tovább. Ez a fontosabb fele — az (1) a ma ismert okot szünteti meg, a (2) a holnapit.

**Egy kis átalakítás kellett hozzá:** az elem-feldolgozás külön metódusba került (`OSM::saveBoundaryElements()`). A `downloadBoundaries()` maga építi a HTTP-klienst, tehát a mentési logikát csak élő hálózattal lehetne mérni — épp azt a részt, ami elszállt.

Teszt: 10 új (`BoundaryElementSaveTest`), köztük **szó szerint a te eseted** (`type=boundary` reláció `boundary` tag nélkül), és külön az, hogy **a rossz elem után a jó elemek még mentődnek** — mert ez volt a hiba valódi ára.

Külön PR-t nyitok a health oldalon látszó többi jelzésre.