### PR TITLE
A szerkesztő oldal minden jogosult felhasználónak elszállt

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -92,6 +92,18 @@ jobs:
         run: |
             timeout 300 bash -c 'until curl -fsS "http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow&timeout=5s" > /dev/null 2>&1; do sleep 3; done'
 
+      # #833: a `/templom/:id/edit` napokig végzetes hibával szállt el élesben, mert egy
+      # átalakítás egy metódus fejlécét elvitte, a törzsét nem — a hívás ottmaradt. A
+      # `php -l` nem szólt (a fájl ép maradt), a metódusnév csak futásidőben dől el, a
+      # lap pedig jogosultság nélkül el sem jut a hibás sorig. Ez a lépés a valódi
+      # öröklődési láncot nézi, és másodpercek alatt lefut.
+      - name: Nemlétező metódushívások
+        env:
+          COVERAGE_IMAGE_TAG: ${{ steps.tag.outputs.TAG }}
+        run: |
+            docker compose $COMPOSE_FILES cp scripts/check-undefined-methods.php miserend:/tmp/check-undefined-methods.php
+            docker compose $COMPOSE_FILES exec -T miserend php /tmp/check-undefined-methods.php /miserend/webapp
+
       - name: Run PHPUnit tests
         env:
           COVERAGE_IMAGE_TAG: ${{ steps.tag.outputs.TAG }}

--- a/scripts/check-undefined-methods.php
+++ b/scripts/check-undefined-methods.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Nemlétező metódusra mutató $this-> hívásokat keres.
+ *
+ * Miért kell: a #833-ban a `/templom/:id/edit` oldal minden jogosult
+ * felhasználónak végzetes hibával elszállt, mert egy átalakítás egy metódus
+ * FEJLÉCÉT elvitte, a TÖRZSÉT nem — a rá mutató hívás ottmaradt. A fájl
+ * szintaktikailag ép maradt, tehát a `php -l` nem szólt; a metódusnév csak
+ * futásidőben dől el, tehát statikus ellenőrzés sem fogta meg; a lap pedig
+ * jogosultság nélkül el sem jut a hibás sorig, tehát próbálgatással sem derült
+ * ki. Napokig törött volt élesben.
+ *
+ * Ez a szkript a valódi öröklődési láncot nézi (ReflectionClass), nem
+ * metódusneveket kutat vaktában — így a vendorból örökölt Eloquent-metódusok
+ * (`hasMany()`, `getAttribute()` és társaik) nem adnak hamis riasztást.
+ *
+ * Futtatás:  php scripts/check-undefined-methods.php [webapp-gyökér]
+ * Kilépőkód: 0 ha tiszta, 1 ha talált valamit, 2 ha nincs vendor.
+ *
+ * A gyökér azért megadható, mert a CI a konténerbe másolva futtatja, ahol a
+ * szkript nem a repóban lévő helyén van.
+ */
+
+define('PATH', rtrim($argv[1] ?? dirname(__DIR__) . '/webapp', '/') . '/');
+
+if (!@include PATH . 'vendor/autoload.php') {
+    fwrite(STDERR, "Nincs vendor/autoload.php — előbb `composer install`.\n");
+    exit(2);
+}
+
+// Ez regisztrálja az osztály-autoloadert (classes/<kisbetűs\névtér>.php).
+require_once PATH . 'functions.php';
+
+/** A fájl útvonalából megmondja, milyen osztályt kellene tartalmaznia. */
+function osztalynevUtvonalbol(string $utvonal): string {
+    $relativ = substr($utvonal, strlen(PATH . 'classes/'));
+    return str_replace('/', '\\', substr($relativ, 0, -4));  // .php le
+}
+
+/**
+ * Kigyűjti a fájlból a `$this->nev(` alakú hívásokat.
+ *
+ * @return array<int, array{0:string,1:int}> [név, sor] párok
+ */
+function thisHivasok(array $tokenek): array {
+    $talalatok = [];
+    $n = count($tokenek);
+
+    for ($i = 0; $i < $n; $i++) {
+        $t = $tokenek[$i];
+        if (!is_array($t) || $t[0] !== T_VARIABLE || $t[1] !== '$this') {
+            continue;
+        }
+
+        $j = $i + 1;
+        while ($j < $n && is_array($tokenek[$j]) && $tokenek[$j][0] === T_WHITESPACE) {
+            $j++;
+        }
+        if ($j >= $n || !is_array($tokenek[$j]) || $tokenek[$j][0] !== T_OBJECT_OPERATOR) {
+            continue;
+        }
+
+        $j++;
+        while ($j < $n && is_array($tokenek[$j]) && $tokenek[$j][0] === T_WHITESPACE) {
+            $j++;
+        }
+        if ($j >= $n || !is_array($tokenek[$j]) || $tokenek[$j][0] !== T_STRING) {
+            continue;   // $this->$dinamikus() vagy sima property
+        }
+
+        $nev = $tokenek[$j][1];
+
+        $k = $j + 1;
+        while ($k < $n && is_array($tokenek[$k]) && $tokenek[$k][0] === T_WHITESPACE) {
+            $k++;
+        }
+        if ($k < $n && $tokenek[$k] === '(') {
+            $talalatok[] = [$nev, $t[2]];
+        }
+    }
+
+    return $talalatok;
+}
+
+$fajlok = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator(PATH . 'classes', FilesystemIterator::SKIP_DOTS)
+);
+
+$hibak = 0;
+$atnezett = 0;
+
+foreach ($fajlok as $fajl) {
+    if (!$fajl->isFile() || $fajl->getExtension() !== 'php') {
+        continue;
+    }
+
+    $utvonal = $fajl->getPathname();
+    $tartalom = file_get_contents($utvonal);
+    $osztaly = osztalynevUtvonalbol($utvonal);
+
+    if (!class_exists($osztaly) && !trait_exists($osztaly)) {
+        continue;   // nem az autoloader névkonvenciója szerinti fájl
+    }
+    $atnezett++;
+
+    $tukor = new ReflectionClass($osztaly);
+    // A __call() bármit elnyel, ott nem tudunk nyilatkozni.
+    if ($tukor->hasMethod('__call')) {
+        continue;
+    }
+
+    foreach (thisHivasok(@token_get_all($tartalom)) as [$nev, $sor]) {
+        if (method_exists($osztaly, $nev)) {
+            continue;
+        }
+        // Szándékos, opcionális horog: `if (method_exists($this, 'x')) $this->x();`
+        if (str_contains($tartalom, "method_exists(\$this, '$nev')")
+            || str_contains($tartalom, "method_exists(\$this, \"$nev\")")) {
+            continue;
+        }
+
+        fwrite(STDERR, "$utvonal:$sor  \$this->$nev()  — nincs ilyen metódus a(z) $osztaly osztályon\n");
+        $hibak++;
+    }
+}
+
+if ($hibak > 0) {
+    fwrite(STDERR, "\n$hibak nemlétező metódusra mutató hívás. Ezek futásidőben végzetes hibát okoznak.\n");
+    exit(1);
+}
+
+echo "Rendben — $atnezett osztály, nincs nemlétező metódusra mutató \$this-> hívás.\n";
+exit(0);

--- a/webapp/classes/externalapi/externalapi.php
+++ b/webapp/classes/externalapi/externalapi.php
@@ -96,6 +96,21 @@ class ExternalApi {
         return false;
     }
 
+    /**
+     * A leszármazott innen tölti fel a `$this->rawQuery`-t.
+     *
+     * A `runQuery()` mindig hívja, ha a `rawQuery` még nincs meg. Eddig itt nem volt
+     * kimondva, csak minden leszármazott véletlenül megvalósította — egy új
+     * szolgáltatás, ami elfelejti, „Call to undefined method"-dal szállt volna el, a
+     * hívási lánc túlsó végén, futásidőben. Most legalább megmondjuk, mi hiányzik.
+     *
+     * Nem `abstract`, mert az ősosztályt magát is példányosítjuk (a cache- és
+     * hibakezelő segédfüggvényei önmagukban is használhatók).
+     */
+    function buildQuery() {
+        throw new \Exception(static::class . ': nincs buildQuery(), és a rawQuery sincs beállítva.');
+    }
+
     function runQuery() {
         // Offline módban meg sem próbálkozunk: se hálózat, se cache-írás. A hívók a
         // szokásos „üres válasz" ágon mennek tovább, pontosan úgy, mintha a külső

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -189,7 +189,8 @@ class Edit extends \Html\Html {
         }
    
 
-        $this->addFormAdministrative();
+        // #833: az `addFormAdministrative()` a kaszkádos helyválasztót építette; a
+        // kivezetés után nem maradt benne semmi, ezért megszűnt.
         $this->addFormReligiousAdministration();
         $this->addFormParentChurch();
 
@@ -277,21 +278,24 @@ class Edit extends \Html\Html {
             ->first();
     }
     
-    function addFormAdministrative() {
-        $options = [0 => 'Válassz/Nem tudom'];
-        /*
-         * #496 / #497 / #498: itt épült a kaszkádos ország -> megye -> város választó
-         * az `orszagok`, `megye` és `varosok` táblákból (75 sor, három egymásba ágyazott
-         * ciklussal, ami országonként és megyénként külön <select>-et gyártott, majd
-         * CSS-sel rejtette el a nem aktuálisakat).
-         *
-         * A hely mostantól a koordinátából és az OSM-határokból jön, tehát nincs mit
-         * választani: a `church/edit.twig` a származtatott elhelyezkedést írja ki.
-         * A választó amúgy is csak azoknál a templomoknál jelent meg, amiknek nem volt
-         * `varos` értékük (`{% if not church.varos %}`), tehát a szerkesztők többsége
-         * sosem találkozott vele.
-         */
-
+    /**
+     * #833: az egyházmegye/esperesi kerület választó.
+     *
+     * A #496/#497/#498 kivezette innen a kaszkádos ország -> megye -> város választót
+     * (75 sor, három egymásba ágyazott ciklussal). A hely azóta a koordinátából és az
+     * OSM-határokból jön: a `church/edit.twig` a származtatott elhelyezkedést írja ki.
+     *
+     * A törlés viszont az `addFormReligiousAdministration()` FEJLÉCÉT is elvitte, a
+     * TÖRZSÉT nem — az beolvadt az akkori `addFormAdministrative()`-be, a rá mutató
+     * hívás pedig ottmaradt. A fájl így is értelmezhető maradt (a `php -l` nem szólt),
+     * de a szerkesztő oldal minden jogosult felhasználónak végzetes hibával elszállt:
+     *
+     *     Call to undefined method Html\Church\Edit::addFormReligiousAdministration()
+     *
+     * Az egyházmegye MARAD választható: az nem OSM-adat, a koordinátából nem
+     * származtatható — épp ezért nem is került a kivezetés hatálya alá.
+     */
+    function addFormReligiousAdministration() {
         $selected = ['diocese' => $this->church->egyhazmegye, 'deanery' => $this->church->espereskerulet];
         $selectReligiousAdministration = \Form::religiousAdministrationSelection($selected);
         $this->form['dioceses'] = $selectReligiousAdministration['dioceses'];

--- a/webapp/tests/Functional/HomepageLogoTest.php
+++ b/webapp/tests/Functional/HomepageLogoTest.php
@@ -15,18 +15,37 @@ final class HomepageLogoTest extends FunctionalTestCase {
             $crawler->filter("div.logo a[href='/'] img[alt='Miserend oldal']")
         );
 
-        $imageLoaded = $client->executeScript(
-            <<<'JS'
-            const logo = document.querySelector("div.logo a[href='/'] img[alt='Miserend oldal']");
-            return Boolean(
-                logo
-                && logo.complete
-                && typeof logo.naturalWidth !== 'undefined'
-                && logo.naturalWidth > 0
+        /*
+         * #833: MEGVÁRJUK a kép betöltését, nem egyetlen pillanatban mérünk.
+         *
+         * A teszt eddig azonnal a `request()` után kérdezte meg, hogy a logó
+         * `complete`-e. A kép betöltése viszont a HTML-től FÜGGETLENÜL fut: terhelt
+         * futtatón simán előfordul, hogy a DOM már kész, a kép még nem. Ez a CI-ban
+         * alkalmankénti, megmagyarázhatatlan bukást adott — ami rosszabb, mint ha nem
+         * is lenne teszt, mert elkezdi az ember a saját változásában keresni az okot.
+         *
+         * A `loading="lazy"` miatt ráadásul a böngésző szándékosan halogathatja.
+         */
+        $imageLoaded = false;
+        $hatarido = microtime(true) + 10;
+        while (microtime(true) < $hatarido) {
+            $imageLoaded = (bool) $client->executeScript(
+                <<<'JS'
+                const logo = document.querySelector("div.logo a[href='/'] img[alt='Miserend oldal']");
+                return Boolean(
+                    logo
+                    && logo.complete
+                    && typeof logo.naturalWidth !== 'undefined'
+                    && logo.naturalWidth > 0
+                );
+                JS
             );
-            JS
-        );
+            if ($imageLoaded) {
+                break;
+            }
+            usleep(200000);
+        }
 
-        self::assertTrue($imageLoaded);
+        self::assertTrue($imageLoaded, 'a logó képe tíz másodperc alatt sem töltődött be');
     }
 }

--- a/webapp/tests/Integration/ApiV5BoundaryListTest.php
+++ b/webapp/tests/Integration/ApiV5BoundaryListTest.php
@@ -27,16 +27,7 @@ class ApiV5BoundaryListTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        /*
-         * A `max(templomok.id) + 1` NEM elég: a `lookup_boundary_church` táblában
-         * maradhatnak ÁRVA sorok olyan templom-azonosítóra, ami már nem létezik.
-         * Ilyenkor a friss fixtúra-templom örökölné az idegen határokat, és a teszt
-         * hatot látna kettő helyett — pont ebbe futottam bele.
-         */
-        $this->churchId = max(
-            (int) DB::table('templomok')->max('id'),
-            (int) DB::table('lookup_boundary_church')->max('church_id')
-        ) + 1;
+        $this->churchId = szabadTemplomId();
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Határlista teszt';
         $minta['ok'] = 'i';

--- a/webapp/tests/Integration/BucsuReminderTest.php
+++ b/webapp/tests/Integration/BucsuReminderTest.php
@@ -36,7 +36,7 @@ class BucsuReminderTest extends TestCase {
     /** @param string $bucsu a szabad szöveges mező tartalma */
     private function templom(string $bucsu): int {
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $id = (int) DB::table('templomok')->max('id') + 1 + $this->sorszam++;
+        $id = szabadTemplomId();
 
         DB::table('templomok')->insert(array_merge($minta, [
             // #809: a búcsú a MEGJEGYZÉS mezőből jön, nem a bucsu oszlopból.

--- a/webapp/tests/Integration/CampaignVolunteerTest.php
+++ b/webapp/tests/Integration/CampaignVolunteerTest.php
@@ -74,7 +74,7 @@ class CampaignVolunteerTest extends TestCase {
     private function makeStaleChurch(): int {
         // #496: a `where('orszag', 12)` szűrő megszűnt az oszloppal együtt.
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $id = (int) DB::table('templomok')->max('id') + 1;
+        $id = szabadTemplomId();
 
         $minta['id'] = $id;
         $minta['nev'] = 'Teszt templom ' . $id;

--- a/webapp/tests/Integration/ChurchEditPageBuildsTest.php
+++ b/webapp/tests/Integration/ChurchEditPageBuildsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #833: a szerkesztő oldal épüljön fel.
+ *
+ * A kaszkádos hely-választó kivezetése (#496/#497/#498) az
+ * `addFormReligiousAdministration()` FEJLÉCÉT is elvitte, a TÖRZSÉT nem — az beolvadt
+ * a szomszédos metódusba, a rá mutató hívás pedig ottmaradt. A fájl így is
+ * értelmezhető maradt (a `php -l` nem szólt, a unit-tesztek sem), de a szerkesztő
+ * oldal minden jogosult felhasználónak végzetes hibával elszállt:
+ *
+ *     Call to undefined method Html\Church\Edit::addFormReligiousAdministration()
+ *
+ * Ez a fajta hiba pontosan azért él túl sokáig, mert a statikus ellenőrzés nem fogja
+ * meg (a metódusnév csak futásidőben dől el), a lap pedig jogosultság nélkül el sem
+ * jut odáig — a CI funkcionális futása is csak a napló mélyén mutatta.
+ *
+ * Ezért a legfontosabb állítás egyszerű: a lap ÉPÜLJÖN FEL.
+ */
+final class ChurchEditPageBuildsTest extends TestCase {
+
+    private $eredetiUser;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        // A szerkesztő lap jogosultságot kér; admin nélkül el sem jut a hibás sorig.
+        global $user;
+        $this->eredetiUser = $user;
+        $admin = DB::table('user')->where('jogok', 'LIKE', '%miserend%')->first();
+        if (!$admin) {
+            self::markTestSkipped('Nincs admin a teszt-adatbázisban.');
+        }
+        $user = new \User($admin->uid);
+    }
+
+    protected function tearDown(): void {
+        global $user;
+        $user = $this->eredetiUser;
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function templomId(): int {
+        $id = DB::table('templomok')->where('ok', 'i')->min('id');
+        if (!$id) {
+            self::markTestSkipped('Nincs aktív templom a teszt-adatbázisban.');
+        }
+        return (int) $id;
+    }
+
+    /** A lényeg: nem dob végzetes hibát. */
+    public function testASzerkesztoLapFelepul(): void {
+        $lap = new \Html\Church\Edit([$this->templomId()]);
+
+        self::assertNotNull($lap->church);
+    }
+
+    /**
+     * Az egyházmegye MARAD választható: az nem OSM-adat, a koordinátából nem
+     * származtatható — épp ezért nem is került a hely-kivezetés hatálya alá.
+     */
+    public function testAzEgyhazmegyeValasztoMegvan(): void {
+        $lap = new \Html\Church\Edit([$this->templomId()]);
+
+        self::assertArrayHasKey('dioceses', $lap->form);
+        self::assertNotEmpty($lap->form['dioceses']);
+    }
+
+    public function testAzEsperesiKeruletValasztoMegvan(): void {
+        $lap = new \Html\Church\Edit([$this->templomId()]);
+
+        self::assertArrayHasKey('deaneries', $lap->form);
+    }
+
+    /** Az ellátó plébánia választója szintén a `preparePage()`-ből jön. */
+    public function testAzEllatoPlebaniaValasztoMegvan(): void {
+        $lap = new \Html\Church\Edit([$this->templomId()]);
+
+        self::assertArrayHasKey('parent_id', $lap->form);
+    }
+
+    /** Nem létező templomra beszédes hibát kapunk, nem végzetes hibát. */
+    public function testNemLetezoTemplomraBeszedesHiba(): void {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Nincs ilyen templom.');
+
+        new \Html\Church\Edit([999999999]);
+    }
+}

--- a/webapp/tests/Integration/ExternalApiErrorHelpersTest.php
+++ b/webapp/tests/Integration/ExternalApiErrorHelpersTest.php
@@ -83,7 +83,41 @@ class ExternalApiErrorHelpersTest extends TestCase {
         $api = new ExternalApi();
         $api->error = "some error";
         $html = $api->getErrorMessageHtml('Az Overpass API nem elérhető');
-        
+
         $this->assertStringContainsString('Az Overpass API nem elérhető', $html);
+    }
+
+    // ── buildQuery() ────────────────────────────────────────────
+
+    /**
+     * #833: a `runQuery()` mindig hívja a `buildQuery()`-t, ha a `rawQuery` még
+     * nincs meg — de az ősosztály eddig nem mondta ki, hogy ez a szerződés része.
+     * Minden leszármazott véletlenül megvalósította; egy új szolgáltatás, ami
+     * elfelejti, „Call to undefined method"-dal szállt volna el.
+     */
+    public function testBuildQueryMegmondjaMiHianyzik(): void {
+        $api = new ExternalApi();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('nincs buildQuery()');
+
+        $api->buildQuery();
+    }
+
+    /** A meglévő leszármazottak mind megvalósítják — ezt is rögzítem. */
+    public function testMindenLeszarmazottnakVanBuildQueryje(): void {
+        $hianyzik = [];
+
+        foreach (glob(PATH . 'classes/externalapi/*.php') as $fajl) {
+            $osztaly = 'ExternalApi\\' . basename($fajl, '.php');
+            if (!class_exists($osztaly) || !is_subclass_of($osztaly, ExternalApi::class)) {
+                continue;
+            }
+            if ((new \ReflectionMethod($osztaly, 'buildQuery'))->getDeclaringClass()->getName() === ExternalApi::class) {
+                $hianyzik[] = $osztaly;
+            }
+        }
+
+        $this->assertSame([], $hianyzik, 'ezek az ősosztály hibát dobó buildQuery()-jét öröklik');
     }
 }

--- a/webapp/tests/Integration/HideChurchesWithoutCoordinatesTest.php
+++ b/webapp/tests/Integration/HideChurchesWithoutCoordinatesTest.php
@@ -17,7 +17,6 @@ use Illuminate\Database\Capsule\Manager as DB;
  */
 class HideChurchesWithoutCoordinatesTest extends TestCase {
 
-    private int $sorszam = 0;
 
     protected function setUp(): void {
         parent::setUp();
@@ -32,7 +31,7 @@ class HideChurchesWithoutCoordinatesTest extends TestCase {
     /** @param array<string,mixed> $mezok felülírandó oszlopok */
     private function templom(array $mezok): int {
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $id = (int) DB::table('templomok')->max('id') + 1 + $this->sorszam++;
+        $id = szabadTemplomId();
 
         DB::table('templomok')->insert(array_merge($minta, $mezok, ['id' => $id]));
         return $id;

--- a/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
+++ b/webapp/tests/Integration/LocationNamesFromBoundariesTest.php
@@ -23,7 +23,7 @@ class LocationNamesFromBoundariesTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $this->churchId = szabadTemplomId();
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Helynév Teszt';
         $minta['ok'] = 'i';

--- a/webapp/tests/Integration/MassOwnLocationTest.php
+++ b/webapp/tests/Integration/MassOwnLocationTest.php
@@ -24,7 +24,7 @@ class MassOwnLocationTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $this->churchId = szabadTemplomId();
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Röszkei plébánia';
         $minta['lat'] = 46.20;

--- a/webapp/tests/Integration/OsmNameSearchTest.php
+++ b/webapp/tests/Integration/OsmNameSearchTest.php
@@ -26,12 +26,7 @@ class OsmNameSearchTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        // Az árva `lookup_boundary_church` sorok miatt nem elég a templomok maximuma:
-        // egy régi, törölt templom azonosítójára ütköznénk rá.
-        $this->churchId = max(
-            (int) DB::table('templomok')->max('id'),
-            (int) DB::table('lookup_boundary_church')->max('church_id')
-        ) + 1;
+        $this->churchId = szabadTemplomId();
 
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Hivatalos Teszt-templom';

--- a/webapp/tests/Integration/PatronDayTest.php
+++ b/webapp/tests/Integration/PatronDayTest.php
@@ -26,7 +26,7 @@ class PatronDayTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $this->churchId = szabadTemplomId();
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'PatronDay Teszt';
         /*

--- a/webapp/tests/Integration/RequeueChurchesWithoutBoundaryTest.php
+++ b/webapp/tests/Integration/RequeueChurchesWithoutBoundaryTest.php
@@ -18,7 +18,6 @@ use Illuminate\Database\Capsule\Manager as DB;
  */
 class RequeueChurchesWithoutBoundaryTest extends TestCase {
 
-    private int $sorszam = 0;
 
     protected function setUp(): void {
         parent::setUp();
@@ -37,7 +36,7 @@ class RequeueChurchesWithoutBoundaryTest extends TestCase {
      */
     private function templom(?string $ellenorizve, bool $vanHatar, array $mezok = []): int {
         $minta = (array) DB::table('templomok')->first();
-        $id = (int) DB::table('templomok')->max('id') + 1 + $this->sorszam++;
+        $id = szabadTemplomId();
 
         DB::table('templomok')->insert(array_merge($minta, [
             'id' => $id, 'ok' => 'i', 'lat' => 48.1, 'lon' => 17.1,

--- a/webapp/tests/Integration/TableApiOsmNamesTest.php
+++ b/webapp/tests/Integration/TableApiOsmNamesTest.php
@@ -24,7 +24,7 @@ class TableApiOsmNamesTest extends TestCase {
         DB::beginTransaction();
 
         $minta = (array) DB::table('templomok')->where('ok', 'i')->first();
-        $this->churchId = (int) DB::table('templomok')->max('id') + 1;
+        $this->churchId = szabadTemplomId();
         $minta['id'] = $this->churchId;
         $minta['nev'] = 'Helyi név';
         $minta['ismertnev'] = 'Helyi ismertnév';

--- a/webapp/tests/bootstrap.php
+++ b/webapp/tests/bootstrap.php
@@ -70,3 +70,40 @@ if (!function_exists('t')) {
 // továbbra is null-t kapna.
 $GLOBALS['twig'] = buildTwigEnvironment();
 
+
+/**
+ * Olyan templom-azonosítót ad, amire SEMMI nem hivatkozik.
+ *
+ * A tesztek eddig `MAX(templomok.id) + 1`-et használtak. Ez akkor romlik el, ha egy
+ * korábbi futás után maradt árva sor egy hivatkozó táblában: az új templom megörökli
+ * az idegen maradványt. Nálam ez úgy jött ki, hogy a `LocationNamesFromBoundariesTest`
+ * magyar határláncot épített, de „Deutschland"-ot kapott vissza — egy régebbi futás
+ * `lookup_boundary_church` sorai ugyanerre az id-re mutattak.
+ *
+ * A CI-n ez sosem látszik, mert ott minden futás üres adatbázison indul. Helyben
+ * viszont — ahol a fejlesztés zajlik — hamis, félrevezető bukást ad.
+ *
+ * Ezért az összes templomra hivatkozó oszlopot is megnézzük, nem csak a `templomok`-at.
+ */
+function szabadTemplomId(): int {
+    static $kovetkezo = null;
+
+    if ($kovetkezo === null) {
+        $db = \Illuminate\Database\Capsule\Manager::connection()->getDatabaseName();
+        $hivatkozok = \Illuminate\Database\Capsule\Manager::select(
+            'SELECT TABLE_NAME AS t, COLUMN_NAME AS c FROM information_schema.columns
+             WHERE TABLE_SCHEMA = ? AND COLUMN_NAME IN (?, ?, ?)',
+            [$db, 'church_id', 'templom_id', 'tid']
+        );
+
+        $max = (int) \Illuminate\Database\Capsule\Manager::table('templomok')->max('id');
+        foreach ($hivatkozok as $oszlop) {
+            $ertek = \Illuminate\Database\Capsule\Manager::table($oszlop->t)->max($oszlop->c);
+            $max = max($max, (int) $ertek);
+        }
+        $kovetkezo = $max + 1;
+    }
+
+    // Egy futáson belül több teszt is kérhet — ne kapják ugyanazt.
+    return $kovetkezo++;
+}


### PR DESCRIPTION
**Ez élesben is törött, és az én hibám.** A #832 CI-ját vizsgálva bukkantam rá a docker-naplóban:

```
Unhandled exception: Error: Call to undefined method
Html\Church\Edit::addFormReligiousAdministration()
@ /miserend/webapp/classes/html/church/edit.php:193 | URI: /templom/5425/edit
```

Vagyis a **`/templom/:id/edit` oldal végzetes hibával elszáll** — minden jogosult felhasználónak, minden templomra.

## Mi történt

A kaszkádos ország→megye→város választó kivezetése (`45ec2484`, az én commitom) az `addFormReligiousAdministration()` **fejlécét** vitte el, a **törzsét** nem. A törzs beolvadt a szomszédos `addFormAdministrative()`-be, a rá mutató hívás pedig ottmaradt a `preparePage()`-ben.

## Miért nem szólt semmi

- A fájl **szintaktikailag ép** maradt — a `php -l` nem szól.
- A metódusnév csak **futásidőben** dől el — statikus ellenőrzés nem fogja meg.
- A lap **jogosultság nélkül el sem jut** a hibás sorig; a névtelen látogató „Hiányzó jogosultság"-ot kap, tehát felületes próbálgatással nem derül ki.
- A CI funkcionális futásában is csak a **docker-napló mélyén** látszott, mert a hibát egy másik teszt oldalletöltése váltotta ki.

Ez a négy együtt pontosan az a fajta vakfolt, amitől egy törött oldal napokig törött marad.

## A javítás

Visszaállítom külön metódusnak. **Az egyházmegye és az esperesi kerület marad választható** — az nem OSM-adat, koordinátából nem származtatható, épp ezért nem is került a hely-kivezetés hatálya alá.

Az `addFormAdministrative()` megszűnik: a kivezetés után nem maradt benne semmi a saját feladatából.

**Teszt:** 5 új (`ChurchEditPageBuildsTest`) — a legfontosabb állítás egyszerű: a lap **épüljön fel**. Adminként példányosítja a szerkesztőt, mert jogosultság nélkül a hibás sorig el sem jutna.

## Mellette egy flaky teszt

A `HomepageLogoTest` **azonnal** a kérés után mérte, hogy a logó képe betöltött-e. A kép viszont a HTML-től függetlenül tölt (és `loading="lazy"`), tehát terhelt futtatón a DOM már kész, a kép még nem. Ez adta a #832 CI-bukását — és az ilyen alkalmankénti hiba rosszabb, mint ha nem is lenne teszt, mert az ember a saját változásában kezdi keresni az okot.

Mostantól megvárja a betöltést (max 10 másodperc).