### PR TITLE
Deploy-lépések leírása, és a health lap külön méri a közigazgatási határt

### DIFF
--- a/docs/deploy-lepesek.md
+++ b/docs/deploy-lepesek.md
@@ -1,0 +1,183 @@
+# Deploy-lépések
+
+A `docker/mysql/migrations/` alatt hat SQL-fájl áll, és eddig **semmi nem mondta meg,
+melyik futott már le**. Ez élesben veszélyes: aki deployol, vagy kihagy egy szükséges
+lépést (és valami némán elromlik), vagy újrafuttat egy megtörténtet (és nem tudja, hogy
+az baj-e).
+
+Ez a jegyzet ezt pótolja. **Minden lépéshez tartozik egy ellenőrző lekérdezés**, ami
+megmondja, kell-e még — így nem kell emlékezni arra, mi történt korábban.
+
+A migrációk **nem futnak le maguktól**. Az `docker/mysql/initdb.d/` csak ÚJ adatbázisnál
+fut (fejlesztői környezet); az éles adatbázis a `migrations/` fájlokat kézzel kapja meg.
+
+## Hogyan használd
+
+```bash
+# ellenőrzés
+docker exec -i mysql mysql -u root -p miserend < ellenorzo.sql
+
+# futtatás
+docker exec -i mysql mysql -u root -p miserend < docker/mysql/migrations/<fájl>.sql
+```
+
+A cronok viszont **maguktól** szinkronizálódnak: a `\Eloquent\Cron::init()` minden
+cron-futásnál felveszi a `webapp/fajlok/crons.php`-ból hiányzó sorokat, és a
+`pruneRemoved()` kitakarítja a onnan kivetteket (#638). Új cronhoz tehát nincs teendő —
+legfeljebb megvárni a következő futást, vagy meglökni: `/index.php?q=cron&cron_init=1`.
+
+---
+
+## Séma-migrációk
+
+### `174-b-nullable-dates.sql`
+
+Dátum-oszlopokat enged NULL-ra (`boundaries.created_at`, `church_holders.updated_at`,
+és társaik). A régi séma `0000-00-00`-t tárolt, amit a mai MySQL nem fogad el.
+
+**Kell-e még?**
+```sql
+SELECT IS_NULLABLE FROM information_schema.COLUMNS
+ WHERE TABLE_SCHEMA='miserend' AND TABLE_NAME='boundaries' AND COLUMN_NAME='created_at';
+-- 'NO'  -> még kell
+-- 'YES' -> megvolt
+```
+
+### `javaslat-kezeloje.sql`
+
+Két oszlop a javaslat-csomagokra: ki és mikor bírálta el. Enélkül az adminfelület
+„vendég"-et mutat kezelőként.
+
+**Kell-e még?**
+```sql
+SELECT COUNT(*) FROM information_schema.COLUMNS
+ WHERE TABLE_SCHEMA='miserend' AND TABLE_NAME='cal_suggestion_packages'
+   AND COLUMN_NAME='handled_by_user_id';
+-- 0 -> még kell
+```
+
+### `706-sema-elteresek.sql`
+
+Eldobja a megszűnt `misek` táblát, és pár oszlop-definíciót a séma-referenciához igazít.
+**Adatot dob el** (`misek`) — előtte érdemes meggyőződni róla, hogy tényleg nem használjuk.
+
+**Kell-e még?**
+```sql
+SELECT COUNT(*) FROM information_schema.TABLES
+ WHERE TABLE_SCHEMA='miserend' AND TABLE_NAME='misek';
+-- 1 -> még kell
+```
+
+### `431-alkalom-sajat-helyszin.sql`
+
+Három oszlop a `cal_masses`-re: az alkalom saját helyszíne, ha nem a templomban van
+(#431). A #813-mal együtt kell kimennie — **enélkül a naptár mentése elszáll**.
+
+**Kell-e még?**
+```sql
+SELECT COUNT(*) FROM information_schema.COLUMNS
+ WHERE TABLE_SCHEMA='miserend' AND TABLE_NAME='cal_masses' AND COLUMN_NAME='location_lat';
+-- 0 -> még kell
+```
+
+### `748-distances-normalizalas.sql`
+
+A `distances` tábla oda-vissza duplikátumait szedi ki. Nem sürgős, csak helyet és
+számolást spórol.
+
+**Kell-e még?**
+```sql
+SELECT COUNT(*) FROM distances d JOIN distances m
+  ON m.fromLat=d.toLat AND m.fromLon=d.toLon
+ AND m.toLat=d.fromLat AND m.toLon=d.fromLon;
+-- >0 -> van még duplikátum
+```
+
+### `496-497-498-oszlopok-eldobasa.sql` — **ezt olvasd el, mielőtt futtatod**
+
+Eldobja a `templomok.orszag`, `.megye`, `.varos` oszlopokat és az `orszagok`, `megye`,
+`varosok` táblákat. A helynevek ezután kizárólag az OSM-határokból jönnek.
+
+**Visszafordíthatatlan.** Előtte a fájl átmenti a koordináta nélküli templomok helyadatát
+a `megjegyzes` mezőbe — az az egyetlen hely, ahol utána megmarad.
+
+**Előfeltétel:** minden fogyasztónak a származtatott neveken kell mennie. A kódban ez kész
+(#805 óta), de a **határ-adatnak is késznek kell lennie**: ha egy templomnak nincs
+boundary-ja, a neve a drop után üres lesz.
+
+```sql
+-- Hány aktív templomnak NINCS közigazgatási határa? Ennyien veszítik el a helynevüket.
+SELECT COUNT(*) FROM templomok t
+ WHERE t.ok='i' AND NOT EXISTS (
+   SELECT 1 FROM lookup_boundary_church l
+     JOIN boundaries b ON b.id=l.boundary_id AND b.boundary='administrative'
+    WHERE l.church_id=t.id);
+```
+
+A /health `Van közigazgatási határa` sora ugyanezt mutatja, felületről (#827).
+**Ne a fölötte lévő sort nézd**: az bármilyen határt beszámít — az OSM sokféle határt ad
+(`postal_code`, `judicial`, `wine_community`), a `religious_administration` határokat
+pedig mi hozzuk létre minden templomhoz. Emiatt ott 100% állhat úgy is, hogy közben
+templomok százainak nincs közigazgatási határa.
+
+> A **fejlesztői** adatbázisban ez a szám ijesztően alacsony (nálam 6 az 5035-ből),
+> mert a seed nem tartalmazza a határ-szinkron eredményét, és az Overpass-lekérdezés
+> nem futott le. Ezt a lépést **csak élesen** van értelme megítélni.
+
+**Kell-e még?**
+```sql
+SELECT COUNT(*) FROM information_schema.COLUMNS
+ WHERE TABLE_SCHEMA='miserend' AND TABLE_NAME='templomok' AND COLUMN_NAME='varos';
+-- 1 -> még nem futott le
+```
+
+---
+
+## Nem SQL, de deploy után kell
+
+### Séma-referencia újragenerálása
+
+A `webapp/schema-reference.json` a `docker/mysql/initdb.d` pillanatképe. Ha az változik és
+ez nem, a /health „a referencia elavult"-at mond, és az összevetés eredménye
+**se pozitív, se negatív irányban nem megbízható**.
+
+**FRISSEN ÉPÍTETT konténerben** kell futtatni, különben az ujjlenyomat megint nem egyezik
+(az a régi image initdb.d-jéből készül):
+
+```bash
+docker exec <konténer> php /miserend/webapp/tools/schema-reference.php
+```
+
+### `LORAWAN_TOKEN`
+
+A szenzoros végpont (gyóntatás-érzékelő) enélkül nem fogad adatot. Környezeti változó,
+nem migráció.
+
+### Elasticsearch
+
+Ezekhez **nincs teendő**: a `reindexMissingMasses` és — a #826 óta — a
+`reindexChurchesWithoutLocation` cron magától pótolja a kimaradt dokumentumokat.
+
+Teljes újraépítés csak akkor kell, ha a **mapping** változik:
+
+```
+/index.php?q=cron&cron_id=38   # templomok
+/index.php?q=cron&cron_id=39   # misék — 30+ perc, 500e+ esemény
+```
+
+Vigyázat: a „templomok `location` nélkül" szám **nem** feltétlenül újraindexelést kíván.
+Akinek nincs koordinátája az adatbázisban, azon az újraindexelés nem segít — a /health
+a #826 óta külön is megmondja, melyikből mennyi van.
+
+### Határok újraszinkronja
+
+Ha a határ-logika változik (admin_level-kezelés, ISO-kód), a meglévő kapcsolatok
+elavulnak. Ilyenkor a sorbaállítás:
+
+```sql
+UPDATE templomok SET boundaries_checked_at = NULL;
+```
+
+A `\OSM::checkBoundaries()` cron ezután fokozatosan újrakérdezi őket az Overpass-tól.
+**Nem gyors**: több ezer templom, ütemezetten. Csak akkor csináld, ha tényleg változott a
+logika — egyébként fölöslegesen terheli az Overpass-t.

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -326,12 +326,38 @@ class Health extends Html {
 			->distinct()
 			->count('lookup_boundary_church.church_id');
 
+		/*
+		 * #827: KÖZIGAZGATÁSI határ — ez külön szám, és ez a fontosabbik.
+		 *
+		 * A fenti sor BÁRMILYEN kapcsolatot beszámít. Csakhogy az OSM sokféle határt
+		 * ad vissza (`postal_code`, `judicial`, `wine_community`, `timezone`…), és a
+		 * `religious_administration` határokat ráadásul MI hozzuk létre minden
+		 * templomhoz az egyházmegyéjéből. Egy templom tehát „100%-ban kereshető"-nek
+		 * látszhat úgy, hogy egyetlen közigazgatási határa sincs.
+		 *
+		 * Márpedig a HELYNEVEK kizárólag közigazgatási határból jönnek
+		 * (`locationCityName()` és társai). Ez a szám dönti el, hogy a `templomok.varos`
+		 * eldobása (#496/#497/#498) hány templomot hagyna helynév nélkül — épp ezért
+		 * nem szabad összemosni a kettőt.
+		 */
+		$churchesWithAdminBoundary = DB::table('lookup_boundary_church')
+			->join('templomok', 'templomok.id', '=', 'lookup_boundary_church.church_id')
+			->join('boundaries', 'boundaries.id', '=', 'lookup_boundary_church.boundary_id')
+			->where('templomok.ok', 'i')
+			->whereNull('templomok.deleted_at')
+			->where('boundaries.boundary', 'administrative')
+			->distinct()
+			->count('lookup_boundary_church.church_id');
+
 		$this->boundariesStats = [
 			'with_osm' => [
 				'count' => $churchBoundaryStats->count ?? 0,
 				'never_checked_count' => $churchBoundaryStats->never_checked_count ?? 0,
 				'with_boundary_count' => $churchesWithBoundary,
 				'without_boundary_count' => max(0, ($churchBoundaryStats->count ?? 0) - $churchesWithBoundary),
+				// #827: a helynevekhez ez a szám kell, nem a fenti.
+				'with_admin_boundary_count' => $churchesWithAdminBoundary,
+				'without_admin_boundary_count' => max(0, ($churchBoundaryStats->count ?? 0) - $churchesWithAdminBoundary),
 				'avg_days_old' => $churchBoundaryStats->avg_days_old ? round($churchBoundaryStats->avg_days_old, 2) : 0,
 				'newest' => $churchBoundaryStats->newest ?? null,
 				'oldest' => $churchBoundaryStats->oldest ?? null

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -323,6 +323,32 @@
 				{% endif %}
 			</td>
 		</tr>
+		{#
+			#827: külön sor a KÖZIGAZGATÁSI határnak.
+			A fenti sor bármilyen kapcsolatot beszámít — az OSM sokféle határt ad
+			(postal_code, judicial, wine_community…), a religious_administration
+			határokat pedig MI hozzuk létre minden templomhoz. A HELYNEVEK viszont
+			kizárólag közigazgatási határból jönnek, és ez a szám dönti el, hány
+			templom maradna helynév nélkül a `templomok.varos` eldobása után.
+		#}
+		<tr>
+			<td><strong>Van közigazgatási határa</strong> <small class="text-muted">(a helynevek ebből jönnek)</small></td>
+			<td>
+				{% set osszes = boundariesStats.with_osm.count %}
+				{% set adminnal = boundariesStats.with_osm.with_admin_boundary_count %}
+				{% if osszes > 0 and adminnal >= osszes %}
+					<span class="badge bg-success">{{ adminnal }}</span> / {{ osszes }} (100%)
+				{% else %}
+					<span class="badge bg-warning">{{ adminnal }}</span> / {{ osszes }}
+					<div class="alert alert-warning" style="margin-top:6px">
+						<strong>{{ boundariesStats.with_osm.without_admin_boundary_count }}</strong> misézőhelynek
+						nincs közigazgatási határa. Ők a <code>templomok.varos</code> oszlop eldobása után
+						(#496/#497/#498) <strong>helynév nélkül maradnának</strong> — a kivezetés előtt
+						ezt érdemes lenullázni.
+					</div>
+				{% endif %}
+			</td>
+		</tr>
 		<tr>
 			<td><strong>Misézőhelyek amiknek nem kerestük még soha</strong> </td>
 			<td>


### PR DESCRIPTION
Két dolog, és a második fontosabb, mint amilyennek elsőre látszik.

## 1. Hat migrációs SQL, és semmi nem mondja meg, melyik futott már le

A `docker/mysql/migrations/` alatt hat fájl áll. Aki deployol, vagy **kihagy** egy szükséges lépést (és valami némán elromlik), vagy **újrafuttat** egy megtörténtet — és egyik esetben sem tudja, baj-e.

Most, hogy egyszerre sok PR megy be, ez konkrét kockázat. Ezért írtam egy jegyzetet (`docs/deploy-lepesek.md`), amiben **minden lépéshez tartozik egy ellenőrző lekérdezés**: lefuttatod, és megmondja, kell-e még. Nem kell emlékezni arra, mi történt korábban.

Mind a hét lekérdezést lefuttattam, működnek. Külön kiemeltem, mi az, amihez **nincs teendő** (a cronok maguktól szinkronizálódnak a #638 óta), és mi az, ami **visszafordíthatatlan**.

## 2. A health lap „Területre kereshető" sora félrevezet

Ez a szám bármilyen határkapcsolatot beszámít. Csakhogy az OSM sokféle határt ad vissza — `postal_code`, `judicial`, `wine_community`, `timezone` —, a `religious_administration` határokat pedig **mi hozzuk létre minden templomhoz** az egyházmegyéjéből.

Egy templom tehát „100%-ban kereshető"-nek látszhat úgy, hogy **egyetlen közigazgatási határa sincs**.

**Miért számít ez most:** a helynevek (`locationCityName()` és társai) kizárólag közigazgatási határból jönnek. Ez a szám dönti el, hogy a `templomok.varos` eldobása (#496/#497/#498) **hány templomot hagyna helynév nélkül** — a lap tehát pont a legfontosabb kérdésre adott megnyugtató választ.

Most külön sor méri, és ha nem 100%, meg is mondja, mit jelent.

> A fejlesztői adatbázisban a két szám egyforma (nálam 6 az 5035-ből), mert a seed nem tartalmazza a határ-szinkron eredményét. Az eltérés **élesen** fog látszani — érdemes ránézni, mielőtt a #496-os migráció elindul.

Ellenőrzés: a teljes PHP-futam zöld, a health lapot valódi adattal lefuttattam.