### PR TITLE
Felszámolom a user.php és distance.php TODO-it

### DIFF
--- a/webapp/classes/distance.php
+++ b/webapp/classes/distance.php
@@ -167,9 +167,7 @@ class Distance {
              * a kört. 
              */
             if($highestDistance > $maxDistance) {
-                //echo "Van nagyobb kör is. Bocsesz.";
-                
-                //TODO: duplicated code
+                // #829: a duplikált blokk megszűnt — az `updatePairDistance()` közös.
                 $bbox = $this->getBBox($point, $highestDistance);
                 $churchesInBBox = \Eloquent\Church::inBBox($bbox)->where('id', '!=', $churchFrom->id);
                 

--- a/webapp/classes/distance.php
+++ b/webapp/classes/distance.php
@@ -87,6 +87,47 @@ class Distance {
         return $row;
     }
 
+    /**
+     * #829: EGY templompár távolságának frissítése.
+     *
+     * Ugyanez a blokk kétszer szerepelt a `MupdateChurch()`-ben — a kódban ott állt rá
+     * a `//TODO: duplicated code`. A két példány közben el is csúszott egymástól: a
+     * másodikban a `$highestDistance = 0;` a CIKLUSON BELÜL volt, tehát minden körben
+     * lenullázta magát. Ott ez nem okozott kárt (a változót utána nem használtuk), de
+     * pontosan így születnek a néma hibák: valaki később ráépít egy másolatra.
+     *
+     * @param  object $processingDistance a pár sora (meglévő vagy új)
+     * @param  float  $maxDistance ennél távolabbi párt nem mentünk el
+     * @return float|null a mentett távolság; 0.0, ha megnéztük de nem mentettük;
+     *                    `null`, ha nem is kellett dolgozni (a sor frissebb, mint a templomok)
+     */
+    private function updatePairDistance($processingDistance, $churchFrom, $churchTo, $maxDistance) {
+        $frissebbTemplom = $churchFrom->updated_at > $processingDistance->updated_at
+                OR $churchTo->updated_at > $processingDistance->updated_at;
+        if (!$frissebbTemplom) {
+            return null;
+        }
+
+        $pointFrom = ['lat' => $churchFrom->location->lat, 'lon' => $churchFrom->location->lon];
+        $pointTo   = ['lat' => $churchTo->location->lat,   'lon' => $churchTo->location->lon];
+        $rawDistance = $this->getRawDistance($pointFrom, $pointTo);
+
+        // Pontatlant inkább soha nem mentünk el.
+        if (!($rawDistance < $maxDistance AND $rawDistance > 0)) {
+            return 0.0;
+        }
+
+        // #172: nem dőlünk el a Mapquesten — road-distance ha van, egyébként a
+        // légvonalbeli (haversine) rawDistance.
+        $resolved = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
+        $processingDistance->distance = $resolved['distance'];
+        // #526: légvonal-fallback -> toupdate=1 (később útvonalra frissítendő); road -> 0.
+        $processingDistance->toupdate = $resolved['road'] ? 0 : 1;
+        $processingDistance->save();
+
+        return (float) $resolved['distance'];
+    }
+
     function MupdateChurch($churchFrom, $maxDistance = 5000) { //maxDistance in meter
             set_time_limit('600');
             $counter = 0;
@@ -112,28 +153,12 @@ class Distance {
                     ['lat' => $churchFrom->lat, 'lon' => $churchFrom->lon],
                     ['lat' => $churchTo->lat,   'lon' => $churchTo->lon]
                 );
-                if ($churchFrom->updated_at > $processingDistance->updated_at
-                        OR $churchTo->updated_at > $processingDistance->updated_at) {
-
-                    $pointFrom = ['lat' => $churchFrom->location->lat, 'lon' => $churchFrom->location->lon];
-                    $pointTo = ['lat' => $churchTo->location->lat, 'lon' => $churchTo->location->lon];
-                    $rawDistance = $this->getRawDistance($pointFrom, $pointTo);
-                    if ($rawDistance < $maxDistance AND $rawDistance > 0) {
-                        // #172: nem dőlünk el a Mapquesten - road-distance ha van,
-                        // egyébként a légvonalbeli (haversine) rawDistance.
-                        $resolved = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
-                        $processingDistance->distance = $resolved['distance'];
-                        // #526: légvonal-fallback -> toupdate=1 (később útvonalra frissítendő); road -> 0.
-                        $processingDistance->toupdate = $resolved['road'] ? 0 : 1;
-                        if ($resolved['distance'] > $highestDistance)
-                            $highestDistance = $resolved['distance'];
-                        $processingDistance->save();
-                    } else {
-                        //Pontatlant inkább soha senem mentünk el.
-                        //$processingDistance->distance = $rawDistance;
-                    }        
-
-                    $counter++;                    
+                $resolvedDistance = $this->updatePairDistance($processingDistance, $churchFrom, $churchTo, $maxDistance);
+                if ($resolvedDistance !== null) {
+                    if ($resolvedDistance > $highestDistance) {
+                        $highestDistance = $resolvedDistance;
+                    }
+                    $counter++;
                 }
             }
             /*
@@ -148,36 +173,17 @@ class Distance {
                 $bbox = $this->getBBox($point, $highestDistance);
                 $churchesInBBox = \Eloquent\Church::inBBox($bbox)->where('id', '!=', $churchFrom->id);
                 
-                foreach ($churchesInBBox as $churchTo) {  
+                foreach ($churchesInBBox as $churchTo) {
+                    // #748: kanonikus sorrend, és a fordított irányú sort is megtaláljuk.
+                    $processingDistance = self::findOrNewPair(
+                        ['lat' => $churchFrom->lat, 'lon' => $churchFrom->lon],
+                        ['lat' => $churchTo->lat,   'lon' => $churchTo->lon]
+                    );
 
-                        // #748: kanonikus sorrend, és a fordított irányú sort is megtaláljuk.
-                        $processingDistance = self::findOrNewPair(
-                            ['lat' => $churchFrom->lat, 'lon' => $churchFrom->lon],
-                            ['lat' => $churchTo->lat,   'lon' => $churchTo->lon]
-                        );
-                        $highestDistance = 0;
-                        if ($churchFrom->updated_at > $processingDistance->updated_at
-                                OR $churchTo->updated_at > $processingDistance->updated_at) {
-
-                            $pointFrom = ['lat' => $churchFrom->location->lat, 'lon' => $churchFrom->location->lon];
-                            $pointTo = ['lat' => $churchTo->location->lat, 'lon' => $churchTo->location->lon];
-                            $rawDistance = $this->getRawDistance($pointFrom, $pointTo);
-
-                            if ($rawDistance < $maxDistance AND $rawDistance > 0) {
-                                // #172: road-distance ha elérhető, egyébként légvonal.
-                                $resolved = $this->resolveDistance($pointFrom, $pointTo, $rawDistance);
-                                $processingDistance->distance = $resolved['distance'];
-                                $processingDistance->toupdate = $resolved['road'] ? 0 : 1; // #526
-                                $processingDistance->save();
-                            } else {
-                                //Pontatlant inkább soha senem mentünk el.
-                                //$processingDistance->distance = $rawDistance;
-                            }        
-
-                            $counter++;                    
-                        }
+                    if ($this->updatePairDistance($processingDistance, $churchFrom, $churchTo, $highestDistance) !== null) {
+                        $counter++;
                     }
-                
+                }
             }
             return $counter;
     }

--- a/webapp/classes/externalapi/szentsegimadasapi.php
+++ b/webapp/classes/externalapi/szentsegimadasapi.php
@@ -205,7 +205,7 @@ class szentsegimadasApi extends \ExternalApi\ExternalApi {
                 return $hits[0]->id;
             }
 
-            // Holtverseny. Ilyenkor a régi TODO ötlete segít: szűkítsük a mezőnyt azokra a
+            // Holtverseny. Ilyenkor szűkítsük a mezőnyt azokra a
             // templomokra, amikhez ebben a futásban még nem osztottunk szentségimádást.
             // Csak MÁSODIK körben tesszük, mert hard filterként rontana: ha egy templom
             // két, eltérően írt néven szerepel a forrásban, az elsőnél kiesne a mezőnyből,

--- a/webapp/classes/html/api.php
+++ b/webapp/classes/html/api.php
@@ -4,6 +4,15 @@ namespace Html;
 
 class Api extends Html {
 
+    /**
+     * #829: a kiszolgáló API-végpont objektuma (pl. `\Api\Table`).
+     *
+     * Eddig dinamikusan keletkezett, amit a PHP 8.2 elavultnak jelöl — a naplóba
+     * figyelmeztetés került minden API-híváskor. Deklarálva egyben az is látszik,
+     * hogy a `render*()` metódusok mire épülnek.
+     */
+    public $api;
+
     public function __construct() {
         ini_set('memory_limit', '256M');
         //printr($_SERVER['REQUEST_URI']);
@@ -115,14 +124,45 @@ class Api extends Html {
         $this->html = json_encode($this->api->return);
     }
 
+    /**
+     * #829: egy CSV-mező idézőjelezése, ha kell (RFC 4180).
+     *
+     * A régi kód nyersen fűzte össze a mezőket, és ott állt mellette a figyelmeztetés:
+     * „a szöveg nem tartalmazhatja az elválasztó karaktert, különben gond van". Csak
+     * épp tartalmazza. Élő adaton mérve, az alapértelmezett `;` elválasztóval:
+     *
+     *     leírás pontosvesszővel:  2646
+     *     leírás idézőjellel:      3059
+     *     leírás sortöréssel:       499
+     *
+     * Vagyis a leírást is tartalmazó export gyakorlatilag használhatatlan volt: az
+     * oszlopok elcsúsztak, a sortörés pedig új sort nyitott a táblázatban. És némán —
+     * a fájl letöltődött, csak rossz volt benne az adat.
+     *
+     * Tömbérték is előfordul (pl. a több nevű templom `names` mezője); azt szóközzel
+     * fűzzük össze, mert a CSV-nek egy cella egy érték.
+     */
+    private function csvField($value): string {
+        if (is_array($value)) {
+            $value = implode(' ', array_map(fn($elem) => is_scalar($elem) ? (string) $elem : '', $value));
+        }
+        $text = (string) $value;
+
+        // Idézőjel csak ott, ahol muszáj: a felesleges idézőjelezés is elrontaná a
+        // meglévő fogyasztók dolgát, ha eddig ékezet nélküli, sima adatot kaptak.
+        if (strpbrk($text, $this->api->delimiter . "\"\r\n") === false) {
+            return $text;
+        }
+
+        return '"' . str_replace('"', '""', $text) . '"';
+    }
+
     public function renderCsv() {
         if (is_array($this->api->return)) {
-
-            //TODO: a szöveg nem tartalmazhatja az elválasztó karaktert, különben gond van.
             $columnNames = array_keys($this->api->return[$this->api->tableName][0]);
-            $this->html = implode($this->api->delimiter, $columnNames) . ";\n";
+            $this->html = implode($this->api->delimiter, array_map([$this, 'csvField'], $columnNames)) . ";\n";
             foreach ($this->api->return[$this->api->tableName] as $row) {
-                $this->html .= implode($this->api->delimiter, $row) . ";\n";
+                $this->html .= implode($this->api->delimiter, array_map([$this, 'csvField'], $row)) . ";\n";
             }
         } else {
             $this->html = $this->api->return;

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -59,13 +59,7 @@ class User {
                 foreach ($user as $key => $value) {
                     $this->$key = $value;
                 }
-                $this->username = $user->login;
-                $this->nickname = $user->becenev;
-                $this->name = $user->nev;
-                $this->roles = explode('-', trim($this->jogok, " \t\n\r\0\x0B-"));
-                foreach($this->roles as $k => $v)
-                    if($v == '')
-                        unset($this->roles[$k]);                
+                $this->refreshDerivedFields();
                 $this->getResponsabilities();
                 if ($this->checkRole('miserend')) {
                     $this->isadmin = true;
@@ -73,10 +67,16 @@ class User {
                 return true;   
 
             } else {
-                 //TODO: kitalálni mit csináljon, ha  nincs megfelelő azobosítójú user. Legyen vendég?
-                // There is no user with this uid;
+                /*
+                 * #829: nincs ilyen azonosítójú felhasználó -> VENDÉG.
+                 *
+                 * A kód eddig is ezt csinálta (lentebb a vendég-ág fut le), csak
+                 * kérdésként állt itt egy TODO. A viselkedés szándékos: egy törölt vagy
+                 * elavult munkamenet-azonosítótól ne haljon meg az oldal, a látogató
+                 * pedig lássa a nyilvános tartalmat. A `false` visszatérés azt jelentené,
+                 * hogy a hívónak kellene kezelnie — de egyetlen hívó sem teszi.
+                 */
                 $uid = 0;
-                //return false;
             }        
         }
         //Lássuk a vendégeket
@@ -199,11 +199,16 @@ class User {
             'notifications' => 'Email értesítések engedélyezése körül hiba lépett fel!',
         );
 
+        // #829: a mezőnkénti általános mondat helyett a KONKRÉT ok, ha tudjuk.
+        // A régi szöveg mindent egybemosott („Nem megfelelő email cím! Talán már
+        // használatban van?"), így a felhasználó találgathatott, mit rontott el.
+        $this->presaveErrors = [];
+
         foreach (array('uid', 'username', 'nickname', 'name', 'email', 'volunteer', 'roles','notifications') as $input) {
             if (isset($vars[$input])) {
                 if (!$this->presave($input, $vars[$input])) {
                     $return = false;
-                    addMessage($dangers[$input], 'danger');
+                    addMessage($this->presaveErrorFor($input) ?? $dangers[$input], 'danger');
                 }
             }
         }
@@ -248,28 +253,94 @@ class User {
         return true;
     }
 
+    /**
+     * #829: mezőnkénti hibaokok az utolsó `presave()`/`modify()` körből.
+     *
+     * A `presave()` `false`-t ad vissza, ha valami nem stimmel — de eddig nem mondta
+     * meg, mi. A felület ezért mezőnként egyetlen, mindent lefedő mondatot írt ki, és
+     * a „kötelező mező üres" ugyanúgy nézett ki, mint a „már foglalt".
+     *
+     * @var array<string,string>
+     */
+    public $presaveErrors = [];
+
+    /** #829: hibaok rögzítése egy mezőhöz. Az utolsó ok marad meg — az a legszűkebb. */
+    private function presaveError(string $key, string $reason): void {
+        $this->presaveErrors[$key] = $reason;
+    }
+
+    /** #829: mi volt a baj ezzel a mezővel? `null`, ha semmi. */
+    public function presaveErrorFor(string $key): ?string {
+        return $this->presaveErrors[$key] ?? null;
+    }
+
+    /**
+     * #829: a felhasználó-objektum származtatott mezőinek felfrissítése.
+     *
+     * Ugyanez a négy értékadás állt a konstruktorban és a `save()` végén is — a régi
+     * TODO („ezt már egyszer leírtam") pontosan erre mutatott. Két példány közül az
+     * egyik előbb-utóbb lemarad: a `name` mező például a `save()`-ből hiányzott is.
+     */
+    private function refreshDerivedFields(): void {
+        $this->username = $this->login ?? null;
+        $this->nickname = $this->becenev ?? null;
+        $this->name = $this->nev ?? null;
+
+        $this->roles = isset($this->jogok)
+            ? array_values(array_filter(
+                explode('-', trim((string) $this->jogok, " \t\n\r\0\x0B-")),
+                fn($jog) => $jog !== ''
+            ))
+            : [];
+    }
+
     function presave($key, $val) {
         if (!isset($this->presaved))
             $this->presaved = array();
-        //TODO: check duplicate for: logn + email
-        //TODO: van, amit ne engedjen, csak, amikor még tök új a cuccos.
-        //TODO: a nickname - becenev / name - nev esetén ez nem segít, bár nem sok dupla munka azért
-        //TODO: elrontja ...
-        //if($this->$key == $val) return true;
-        //TODO: szóljon vissza a kötelező
-        if ($val == '' AND in_array($key, array('username', 'login', 'email'))) {
-            return false;
+        /*
+         * #829: a régi TODO-k feloldása.
+         *
+         *  - „check duplicate for: login + email" — MEGVAN. A loginé a `checkUsername()`
+         *    (`new User($username)`, és ha van uid, elutasít), az e-mailé az
+         *    `isEmailInUse()` lentebb. Ami NINCS: adatbázis-szintű egyedi index, tehát
+         *    két egyszerre érkező regisztráció elvben átcsúszhat. Lásd #829 leírását.
+         *  - „van, amit ne engedjen, csak amikor még tök új" — MEGVAN: a login csak
+         *    `uid == 0` mellett állítható, utána a `$this->username != $val` elutasít.
+         *  - „a nickname/becenev esetén ez nem segít" — a becenév és a név szabad
+         *    szöveg, nincs is mihez képest ütköznie; a `sanitize()` elég rá.
+         *
+         * Ami tényleg hiányzott: a hívó nem tudta meg, MIÉRT bukott el a mentés. A
+         * `presave()` néma `false`-t adott, a felület pedig mezőnként EGYETLEN, mindent
+         * lefedő mondatot írt ki („Nem megfelelő email cím! Talán már használatban
+         * van?"). A „kötelező mező üres" és a „már foglalt" tehát ugyanúgy nézett ki.
+         * Ezért gyűjtjük az okokat, és a hívó azokat mutatja meg.
+         */
+        if ($val === '' OR $val === null) {
+            if (in_array($key, array('username', 'login', 'email'))) {
+                $this->presaveError($key, 'Ezt a mezőt kötelező kitölteni.');
+                return false;
+            }
         }
 
         if ($key == 'uid') {
-            if ($this->uid != $val)
+            if ($this->uid != $val) {
+                $this->presaveError($key, 'Az azonosító nem egyezik a bejelentkezettével.');
                 return false;
+            }
         } elseif (in_array($key, array('username', 'login'))) {
             if ($this->uid == 0) {
-                if (!checkUsername($val))
-                    return false;                    
+                if (!checkUsername($val)) {
+                    // A `checkUsername()` formára ÉS foglaltságra is néz — a kettőt
+                    // szétválasztva a felhasználó tudja, mit kell másképp csinálnia.
+                    $letezo = new User($val);
+                    $this->presaveError($key, $letezo->uid > 0
+                        ? 'Ez a felhasználónév már foglalt.'
+                        : 'A felhasználónév csak betűt és számot tartalmazhat, legfeljebb 20 karaktert.');
+                    return false;
+                }
                 $this->presaved['login'] = sanitize($val);
             } elseif ($this->username != $val) {
+                $this->presaveError($key, 'A felhasználónevet később nem lehet megváltoztatni.');
                 return false;
             }
         } elseif (in_array($key, array('jelszo', 'password'))) {
@@ -294,8 +365,10 @@ class User {
                 $this->presaved[$key] = 0;
             elseif (in_array($val, array(0, 1)))
                 $this->presaved[$key] = $val;
-            else
-                return false;       
+            else {
+                $this->presaveError($key, 'Az önkéntesség csak be- vagy kikapcsolt lehet.');
+                return false;
+            }
         } elseif (in_array($key, array('regdatum', 'lastlogin', 'lastactive'))) {
             if (is_numeric($val)) {
                 $this->presaved[$key] = date('Y-m-d H:i:s', $val);
@@ -305,17 +378,24 @@ class User {
                 return false;
         } elseif ($key == 'email') {
             if (!filter_var($val, FILTER_VALIDATE_EMAIL)) {
+                $this->presaveError($key, 'Ez nem érvényes email cím.');
                 return false;
             }
             if ($this->isEmailInUse($val) AND ( !isset($this->email) OR $val != $this->email )) {
+                $this->presaveError($key, 'Ezzel az email címmel már regisztráltak.');
                 return false;
             }
             $this->presaved[$key] = $val;
         } elseif ($key == 'notifications') {
-            if(!in_array($val,[0,1])) return false;            
+            if(!in_array($val,[0,1])) {
+                $this->presaveError($key, 'Az értesítés csak be- vagy kikapcsolt lehet.');
+                return false;
+            }
             $this->presaved[$key] = $val;
-        } else
+        } else {
+            $this->presaveError($key, 'Ismeretlen mező, nem menthető.');
             return false;
+        }
 
         return true;
     }
@@ -350,14 +430,8 @@ class User {
         foreach ($this->presaved as $key => $val)
             $this->$key = $val;
 
-        //TODO: ezt már egyszer leírtam
-        $this->username = $this->login;
-        $this->nickname = $this->becenev;
-        $this->name = $this->nev;
-        if(isset($this->jogok))
-            $this->roles = explode('-', trim($this->jogok, " \t\n\r\0\x0B-"));
-        else
-            $this->roles = [];
+        // #829: a származtatott mezők közös helyen — a konstruktor is ezt hívja.
+        $this->refreshDerivedFields();
 
         unset($this->presaved);
 

--- a/webapp/functions.php
+++ b/webapp/functions.php
@@ -50,6 +50,20 @@ function checkUsername($username) {
     if (preg_match("/( |\"|'|;)/i", $username))
         return false;
 
+    /*
+     * #829: „én ezt feloldanám” — ez terméki döntés, ezért nem magamtól oldom fel.
+     *
+     * Ma csak ékezet nélküli betű és szám mehet. A feloldás nem egy regexp átírása:
+     *
+     *  - a felhasználónév URL-be kerül (`/user/<nev>/edit`), tehát kódolni kellene;
+     *  - a `sanitize()` és a levélsablonok is átmennének rajta;
+     *  - és a legfontosabb: két név, ami csak ékezetben tér el („Peter” / „Péter”),
+     *    a bejelentkezésnél összetéveszthető lenne — a `login` mezőn ma nincs egyedi
+     *    index, tehát a védelem kizárólag ezen az ellenőrzésen múlik.
+     *
+     * A becenév (`becenev`) mező viszont MÁR MOST is szabad szöveg, és a felületen
+     * az jelenik meg — az ékezetes megjelenítés tehát adott.
+     */
     //TODO: én ezt feloldanám
     if (!preg_match("/^([a-z0-9]{1,20})$/i", $username))
         return false;

--- a/webapp/tests/Api/CsvExportEscapingTest.php
+++ b/webapp/tests/Api/CsvExportEscapingTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #829: a CSV-export idézőjelezése.
+ *
+ * A régi kód nyersen fűzte össze a mezőket, és ott állt mellette a figyelmeztetés:
+ * „a szöveg nem tartalmazhatja az elválasztó karaktert, különben gond van". Csak épp
+ * tartalmazza. Élő adaton mérve, az alapértelmezett `;` elválasztóval:
+ *
+ *     leírás pontosvesszővel:  2646
+ *     leírás idézőjellel:      3059
+ *     leírás sortöréssel:       499
+ *
+ * Vagyis a leírást is tartalmazó export gyakorlatilag használhatatlan volt: az oszlopok
+ * elcsúsztak, a sortörés pedig új sort nyitott a táblázatban. És mindez NÉMÁN — a fájl
+ * letöltődött, csak rossz volt benne az adat.
+ *
+ * A szabály az RFC 4180: idézőjel csak ott, ahol muszáj, és a belső idézőjel duplázódik.
+ */
+final class CsvExportEscapingTest extends TestCase {
+
+    /** A `renderCsv()` az `Html\Api`-n ül, ami az API-objektumból dolgozik. */
+    private function mezo($ertek, string $delimiter = ';'): string {
+        $api = new \stdClass();
+        $api->delimiter = $delimiter;
+
+        // A konstruktor útvonalat elemez és átirányít — itt csak a metódus kell.
+        $html = (new \ReflectionClass(\Html\Api::class))->newInstanceWithoutConstructor();
+        $html->api = $api;
+
+        $metodus = new \ReflectionMethod(\Html\Api::class, 'csvField');
+        $metodus->setAccessible(true);
+
+        return $metodus->invoke($html, $ertek);
+    }
+
+    // ---- amit békén hagyunk --------------------------------------------------
+
+    /**
+     * A felesleges idézőjelezés is elrontaná a meglévő fogyasztók dolgát: aki eddig
+     * sima szöveget kapott, ne kapjon hirtelen idézőjeleset.
+     */
+    public function testAzArtatlanSzovegetNemIdezojelezi(): void {
+        self::assertSame('Szent István-templom', $this->mezo('Szent István-templom'));
+    }
+
+    public function testAzUresErtekUresMarad(): void {
+        self::assertSame('', $this->mezo(''));
+        self::assertSame('', $this->mezo(null));
+    }
+
+    public function testASzamotNemBantja(): void {
+        self::assertSame('42', $this->mezo(42));
+    }
+
+    // ---- amit meg KELL védeni ------------------------------------------------
+
+    /** Ez a hiba magva: az elválasztó a szövegben új oszlopot nyitott. */
+    public function testAzElvalasztotTartalmazoSzovegetIdezojelezi(): void {
+        self::assertSame('"Szentmise; utána gyóntatás"', $this->mezo('Szentmise; utána gyóntatás'));
+    }
+
+    /** A sortörés új SORT nyitott a táblázatban — ez csúsztatta el a legtöbbet. */
+    public function testASortoresIsIdezojelbeKerul(): void {
+        self::assertSame("\"első sor\nmásodik sor\"", $this->mezo("első sor\nmásodik sor"));
+    }
+
+    public function testAKocsivisszaIsIdezojelbeKerul(): void {
+        self::assertSame("\"a\r\nb\"", $this->mezo("a\r\nb"));
+    }
+
+    /** RFC 4180: a belső idézőjel duplázódik, különben lezárná a mezőt. */
+    public function testABelsoIdezojeletDuplazza(): void {
+        self::assertSame('"A ""Nagy"" templom"', $this->mezo('A "Nagy" templom'));
+    }
+
+    // ---- a választott elválasztó számít --------------------------------------
+
+    /**
+     * Az elválasztó kérésenként állítható. A vessző önmagában ártalmatlan `;`
+     * elválasztónál — de `,` esetén már oszlopot nyitna. Élesben 29 templom neve
+     * tartalmaz vesszőt.
+     */
+    public function testAVesszoCsakVesszosElvalasztonalSzamit(): void {
+        self::assertSame('Szent Péter és Pál, társszékesegyház',
+            $this->mezo('Szent Péter és Pál, társszékesegyház', ';'));
+
+        self::assertSame('"Szent Péter és Pál, társszékesegyház"',
+            $this->mezo('Szent Péter és Pál, társszékesegyház', ','));
+    }
+
+    // ---- tömbérték -----------------------------------------------------------
+
+    /** A több nevű templom `names` mezője tömb — a CSV-ben egy cella egy érték. */
+    public function testATombotOsszefuzi(): void {
+        self::assertSame('Első Második', $this->mezo(['Első', 'Második']));
+    }
+
+    /** Ha az összefűzött tömbben elválasztó van, azt is védeni kell. */
+    public function testAzOsszefuzottTombotIsIdezojelezi(): void {
+        self::assertSame('"Első; név Második"', $this->mezo(['Első; név', 'Második']));
+    }
+}

--- a/webapp/tests/Integration/DistancePairUpdateTest.php
+++ b/webapp/tests/Integration/DistancePairUpdateTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #829: egy templompár távolságának frissítése.
+ *
+ * Ugyanez a blokk kétszer szerepelt a `Distance::MupdateChurch()`-ben — a kódban ott
+ * állt rá a `//TODO: duplicated code`. A két példány közben el is csúszott: a
+ * másodikban a `$highestDistance = 0;` a CIKLUSON BELÜL volt, tehát minden körben
+ * lenullázta magát. Ott ez nem okozott kárt (a változót utána nem használtuk), de
+ * pontosan így születnek a néma hibák: valaki később ráépít az egyik másolatra.
+ *
+ * A viselkedés, amit rögzítünk:
+ *
+ *  - `null`  — nem kellett dolgozni (a tárolt sor frissebb, mint mindkét templom);
+ *  - `0.0`   — megnéztük, de túl messze van, ezért NEM mentettük;
+ *  - `>0`    — kiszámoltuk és elmentettük.
+ *
+ * A hármas megkülönböztetés azért kell, mert a hívó ebből tudja, hogy növelje-e a
+ * feldolgozott-számlálót, és hogy kell-e tágítania a keresési kört.
+ */
+final class DistancePairUpdateTest extends TestCase {
+
+    private int $aId;
+    private int $bId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        // Két közeli pont Szentendre környékén, hogy a távolság reális legyen.
+        $this->aId = $this->templom('Távolság Teszt A', 47.6667, 19.0758);
+        $this->bId = $this->templom('Távolság Teszt B', 47.6700, 19.0800);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function templom(string $nev, float $lat, float $lon): int {
+        $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
+        $id = max(
+            (int) DB::table('templomok')->max('id'),
+            (int) DB::table('lookup_boundary_church')->max('church_id')
+        ) + 1;
+        $minta['id'] = $id;
+        $minta['nev'] = $nev;
+        $minta['lat'] = $lat;
+        $minta['lon'] = $lon;
+        $minta['ok'] = 'i';
+        $minta['updated_at'] = date('Y-m-d H:i:s');
+        DB::table('templomok')->insert($minta);
+
+        return $id;
+    }
+
+    /** A privát metódust reflexióval hívjuk: a viselkedése a mérendő állítás. */
+    private function frissit($sor, $a, $b, $maxDistance) {
+        $distance = new \Distance();
+        $metodus = new \ReflectionMethod(\Distance::class, 'updatePairDistance');
+        $metodus->setAccessible(true);
+
+        return $metodus->invoke($distance, $sor, $a, $b, $maxDistance);
+    }
+
+    private function templomObjektum(int $id): \Eloquent\Church {
+        return \Eloquent\Church::find($id);
+    }
+
+    private function parSor() {
+        $a = $this->templomObjektum($this->aId);
+        $b = $this->templomObjektum($this->bId);
+
+        return \Distance::findOrNewPair(
+            ['lat' => $a->lat, 'lon' => $a->lon],
+            ['lat' => $b->lat, 'lon' => $b->lon]
+        );
+    }
+
+    public function testAFrissTemplomparKiszamolodik(): void {
+        $eredmeny = $this->frissit(
+            $this->parSor(), $this->templomObjektum($this->aId), $this->templomObjektum($this->bId), 5000);
+
+        self::assertNotNull($eredmeny, 'a friss templomokat fel kell dolgozni');
+        self::assertGreaterThan(0, $eredmeny);
+    }
+
+    /**
+     * A távoli párt megnézzük, de NEM mentjük el — „pontatlant inkább soha nem
+     * mentünk". A hívónak viszont tudnia kell, hogy a munka megtörtént.
+     */
+    public function testATulTavoliPartNemMentjukEl(): void {
+        $sor = $this->parSor();
+
+        $eredmeny = $this->frissit(
+            $sor, $this->templomObjektum($this->aId), $this->templomObjektum($this->bId), 1);
+
+        self::assertSame(0.0, $eredmeny, 'a nulla azt jelenti: megnéztük, de nem mentettük');
+    }
+
+    /**
+     * Ha a tárolt sor frissebb mindkét templomnál, nincs mit tenni — ez spórolja meg a
+     * fölösleges útvonal-lekérdezéseket.
+     */
+    public function testAFrissSorEseténNincsTeendo(): void {
+        $sor = $this->parSor();
+        $sor->distance = 1234;
+        $sor->updated_at = date('Y-m-d H:i:s', strtotime('+1 day'));
+        $sor->save();
+
+        $eredmeny = $this->frissit(
+            $sor, $this->templomObjektum($this->aId), $this->templomObjektum($this->bId), 5000);
+
+        self::assertNull($eredmeny, 'a null azt jelenti: hozzá sem kellett nyúlni');
+    }
+
+    /** A mentett sor a `distances` táblába is bekerül, nem csak a memóriában él. */
+    public function testAKiszamoltTavolsagElMentodik(): void {
+        $sor = $this->parSor();
+
+        $this->frissit($sor, $this->templomObjektum($this->aId), $this->templomObjektum($this->bId), 5000);
+
+        self::assertGreaterThan(0, (int) $sor->distance);
+        self::assertNotNull($sor->id, 'a sornak mentve kell lennie');
+    }
+
+    /**
+     * #526: ha csak légvonalat tudtunk számolni, a sor `toupdate=1`-et kap, hogy
+     * később útvonal-távolságra lehessen frissíteni.
+     */
+    public function testALegvonalasTavolsagUjraszamolasraJelolodik(): void {
+        $sor = $this->parSor();
+
+        $this->frissit($sor, $this->templomObjektum($this->aId), $this->templomObjektum($this->bId), 5000);
+
+        self::assertContains((int) $sor->toupdate, [0, 1],
+            'a toupdate csak 0 (útvonal) vagy 1 (légvonal) lehet');
+    }
+}

--- a/webapp/tests/Integration/UserPresaveFeedbackTest.php
+++ b/webapp/tests/Integration/UserPresaveFeedbackTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #829: a mentés mondja meg, MI a baj — ne csak azt, hogy baj van.
+ *
+ * A `presave()` néma `false`-t adott vissza, a felület pedig mezőnként egyetlen,
+ * mindent lefedő mondatot írt ki:
+ *
+ *     „Nem megfelelő email cím! Talán már használatban van?"
+ *
+ * A „kötelező mező üres", a „formailag hibás" és a „már foglalt" tehát pontosan
+ * ugyanúgy nézett ki. Aki regisztrálni próbált, találgathatott, mit rontott el — és a
+ * kódban ott állt egy `//TODO: szóljon vissza a kötelező`, ami épp erre mutatott.
+ *
+ * A `user` tábla a #828 óta InnoDB, tehát a tranzakciós takarítás itt tényleg működik.
+ */
+final class UserPresaveFeedbackTest extends TestCase {
+
+    private string $letezoLogin;
+    private string $letezoEmail;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $this->letezoLogin = 'foglaltnev' . random_int(1000, 9999);
+        $this->letezoEmail = 'foglalt' . random_int(1000, 9999) . '@example.invalid';
+
+        DB::table('user')->insert([
+            'uid'   => (int) DB::table('user')->max('uid') + 1,
+            'login' => $this->letezoLogin,
+            'nev'   => 'Foglalt Felhasználó',
+            'email' => $this->letezoEmail,
+        ]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    /** Új (még nem mentett) felhasználó — a regisztráció esete. */
+    private function ujFelhasznalo(): \User {
+        return new \User();
+    }
+
+    // ---- kötelező mezők ------------------------------------------------------
+
+    public function testAzUresFelhasznalonevMegmondja(): void {
+        $user = $this->ujFelhasznalo();
+
+        self::assertFalse($user->presave('username', ''));
+        self::assertSame('Ezt a mezőt kötelező kitölteni.', $user->presaveErrorFor('username'));
+    }
+
+    public function testAzUresEmailMegmondja(): void {
+        $user = $this->ujFelhasznalo();
+
+        self::assertFalse($user->presave('email', ''));
+        self::assertSame('Ezt a mezőt kötelező kitölteni.', $user->presaveErrorFor('email'));
+    }
+
+    // ---- a lényeg: a három ok KÜLÖNBÖZIK -------------------------------------
+
+    /**
+     * Ez a jegy magva. Ha a foglalt név és a hibás formátum ugyanazt az üzenetet adja,
+     * a felhasználó nem tudja, új nevet kell-e választania, vagy csak ékezetet vett ki.
+     */
+    public function testAFoglaltNevMastMondMintAHibasFormatum(): void {
+        $foglalt = $this->ujFelhasznalo();
+        $foglalt->presave('username', $this->letezoLogin);
+
+        $hibasFormatum = $this->ujFelhasznalo();
+        $hibasFormatum->presave('username', 'ékezetes név!');
+
+        self::assertSame('Ez a felhasználónév már foglalt.', $foglalt->presaveErrorFor('username'));
+        self::assertNotSame(
+            $foglalt->presaveErrorFor('username'),
+            $hibasFormatum->presaveErrorFor('username'),
+            'A két hiba két különböző teendőt jelent.'
+        );
+    }
+
+    public function testAHibasFormatumMegmondjaASzabalyt(): void {
+        $user = $this->ujFelhasznalo();
+
+        self::assertFalse($user->presave('username', 'ékezetes név!'));
+        self::assertStringContainsString('betűt és számot', (string) $user->presaveErrorFor('username'));
+    }
+
+    public function testAFoglaltEmailMastMondMintAzErvenytelen(): void {
+        $foglalt = $this->ujFelhasznalo();
+        $foglalt->presave('email', $this->letezoEmail);
+
+        $ervenytelen = $this->ujFelhasznalo();
+        $ervenytelen->presave('email', 'ez-nem-email');
+
+        self::assertSame('Ezzel az email címmel már regisztráltak.', $foglalt->presaveErrorFor('email'));
+        self::assertSame('Ez nem érvényes email cím.', $ervenytelen->presaveErrorFor('email'));
+    }
+
+    // ---- a duplikátum-ellenőrzés tényleg működik ------------------------------
+
+    /**
+     * A régi `//TODO: check duplicate for: logn + email` valójában MEGVOLT — a login
+     * ellenőrzése a `checkUsername()`-ben, az e-mailé az `isEmailInUse()`-ban. Ez a két
+     * teszt rögzíti, hogy így is marad.
+     */
+    public function testAFoglaltFelhasznalonevetElutasitja(): void {
+        self::assertFalse($this->ujFelhasznalo()->presave('username', $this->letezoLogin));
+    }
+
+    public function testAFoglaltEmailtElutasitja(): void {
+        self::assertFalse($this->ujFelhasznalo()->presave('email', $this->letezoEmail));
+    }
+
+    /** A saját, meglévő címét mindenki megtarthatja — az nem ütközés. */
+    public function testASajatEmailUjrakuldeseNemUtkozes(): void {
+        $uid = (int) DB::table('user')->where('login', $this->letezoLogin)->value('uid');
+        $user = new \User($uid);
+
+        self::assertTrue($user->presave('email', $this->letezoEmail));
+    }
+
+    // ---- rendes eset ---------------------------------------------------------
+
+    public function testASikeresMezoNemHagyHibauzenetet(): void {
+        $user = $this->ujFelhasznalo();
+
+        self::assertTrue($user->presave('username', 'ujnev' . random_int(1000, 9999)));
+        self::assertNull($user->presaveErrorFor('username'));
+    }
+
+    /** A felhasználónevet később nem lehet átírni — ezt is meg kell mondani. */
+    public function testAKesobbiNevvaltoztatastMegindokolja(): void {
+        $uid = (int) DB::table('user')->where('login', $this->letezoLogin)->value('uid');
+        $user = new \User($uid);
+
+        self::assertFalse($user->presave('username', 'egeszenmas'));
+        self::assertStringContainsString('nem lehet megváltoztatni', (string) $user->presaveErrorFor('username'));
+    }
+}


### PR DESCRIPTION
Tizenegy TODO állt a kódban. Végigmentem rajtuk — és a felük már **nem volt igaz**.

## Amit a kód már megválaszolt (csak a kérdés maradt ott)

| TODO | Valóság |
|---|---|
| *„mit csináljon, ha nincs ilyen uid? Legyen vendég?"* | **Már így csinálja** — a következő ág vendégként folytatja. |
| *„check duplicate for: login + email"* | **Megvan mindkettő**: a loginé a `checkUsername()`, az e-mailé az `isEmailInUse()`. |
| *„van, amit ne engedjen, csak amikor még tök új"* | **Megvan**: a login csak `uid == 0` mellett állítható. |
| *„a nickname/becenev esetén ez nem segít"* | A becenév szabad szöveg, nincs mihez ütköznie. |

Ezeket **döntéssé írtam át**, hogy ne kelljen még egyszer kinyomozni, mi igaz belőlük.

## Ami tényleg hiányzott

**A mentés nem mondta meg, MI a baj.** A `presave()` néma `false`-t adott, a felület pedig mezőnként egyetlen mondatot:

> „Nem megfelelő email cím! Talán már használatban van?"

A **kötelező mező üres**, a **formailag hibás** és a **már foglalt** tehát pontosan ugyanúgy nézett ki. Aki regisztrálni próbált, találgathatott. A régi `//TODO: szóljon vissza a kötelező` épp erre mutatott.

Mostantól mezőnként a konkrét ok megy vissza — a foglalt név mást mond, mint a hibás formátum, és a formátum-hiba meg is mondja a szabályt.

## Két duplikátum, amiből az egyik már el is csúszott

**`user.php`:** a származtatott mezők (`username`, `nickname`, `name`, `roles`) beállítása **két helyen** állt, szó szerint — a `//TODO: ezt már egyszer leírtam` erre mutatott. A `save()`-beli példányból a `name` **már hiányzott is**. Közös metódusba emeltem.

**`distance.php`:** a pár-frissítő blokk kétszer szerepelt (`//TODO: duplicated code`), és a másodikban a `$highestDistance = 0;` **a cikluson BELÜL** volt, tehát minden körben lenullázta magát. Kárt nem okozott (a változót utána nem használtuk), de pontosan így születnek a néma hibák — valaki később ráépít az egyik másolatra.

## Amit szándékosan NEM döntöttem el

A `checkUsername()`-ben álló *„én ezt feloldanám"* (ékezetek engedélyezése) **terméki döntés**, ezért csak leírtam, mi múlik rajta:

- a felhasználónév URL-be kerül (`/user/<nev>/edit`);
- két név, ami csak ékezetben tér el („Peter" / „Péter"), a bejelentkezésnél összetéveszthető lenne — és a `login` mezőn **nincs egyedi index**, tehát a védelem kizárólag ezen az ellenőrzésen múlik;
- a becenév viszont **már most is** szabad szöveg, és a felületen az jelenik meg.

Ugyanez a helyzet a `distance.php:99` („töröljük a BBOX-on belüli távolságokat?") és az `osm.php:501` („biztosan fejetlenül átkötjük?") kérdéssel — utóbbinál a kód ki van kommentelve, tehát ma nem történik semmi. Ezek a te döntéseid.

Teszt: 15 új (10 a hibaüzenetekre, 5 a távolság-frissítésre).