### PR TITLE
Nem felejtjük el 90 naponta, hogy egy cím kézbesíthetetlen

### DIFF
--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -158,10 +158,29 @@ class Crons {
 			'churchholders_asked_admin',
 			'image_admin', 'image_diocese', 'image_responsible',
 		];
+		/*
+		 * #823: a HIBÁS leveleket megtartjuk.
+		 *
+		 * A `User::isUndeliverable()` pontosan ezekből a sorokból tudja, hogy egy címre
+		 * már háromszor nem sikerült kézbesíteni — az az egyetlen bizonyíték. Ha 90 nap
+		 * után kitöröljük, a bizonyíték eltűnik, és az értesítő cron újrakezdi a
+		 * próbálkozást: három kísérlet, majd megint 90 nap, megint három. Örökre.
+		 *
+		 * Nem nő el: a harmadik hiba után nem küldünk többet, tehát címenként és
+		 * típusonként legfeljebb három ilyen sor keletkezik. Ha a cím később mégis
+		 * működni kezd, a sikeres levél időbélyege érvényteleníti a korábbi hibákat
+		 * (az `isUndeliverable()` csak az utolsó siker UTÁNI hibákat számolja).
+		 */
 		$cutoff = date('Y-m-d H:i:s', strtotime('-90 days'));
 		DB::table('emails')
 			->where('created_at', '<', $cutoff)
 			->whereIn('type', $deletableTypes)
+			// A NULL státuszt is töröljük: az nem hiba-bizonyíték, csak régi, státusz
+			// nélküli sor — a puszta `<> 'error'` viszont az SQL NULL-logikája miatt
+			// kihagyná (NULL <> 'error' eredménye NULL, nem igaz).
+			->where(function ($q) {
+				$q->whereNull('status')->orWhere('status', '<>', 'error');
+			})
 			->delete();
 	}
 

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -924,6 +924,22 @@ class User {
 		// $tmp = new stdClass(); $tmp->uid = 1595; $users2notify = [ $tmp ];
 				
 		foreach($users2notify as $user2notify) {
+			/*
+			 * #823: a kézbesíthetetlen címeket itt is kihagyjuk.
+			 *
+			 * A másik két értesítő (`user_pleaseactivate`, `user_pleaselogin`) már így
+			 * működik, ez viszont kimaradt — pedig ugyanabba a körbe fut: a levél
+			 * elhasal, a fiók marad, a következő futás újra próbálkozik. A fenti SQL
+			 * csak KÉT HÉTIG véd (a `NOT EXISTS` ablak), utána újraindul a kör.
+			 *
+			 * Ráadásul minden sikertelen kísérlet előtt tokent is írunk a
+			 * `church_update_tokens`-be — vagyis a hiábavaló próbálkozás nem csak
+			 * levélszemét, hanem adatbázis-szemét is.
+			 */
+			if (self::skipUnnotifiable('user_pleaseupdate', $user2notify)) {
+				continue;
+			}
+
 			$user = new User($user2notify->uid);
 			$user->getResponsabilities();
 

--- a/webapp/tests/Integration/UndeliverableEvidenceTest.php
+++ b/webapp/tests/Integration/UndeliverableEvidenceTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #823: a kézbesíthetetlen címek elleni védelem két résen szivárgott el.
+ *
+ * A `User::isUndeliverable()` abból tudja, hogy egy címre nem érdemes tovább
+ * próbálkozni, hogy az `emails` táblában három hibás sor áll rá. Ez az EGYETLEN
+ * bizonyíték — nincs külön „ez a cím halott" jelölés.
+ *
+ * **Első rés:** a `Crons::cleanNotificationEmails()` 90 nap után törölte ezeket a
+ * sorokat. A bizonyíték eltűnt, az értesítő cron pedig újrakezdte: három kísérlet,
+ * majd megint 90 nap, megint három — örökre. A védelem tehát csak 90 napig védett.
+ *
+ * **Második rés:** a `sendUpdateNotification()` (`user_pleaseupdate`, élesben 152
+ * kiküldött levél) egyáltalán nem kérdezte meg, hogy elérhető-e a cím. A másik két
+ * értesítő már igen. Ott a beépített `NOT EXISTS` csak KÉT HÉTIG véd, utána újraindul
+ * a kör — és minden hiábavaló próbálkozás egy-egy tokent is beír a
+ * `church_update_tokens` táblába.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class UndeliverableEvidenceTest extends TestCase {
+
+    private const CIM = 'halott.cim@example.invalid';
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** @param string $status  @param string $mikor strtotime-kifejezés */
+    private function level(string $type, string $status, string $mikor, string $cim = self::CIM): void {
+        $idopont = date('Y-m-d H:i:s', strtotime($mikor));
+        DB::table('emails')->insert([
+            'type'       => $type,
+            'to'         => $cim,
+            'subject'    => 'teszt',
+            'body'       => 'teszt',
+            'status'     => $status,
+            'created_at' => $idopont,
+            'updated_at' => $idopont,
+        ]);
+    }
+
+    private function hibasSorokSzama(string $cim = self::CIM): int {
+        return DB::table('emails')->where('to', $cim)->where('status', 'error')->count();
+    }
+
+    // ---- a takarítás megőrzi a bizonyítékot ----------------------------------
+
+    /**
+     * Ez a lényeg: a három hibás sor a takarítás után is megmarad, különben a
+     * következő futás elölről kezdi a próbálkozást.
+     */
+    public function testATakaritasNemTorliAHibasLeveleket(): void {
+        $this->level('user_pleaselogin', 'error', '-200 days');
+        $this->level('user_pleaselogin', 'error', '-150 days');
+        $this->level('user_pleaselogin', 'error', '-120 days');
+
+        \Crons::cleanNotificationEmails();
+
+        self::assertSame(3, $this->hibasSorokSzama(),
+            'A hibás sorok az egyetlen bizonyítékok arra, hogy a cím halott.');
+    }
+
+    /** A sikeres, régi levelek viszont ugyanúgy takarodnak, mint eddig. */
+    public function testASikeresRegiLevelekTovabbraIsTorlodnek(): void {
+        $this->level('user_pleaselogin', 'sent', '-200 days');
+
+        \Crons::cleanNotificationEmails();
+
+        self::assertSame(0, DB::table('emails')->where('to', self::CIM)->where('status', 'sent')->count());
+    }
+
+    /** A friss levelekhez nem nyúlunk, se sikereshez, se hibáshoz. */
+    public function testAFrissLevelekMaradnak(): void {
+        $this->level('user_pleaselogin', 'sent', '-3 days');
+        $this->level('user_pleaselogin', 'error', '-3 days');
+
+        \Crons::cleanNotificationEmails();
+
+        self::assertSame(2, DB::table('emails')->where('to', self::CIM)->count());
+    }
+
+    /** A nem takarítható típusokat továbbra sem bántjuk. */
+    public function testANemTakarithatoTipusMarad(): void {
+        $this->level('remark_admin', 'sent', '-200 days');
+
+        \Crons::cleanNotificationEmails();
+
+        self::assertSame(1, DB::table('emails')->where('to', self::CIM)->count());
+    }
+
+    // ---- a bizonyítékból következő döntés ------------------------------------
+
+    /**
+     * A takarítás UTÁN is kézbesíthetetlennek kell látszania — ez köti össze a két
+     * felet, és ezt vesztettük el eddig.
+     */
+    public function testATakaritasUtanIsKezbesithetetlenMarad(): void {
+        $this->level('user_pleaselogin', 'error', '-200 days');
+        $this->level('user_pleaselogin', 'error', '-150 days');
+        $this->level('user_pleaselogin', 'error', '-120 days');
+
+        \Crons::cleanNotificationEmails();
+
+        self::assertTrue($this->kezbesithetetlen('user_pleaselogin', self::CIM));
+    }
+
+    /** Három hiba alatt még próbálkozunk — a küszöb nem csúszhat el. */
+    public function testKetHibaUtanMegProbalkozunk(): void {
+        $this->level('user_pleaselogin', 'error', '-10 days');
+        $this->level('user_pleaselogin', 'error', '-5 days');
+
+        self::assertFalse($this->kezbesithetetlen('user_pleaselogin', self::CIM));
+    }
+
+    /**
+     * Ha a cím közben mégis működni kezdett, a régi hibák nem számítanak — enélkül
+     * egy időszakos postafiók-hiba örökre kizárná a felhasználót az értesítőkből.
+     */
+    public function testASikeresLevelUtanUjraProbalkozunk(): void {
+        $this->level('user_pleaselogin', 'error', '-30 days');
+        $this->level('user_pleaselogin', 'error', '-29 days');
+        $this->level('user_pleaselogin', 'error', '-28 days');
+        $this->level('user_pleaselogin', 'sent',  '-2 days');
+
+        self::assertFalse($this->kezbesithetetlen('user_pleaselogin', self::CIM));
+    }
+
+    /** A típusok nem keverednek: a bejelentkezős hibák nem tiltják a frissítőset. */
+    public function testAHibakTipusonkentSzamitanak(): void {
+        $this->level('user_pleaselogin', 'error', '-10 days');
+        $this->level('user_pleaselogin', 'error', '-9 days');
+        $this->level('user_pleaselogin', 'error', '-8 days');
+
+        self::assertTrue($this->kezbesithetetlen('user_pleaselogin', self::CIM));
+        self::assertFalse($this->kezbesithetetlen('user_pleaseupdate', self::CIM));
+    }
+
+    /**
+     * A `sendUpdateNotification` eddig nem kérdezte meg ezt — most már igen, tehát a
+     * `user_pleaseupdate` típusnak is működnie kell.
+     */
+    public function testAFrissitesiErtesitoreIsErvenyes(): void {
+        $this->level('user_pleaseupdate', 'error', '-10 days');
+        $this->level('user_pleaseupdate', 'error', '-9 days');
+        $this->level('user_pleaseupdate', 'error', '-8 days');
+
+        self::assertTrue($this->kezbesithetetlen('user_pleaseupdate', self::CIM));
+    }
+
+    /** A privát metódust reflexióval hívjuk: a döntés maga a mérendő állítás. */
+    private function kezbesithetetlen(string $type, string $cim): bool {
+        $metodus = new \ReflectionMethod(\User::class, 'isUndeliverable');
+        $metodus->setAccessible(true);
+
+        return (bool) $metodus->invoke(null, $type, $cim);
+    }
+}


### PR DESCRIPTION
A health oldal `user_pleaselogin` sorára: **129 hiba / 47 sikeres**, több mint 70% hibaarány.

**Először a jó hír:** a fő javítás már benne van a masterben (`454cac91`, „Leállítom a kézbesíthetetlen címek örök újraküldését"), csak **még nincs kint élesben** — az oldalon látszó `1a43eb0b` verzió még nem tartalmazza. Tehát az a 129 hiba a régi kódtól van, és a deploy után magától elapad.

**De találtam két rést**, amin a védelem elszivárog. Mindkettő a masterben van most is.

## 1. A takarítás kitörli a bizonyítékot

Az `isUndeliverable()` abból tudja, hogy egy címre nem érdemes tovább próbálkozni, hogy **három hibás levél áll rá** az `emails` táblában. Ez az egyetlen bizonyíték — nincs külön „ez a cím halott" jelölés.

A `cleanNotificationEmails()` viszont a `user_pleaselogin` és `user_pleaseupdate` sorokat **90 nap után törli**. A bizonyíték eltűnik, az értesítő pedig újrakezdi: három kísérlet, majd megint 90 nap, megint három. **A védelem tehát csak 90 napig védett.**

Mostantól a **hibás** leveleket megtartjuk. Nem nő el: a harmadik hiba után nem küldünk többet, tehát címenként és típusonként legfeljebb három ilyen sor keletkezik. Ha a cím később mégis működni kezd, a sikeres levél érvényteleníti a korábbi hibákat — az `isUndeliverable()` csak az utolsó siker *utáni* hibákat számolja.

## 2. A frissítési értesítő meg sem kérdezte

A `sendUpdateNotification()` (`user_pleaseupdate`, élesben **152** kiküldött levél) egyáltalán nem nézte, hogy elérhető-e a cím — a másik két értesítő már igen. A benne lévő `NOT EXISTS` csak **két hétig** véd, utána újraindul a kör.

Ez itt drágább is a szokásosnál: minden próbálkozás előtt **tokent írunk** a `church_update_tokens` táblába, tehát a hiábavaló kísérlet nem csak levélszemét, hanem adatbázis-szemét is.

---

**Egy apróság, ami majdnem elrontotta:** a `status <> 'error'` szűrő az SQL NULL-logikája miatt a **státusz nélküli** sorokat is kihagyta volna a törlésből (`NULL <> 'error'` eredménye NULL, nem igaz). Egy meglévő teszt (`CronsStatsCleanupTest`) elkapta — azok a sorok nem hiba-bizonyítékok, továbbra is törlődnek.

**Amit szándékosan NEM csináltam:** a kézbesíthetetlen fiókokat nem töröljük. A kézbesíthetetlenség nem bizonyítja, hogy a fiók elhagyott, a törlés viszont visszafordíthatatlan.

Teszt: 9 új (`UndeliverableEvidenceTest`) — külön az, hogy a takarítás **után is** kézbesíthetetlennek látszik a cím, és hogy egy időszakos hiba után a sikeres levél feloldja a tiltást.