### PR TITLE
Elrontottam a #832-vel: minden időszak egy nappal hosszabb lett

### DIFF
--- a/webapp/classes/eloquent/calmass.php
+++ b/webapp/classes/eloquent/calmass.php
@@ -358,7 +358,13 @@ class CalMass extends CalModel
                             $periods->push((object)[
                                 'id' => $mass->id."-".Carbon::parse($mass->start_date)->format('YmdHis'), // ideiglenes id
                                 'start_date' => $mass->start_date,
-                                'end_date' => $mass->start_date, // Ezek egy napos események ugye
+                                // Egynapos esemény. Az `end_date` KIZÁRÓ, ezért a következő
+                                // nap — pontosan úgy, ahogy a
+                                // `CalPeriod::generateCalGeneratedPeriods()` is `addDay()`-t
+                                // ad az egynapos időszakokra (Szenteste: 12-24 → 12-25).
+                                // Enélkül ez a szintetikus időszak a MÁSIK konvenciót
+                                // követné, és ugyanaz a ciklus kétféle adatot kapna.
+                                'end_date' => Carbon::parse($mass->start_date)->addDay()->toDateString(),
                                 'name' => 'Ideiglenes időszak egyetlen napra',
                                 'color' => false
                             ]);                            
@@ -375,7 +381,8 @@ class CalMass extends CalModel
                                 $periods->push((object)[
                                     'id' => $mass->id."-".str_replace(['-',' ',':'], '', $dateString), // ideiglenes id
                                     'start_date' => $dateString,
-                                    'end_date' => $dateString, // Ezek egy napos események ugye
+                                    // Kizáró vég, mint fent.
+                                    'end_date' => Carbon::parse($dateString)->addDay()->toDateString(),
                                     'name' => 'Ideiglenes időszak egyetlen napra',
                                     'color' => false
                                 ]); 
@@ -402,11 +409,20 @@ class CalMass extends CalModel
                 }
                 foreach ($periods as $generatedPeriod) {
                     $start = Carbon::parse($generatedPeriod->start_date)->startOfDay()->setTimezone($timezone);
-                    // #832: az `end_date` BELEÉRTENDŐ — a nap végéig tart az időszak.
-                    // A régi jegyzet („valamiért itt volt egy subDay […] Passz.")
-                    // bizonytalan volt; a kizárás ága mostantól ugyanezt a szabályt
-                    // követi, tehát a két olvasat nem tér el egymástól.
-                    $end = Carbon::parse($generatedPeriod->end_date)->endOfDay()->setTimezone($timezone);
+                    /*
+                     * Az `end_date` KIZÁRÓ: az időszak `[start_date, end_date)`.
+                     *
+                     * A #832-ben beleértendőnek olvastam, és eszerint vettem ki innen a
+                     * `subDay()`-t. Rosszul. A bizonyíték a tárolt adatban van: a
+                     * `CalPeriod::generateCalGeneratedPeriods()` `addDay()`-t ad, ha a
+                     * záró nap BELETARTOZIK az időszakba — épp ez fordítja a szándékot
+                     * kizáró tárolási formára. Ezért a Szenteste (12-24, egyetlen nap)
+                     * tárolt vége 12-25, a Májusé pedig 06-01.
+                     *
+                     * Beleértendő olvasattal tehát MINDEN időszak egy nappal hosszabb:
+                     * a májusi miserend június 1-jén is generálódott.
+                     */
+                    $end = Carbon::parse($generatedPeriod->end_date)->subDay()->endOfDay()->setTimezone($timezone);
 
                     /*
                     Ezt nem tudom pontosan mit akart itt cisnálni. De gondot okozott.*/
@@ -429,39 +445,31 @@ class CalMass extends CalModel
                     // Experiod feldolgozása: csak az adott időszakba eső periódusok érdeklnek
                     // Aztán a beleeső napokat áttesszük exDate-be
                     /*
-                     * #832: a kizárt időszak UTOLSÓ NAPJA is kizárt.
+                     * A kizárt időszak határai ugyanazzal a kizáró olvasattal, mint fent.
                      *
-                     * A régi jelzés itt állt: „az átfedésre nem biztos hogy ez jó!" —
-                     * és tényleg nem volt jó. Ugyanezt az `end_date` oszlopot a
-                     * függvény KÉTFÉLEKÉPPEN olvasta: a mise saját időszakánál
-                     * `endOfDay()` (a nap beleértve), a kizárt időszaknál viszont
-                     * `subDay()->endOfDay()`, vagyis egy nappal korábban.
+                     * A #832-ben azt hittem, hogy a két ág eltérése (itt `subDay()`, a
+                     * mise saját időszakánál nem) hiba, és a `subDay()`-t vettem ki.
+                     * Fordítva kellett volna: a `subDay()` volt a helyes, a másik ágból
+                     * hiányzott. A mérésem is emiatt tévedett — a fixtúráimat magam
+                     * írtam beleértendő alakban, tehát a saját feltevésemet mértem
+                     * vissza, nem a rendszer tárolási formáját.
                      *
-                     * Megmérve: egy 06-01..06-10 kizárt időszak csak 06-09-ig zárt ki,
-                     * tehát a mise a kizárás UTOLSÓ NAPJÁN megjelent. Élesben ez azt
-                     * jelenti, hogy pl. a nyári szünet záró napján a tanévi miserend is
-                     * kiírásra került — és senki nem szólt érte, mert nem hiba, csak
-                     * egy fölösleges sor a listában.
-                     *
-                     * Az `end_date` a rendszerben beleértendő (a „Nyári szünet
-                     * 06-16..08-31" utolsó napja is szünet), tehát a `subDay()` volt a
-                     * hibás. A lekérdezés `>` feltétele ugyanez az elcsúszás: ha a
-                     * kizárt időszak épp a mise időszakának első napján ér véget, az
-                     * még átfedés.
+                     * A `>` szintén ezt követi: ha a kizárt időszak épp a mise
+                     * időszakának első napján ér véget, akkor a kizárás az előző nappal
+                     * bezárólag tartott — nincs átfedés.
                      */
                     foreach($excludedPeriods as $exPeriodString) {
                         $exGeneratedPeriods = CalGeneratedPeriod::where('period_id', $exPeriodString)
                                             ->where('start_date', '<=', $end->toDateString())
-                                            ->where('end_date', '>=', $start->toDateString())
+                                            ->where('end_date', '>', $start->toDateString())
                                             ->get();
                         //Nagyon nagyon furcsa lenne, ha kettő is lenne belőle, de ugye....                                            
                         foreach($exGeneratedPeriods as $exGeneratedPeriod) {
                             
                             // ExGeneratedPeriod intervallum (igazítva napokra, ugyanabban a timezone-ban mint $start/$end)
                             $exStart = Carbon::parse($exGeneratedPeriod->start_date)->startOfDay()->setTimezone($timezone);
-                            // #832: nincs `subDay()` — az `end_date` beleértendő, ahogy a
-                            // mise saját időszakánál is.
-                            $exEnd   = Carbon::parse($exGeneratedPeriod->end_date)->endOfDay()->setTimezone($timezone);
+                            // Ugyanaz a kizáró olvasat, mint fent.
+                            $exEnd   = Carbon::parse($exGeneratedPeriod->end_date)->subDay()->endOfDay()->setTimezone($timezone);
 
                             // Ha nincs átfedés, kihagyjuk
                             if ($exEnd->lt($start) || $exStart->gt($end)) {

--- a/webapp/tests/Integration/ExcludedPeriodBoundaryTest.php
+++ b/webapp/tests/Integration/ExcludedPeriodBoundaryTest.php
@@ -68,7 +68,11 @@ final class ExcludedPeriodBoundaryTest extends TestCase {
         $mise->start_date = '2026-01-01';
         $mise->duration = 60;
         $mise->rrule = ['freq' => 'daily', 'dtstart' => '2026-01-01T07:00:00'];
-        $mise->experiod = $experiod;
+        // A FELHASZNÁLÓ által beállított kizárás mezője a `manual_experiod`. Az
+        // `experiod` a SZÁMÍTOTT párja, amit a generálás évenként újraszámol (és a
+        // #747 nullázza is) — abba írni annyi, mintha a saját szándékunkat egy
+        // munkaváltozóba tennénk.
+        $mise->manual_experiod = $experiod;
         $mise->save();
 
         $peldanyok = \Eloquent\CalMass::generateMassPeriodInstancesForYears([$mise], [], [2026]);

--- a/webapp/tests/Integration/ExcludedPeriodBoundaryTest.php
+++ b/webapp/tests/Integration/ExcludedPeriodBoundaryTest.php
@@ -4,17 +4,17 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 
 /**
- * #832: a kizárt időszak UTOLSÓ NAPJA is kizárt.
+ * A kizárt időszak a tartománya MINDEN napján kizár — az elsőn és az utolsón is.
  *
- * A `CalMass::generateMassPeriodInstancesForYears()` ugyanazt az `end_date` oszlopot
- * KÉTFÉLEKÉPPEN olvasta: a mise saját időszakánál `endOfDay()` (a nap beleértve), a
- * kizárt időszaknál viszont `subDay()->endOfDay()`, vagyis egy nappal korábban. A
- * kódban ott is állt rá a jelzés: „az átfedésre nem biztos hogy ez jó!".
+ * A `generateMassPeriodInstancesForYears()` ugyanazt az `end_date` oszlopot
+ * KÉTFÉLEKÉPPEN olvasta: a mise saját időszakánál a nap végéig, a kizárt időszaknál
+ * viszont eggyel korábbig. A kódban ott is állt rá a jelzés: „az átfedésre nem
+ * biztos hogy ez jó!".
  *
- * Megmérve: egy 06-01..06-10 kizárt időszak csak 06-09-ig zárt ki, tehát a mise a
- * kizárás utolsó napján megjelent. Élesben ez azt jelenti, hogy pl. a nyári szünet
- * záró napján a tanévi miserend is kiírásra került — és senki nem szólt érte, mert nem
- * hiba, csak egy fölösleges sor a listában. Épp ezért érdemes tesztelni.
+ * A #832-ben a rossz irányba egyenlítettem ki: a `subDay()`-t vettem ki, holott az
+ * volt a helyes. A tárolt `end_date` KIZÁRÓ — l. `GeneratedPeriodEndDateTest`, ami
+ * ezt a valódi törzsadaton méri. A fixtúrákat itt magam írtam beleértendő alakban,
+ * tehát a saját feltevésemet mértem vissza; a helper most már elvégzi a fordítást.
  *
  * Tranzakcióban fut, tearDown-ban rollback.
  */
@@ -36,11 +36,20 @@ final class ExcludedPeriodBoundaryTest extends TestCase {
         parent::tearDown();
     }
 
+    /**
+     * @param string $ig az UTOLSÓ NAP, ami még beletartozik
+     *
+     * A tárolt `end_date` KIZÁRÓ, ezért egy nappal későbbre kerül — pontosan úgy,
+     * ahogy a `CalPeriod::generateCalGeneratedPeriods()` is `addDay()`-t ad. Ezt a
+     * fordítást eredetileg nem végeztem el itt, és így a fixtúra a saját téves
+     * feltevésemet rögzítette a rendszer tárolási formája helyett.
+     */
     private function idoszak(string $nev, int $suly, string $tol, string $ig): int {
         $id = DB::table('cal_periods')->insertGetId(['name' => $nev, 'weight' => $suly]);
         DB::table('cal_generated_periods')->insert([
             'period_id' => $id, 'name' => $nev, 'weight' => $suly,
-            'start_date' => $tol, 'end_date' => $ig,
+            'start_date' => $tol,
+            'end_date' => \Carbon\Carbon::parse($ig)->addDay()->toDateString(),
         ]);
 
         return $id;
@@ -98,12 +107,54 @@ final class ExcludedPeriodBoundaryTest extends TestCase {
     }
 
     /**
-     * Egynapos kizárt időszak: a régi, `subDay()`-es olvasat ilyenkor NULLA napot
-     * zárt ki — vagyis a kizárás teljesen hatástalan volt.
+     * Egynapos kizárt időszak. A tárolt alakja `06-20 → 06-21`, ahogy a valódi
+     * egynapos időszakoké (Szenteste: `12-24 → 12-25`).
      */
     public function testAzEgynaposKizarasIsMukodik(): void {
         $egynapos = $this->idoszak('TESZT egynapos', 7, '2026-06-20', '2026-06-20');
 
         self::assertSame(['2026-06-20'], $this->kizartNapok([$egynapos]));
+    }
+
+    /** @return array{0:string,1:string} a mise LEFEDETT tartománya [első nap, utolsó nap] */
+    private function lefedettTartomany(int $periodId): array {
+        $mise = new \Eloquent\CalMass();
+        $mise->church_id = 1;
+        $mise->period_id = $periodId;
+        $mise->title = 'Teszt';
+        $mise->types = [];
+        $mise->rite = 'ROMAN_CATHOLIC';
+        $mise->lang = 'hu';
+        $mise->comment = '';
+        $mise->start_date = '2026-01-01';
+        $mise->duration = 60;
+        $mise->rrule = ['freq' => 'daily', 'dtstart' => '2026-01-01T07:00:00'];
+        $mise->experiod = [];
+        $mise->save();
+
+        $peldanyok = \Eloquent\CalMass::generateMassPeriodInstancesForYears([$mise], [], [2026]);
+        $elso = reset($peldanyok);
+
+        return [$elso['start_date'], $elso['end_date']];
+    }
+
+    /**
+     * A mise SAJÁT időszaka is kizáró végű.
+     *
+     * Ez volt a súlyosabbik ág: beleértendő olvasattal MINDEN időszak egy nappal
+     * hosszabb lett, tehát a májusi miserend június 1-jén is generálódott volna. A
+     * legbeszédesebb eset az egynapos időszak — abból kettő nap lett.
+     */
+    public function testAzEgynaposIdoszakEgyetlenNapotFedLe(): void {
+        $egynapos = $this->idoszak('TESZT egynapos saját', 9, '2026-06-20', '2026-06-20');
+
+        self::assertSame(['2026-06-20', '2026-06-20'], $this->lefedettTartomany($egynapos));
+    }
+
+    /** Tíznapos időszak a tizedik nappal bezárólag tart. */
+    public function testATizNaposIdoszakAzUtolsoNappalBezarolagTart(): void {
+        $tiznapos = $this->idoszak('TESZT tíznapos', 9, '2026-06-01', '2026-06-10');
+
+        self::assertSame(['2026-06-01', '2026-06-10'], $this->lefedettTartomany($tiznapos));
     }
 }

--- a/webapp/tests/Integration/GeneratedPeriodEndDateTest.php
+++ b/webapp/tests/Integration/GeneratedPeriodEndDateTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+use Carbon\Carbon;
+
+/**
+ * A `cal_generated_periods.end_date` KIZÁRÓ: az időszak `[start_date, end_date)`.
+ *
+ * A #832-ben ezt beleértendőnek olvastam, és eszerint írtam át a mise-generátort.
+ * Rosszul: minden időszak egy nappal hosszabb lett. A bizonyíték magában az
+ * adatban van, ezért ezek a tesztek a VALÓDI törzsadaton mérnek, nem fixtúrán.
+ *
+ * A tárolási forma a `CalPeriod::generateCalGeneratedPeriods()`-ból jön:
+ *
+ *     if ($endDate->equalTo($startDate) || $period->all_inclusive) {
+ *         $endDate->addDay();
+ *     }
+ *
+ * Ez az `addDay()` PONTOSAN az a lépés, ami a „beleértendő" szándékot kizáró
+ * tárolási formára fordítja. Ha az `end_date` beleértendő volna, ez a sor egy
+ * nappal túlnyújtaná az időszakot — az egynapos időszak kettő lenne.
+ */
+final class GeneratedPeriodEndDateTest extends TestCase {
+
+    /** Egy adott év adott nevű időszaka. */
+    private function idoszak(string $nev, int $ev): ?object {
+        return DB::table('cal_generated_periods')
+            ->where('name', $nev)
+            ->whereYear('start_date', $ev)
+            ->first();
+    }
+
+    /**
+     * A Szenteste egyetlen nap. A `cal_periods`-ban 12-24 → 12-24, tehát a
+     * generátor `addDay()`-t ad rá — a tárolt vég 12-25.
+     */
+    public function testAzEgynaposIdoszakTaroltVegeAKovetkezoNap(): void {
+        $szenteste = $this->idoszak('Szenteste', 2026);
+        if (!$szenteste) {
+            self::markTestSkipped('Nincs 2026-os Szenteste a törzsadatban.');
+        }
+
+        self::assertSame('2026-12-24', Carbon::parse($szenteste->start_date)->toDateString());
+        self::assertSame('2026-12-25', Carbon::parse($szenteste->end_date)->toDateString());
+
+        // Kizáró olvasattal ez egy nap. Beleértendővel kettő lenne — és a Szenteste
+        // nem tart karácsony első napjáig.
+        $napok = Carbon::parse($szenteste->start_date)->diffInDays(Carbon::parse($szenteste->end_date));
+        self::assertSame(1, (int) $napok, 'a Szenteste egyetlen nap');
+    }
+
+    /**
+     * A naptári hónapok a legbeszédesebbek: a „Május" tárolt vége június 1.
+     * Beleértendő olvasattal június 1. is május volna.
+     */
+    public function testAHonapTaroltVegeAKovetkezoHonapElsejeu(): void {
+        $majus = $this->idoszak('Május', 2026);
+        if (!$majus) {
+            self::markTestSkipped('Nincs 2026-os Május a törzsadatban.');
+        }
+
+        self::assertSame('2026-05-01', Carbon::parse($majus->start_date)->toDateString());
+        self::assertSame('2026-06-01', Carbon::parse($majus->end_date)->toDateString());
+
+        $napok = Carbon::parse($majus->start_date)->diffInDays(Carbon::parse($majus->end_date));
+        self::assertSame(31, (int) $napok, 'a május 31 napos');
+    }
+
+    /**
+     * Az `all_inclusive = 0` a másik irány: a záró dátum NEM tartozik bele.
+     * A húsvétig tartó nagyböjtbe a húsvét ne essen bele — borazslo példája.
+     */
+    public function testANemBeleertendoIdoszakVegeNemTartozikBele(): void {
+        $sor = DB::table('cal_generated_periods AS g')
+            ->join('cal_periods AS p', 'p.id', '=', 'g.period_id')
+            ->where('p.all_inclusive', 0)
+            ->whereYear('g.start_date', 2026)
+            ->select('g.start_date', 'g.end_date', 'p.name')
+            ->first();
+
+        if (!$sor) {
+            self::markTestSkipped('Nincs all_inclusive=0 időszak a 2026-os adatban.');
+        }
+
+        // A generátor ilyenkor NEM ad hozzá napot: a tárolt vég maga a nem
+        // beleértendő nap. Kizáró olvasattal ez pont jó.
+        self::assertTrue(
+            Carbon::parse($sor->end_date)->gt(Carbon::parse($sor->start_date)),
+            "a(z) {$sor->name} vége a kezdete után van"
+        );
+    }
+
+    /**
+     * A tényleges bizonyíték: a naptári hónapok tárolt hossza pontosan a hónap
+     * naptári hossza. Ha az `end_date` beleértendő volna, mind eggyel több lenne.
+     */
+    public function testMindenNaptariHonapPontosanAnnyiNapAmennyi(): void {
+        $honapok = [
+            'Január' => 31, 'Február' => 28, 'Március' => 31, 'Április' => 30,
+            'Május' => 31, 'Június' => 30, 'Július' => 31, 'Augusztus' => 31,
+            'Szeptember' => 30, 'Október' => 31, 'November' => 30, 'December' => 31,
+        ];
+
+        $merve = [];
+        foreach ($honapok as $nev => $vart) {
+            $sor = $this->idoszak($nev, 2026);
+            if (!$sor) {
+                continue;
+            }
+            $merve[$nev] = (int) Carbon::parse($sor->start_date)
+                ->diffInDays(Carbon::parse($sor->end_date));
+        }
+
+        if (!$merve) {
+            self::markTestSkipped('Nincsenek naptári hónapok a törzsadatban.');
+        }
+
+        $vart = array_intersect_key($honapok, $merve);
+        self::assertSame($vart, $merve, 'a tárolt hossz a kizáró olvasat szerinti');
+    }
+}


### PR DESCRIPTION
@borazslo a #832-höz írt megjegyzésed miatt néztem utána — és kiderült, hogy **rossz a #832 megoldása, az én hibám.** Élesben van, ezért sürgős.

## A konvenció

A `cal_generated_periods.end_date` **kizáró**: az időszak `[start_date, end_date)`. A bizonyíték abban van, amit te is említettél — a `generateCalGeneratedPeriods()`:

```php
if ($endDate->equalTo($startDate) || $period->all_inclusive) {
    $endDate->addDay();
}
```

Ez az `addDay()` **pontosan az a lépés, ami a „beleértendő" szándékot kizáró tárolási formára fordítja.** Vagyis a generált időszakok tényleg mindig jót tartalmaztak — csak nem úgy, ahogy én olvastam őket.

A valódi adat 2026-ra:

| időszak | all_inclusive | start_date | end_date | napok |
|---|---|---|---|---|
| Szenteste (12-24) | 1 | 2026-12-24 | 2026-12-25 | 1 |
| Május (05-01..05-31) | 1 | 2026-05-01 | 2026-06-01 | 31 |
| December | 1 | 2026-12-01 | 2027-01-01 | 31 |
| Nagycsütörtök | 0 | 2026-04-02 | 2026-04-03 | 1 |

Beleértendő olvasattal a Szenteste két napos volna, június 1. pedig május.

## Amit elrontottam

A #832-ben azt láttam, hogy ugyanazt az oszlopot a függvény kétféleképpen olvassa (a mise saját időszakánál `subDay()` nélkül, a kizártnál `subDay()`-jel), és **a rossz irányba egyenlítettem ki**: a `subDay()`-t vettem ki, holott az volt a helyes — a másik ágból hiányzott.

Következmény élesben:
- a **májusi miserend június 1-jén is** generálódott (minden időszak egy nappal hosszabb),
- a **tíznapos kizárás tizenegy napot** zárt ki.

**A mérésem is ezért tévedett.** A fixtúrákat magam írtam beleértendő alakban, tehát a saját feltevésemet mértem vissza, nem a rendszer tárolási formáját. Ez a tanulságosabb rész: a teszt zöld volt, csak nem azt mérte, amit hittem.

## A javítás

1. `subDay()` vissza **mindkét** ágra, és `>` vissza a lekérdezésbe.
2. A mise **saját** időszakára is — onnan eredetileg hiányzott, és ez volt a két ág eltérésének az oka.
3. **A szintetikus időszakok egységesítése.** A periódus nélküli, egynapos eseményekhez ideiglenes időszak készül, `end_date = start_date`-tel („Ezek egy napos események ugye") — vagyis a *másik* konvencióval. Ugyanaz a ciklus kapott kétféle adatot. Ez bukott ki a `MassOwnLocationTest`-en, amikor a DB-s ágat megjavítottam; most ezek is kizáró véggel készülnek.

## A teszt, hogy ne ismétlődjön

Az új `GeneratedPeriodEndDateTest` a **valódi törzsadaton** méri a konvenciót (Szenteste, naptári hónapok, `all_inclusive = 0`), nem fixtúrán — épp azért, hogy ne lehessen még egyszer a saját feltevésemet visszamérni.

A `ExcludedPeriodBoundaryTest` fixtúra-építője mostantól ugyanazt a fordítást végzi, amit a generátor, és két új teszt a mise saját időszakának hosszát is rögzíti. Visszatéve a #832-es olvasatot, négy teszt bukik.