### PR TITLE
A CI három ponton hallgatott arról, ami baj

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,6 +44,9 @@ jobs:
           key: ${{ secrets.STAGING_SSH_KEY }}
           port: ${{ secrets.STAGING_SSH_PORT || 22 }}
           command_timeout: 40m
+          # Lásd a staging-workflow indoklását: a 30 másodperces alapértelmezés
+          # kevés, ha a gépen épp egy másik deploy buildje fut.
+          timeout: 2m
           script: |
             set -euo pipefail
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -50,6 +50,11 @@ jobs:
           key: ${{ secrets.STAGING_SSH_KEY }}
           port: ${{ secrets.STAGING_SSH_PORT || 22 }}
           command_timeout: 40m   # a Dockerfile-build (npm + calendar + PHP) + a friss seed hosszú
+          # A KAPCSOLÓDÁS felső korlátja (alapértelmezés 30s). A 2026-08-16-i futás
+          # pont 30 másodpercnél halt el `dial tcp ... i/o timeout`-tal: az előző
+          # deploy buildje még dolgozott, a gép nem ért rá válaszolni. A parancs
+          # futhat sokáig, a kézfogásra viszont ne másodperceken múljon a deploy.
+          timeout: 2m
           script: |
             set -euo pipefail
 

--- a/.github/workflows/elasticsearch-data.yaml
+++ b/.github/workflows/elasticsearch-data.yaml
@@ -63,10 +63,32 @@ jobs:
             exit 1
           fi
 
-          ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          # A `2>/dev/null` + `set -e` együtt NÉMA halált adott: a 2026-08-17-i futás
+          # hat másodperc alatt, egyetlen sor kimenet nélkül bukott el. Ha a szerver
+          # nem érhető el, azt mondjuk is meg — nem a futó dolga kitalálni.
+          if ! ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/tmp/keyscan.err; then
+            echo "✗ Az ssh-keyscan nem érte el a szervert (port: $SSH_PORT):"
+            sed 's/^/    /' /tmp/keyscan.err
+            exit 1
+          fi
 
           # BatchMode: sose próbáljon jelszót kérni, inkább bukjon el azonnal, érthetően.
-          SSH="ssh -i $HOME/.ssh/deploy_key -p $SSH_PORT -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+          SSH="ssh -i $HOME/.ssh/deploy_key -p $SSH_PORT -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15"
+
+          # Hálózati kimaradás miatt ne bukjon a heti mentés: háromszor próbálkozunk.
+          # A szerver ugyanazon a gépen futtatja a stagingot is, és a deploy is ütközhet vele.
+          for probalkozas in 1 2 3; do
+            if $SSH -o ConnectTimeout=15 "$SSH_USER@$SSH_HOST" true 2>/tmp/ssh.err; then
+              break
+            fi
+            if [ "$probalkozas" = 3 ]; then
+              echo "✗ Három próbálkozásból sem sikerült beloginolni SSH-val:"
+              sed 's/^/    /' /tmp/ssh.err
+              exit 1
+            fi
+            echo "… $probalkozas. próbálkozás nem sikerült, várok 30 másodpercet."
+            sleep 30
+          done
 
           # A konténer neve a compose projekt-prefixtől függ (pl. miserend-elasticsearch-1),
           # ezért nem drótozzuk be "elasticsearch"-nek. FONTOS: ugyanazon a gépen fut a

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,6 +2,14 @@ name: PHPUnit
 
 on:
   pull_request:
+  # A masteren 2026. június 5. óta NEM futott le a tesztsor. A `workflow_run` az
+  # app-image buildhez van kötve, az viszont csak TAG-re indul — tehát a beolvasztott
+  # állapotot senki nem próbálta ki. Minden PR a SAJÁT fejére zöld; hogy a merge után
+  # mi lesz belőlük együtt, arról eddig semmit nem tudtunk.
+  #
+  # Ez nem elméleti: a #833-ban javított végzetes hiba pont így élt túl a masteren.
+  push:
+    branches: [master]
   workflow_run:
     workflows: ["🐳 Build & publish app image"]
     types:

--- a/webapp/tests/Functional/HomepageLogoTest.php
+++ b/webapp/tests/Functional/HomepageLogoTest.php
@@ -15,18 +15,37 @@ final class HomepageLogoTest extends FunctionalTestCase {
             $crawler->filter("div.logo a[href='/'] img[alt='Miserend oldal']")
         );
 
-        $imageLoaded = $client->executeScript(
-            <<<'JS'
-            const logo = document.querySelector("div.logo a[href='/'] img[alt='Miserend oldal']");
-            return Boolean(
-                logo
-                && logo.complete
-                && typeof logo.naturalWidth !== 'undefined'
-                && logo.naturalWidth > 0
+        /*
+         * #833: MEGVÁRJUK a kép betöltését, nem egyetlen pillanatban mérünk.
+         *
+         * A teszt eddig azonnal a `request()` után kérdezte meg, hogy a logó
+         * `complete`-e. A kép betöltése viszont a HTML-től FÜGGETLENÜL fut: terhelt
+         * futtatón simán előfordul, hogy a DOM már kész, a kép még nem. Ez a CI-ban
+         * alkalmankénti, megmagyarázhatatlan bukást adott — ami rosszabb, mint ha nem
+         * is lenne teszt, mert elkezdi az ember a saját változásában keresni az okot.
+         *
+         * A `loading="lazy"` miatt ráadásul a böngésző szándékosan halogathatja.
+         */
+        $imageLoaded = false;
+        $hatarido = microtime(true) + 10;
+        while (microtime(true) < $hatarido) {
+            $imageLoaded = (bool) $client->executeScript(
+                <<<'JS'
+                const logo = document.querySelector("div.logo a[href='/'] img[alt='Miserend oldal']");
+                return Boolean(
+                    logo
+                    && logo.complete
+                    && typeof logo.naturalWidth !== 'undefined'
+                    && logo.naturalWidth > 0
+                );
+                JS
             );
-            JS
-        );
+            if ($imageLoaded) {
+                break;
+            }
+            usleep(200000);
+        }
 
-        self::assertTrue($imageLoaded);
+        self::assertTrue($imageLoaded, 'a logó képe tíz másodperc alatt sem töltődött be');
     }
 }


### PR DESCRIPTION
Három dolog, mindhárom ugyanarról szól: **a CI nem mondta meg, mi a helyzet.**

## 1. A master tesztjei két hónapja nem futottak le

Ez a legsúlyosabb. A PHPUnit-workflow `workflow_run`-nal az app-image buildhez van kötve:

```yaml
workflow_run:
  workflows: ["🐳 Build & publish app image"]
```

Az az image-build viszont **csak tagre indul** (`on: push: tags: ['*']`), és utoljára **2026. június 5-én** futott. Azóta a masteren **egyetlen tesztfutás sem volt**.

Minden PR a saját fejére zöld. Hogy a beolvasztott állapot mit csinál együtt, arról eddig semmit nem tudtunk — és ez nem elméleti gond: a #833-ban javított végzetes hiba pont ezen a résen élt túl.

Push-ra is elindítom a masteren. Egy merge = egy futás, öt-nyolc perc; a `concurrency` csoport a torlódást már kezeli.

## 2. A heti Elasticsearch-mentés némán halt meg

A ma hajnali futás **hat másodperc alatt, egyetlen sor kimenet nélkül** elhasalt:

```bash
ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
```

A `2>/dev/null` elnyeli a hibát, a `set -e` pedig ott helyben megöli a lépést — a lentebbi, szépen megfogalmazott hibaágak el sem érhetők. Aki ránéz, csak `exit code 1`-et lát.

Most kiírja, mi történt, és **háromszor próbálkozik**. Ez a mentés hetente egyszer fut: ha egy múló hálózati kimaradás elviszi, egy hétig nincs friss index-adat.

## 3. A staging-deploy 30 másodpercnél adta fel

```
2026/08/16 20:57:14 dial tcp 193.x.x.x:xx: i/o timeout   (duration_ms=30189)
```

Pontosan 30 másodperc — ez az `appleboy/ssh-action` alapértelmezett **kapcsolódási** korlátja. Tíz perccel korábban indult egy másik deploy, aminek a Docker-buildje még dolgozott; a gép nem ért rá válaszolni a kézfogásra.

A `command_timeout` már 40 perc, tehát a hosszú build nem probléma — csak a bejelentkezés. Két percre emelem, a productionnél is.

---

A szerver elérhetetlensége nem a mi hibánk. Az igen, hogy nem mondjuk meg — és az is, hogy a masterről két hónapja nem tudjuk, működik-e.