### PR TITLE
Megmutatom, mik az árva határok, nem csak azt, hogy hányan vannak

### DIFF
--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -345,6 +345,29 @@ class Health extends Html {
 			->count();
 		
 		$this->boundariesStats['orphan_count'] = $orphanBoundaries;
+
+		/*
+		 * #825: nem csak a SZÁMUKAT mutatjuk meg, hanem magukat a sorokat is.
+		 *
+		 * Eddig egy piros szám állt itt, tennivaló nélkül. Egy szám alapján viszont nem
+		 * lehet eldönteni, hogy baj-e: az árva határ lehet ártalmatlan maradék (a
+		 * templom átkerült egy másik határ alá), lehet egy elrontott szinkron nyoma, és
+		 * lehet olyan egyházmegye-határ is, amit MI hozunk létre — utóbbi teljesen
+		 * szabályos, csak épp nincs alatta templom.
+		 *
+		 * Törölni szándékosan NEM törlünk: a határ-sor eldobása visszafordíthatatlan,
+		 * és egy ma árva határ holnap újra kötődhet. Előbb látni kell, mik ezek.
+		 */
+		$this->boundariesStats['orphan_list'] = DB::table('boundaries')
+			->leftJoin('lookup_boundary_church', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+			->whereNull('lookup_boundary_church.church_id')
+			->select('boundaries.id', 'boundaries.name', 'boundaries.boundary',
+				'boundaries.admin_level', 'boundaries.osmtype', 'boundaries.osmid',
+				'boundaries.updated_at')
+			->orderBy('boundaries.boundary')
+			->orderBy('boundaries.admin_level')
+			->limit(200)
+			->get();
 		
 		// 3. Templomok száma, amiknek nincs olyan boundary, aminek van osmid és osmtype
 		$churchesWithoutOsmBoundary = DB::table('templomok')

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -382,7 +382,31 @@
 				{% if boundariesStats.orphan_count == 0 %}
 						<span class="badge bg-success">0</span>
 				{% else %}
-						<span class="badge bg-danger">{{ boundariesStats.orphan_count }}</span>							
+						{# #825: a puszta szám alapján nem lehet eldönteni, baj-e. Az árva határ
+						   lehet ártalmatlan maradék, elrontott szinkron nyoma, vagy szabályos
+						   egyházmegye-határ templom nélkül. Ezért kilistázzuk őket. #}
+						<span class="badge bg-warning">{{ boundariesStats.orphan_count }}</span>
+						{% if boundariesStats.orphan_list|length > 0 %}
+							<details style="margin-top:6px">
+								<summary class="kicsi" style="cursor:pointer">Mik ezek?</summary>
+								<table class="table table-condensed kicsi" style="margin-top:6px">
+									<tr><th>név</th><th>típus</th><th>szint</th><th>OSM</th><th>frissítve</th></tr>
+									{% for b in boundariesStats.orphan_list %}
+										<tr>
+											<td>{{ b.name }}</td>
+											<td>{{ b.boundary }}</td>
+											<td>{{ b.admin_level }}</td>
+											<td>
+												{% if b.osmtype and b.osmid %}
+													<a href="https://www.openstreetmap.org/{{ b.osmtype }}/{{ b.osmid }}" target="_blank" rel="noopener">{{ b.osmtype }}/{{ b.osmid }}</a>
+												{% endif %}
+											</td>
+											<td>{{ b.updated_at }}</td>
+										</tr>
+									{% endfor %}
+								</table>
+							</details>
+						{% endif %}
 				{% endif %}
 			</td>
 		</tr>


### PR DESCRIPTION
A health oldalon **71 „Orphan Boundary"** áll pirosan, tennivaló nélkül.

**Nem írtam rá takarítást, és ezt szeretném megindokolni**, mert kézenfekvő lett volna:

- A határ-sor eldobása **visszafordíthatatlan**, egy ma árva határ holnap újra kötődhet (a `checkBoundaries` folyamatosan újraköti őket).
- A fejlesztői adatbázisban **nulla** ilyen sor van, tehát egy takarítást nem tudnék megmérni — vakon írt törlő cron pont az a fajta kód, amit nem szabad.
- És egy szám alapján **nem lehet eldönteni, hogy baj-e**. Az árva határ lehet ártalmatlan maradék, lehet elrontott szinkron nyoma, és lehet teljesen szabályos egyházmegye-határ is, ami alatt épp nincs templom — utóbbit MI hozzuk létre.

**Ehelyett megmutatom, mik ezek.** Lenyitható részletben, névvel, típussal, admin szinttel, OSM-hivatkozással és frissítési dátummal. Ha ránézel, egy pillanat alatt eldönthető, melyik csoportba tartoznak — és ha kiderül, hogy tényleg szemét, akkor a takarítás már célzottan, mérhetően megírható.

A jelzés pirosból **sárga** lett: ez nem hiba, hanem megnézendő.

Kapcsolódik: a #821 az utánpótlást szünteti meg (a `boundary` tag nélküli elemek eddig besorolás nélküli sorként kerültek be, és ezek pont ilyen árvák lettek).