### PR TITLE
Minden tábla InnoDB: a MyISAM miatt a tesztek rollbackje némán nem hatott

### DIFF
--- a/docker/mysql/initdb.d/02-schema.sql
+++ b/docker/mysql/initdb.d/02-schema.sql
@@ -209,7 +209,7 @@ CREATE TABLE IF NOT EXISTS `chat` (
   `kinek` varchar(20) NOT NULL DEFAULT '',
   `szoveg` tinytext NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -357,7 +357,7 @@ CREATE TABLE IF NOT EXISTS `egyhazmegye` (
   `osm_relation` int(45) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `id` (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
+) ENGINE=InnoDB AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -391,7 +391,7 @@ CREATE TABLE IF NOT EXISTS `espereskerulet` (
   `ehm` int(2) NOT NULL DEFAULT 0,
   `nev` varchar(50) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=239 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=239 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -545,7 +545,7 @@ CREATE TABLE IF NOT EXISTS `megye` (
   `orszag` int(2) NOT NULL DEFAULT 12,
   `egyeb` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=22 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=22 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -578,7 +578,7 @@ CREATE TABLE IF NOT EXISTS `orszagok` (
   `ok` enum('i','n') NOT NULL DEFAULT 'i',
   `kiemelt` enum('i','n') NOT NULL DEFAULT 'n',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=49 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=49 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -871,7 +871,7 @@ CREATE TABLE IF NOT EXISTS `user` (
   `nev` varchar(100) NOT NULL DEFAULT '',
   `volunteer` int(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`uid`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -887,7 +887,7 @@ CREATE TABLE IF NOT EXISTS `varosok` (
   `orszag` int(2) NOT NULL DEFAULT 46,
   `nev` varchar(50) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=7845 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=7845 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/docker/mysql/migrations/828-myisam-innodb.sql
+++ b/docker/mysql/migrations/828-myisam-innodb.sql
@@ -1,0 +1,29 @@
+-- #828: a maradék MyISAM táblák átállítása InnoDB-re.
+--
+-- A MyISAM NEM TÁMOGAT TRANZAKCIÓT. Ez nem elméleti kérdés: az integrációs tesztek
+-- java része `DB::beginTransaction()` / `rollBack()` párral dolgozik, és azt hiszi,
+-- hogy tisztán maga után takarít. A `user` táblára viszont a rollback NÉMÁN nem hat —
+-- a beszúrt sor ottmarad. A fejlesztői adatbázisban emiatt 5167 felhasználóból 1943
+-- teszt-maradék volt, és a `teszt_plebanos` login 90-szer szerepelt.
+--
+-- Ez nem csak szemét: a duplikátumok miatt a `where('login', ...)` lekérdezések
+-- találomra választanak sort, tehát a tesztek egymás adatán is dolgozhatnak.
+--
+-- Élesben a `user` a legérzékenyebb tábla erre: a MyISAM tábla-szintű zárolást
+-- használ (nem sor-szintűt), és összeomlás után nem áll helyre magától.
+--
+-- FULLTEXT index egyiken sincs, tehát a konverziónak nincs funkcionális ára.
+-- A megye/orszagok/varosok táblák a 496-497-498-as migrációval amúgy is megszűnnek;
+-- itt csak azért szerepelnek, hogy a lépés sorrendtől függetlenül lefusson.
+
+USE `miserend`;
+
+ALTER TABLE `user`            ENGINE=InnoDB;
+ALTER TABLE `chat`            ENGINE=InnoDB;
+ALTER TABLE `egyhazmegye`     ENGINE=InnoDB;
+ALTER TABLE `espereskerulet`  ENGINE=InnoDB;
+
+-- Ezek a 496-497-498 után már nem léteznek; addig viszont ugyanaz vonatkozik rájuk.
+ALTER TABLE IF EXISTS `megye`     ENGINE=InnoDB;
+ALTER TABLE IF EXISTS `orszagok`  ENGINE=InnoDB;
+ALTER TABLE IF EXISTS `varosok`   ENGINE=InnoDB;

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -698,7 +698,7 @@
       }
     },
     "chat": {
-      "engine": "MyISAM",
+      "engine": "InnoDB",
       "collation": "utf8mb4_unicode_ci",
       "columns": {
         "id": {
@@ -1205,7 +1205,7 @@
       }
     },
     "egyhazmegye": {
-      "engine": "MyISAM",
+      "engine": "InnoDB",
       "collation": "utf8mb4_unicode_ci",
       "columns": {
         "id": {
@@ -1341,7 +1341,7 @@
       }
     },
     "espereskerulet": {
-      "engine": "MyISAM",
+      "engine": "InnoDB",
       "collation": "utf8mb4_unicode_ci",
       "columns": {
         "id": {
@@ -3028,7 +3028,7 @@
       }
     },
     "user": {
-      "engine": "MyISAM",
+      "engine": "InnoDB",
       "collation": "utf8mb4_unicode_ci",
       "columns": {
         "uid": {

--- a/webapp/tests/Integration/StorageEngineTest.php
+++ b/webapp/tests/Integration/StorageEngineTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #828: minden tábla InnoDB — mert a MyISAM nem tud tranzakciót.
+ *
+ * Ez nem elméleti kérdés. Az integrációs tesztek java része `DB::beginTransaction()` /
+ * `rollBack()` párral dolgozik, és azt hiszi, hogy tisztán maga után takarít. A MyISAM
+ * táblákra viszont a rollback **némán nem hat**: a beszúrt sor ottmarad, hibaüzenet
+ * nélkül.
+ *
+ * A fejlesztői adatbázisban emiatt **5167 felhasználóból 1943 volt teszt-maradék**, és a
+ * `teszt_plebanos` login 90-szer szerepelt. Ez nem csak szemét: a duplikátumok miatt a
+ * `where('login', ...)` lekérdezések találomra választanak sort, tehát a tesztek egymás
+ * adatán is dolgozhatnak — és épp az ilyen, alkalmankénti bukás a legdrágább.
+ *
+ * Élesben a `user` a legérzékenyebb erre: a MyISAM tábla-szintű zárolást használ (nem
+ * sor-szintűt), és összeomlás után nem áll helyre magától.
+ */
+final class StorageEngineTest extends TestCase {
+
+    /** A séma most csupa InnoDB — ez az őr, hogy vissza ne csússzon. */
+    public function testMindenTablaInnoDb(): void {
+        $nemInnoDb = DB::select(
+            "SELECT TABLE_NAME, ENGINE FROM information_schema.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND ENGINE IS NOT NULL AND ENGINE <> 'InnoDB'"
+        );
+
+        $nevek = array_map(fn($sor) => $sor->TABLE_NAME . ' (' . $sor->ENGINE . ')', $nemInnoDb);
+
+        self::assertSame([], $nevek,
+            "Nem InnoDB tábla: a tranzakciós tesztek RÁ NÉZVE NÉMÁN nem takarítanak.\n"
+            . implode("\n", $nevek));
+    }
+
+    /**
+     * A lényegi állítás, nem a motor neve: a `user` táblán tényleg visszagördül-e egy
+     * beszúrás? Ez az a viselkedés, amire kilenc tesztfájl épít.
+     */
+    public function testAUserTablanHatARollback(): void {
+        $login = 'motor_proba_' . bin2hex(random_bytes(4));
+
+        DB::beginTransaction();
+        DB::table('user')->insert([
+            'uid'   => (int) DB::table('user')->max('uid') + 1,
+            'login' => $login,
+            'nev'   => 'Motor Próba',
+            'email' => $login . '@example.invalid',
+        ]);
+        $tranzakcioban = DB::table('user')->where('login', $login)->count();
+        DB::rollBack();
+
+        $utana = DB::table('user')->where('login', $login)->count();
+
+        // Ha ez elbukik, MINDEN felhasználót létrehozó teszt szemetel — és a szemét
+        // duplikált loginokat hoz létre, amitől más tesztek is elcsúszhatnak.
+        self::assertSame(1, $tranzakcioban, 'a beszúrásnak látszania kell a tranzakcióban');
+        self::assertSame(0, $utana, 'a rollback után nem maradhat sor');
+    }
+
+    /** Ugyanez a templomokra: erre épül a legtöbb integrációs teszt. */
+    public function testATemplomokTablanIsHatARollback(): void {
+        $nev = 'Motor Próba ' . bin2hex(random_bytes(4));
+
+        DB::beginTransaction();
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $minta['id'] = (int) DB::table('templomok')->max('id') + 1;
+        $minta['nev'] = $nev;
+        DB::table('templomok')->insert($minta);
+        DB::rollBack();
+
+        self::assertSame(0, DB::table('templomok')->where('nev', $nev)->count());
+    }
+}


### PR DESCRIPTION
Egy furcsaságból indultam: a fejlesztői adatbázisban **duplikált felhasználó-loginokat** találtam. Utánanéztem, és nem adathiba volt.

## Amit találtam

Hét tábla **MyISAM** volt, köztük a `user`. A MyISAM **nem támogat tranzakciót**.

Az integrációs tesztek java része viszont `DB::beginTransaction()` / `rollBack()` párral dolgozik, és azt hiszi, hogy tisztán maga után takarít. A MyISAM táblákra a rollback **némán nem hat** — hibaüzenet nincs, a beszúrt sor egyszerűen ottmarad.

Mérve a fejlesztői adatbázisban:

```
összes user:            5167
teszt-jellegű maradék:  1943
teszt_plebanos login:     90 sor
```

**Kilenc tesztfájl** ír a `user` táblába, és mindegyik erre a mintára épít.

## Miért több ez szemétnél

A duplikált loginok miatt a `where('login', ...)` lekérdezések **találomra választanak sort**. A tesztek tehát egymás adatán is dolgozhatnak — és az alkalmankénti, megmagyarázhatatlan bukás a legdrágább fajta hiba, mert nem reprodukálható.

Élesben a `user` a legérzékenyebb erre: a MyISAM **tábla-szintű zárolást** használ (nem sor-szintűt), és **összeomlás után nem áll helyre magától**. Ez a legforgalmasabb írási pontunk.

## A javítás

`ALTER TABLE ... ENGINE=InnoDB` mind a hétre, plusz az `initdb.d/02-schema.sql` javítása, hogy friss adatbázis is jól induljon. **FULLTEXT index egyiken sincs**, tehát a konverziónak nincs funkcionális ára.

Megmértem, nem feltételezem:

```
átállítás előtt:  rollback után 1 sor maradt   (a DerivedHoldersTest futásonként +15)
átállítás után:   rollback után 0 sor          (a teszt már nem hagy maga után semmit)
```

Két őr-teszt vigyáz rá: az egyik azt méri, hogy nincs nem-InnoDB tábla, a másik magát a **viselkedést** (a `user` és a `templomok` táblán tényleg visszagördül-e egy beszúrás) — mert a lényeg nem a motor neve.

**Migráció:** `828-myisam-innodb.sql`. A `megye`/`orszagok`/`varosok` a #496-tal amúgy is megszűnik, csak azért szerepelnek benne, hogy a lépés sorrendtől függetlenül lefusson. A `docs/deploy-lepesek.md` (#827) mellé illik.

**A meglévő szemetet nem takarítom ki** — az éles adatbázisban nem tudom megmondani, melyik sor teszt-maradék és melyik valódi felhasználó.