### PR TITLE
docker/README pontosítása

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -69,10 +69,17 @@ docker compose -f docker/compose.yml -f docker/compose.test.yml up
 ```
 
 - Kibana hozzáadása:
-Az előbbi paransokhoz csak add hozzá a kibana compose fájlt:
+Az előbbi parancsokhoz csak add hozzá a kibana compose fájlt az `up` elé:
 
 ```
   -f docker/compose.kibana.yml
+```
+
+- OSRM hozzáadása:
+Az előbbiekhez csak a következő kapcsolót kell hozzáadni az `up` elé:
+
+```
+--profile osrm
 ```
 
 A fájlokat egymásra rétegezve is használhatod, pl. fejlesztés közben Kibana-val:

--- a/docker/README.md
+++ b/docker/README.md
@@ -59,20 +59,20 @@ Ez a fájl akkor hasznos, ha automatizált teszteket futtatsz, és szükséged v
 
 - Fejlesztéshez:
 ```
-docker compose -f compose.yaml -f compose.dev.yml up
+docker compose -f docker/compose.yml -f docker/compose.dev.yml up
 ```
 
 - Teszteléshez:
 
 ```
-docker compose -f compose.yml -f compose.test.yml up
+docker compose -f docker/compose.yml -f docker/compose.test.yml up
 ```
 
 - Kibana hozzáadása:
 Az előbbi paransokhoz csak add hozzá a kibana compose fájlt:
 
 ```
-  -f compose.kibana.yml
+  -f docker/compose.kibana.yml
 ```
 
 A fájlokat egymásra rétegezve is használhatod, pl. fejlesztés közben Kibana-val:


### PR DESCRIPTION
Több parancs is kimásolva nem működött, mert lemaradt a `docker/` előtag a compose fájlok útvonalánál.
Kisebb elírások javítása, például: .yaml -> .yml
OSRM indításának dokumentálása ide is.