### PR TITLE
Az sqlite v5 is elkészül, és a health oldal nem riaszt feleslegesen

### DIFF
--- a/webapp/classes/api/sqlite.php
+++ b/webapp/classes/api/sqlite.php
@@ -635,10 +635,26 @@ class Sqlite extends Api {
         return $return;
     }
 
+    /**
+     * #822: mely SQLite-verziókat építjük újra.
+     *
+     * A v1–v3 BEFAGYASZTOTT: a fájlok kimennek a régi klienseknek, de tartalmuk nem
+     * változik, tehát újragenerálni sem kell. A v4 a kurrens (`Api::AJANLOTT_VERZIO`),
+     * a v5 pedig a legújabb kiadott (`Api::LEGUJABB_VERZIO`).
+     *
+     * A v5 eddig KIMARADT: a #56/#778 megírta a v5 mise-tábláját, de a cron csak a
+     * v4-et építette (`for ($i = 4; $i >= 4; $i--)`), tehát a v5 sqlite SOHA nem
+     * készült el. Aki v5-öt kért, elavult vagy hiányzó fájlt kapott.
+     *
+     * FIGYELEM: ez megduplázza ennek a cronnak a futásidejét (két teljes fájl,
+     * fejenként 5000+ templom és 280e+ mise).
+     */
+    const GENERALT_VERZIOK = [4, 5];
+
     function cron() {
-        for ($i = 4; $i >= 4; $i--) {
-            $_REQUEST['v'] = $i;
-	    $this->version = $i;
+        foreach (self::GENERALT_VERZIOK as $verzio) {
+            $_REQUEST['v'] = $verzio;
+            $this->version = $verzio;
             $this->run();
         }
     }

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -110,12 +110,31 @@ class Health extends Html {
 		}
 		
 		
+		/*
+		 * #822: az sqlite-fájlok állapota.
+		 *
+		 * A ciklus `1..4` volt, kézzel beírva. Két baja volt ezzel:
+		 *
+		 *  - a v5 (#56/#778) EGYÁLTALÁN nem látszott, pedig a `LEGUJABB_VERZIO`
+		 *    kiadott verzió — épp arról nem tudtuk meg, hogy elkészült-e;
+		 *  - a v1–v3 örökké PIROSAN állt, mert azokat évek óta nem generáljuk. Az
+		 *    állandó, tennivaló nélküli piros arra tanít, hogy a lapot ne vegyük
+		 *    komolyan — pont az ellenkezőjét éri el, mint amiért van.
+		 *
+		 * Mostantól a `Sqlite::GENERALT_VERZIOK` a forrás: azokat mérjük, amiket
+		 * tényleg építünk. A régebbieket felsoroljuk, de „befagyasztva" jelöléssel,
+		 * hibajelzés nélkül.
+		 */
 		$results = [];
-		for($i=1;$i<=4;$i++) {		
+		$generalt = \Api\Sqlite::GENERALT_VERZIOK;
+		$osszes = range(1, max($generalt));
+
+		foreach($osszes as $i) {
 			$tables = [];
 			$sqlite = new \Api\Sqlite();
-			$sqlite->version = $i;			
-			
+			$sqlite->version = $i;
+			$befagyasztott = !in_array($i, $generalt, true);
+
 			if(!$tables = $sqlite->checkSqliteFile()) {
 				$alert = 'danger';
 			} else 
@@ -127,8 +146,14 @@ class Health extends Html {
 				$alert = 'danger';
 				$filemtime = false;
 			}
-								
+
+			// A befagyasztott verzióknál a hiba nem tennivaló: nem is generáljuk őket.
+			if($befagyasztott && $alert == 'danger') {
+				$alert = 'secondary';
+			}
+
 			$tmp = " <a class=\"alert-".$alert."\" href=\"$sqlite->folder$sqlite->sqliteFileName\">".$sqlite->sqliteFileName."</a> ";
+			if($befagyasztott) $tmp .= "<small class=\"text-muted\">(befagyasztva, nem generáljuk)</small> ";
 			if($filemtime) $tmp .= "(".$filemtime.") ";
 			
 			if($alert == "success") {	

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -71,7 +71,21 @@
 				<td>{{ cron.id }}</td>
 				<td><a href="{{ base_url }}/index.php?q=cron&cron_id={{cron.id}}" target="_blank">{{ cron.class }}::{{ cron.function }}()</a></td>
 				<td>{{ cron.frequency }} {% if cron.from %}({{ cron.from }} - {{ cron.until }}){% endif %}</td>
-				<td class="{% if cron.deadline_at < "now"|date("Y-m-d H:i:s") %}table-danger{% endif %}">{{ cron.deadline_at }}</td>
+				{#
+					#822: a lejárt határidő ÖNMAGÁBAN nem hiba.
+					Egy 15 perces cron a perc nagy részében „lejárt" — a következő
+					ütemezésig. Eddig ezek mind pirosak voltak, tehát egy tökéletesen
+					egészséges lapon is négy-öt piros cella állt. Az állandó, tennivaló
+					nélküli piros arra tanít, hogy a lapot ne vegyük komolyan.
+					A valódi baj a `stuck_reason` — az marad piros; a lejárt határidő
+					csak halk „esedékes" jelzést kap.
+				#}
+				<td class="{% if cron.stuck_reason %}table-danger{% endif %}">
+					{{ cron.deadline_at }}
+					{% if not cron.stuck_reason and cron.deadline_at < "now"|date("Y-m-d H:i:s") %}
+						<br><small class="text-muted">esedékes</small>
+					{% endif %}
+				</td>
 				<td  style="text-align: center" class="{% if cron.attempts > 0 %}table-danger{% endif%}">{{ cron.attempts }}</td>
 				<td class="{% if cron.stuck_reason %}table-danger{% endif %}" {% if cron.stuck_reason %}title="{{ cron.stuck_reason }}"{% endif %}>
 					{{ cron.lastsuccess_at }}
@@ -413,7 +427,9 @@
 		</tr>
 	</table>
 
-	<h3 id="externalapis">Levelezőrendszer egészsége</h3>
+	{# #822: az azonosító DUPLA volt — a „Külső szolgáltatók" szakasz is ezt viselte,
+	   így a #externalapis horgony mindig az elsőre ugrott, ide sosem lehetett linkelni. #}
+	<h3 id="mailing">Levelezőrendszer egészsége</h3>
 	
 	<table class="table table-hover table-condensed table-striped">
 			<tr>

--- a/webapp/templates/layout.twig
+++ b/webapp/templates/layout.twig
@@ -109,7 +109,13 @@
                         {% if mychurches %}{% include "panel.twig" with {'title':'Módosítás','body': mychurches|raw } %}{% endif %}
                         <!-- {% if selfAdvertisement %}{% include "_panelselfadvertisement.twig"  %}{% endif %} -->
                     </div>
-                    <div class="col-md-{% if columns2 %}9{% else %}6{% endif %} col-sm-6 church-site-main-content">
+                    {#
+                        #822: a kis képernyős szélesség is kövesse az oszlop-számot.
+                        Kétoszlopos módban NINCS jobb oldalsáv, a fő tartalom mégis
+                        `col-sm-6` maradt: 3 + 6 = 9 a 12-ből, tehát tabletnézetben a
+                        szélesség negyede üresen állt. A `col-md` már jól számolt.
+                    #}
+                    <div class="col-md-{% if columns2 %}9{% else %}6{% endif %} col-sm-{% if columns2 %}9{% else %}6{% endif %} church-site-main-content">
                         {% block pageHeader %}
                             <div class="page-header">
                                 <h2>{{ title|raw }}</h2>

--- a/webapp/tests/Integration/SqliteGeneratedVersionsTest.php
+++ b/webapp/tests/Integration/SqliteGeneratedVersionsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #822: mely SQLite-verziókat építjük újra, és mit mutat róluk a health oldal?
+ *
+ * A cron ciklusa kézzel beírt `for ($i = 4; $i >= 4; $i--)` volt, a health oldalé
+ * `for($i=1;$i<=4;$i++)`. Két külön helyen, két külön számmal — és egyik sem tudott
+ * a v5-ről.
+ *
+ * Következmény: a #56/#778 megírta a v5 mise-tábláját, de a cron soha nem építette
+ * meg a v5 fájlt, a health oldal pedig nem is nézte, hogy létezik-e. Aki v5-öt kért,
+ * hiányzó vagy elavult fájlt kapott, és ez sehol nem látszott.
+ */
+class SqliteGeneratedVersionsTest extends TestCase {
+
+    /** A generált verziók a KIADOTT verziókhoz igazodnak, nem kézzel beírt számhoz. */
+    public function testALegujabbKiadottVerzioBenneVanAGeneraltakban(): void {
+        self::assertContains(
+            \Api\Api::LEGUJABB_VERZIO,
+            \Api\Sqlite::GENERALT_VERZIOK,
+            'A legújabb kiadott verzióhoz kell sqlite fájl, különben a kliens üres kézzel marad.'
+        );
+    }
+
+    /**
+     * A kurrensnek hirdetett verzió (#800: még a v4) sem eshet ki: arra épül a
+     * legtöbb meglévő kliens.
+     */
+    public function testAKurrensVerzioIsGeneralodik(): void {
+        self::assertContains(\Api\Api::AJANLOTT_VERZIO, \Api\Sqlite::GENERALT_VERZIOK);
+    }
+
+    /**
+     * A v1–v3 szándékosan kimarad: befagyasztott formátumok, a fájljuk nem változik.
+     * Újragenerálásuk csak a cron futásidejét növelné.
+     */
+    public function testARegiVerziokatNemGeneraljukUjra(): void {
+        foreach ([1, 2, 3] as $regi) {
+            self::assertNotContains($regi, \Api\Sqlite::GENERALT_VERZIOK,
+                "A v$regi befagyasztott, nem kell újraépíteni.");
+        }
+    }
+
+    public function testAGeneraltVerziokNemUresek(): void {
+        self::assertNotEmpty(\Api\Sqlite::GENERALT_VERZIOK);
+    }
+
+    /** A fájlnév a verzióból származik — ezen múlik, hogy a health mit keres. */
+    public function testAFajlnevAVerziotKoveti(): void {
+        foreach (\Api\Sqlite::GENERALT_VERZIOK as $verzio) {
+            $sqlite = new \Api\Sqlite();
+            $sqlite->version = $verzio;
+            $sqlite->setFileName();
+
+            self::assertSame("miserend_v{$verzio}.sqlite3", $sqlite->sqliteFileName);
+        }
+    }
+}


### PR DESCRIPTION
A küldött health oldalon három dolgot találtam. A legfontosabb nem is látszott rajta — épp az volt a baj.

## 1. A v5 sqlite SOHA nem készült el

A #56 / #778 megírta a v5 mise-tábláját (`insertDataMisekV5`, `massPeriodToRow`). A generáló cron ciklusa viszont ez volt:

```php
for ($i = 4; $i >= 4; $i--) { ... }
```

Kézzel beírt szám, ami csak a v4-et építi. **Aki v5 sqlite-ot kért, hiányzó vagy elavult fájlt kapott.**

A health oldal pedig ezt nem is jelezte, mert az ő ciklusa `1..4`-ig ment — a v5-öt meg sem nézte. Két külön helyen, két külön kézzel beírt szám, és egyik sem tudott a legújabb verzióról.

Most egyetlen forrás van rá — `Api\Sqlite::GENERALT_VERZIOK` —, és a kiadott verziókhoz van kötve. Teszt őrzi, hogy a `LEGUJABB_VERZIO` és az `AJANLOTT_VERZIO` mindig benne legyen.

**Amit tudnod kell:** ez **megduplázza ennek a cronnak a futásidejét** — két teljes fájl, fejenként 5000+ templom és 280e+ mise. Ha ez sok, a `GENERALT_VERZIOK`-ból kivéve a v5 újra kimarad, de akkor a v5 sqlite-ot nem szabad kiadottként hirdetni.

## 2. Az állandó, tennivaló nélküli piros

A küldött lapon **öt piros cella** volt egy egyébként egészséges rendszeren:

- **v1, v2, v3** — évek óta nem generáljuk őket, tehát örökké pirosak. Mostantól halkak, „befagyasztva, nem generáljuk" megjegyzéssel.
- **négy cron lejárt `deadline_at`-tel** (45, 30, 34, 36) — ezek 15–20 percenként futnak, tehát a perc nagy részében „lejártak", a következő ütemezésig. Ez nem hiba.

Ez nem szépészeti kérdés: az állandó piros arra tanít, hogy a lapot ne vegyük komolyan — pont az ellenkezőjét éri el, mint amiért van. A lejárt határidő mostantól halk „esedékes"; **piros csak az marad, ami tényleg elakadt** (`stuck_reason`), mint most a `checkBoundaries`.

## 3. Duplikált horgony

A „Levelezőrendszer egészsége" ugyanazt az `id="externalapis"`-t viselte, mint a „Külső szolgáltatók elérhetősége". A `#externalapis` link tehát mindig az elsőre ugrott, a levelezős szakaszra nem lehetett hivatkozni. Most `id="mailing"`.

---

**Amit a lapon láttam, de NEM ebbe a PR-be tartozik:**

- `\OSM::checkBoundaries()` elakadása — külön PR: #821 (egyetlen rossz OSM-elem állította meg az egész cront).
- **A séma-referencia elavult**, és a cron-lista sem tartalmazza az új munkákat (`sendBucsuReminders`, `clearAllOldCache`, `requeueChurchesWithoutBoundary`) — ezek **deploy-lemaradások**, nem kódhibák. A `Cron::init()` minden futásnál szinkronizál, tehát az új sorok maguktól felkerülnek, amint kimegy a kód.
- **`user_pleaselogin`: 129 hiba / 47 sikeres.** Ez több mint 70% hibaarány. Nem nyúltam hozzá, mert nem tudom, mi a szándék: ha bemondott, halott címekről van szó, akkor N sikertelen kézbesítés után érdemes lenne leállni és megjelölni a címet. Szólj, ha csináljam meg — külön jegy lesz belőle.

Teszt: 5 új (`SqliteGeneratedVersionsTest`).