### PR TITLE
Helyszín az iCal-eseményekbe a templomi miséknél is

### DIFF
--- a/webapp/classes/html/church/ical.php
+++ b/webapp/classes/html/church/ical.php
@@ -10,6 +10,9 @@ use SimpleRRule;
 
 class Ical extends \Html\Html {
 
+    /** #831: a szerkesztett templom — az események helyszínének tartaléka. */
+    public $church;
+
     public function __construct($path) {
         // Expect path like [id]
         if (empty($path[0]) || !is_numeric($path[0])) {
@@ -19,6 +22,9 @@ class Ical extends \Html\Html {
 
         // Fetch church and masses
         $church = Church::find($tid);
+        // #831: az eseményekbe a templom helye is bekerül, ha az alkalomnak nincs
+        // sajátja — a `createCalendarEvent()` innen veszi.
+        $this->church = $church;
         $masses = CalMass::where('church_id', $tid)->get()->all();
 
         $massPeriods = CalMass::generateMassPeriodInstancesForYears( $masses, [], [date('Y'),date('Y')+1]);
@@ -119,6 +125,54 @@ class Ical extends \Html\Html {
         return is_string($host) && $host !== '' ? $host : 'miserend.hu';
     }
 
+    /**
+     * #831: a TEMPLOM helyszíne, tartaléknak az alkalom saját helyszíne mellé.
+     *
+     * A `LOCATION`/`GEO` eddig CSAK akkor került az eseménybe, ha az alkalomnak volt
+     * saját koordinátája (#431). A misék túlnyomó része viszont a templomban van —
+     * azokban az eseményekben tehát semmilyen helyszín nem szerepelt.
+     *
+     * Aki feliratkozik a naptárra, pontosan ezt veszíti el: a telefonja nem tudja
+     * megmutatni térképen, és nem tud útvonalat tervezni oda. Márpedig a naptár-export
+     * fő haszna épp az, hogy a mise bekerül a saját naptáradba — hely nélkül fél adat.
+     *
+     * @return array{name: string, lat: ?float, lon: ?float}
+     */
+    private function churchLocation(): array {
+        $church = $this->church ?? null;
+        if (!$church) {
+            return ['name' => '', 'lat' => null, 'lon' => null];
+        }
+
+        $mezo = static function ($kulcs) use ($church) {
+            return is_array($church) ? ($church[$kulcs] ?? null) : ($church->$kulcs ?? null);
+        };
+
+        // A megnevezés a naptáralkalmazásban egy sorban jelenik meg: név, majd cím.
+        $reszek = array_filter([
+            trim((string) $mezo('nev')),
+            trim((string) $mezo('cim')),
+        ], fn($resz) => $resz !== '');
+
+        $lat = $mezo('lat');
+        $lon = $mezo('lon');
+
+        return [
+            'name' => implode(', ', $reszek),
+            // A 0 nem koordináta: az adatbázisban a hiányzó érték jelölése (#497).
+            'lat' => ($lat !== null && (float) $lat != 0.0) ? (float) $lat : null,
+            'lon' => ($lon !== null && (float) $lon != 0.0) ? (float) $lon : null,
+        ];
+    }
+
+    /** #831: iCal `GEO` alak — szélesség és hosszúság pontosvesszővel, tizedesponttal. */
+    private function geoLine(float $lat, float $lon): string {
+        $szam = static fn(float $ertek): string =>
+            rtrim(rtrim(number_format($ertek, 6, '.', ''), '0'), '.');
+
+        return sprintf('GEO:%s;%s', $szam($lat), $szam($lon));
+    }
+
     private function createCalendarEvent($mass) {
         $lines = [];
            //printr($mass);         
@@ -162,13 +216,24 @@ class Ical extends \Html\Html {
          * mutatják, ami használható, csak csúnya.
          */
         if (!empty($mass['location_lat']) && !empty($mass['location_lon'])) {
-            $lines[] = sprintf('GEO:%s;%s',
-                rtrim(rtrim(number_format((float) $mass['location_lat'], 6, '.', ''), '0'), '.'),
-                rtrim(rtrim(number_format((float) $mass['location_lon'], 6, '.', ''), '0'), '.')
-            );
+            $lines[] = $this->geoLine((float) $mass['location_lat'], (float) $mass['location_lon']);
 
             if (!empty($mass['location_name'])) {
                 $lines[] = 'LOCATION:' . $this->escapeString($mass['location_name']);
+            }
+        } else {
+            /*
+             * #831: nincs saját helyszín -> a TEMPLOM helye kerül be.
+             *
+             * Enélkül a misék túlnyomó része hely nélkül került a feliratkozó
+             * naptárába: nem lehetett térképen megnézni, se útvonalat tervezni oda.
+             */
+            $templom = $this->churchLocation();
+            if ($templom['lat'] !== null && $templom['lon'] !== null) {
+                $lines[] = $this->geoLine($templom['lat'], $templom['lon']);
+            }
+            if ($templom['name'] !== '') {
+                $lines[] = 'LOCATION:' . $this->escapeString($templom['name']);
             }
         }
 
@@ -233,7 +298,9 @@ class Ical extends \Html\Html {
         $counter = 1;
         
         foreach ($masses as $m) {
-            $lines = array_merge($lines, $this->createCalendarEvent($m)); //TODO: bele a LOCATION és GEO
+            // #431/#831: a LOCATION és a GEO az eseményben van — az alkalom saját
+            // helyszíne, ha van, egyébként a templomé.
+            $lines = array_merge($lines, $this->createCalendarEvent($m));
         }
 
         $lines[] = 'END:VCALENDAR';

--- a/webapp/tests/Integration/IcalLocationTest.php
+++ b/webapp/tests/Integration/IcalLocationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #831: helyszín az iCal-eseményekben.
+ *
+ * A `LOCATION` és a `GEO` eddig CSAK akkor került az eseménybe, ha az alkalomnak volt
+ * saját koordinátája (#431). A misék túlnyomó része viszont a templomban van — azokban
+ * az eseményekben tehát semmilyen helyszín nem szerepelt. Élőben ellenőrizve: a
+ * `/templom/:id/ical` kimenetében `SUMMARY` után rögtön `END:VEVENT` jött.
+ *
+ * Aki feliratkozik a naptárra, pontosan ezt veszíti el: a telefonja nem tudja térképen
+ * megmutatni, és nem tud útvonalat tervezni oda. A naptár-export fő haszna épp az, hogy
+ * a mise bekerül a saját naptáradba — hely nélkül fél adat.
+ *
+ * A régi `//TODO: bele a LOCATION és GEO` pontosan erre mutatott.
+ */
+final class IcalLocationTest extends TestCase {
+
+    /** @param array<string,mixed> $church  @param array<string,mixed> $mass */
+    private function esemeny(array $mass, array $church): array {
+        $ical = (new ReflectionClass(\Html\Church\Ical::class))->newInstanceWithoutConstructor();
+        $ical->church = (object) $church;
+
+        $metodus = new ReflectionMethod(\Html\Church\Ical::class, 'createCalendarEvent');
+        $metodus->setAccessible(true);
+
+        return $metodus->invoke($ical, $mass + [
+            'start_date' => date('Y-m-d\TH:i:s'),
+            'mass_id' => 1,
+            'generated_period_id' => 1,
+            'duration_minutes' => 60,
+            'title' => 'Szentmise',
+        ]);
+    }
+
+    private function templom(): array {
+        return ['id' => 1, 'nev' => 'Nagy Szent Teréz-templom', 'cim' => '7300 Komló, Templom tér 1.',
+                'lat' => 46.171093, 'lon' => 18.093341];
+    }
+
+    /** @param string[] $lines */
+    private function sor(array $lines, string $kulcs): ?string {
+        foreach ($lines as $sor) {
+            if (str_starts_with($sor, $kulcs . ':')) {
+                return $sor;
+            }
+        }
+        return null;
+    }
+
+    // ---- a templomi mise (a misék túlnyomó része) -----------------------------
+
+    public function testATemplomiMiseIsKapKoordinatat(): void {
+        $lines = $this->esemeny([], $this->templom());
+
+        self::assertSame('GEO:46.171093;18.093341', $this->sor($lines, 'GEO'));
+    }
+
+    /**
+     * A megnevezésben a név ÉS a cím — a naptáralkalmazás így tud útvonalat tervezni.
+     *
+     * A vessző `\,` alakban megy ki: az RFC 5545 szerint a szöveges mezőkben a vessző
+     * elválasztó jelentésű, tehát escape-elni kell. Enélkül a naptáralkalmazás három
+     * külön értéknek olvasná a nevet és a cím két felét.
+     */
+    public function testATemplomiMiseHelyszineANevEsACim(): void {
+        $lines = $this->esemeny([], $this->templom());
+
+        self::assertSame(
+            'LOCATION:Nagy Szent Teréz-templom\, 7300 Komló\, Templom tér 1.',
+            $this->sor($lines, 'LOCATION')
+        );
+    }
+
+    // ---- az alkalom saját helyszíne (#431) elsőbbséget élvez ------------------
+
+    /**
+     * Ez a lényeg: ha a mise NEM a templomban van, a templom koordinátája rossz válasz
+     * lenne — a hívő oda menne, ahol nincs mise.
+     */
+    public function testASajatHelyszinFelulirjaATemplomet(): void {
+        $lines = $this->esemeny(
+            ['location_lat' => 46.18, 'location_lon' => 20.03, 'location_name' => 'Röszkei puszta'],
+            $this->templom()
+        );
+
+        self::assertSame('GEO:46.18;20.03', $this->sor($lines, 'GEO'));
+        self::assertSame('LOCATION:Röszkei puszta', $this->sor($lines, 'LOCATION'));
+    }
+
+    /** Név nélküli saját helyszínnél a koordináta marad — az legalább pontos. */
+    public function testNevNelkuliSajatHelyszinnelIsAKoordinataAzErvenyes(): void {
+        $lines = $this->esemeny(
+            ['location_lat' => 46.18, 'location_lon' => 20.03],
+            $this->templom()
+        );
+
+        self::assertSame('GEO:46.18;20.03', $this->sor($lines, 'GEO'));
+        self::assertNull($this->sor($lines, 'LOCATION'), 'a templom neve itt félrevezetne');
+    }
+
+    // ---- hiányzó adat --------------------------------------------------------
+
+    /**
+     * 47 templomnak nincs koordinátája (#497). Náluk a GEO kimarad — de a NÉV attól
+     * még hasznos, abból a naptáralkalmazás is tud keresni.
+     */
+    public function testKoordinataNelkuliTemplomnalCsakANevMegy(): void {
+        $lines = $this->esemeny([], ['id' => 1, 'nev' => 'Kápolna', 'cim' => 'Fő utca 1.',
+                                     'lat' => null, 'lon' => null]);
+
+        self::assertNull($this->sor($lines, 'GEO'));
+        self::assertSame('LOCATION:Kápolna\, Fő utca 1.', $this->sor($lines, 'LOCATION'));
+    }
+
+    /** A 0 nem koordináta, hanem a hiányzó érték jelölése — nem küldhetjük ki. */
+    public function testANullaKoordinatatNemKuldjukKi(): void {
+        $lines = $this->esemeny([], ['id' => 1, 'nev' => 'Kápolna', 'cim' => '',
+                                     'lat' => 0, 'lon' => 0]);
+
+        self::assertNull($this->sor($lines, 'GEO'), 'a 0;0 a Guineai-öbölbe vinné a hívőt');
+    }
+
+    /** Templom-adat nélkül se hasaljon el az export. */
+    public function testTemplomAdatNelkulSemSzallEl(): void {
+        $ical = (new ReflectionClass(\Html\Church\Ical::class))->newInstanceWithoutConstructor();
+        $metodus = new ReflectionMethod(\Html\Church\Ical::class, 'createCalendarEvent');
+        $metodus->setAccessible(true);
+
+        $lines = $metodus->invoke($ical, [
+            'start_date' => date('Y-m-d\TH:i:s'), 'mass_id' => 1,
+            'generated_period_id' => 1, 'duration_minutes' => 60, 'title' => 'Szentmise',
+        ]);
+
+        self::assertNotSame([], $lines);
+        self::assertNull($this->sor($lines, 'GEO'));
+    }
+}


### PR DESCRIPTION
Az utolsó TODO-átfésülésnél találtam: `//TODO: bele a LOCATION és GEO`.

**Kiderült, hogy félig már megvolt** — a #431 óta az alkalom **saját** helyszíne bekerül az eseménybe. De csak az. Megnéztem élőben, mit kap egy feliratkozó egy sima templomi misénél:

```
BEGIN:VEVENT
SUMMARY:Szentmise
END:VEVENT
```

**Semmilyen helyszín.** És a misék túlnyomó része ilyen.

Aki feliratkozik a naptárra, pontosan ezt veszíti el: a telefonja nem tudja térképen megmutatni, és nem tud útvonalat tervezni oda. A naptár-export fő haszna épp az, hogy a mise bekerül a saját naptáradba — hely nélkül az fél adat.

Most így néz ki ugyanaz:

```
SUMMARY:Szentmise
GEO:46.171093;18.093341
LOCATION:Nagy Szent Teréz-templom\, 7300 Komló\, Templom tér 1.
```

**A sorrend számít:** az alkalom saját helyszíne **felülírja** a templomét. Ha a mise nem a templomban van, a templom koordinátája nem csak pontatlan lenne, hanem rossz — a hívő odamenne, ahol nincs mise.

**Két apróság, ami könnyen elkerülné a figyelmet:**

- **Koordináta nélküli templomnál** (élesben 47 ilyen, #497) a `GEO` kimarad, de a **név megy** — abból a naptáralkalmazás is tud keresni.
- **A `0` értéket nem küldjük ki.** Az nem koordináta, hanem a hiányzó adat jelölése — a `GEO:0;0` a Guineai-öbölbe vinné a hívőt.

A vessző `\,` alakban megy ki, ahogy az RFC 5545 előírja: a szöveges mezőkben a vessző elválasztó jelentésű. Ez a saját tesztemet meg is buktatta először — a kód volt jó, az elvárásom rossz.

Teszt: 7 új (`IcalLocationTest`).