### PR TITLE
Az oszlop-kivezetés két maradéka és két sorrendfüggő teszt

### DIFF
--- a/webapp/classes/api/table.php
+++ b/webapp/classes/api/table.php
@@ -162,13 +162,11 @@ class Table extends Api {
      * @return string beilleszthető SQL-részlet (a külső lekérdezésben `t` a templom)
      */
     private static function boundaryNameSql(array $szintek): string {
-        $lista = implode(', ', array_map('intval', $szintek));
-
-        return "(SELECT b.name FROM lookup_boundary_church lbc"
-            . " JOIN boundaries b ON b.id = lbc.boundary_id"
-            . " WHERE lbc.church_id = t.id AND b.boundary = 'administrative'"
-            . " AND b.admin_level IN ($lista)"
-            . " ORDER BY FIELD(b.admin_level, $lista) LIMIT 1)";
+        // #824: a definíció a `Church`-ben él, hogy ne legyen belőle három változat.
+        // Egy ilyen másolat már el is csúszott: a `User::sendUpdateNotification()`
+        // `ORDER BY admin_level DESC`-et használt `FIELD()` helyett, és visszaesett a
+        // közben eldobott `templomok.varos` oszlopra.
+        return \Eloquent\Church::boundaryNameSubquerySql($szintek, 't.id');
     }
 
     function mapTemplomok() {

--- a/webapp/classes/campaign.php
+++ b/webapp/classes/campaign.php
@@ -81,6 +81,16 @@ class Campaign {
         $staleDate = (new DateTime())->modify('-' . self::STALE_MONTHS . ' months')->format('Y-m-d');
         $assignableChurches = DB::table('templomok AS t')
             ->select('t.id', 't.nev', 't.ismertnev', 't.frissites')
+            /*
+             * #824: a település a levélhez. Itt `DB::table()` fut, tehát nyers
+             * `stdClass` sorok jönnek — azokon a `locationCityName()` nem létezik, és
+             * a heti önkéntes-levél emiatt SOHA nem ment ki:
+             *   „Call to undefined method stdClass::locationCityName()"
+             * A templomok addigra már ki voltak osztva (az `updates` sorok bementek),
+             * tehát az önkéntes nem is értesült a munkájáról, a templom viszont
+             * hónapokra kiesett az újraosztásból.
+             */
+            ->selectRaw(\Eloquent\Church::citySubquerySql('t.id') . ' AS varos')
             ->where('t.ok', 'i')
             // #498: a `t.orszag = 12` helyett országhatár. Névre és ISO-kódra is
             // illesztünk, mert az ISO ma még alig van kitöltve.
@@ -281,8 +291,8 @@ class Campaign {
                     'id' => $c->id,
                     'nev' => $c->nev,
                     'ismertnev' => $c->ismertnev,
-                    // #497: a levélben a település a boundary-ból, mint mindenhol máshol.
-                    'varos' => $c->locationCityName(),
+                    // #497/#824: a település a boundary-ból, a lekérdezés alkérdésével.
+                    'varos' => $c->varos ?? '',
                     'frissites' => $c->frissites,
                 ];
             }, $churches),

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1794,6 +1794,46 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         return $misek;
     }
 
+    /**
+     * #824: a település neve SQL-ből, tömeges lekérdezésekhez.
+     *
+     * A `locationCityName()` Eloquent-modellt kér. Több tömeges lekérdezés viszont
+     * `DB::table()`-lel dolgozik, és nyers `stdClass` sorokat kap — azokon nincs
+     * metódus. Ez már meg is bosszulta magát: a `Campaign::sendWeeklyEmail()`
+     * `$c->locationCityName()`-t hívott egy `stdClass`-on, és a heti önkéntes-levél
+     * emiatt SOHA nem ment ki („Call to undefined method stdClass::locationCityName()").
+     *
+     * A másik hiba ugyanebből a családból: a `User::sendUpdateNotification()` a
+     * `templomok.varos` oszlopra esett vissza — arra, amit a kivezetés eldobott.
+     *
+     * Ezért van egy közös definíció: aki SQL-ben kéri a települést, innen vegye.
+     *
+     * @param string $churchIdColumn a templom azonosítója a külső lekérdezésben
+     *                               (pl. `templomok.id` vagy `t.id`)
+     */
+    public static function citySubquerySql(string $churchIdColumn = 'templomok.id'): string {
+        return self::boundaryNameSubquerySql([8, 9, 10], $churchIdColumn);
+    }
+
+    /**
+     * #824: egy adminisztratív határ neve alkérdésként, szint-sorrenddel.
+     *
+     * A `FIELD()` rendezés adja a preferenciát: a felsorolás sorrendje dönt, nem a
+     * szint nagysága — így ugyanaz a szabály érvényesül, mint a modell-oldali
+     * `adminBoundaryName()`-ben.
+     *
+     * @param int[] $szintek admin_level értékek, preferencia szerint
+     */
+    public static function boundaryNameSubquerySql(array $szintek, string $churchIdColumn = 'templomok.id'): string {
+        $lista = implode(', ', array_map('intval', $szintek));
+
+        return "(SELECT b.name FROM lookup_boundary_church lbc"
+            . " JOIN boundaries b ON b.id = lbc.boundary_id"
+            . " WHERE lbc.church_id = $churchIdColumn AND b.boundary = 'administrative'"
+            . " AND b.admin_level IN ($lista)"
+            . " ORDER BY FIELD(b.admin_level, $lista) LIMIT 1)";
+    }
+
     private function adminBoundaryName(array $szintek): ?string {
         $talalat = $this->boundaries()
                 ->where('boundary', 'administrative')

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -878,14 +878,14 @@ class User {
 
 			$users2notify = DB::table('templomok')
 				// #497: a `varos` alias a levélsablonnak kell. Tömeges lekérdezés, ezért
-				// nem templomonként kérdezünk, hanem korrelált alkérdéssel — a boundary
-				// neve, visszaeséssel a régi oszlopra, amíg az létezik.
+				// nem templomonként kérdezünk, hanem korrelált alkérdéssel.
+				//
+				// #824: a `templomok.varos`-ra való visszaesés KIKERÜLT. Az oszlopot a
+				// kivezetés eldobta, tehát a `COALESCE` egy nem létező oszlopra
+				// hivatkozott — a lekérdezés az éles migráció után azonnal elhasalt
+				// volna, és vele az egész „frissítsd az adataidat" értesítő.
 				->select('templomok.id as tid','templomok.nev','templomok.ismertnev','templomok.frissites')
-				->selectRaw("COALESCE((SELECT b.name FROM lookup_boundary_church lbc"
-					. " JOIN boundaries b ON b.id = lbc.boundary_id"
-					. " WHERE lbc.church_id = templomok.id AND b.boundary = 'administrative'"
-					. " AND b.admin_level IN (8,9,10) ORDER BY b.admin_level DESC LIMIT 1),"
-					. " templomok.varos) AS varos")
+				->selectRaw(\Eloquent\Church::citySubquerySql('templomok.id') . ' AS varos')
 				->join('church_holders','templomok.id','=','church_holders.church_id')
 				->addSelect('church_holders.description')
 				->join('user','user.uid','=','church_holders.user_id')

--- a/webapp/tests/Integration/CampaignVolunteerTest.php
+++ b/webapp/tests/Integration/CampaignVolunteerTest.php
@@ -201,4 +201,76 @@ class CampaignVolunteerTest extends TestCase {
 
         $this->assertTrue($this->isVolunteer($user->uid));
     }
+
+    // ---- #824: a heti levél tényleg kimegy ------------------------------------
+
+    /**
+     * A kiosztható templomokat `DB::table()` kérdezi le, tehát nyers `stdClass` sorok
+     * jönnek. A levélösszeállítás mégis `$c->locationCityName()`-t hívott rajtuk:
+     *
+     *   Call to undefined method stdClass::locationCityName()
+     *
+     * Ettől a levél SOHA nem ment ki. A templomok addigra viszont már ki voltak
+     * osztva (az `updates` sorok bementek), tehát az önkéntes nem értesült a
+     * munkájáról, a templom pedig hónapokra kiesett az újraosztásból — a hiba tehát
+     * nem csak egy elmaradt levél volt, hanem elveszett munka is.
+     */
+    public function testAKiosztasNemHibazikEl(): void {
+        $this->makeVolunteer();
+        $this->makeStaleChurch();
+
+        $stats = \Campaign::assignUpdates();
+
+        self::assertSame([], $stats['errors'],
+            'A kiosztásnak hiba nélkül végig kell futnia — enélkül a levél sem megy ki.');
+    }
+
+    public function testAKiosztasElKuldiALevelet(): void {
+        $this->makeVolunteer();
+        $this->makeStaleChurch();
+
+        $stats = \Campaign::assignUpdates();
+
+        self::assertSame(1, $stats['emails_sent']);
+    }
+
+    /** A település a határláncból jön — a `templomok.varos` oszlop már nincs meg. */
+    public function testATelepulesAHatarlancbolJon(): void {
+        $this->makeVolunteer();
+        $churchId = $this->makeStaleChurch();
+        $this->boundaryhozKot($churchId, 'Tesztfalu');
+
+        \Campaign::assignUpdates();
+
+        $level = DB::table('emails')->where('type', 'volunteer_weekly')
+            ->orderBy('id', 'desc')->first();
+
+        self::assertNotNull($level, 'kellett volna levelet írnia');
+        self::assertStringContainsString('Tesztfalu', (string) $level->body);
+    }
+
+    /** Település-határ nélkül se hasaljon el: üres marad, de a levél kimegy. */
+    public function testHatarNelkulIsKimegyALevel(): void {
+        $this->makeVolunteer();
+        $this->makeStaleChurch();
+
+        $stats = \Campaign::assignUpdates();
+
+        self::assertSame(1, $stats['emails_sent']);
+    }
+
+    /** 8-as szintű (település) határt köt a templomhoz. */
+    private function boundaryhozKot(int $churchId, string $nev): void {
+        $boundaryId = DB::table('boundaries')->insertGetId([
+            'boundary'    => 'administrative',
+            'admin_level' => 8,
+            'name'        => $nev,
+            'osmtype'     => 'relation',
+            'osmid'       => 970000 + $churchId,
+        ]);
+        DB::table('lookup_boundary_church')->insert([
+            'boundary_id' => $boundaryId,
+            'church_id'   => $churchId,
+        ]);
+    }
 }

--- a/webapp/tests/Integration/ExternalApiQuietTest.php
+++ b/webapp/tests/Integration/ExternalApiQuietTest.php
@@ -48,6 +48,18 @@ final class ExternalApiQuietTest extends TestCase {
     private function unreachableOverpass(): \ExternalApi\OverpassApi {
         $api = new \ExternalApi\OverpassApi();
         $api->apiUrl = 'http://127.0.0.1:9/nincs-itt-semmi';
+        /*
+         * #824: a TARTALÉK végpontokat is le kell tiltani.
+         *
+         * A `run()` a `fallbackUrls` listát járja be, ha az nem üres — a konstruktor
+         * pedig feltölti a config valódi, publikus tükreivel. Az `apiUrl` felülírása
+         * tehát ELVESZETT: a hívás a valódi Overpass-tükrökre ment. Emiatt ez a teszt
+         * hálózatfüggő volt (a naplóban „Operation timed out after 2003 ms"), és a
+         * teljes futamban hol elbukott, hol nem. A szomszédos
+         * `testBoundaryDownloadStaysSilentOnFailure` ezt a configon már kezeli — itt
+         * kimaradt.
+         */
+        $api->fallbackUrls = ['http://127.0.0.1:9/nincs-itt-semmi'];
         $api->cache = false;
         $api->queryTimeout = 2;
         return $api;

--- a/webapp/tests/bootstrap.php
+++ b/webapp/tests/bootstrap.php
@@ -62,6 +62,19 @@ if (!function_exists('t')) {
     }
 }
 
+/*
+ * #824: a globális `$user`-t a load.php állítja be a munkamenetből, a tesztek viszont
+ * nem azt töltik be. Enélkül minden jogosultság-vizsgálat „Call to a member function
+ * checkRole() on null"-lal hasal el — a `ChurchPrintableScheduleTest` például külön
+ * futtatva 12-ből 9 hibával állt meg, a teljes futamban viszont zöld volt, mert egy
+ * korábbi teszt véletlenül beállította. Az ilyen sorrendfüggés a legrosszabb fajta
+ * hiba: nem a kód romlik el tőle, hanem a mérés hitele.
+ *
+ * VENDÉG felhasználót adunk, mert az a nyilvános alapállapot: aki bejelentkezettet
+ * akar mérni, az állítsa be magának a saját tesztjében.
+ */
+$GLOBALS['user'] = new \User();
+
 // A levélküldés Twig-sablonból áll elő (\Eloquent\Email::render()), így $twig nélkül
 // egyetlen email-út sem tesztelhető. Ugyanaz a környezet, mint amit a load.php épít.
 //


### PR DESCRIPTION
Négy hiba, kettő közülük **élesben is működésképtelen kódot** hagyott hátra. Mindet a teljes tesztfutam naplójában vettem észre — a futás zöld volt, a hibák a kimenetben álltak.

## 1. A heti önkéntes-levél soha nem ment ki

```
Campaign::assignUpdates(): users_processed=0, churches_assigned=0, emails_sent=0, errors=1
  HIBA: user 6720: Call to undefined method stdClass::locationCityName()
```

A kiosztható templomokat `DB::table()` kérdezi le, tehát nyers `stdClass` sorok jönnek — azokon nincs `locationCityName()`.

**Ami ezt komollyá teszi:** a kivétel a levélküldésnél dobott, az `updates` sorok viszont **már bementek**. Tehát a templomok ki lettek osztva az önkéntesnek, ő nem értesült róla, a templom pedig a `SKIP_RECENT_REMARK_MONTHS` miatt hónapokra kiesett az újraosztásból. Nem csak egy elmaradt levél — **elveszett munka**.

## 2. A frissítési értesítő egy eldobott oszlopra hivatkozott

A `User::sendUpdateNotification()` lekérdezése:

```sql
COALESCE((SELECT b.name FROM ...), templomok.varos) AS varos
```

A `templomok.varos` oszlopot a kivezetés **eldobta**. Élesben ez még működik, mert ott a migráció nem futott le — de a `496-497-498-oszlopok-eldobasa.sql` napján a lekérdezés azonnal elhasalna, és vele az egész „frissítsd az adataidat" értesítő.

**Mindkettőre egy közös definíció felel mostantól** (`Church::citySubquerySql()`), és az `api/table.php` harmadik másolata is arra hivatkozik. Épp ezek a másolatok csúsztak el egymástól: az egyik `FIELD()`-del rendezett, a másik `admin_level DESC`-cel, a harmadik egy nem létező oszlopra esett vissza.

## 3. `ChurchPrintableScheduleTest` — külön futtatva 12-ből 9 hiba

`Call to a member function checkRole() on null`: a globális `$user`-t a `load.php` állítja be, a tesztek viszont nem azt töltik be. A teljes futamban zöld volt, mert egy korábbi teszt **véletlenül** beállította.

Ez a legrosszabb fajta hiba: nem a kód romlik el tőle, hanem a mérés hitele. A bootstrap mostantól **vendég** felhasználót ad — az a nyilvános alapállapot; aki bejelentkezettet mér, állítsa be magának.

## 4. `ExternalApiQuietTest` — hálózatfüggő volt

A teszt „elérhetetlen végpontot" állított be az `apiUrl`-be, de a `fallbackUrls` listát nem — a `run()` viszont **azt** járja be, ha nem üres, és a konstruktor feltölti a valódi, publikus Overpass-tükrökkel. A hívás tehát kiment az internetre (a naplóban: `Operation timed out after 2003 milliseconds`), és a teljes futamban hol elbukott, hol nem.

A szomszédos `testBoundaryDownloadStaysSilentOnFailure` ezt a configon már kezelte — a kommentje pontosan ezt magyarázza. Itt kimaradt.

---

**Ellenőrzés:** a teljes PHP-futam **háromszor egymás után** ugyanazt adja, ingadozás nélkül. Teszt: 4 új a kampányra (a kiosztás hiba nélkül fut le, a levél tényleg kimegy, a település a határláncból jön).