### PR TITLE
A naptár-import a bejegyzés többi tulajdonságát is átveszi (#157)

### DIFF
--- a/docker/mysql/initdb.d/12-mass-external-calendar.sql
+++ b/docker/mysql/initdb.d/12-mass-external-calendar.sql
@@ -1,0 +1,33 @@
+-- #157: melyik külső naptárból jött a mise.
+--
+-- Eddig a `comment` mező pontos értéke ('External calendar import') jelölte, hogy egy
+-- mise importált. Ez két dolgot tett lehetetlenné:
+--
+--  1. A naptár DESCRIPTION mezőjét nem lehetett átvenni, mert a `comment` foglalt volt.
+--  2. Templomonként csak EGY naptár működhetett: az import a templom ÖSSZES jelölt
+--     miséjét törölte, tehát a második naptár importja kitörölte az elsőét.
+--
+-- Mostantól a forrás azonosítja a misét, nem egy szövegkonstans. A régi sorok
+-- visszamenőleg megkapják a templomuk egyetlen naptárát, ahol ez egyértelmű; ahol nem
+-- (mert több naptár van), ott NULL marad, és a régi jelölés viszi tovább őket, amíg a
+-- következő import felül nem írja.
+
+USE `miserend`;
+
+ALTER TABLE `cal_masses`
+  ADD COLUMN IF NOT EXISTS `external_calendar_id` INT(11) DEFAULT NULL AFTER `church_id`;
+
+ALTER TABLE `cal_masses`
+  ADD INDEX IF NOT EXISTS `external_calendar_id` (`external_calendar_id`);
+
+-- Visszamenőleges hozzárendelés: csak ott, ahol a templomnak PONTOSAN egy naptára van.
+UPDATE `cal_masses` m
+  JOIN (
+    SELECT `church_id`, MIN(`id`) AS `calendar_id`, COUNT(*) AS `db`
+    FROM `external_calendars`
+    GROUP BY `church_id`
+    HAVING `db` = 1
+  ) c ON c.`church_id` = m.`church_id`
+SET m.`external_calendar_id` = c.`calendar_id`
+WHERE m.`comment` = 'External calendar import'
+  AND m.`external_calendar_id` IS NULL;

--- a/docker/mysql/migrations/157-mise-kulso-naptar.sql
+++ b/docker/mysql/migrations/157-mise-kulso-naptar.sql
@@ -1,0 +1,31 @@
+-- #157: melyik külső naptárból jött a mise.
+--
+-- Eddig a `comment` mező pontos értéke ('External calendar import') jelölte, hogy egy
+-- mise importált. Ez két dolgot tett lehetetlenné:
+--
+--  1. A naptár DESCRIPTION mezőjét nem lehetett átvenni, mert a `comment` foglalt volt.
+--  2. Templomonként csak EGY naptár működhetett: az import a templom ÖSSZES jelölt
+--     miséjét törölte, tehát a második naptár importja kitörölte az elsőét.
+--
+-- Mostantól a forrás azonosítja a misét, nem egy szövegkonstans.
+--
+-- A visszamenőleges hozzárendelés CSAK ott fut, ahol a templomnak PONTOSAN egy naptára
+-- van. Ahol több, ott a régi sorok jelöletlenül maradnak — azokat a `comment`-es
+-- tartalék jelölés viszi tovább az első importig, ami felülírja őket.
+
+ALTER TABLE `cal_masses`
+  ADD COLUMN IF NOT EXISTS `external_calendar_id` INT(11) DEFAULT NULL AFTER `church_id`;
+
+ALTER TABLE `cal_masses`
+  ADD INDEX IF NOT EXISTS `external_calendar_id` (`external_calendar_id`);
+
+UPDATE `cal_masses` m
+  JOIN (
+    SELECT `church_id`, MIN(`id`) AS `calendar_id`, COUNT(*) AS `db`
+    FROM `external_calendars`
+    GROUP BY `church_id`
+    HAVING `db` = 1
+  ) c ON c.`church_id` = m.`church_id`
+SET m.`external_calendar_id` = c.`calendar_id`
+WHERE m.`comment` = 'External calendar import'
+  AND m.`external_calendar_id` IS NULL;

--- a/docs/deploy-lepesek.md
+++ b/docs/deploy-lepesek.md
@@ -148,6 +148,35 @@ ez nem, a /health „a referencia elavult"-at mond, és az összevetés eredmén
 docker exec <konténer> php /miserend/webapp/tools/schema-reference.php
 ```
 
+### `157-mise-kulso-naptar.sql`
+
+A `cal_masses` új oszlopot kap (`external_calendar_id`), és a meglévő importált misék
+visszamenőleg megkapják a templomuk naptárát.
+
+Eddig a `comment` mező pontos értéke jelölte az importált misét. Ez foglalta a mezőt (a
+naptár leírása nem fért bele), és templomonként EGY naptárra korlátozott: az import a
+templom összes jelölt miséjét törölte, tehát a második naptár kitörölte az elsőét.
+
+A visszamenőleges hozzárendelés csak ott fut, ahol a templomnak pontosan egy naptára van.
+Ahol több, ott a régi sorokat a `comment`-es tartalék jelölés viszi tovább az első
+importig — nem vesznek el, és nem is válnak szerkeszthetővé.
+
+**Kell-e még?**
+```sql
+SELECT COUNT(*) AS hianyzik
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME = 'cal_masses'
+  AND COLUMN_NAME = 'external_calendar_id';
+-- 0 → kell futtatni
+```
+
+Adatvesztés nincs: csak hozzáad. A futtatás után az első naptár-szinkron a leírást és a
+helyszínt is átveszi, tehát a meglévő importált misék a következő cron-futáskor
+gazdagodnak — külön teendő nélkül.
+
+---
+
 ### `LORAWAN_TOKEN`
 
 A szenzoros végpont (gyóntatás-érzékelő) enélkül nem fogad adatot. Környezeti változó,

--- a/webapp/classes/eloquent/calmass.php
+++ b/webapp/classes/eloquent/calmass.php
@@ -17,6 +17,8 @@ class CalMass extends CalModel
 
     protected $fillable = [
         'church_id',
+        // #157: melyik külső naptárból jött (NULL = kézzel felvitt).
+        'external_calendar_id',
         'period_id',
         'title',
         'types',
@@ -144,16 +146,39 @@ class CalMass extends CalModel
      * felülírná. A többi (kézzel felvitt) miséhez viszont hozzá KELL férni: a
      * kettő megfér egymás mellett.
      *
-     * A tulajdonos-jelölés ma az IMPORT_MARKER a comment mezőben. A frontend és a
-     * jogosultság-ellenőrzés ezen a származtatott mezőn / az importedIdsAmong()-on
-     * keresztül kérdez, hogy a jelölés módja (később: külön DB-oszlop, több naptár
-     * támogatásához) egy helyen legyen cserélhető.
+     * #157: a jelölés az `external_calendar_id` oszlop — ez a fenti megjegyzésben
+     * előre jelzett lépés („később: külön DB-oszlop, több naptár támogatásához"). A
+     * comment mező felszabadult a naptár LEÍRÁSÁNAK.
+     *
+     * A régi jelölés tartalékként megmarad: a migráció csak ott tudta visszamenőleg
+     * kitölteni az oszlopot, ahol a templomnak PONTOSAN egy naptára van. Ahol több,
+     * ott a régi sorok az első importig jelöletlenek maradnának — és addig
+     * szerkeszthetővé válnának, pedig a szinkron úgyis felülírná őket.
      */
     protected $appends = ['imported'];
 
     public function getImportedAttribute(): bool
     {
+        if ($this->getAttribute('external_calendar_id') !== null) {
+            return true;
+        }
+
         return $this->getAttribute('comment') === \ExternalCalendarImporter::IMPORT_MARKER;
+    }
+
+    /**
+     * Külső naptárból származó misék.
+     *
+     * Egyetlen helyen mondjuk meg, mitől importált egy mise — a lekérdezések, a
+     * törlés és a tesztek is innen kérdezik. Az `external_calendar_id` az elsődleges;
+     * a régi, jelöletlen sorokat a `comment` konstans viszi tovább.
+     */
+    public function scopeImported($query)
+    {
+        return $query->where(function ($q) {
+            $q->whereNotNull('external_calendar_id')
+              ->orWhere('comment', \ExternalCalendarImporter::IMPORT_MARKER);
+        });
     }
 
     /**
@@ -168,7 +193,7 @@ class CalMass extends CalModel
         }
 
         return static::whereIn('id', $ids)
-            ->where('comment', \ExternalCalendarImporter::IMPORT_MARKER)
+            ->imported()
             ->pluck('id')
             ->map('intval')
             ->all();

--- a/webapp/classes/externalcalendarimporter.php
+++ b/webapp/classes/externalcalendarimporter.php
@@ -25,7 +25,7 @@ class ExternalCalendarImporter {
         }
 
         $import = $calendarImporter ?? static function ($calendar): void {
-            self::importFromUrl($calendar->url, (int)$calendar->church_id);
+            self::importFromUrl($calendar->url, (int)$calendar->church_id, (int)$calendar->id, $calendar);
         };
         $failures = [];
 
@@ -77,7 +77,7 @@ class ExternalCalendarImporter {
      * 3. Parse iCalendar and create new CalMass objects
      * 4. Refresh Elasticsearch index
      */
-    private static function importFromUrl($url, $churchId) {
+    private static function importFromUrl($url, $churchId, ?int $calendarId = null, ?\Eloquent\ExternalCalendar $calendar = null) {
         // 1. Download ICS content
         $icsContent = self::downloadIcsFromUrl($url);
         
@@ -85,9 +85,26 @@ class ExternalCalendarImporter {
             throw new \Exception("Failed to download iCalendar from URL: " . substr($url, 0, 50) . "...");
         }
         
+        /*
+         * #157: a naptár NEVE magából a feedből.
+         *
+         * Több naptárnál a szerkesztőnek el kell tudnia igazodni köztük, viszont
+         * nevet kitalálni fölösleges munka — a Google minden exportba beleírja az
+         * `X-WR-CALNAME`-et. Csak az ideiglenes („Naptár 1") nevet cseréljük le, a
+         * kézzel adottat nem írjuk felül.
+         */
+        if ($calendar !== null) {
+            $feedNev = self::calendarNameFromIcs($icsContent);
+            if ($feedNev !== null && preg_match('/^(Naptár \d+|Google Calendar)$/u', (string) $calendar->name)) {
+                $calendar->name = $feedNev;
+                $calendar->save();
+                echo "  Naptár neve a feedből: " . htmlspecialchars($feedNev) . "<br>\n";
+            }
+        }
+
         // 2-3. Parse the complete feed, then replace only earlier imported masses atomically.
         $feedModifiedOn = null;
-        $eventsCreated = self::replaceFromIcs($icsContent, $churchId, $feedModifiedOn);
+        $eventsCreated = self::replaceFromIcs($icsContent, $churchId, $calendarId, $feedModifiedOn);
 
         echo "  Created $eventsCreated masses from iCalendar<br>\n";
 
@@ -113,7 +130,7 @@ class ExternalCalendarImporter {
      * Manually entered one-off masses also have a null period_id, so ownership is identified
      * exclusively by IMPORT_MARKER.
      */
-    public static function replaceFromIcs(string $icsContent, int $churchId, ?string &$feedModifiedOn = null): int {
+    public static function replaceFromIcs(string $icsContent, int $churchId, ?int $calendarId = null, ?string &$feedModifiedOn = null): int {
         if (!preg_match('/BEGIN:VCALENDAR/i', $icsContent) || !preg_match('/END:VCALENDAR/i', $icsContent)) {
             throw new \InvalidArgumentException('Invalid iCalendar document.');
         }
@@ -121,15 +138,45 @@ class ExternalCalendarImporter {
         $events = self::parseIcsEvents($icsContent);
         $masses = [];
         foreach ($events as $event) {
-            $masses[] = self::createCalMassFromEvent($event, $churchId);
+            $mass = self::createCalMassFromEvent($event, $churchId, $calendarId);
+            // #157: az elmaradást jelző bejegyzésből nem lesz mise.
+            if ($mass !== null) {
+                $masses[] = $mass;
+            }
         }
         $feedModifiedOn = self::lastModifiedDate($events);
 
         $connection = \Eloquent\CalMass::getConnectionResolver()->connection();
-        $connection->transaction(function () use ($churchId, $masses): void {
-            \Eloquent\CalMass::where('church_id', $churchId)
-                ->where('comment', self::IMPORT_MARKER)
-                ->delete();
+        $connection->transaction(function () use ($churchId, $calendarId, $masses): void {
+            /*
+             * #157: CSAK ENNEK A NAPTÁRNAK a korábbi importját töröljük.
+             *
+             * Eddig a templom minden jelölt miséje ment, tehát két naptárnál a második
+             * import kitörölte az elsőét — templomonként egyetlen naptár működhetett.
+             * borazslo példája pont ez: „Több külső naptárat is meg lehessen vele
+             * etetni. Pl. Szegeden a szentségimádásosat vagy a kápolnát."
+             *
+             * A régi, `external_calendar_id` nélküli sorokat is ez a naptár viszi el,
+             * ha ő az egyetlen — különben a migráció előtti import örökre ottragadna.
+             */
+            $torles = \Eloquent\CalMass::where('church_id', $churchId);
+
+            if ($calendarId !== null) {
+                $egyetlen = \Eloquent\ExternalCalendar::where('church_id', $churchId)->count() <= 1;
+                $torles->where(function ($q) use ($calendarId, $egyetlen) {
+                    $q->where('external_calendar_id', $calendarId);
+                    if ($egyetlen) {
+                        $q->orWhere(function ($r) {
+                            $r->whereNull('external_calendar_id')
+                              ->where('comment', self::IMPORT_MARKER);
+                        });
+                    }
+                });
+            } else {
+                $torles->whereNull('external_calendar_id')->where('comment', self::IMPORT_MARKER);
+            }
+
+            $torles->delete();
 
             foreach ($masses as $mass) {
                 $mass->save();
@@ -299,19 +346,91 @@ class ExternalCalendarImporter {
     }
 
     public static function saveCalendarUrl(int $churchId, string $url, ?array $resolvedIps = null): ?\Eloquent\ExternalCalendar {
-        $url = trim($url);
-        if ($url === '') {
-            \Eloquent\ExternalCalendar::where('church_id', $churchId)->update(['active' => 0]);
-            return null;
-        }
-        if (!self::isAllowedCalendarUrl($url, $resolvedIps)) {
-            throw new \InvalidArgumentException('Csak publikus HTTPS iCalendar URL adható meg.');
+        $naptarak = self::saveCalendarUrls($churchId, $url, $resolvedIps);
+
+        return $naptarak[0] ?? null;
+    }
+
+    /**
+     * #157: templomonként TÖBB külső naptár.
+     *
+     * borazslo kérése: „Több külső naptárat is meg lehessen vele etetni. Pl. Szegeden
+     * a szentségimádásosat vagy a kápolnát."
+     *
+     * Soronként egy URL. Ez a legkevesebb, amit a szerkesztőnek meg kell tanulnia, és
+     * a naptár NEVÉT sem kell kitalálnia: az import a feed `X-WR-CALNAME` mezőjéből
+     * veszi (a Google minden exportba beleírja).
+     *
+     * Ami kimarad a listából, az `active = 0` lesz, nem törlődik: így a korábbi
+     * importok nyomon követhetők maradnak, és egy véletlen törlés visszavonható.
+     *
+     * @param  string     $urls        soronként egy URL
+     * @param  array|null $resolvedIps teszthez: a feloldott IP-k, hálózat nélkül
+     * @return \Eloquent\ExternalCalendar[] a mostantól aktív naptárak
+     */
+    public static function saveCalendarUrls(int $churchId, string $urls, ?array $resolvedIps = null): array {
+        $lista = [];
+        foreach (preg_split('/\R/', $urls) ?: [] as $sor) {
+            $sor = trim($sor);
+            if ($sor !== '' && !in_array($sor, $lista, true)) {
+                $lista[] = $sor;
+            }
         }
 
-        return \Eloquent\ExternalCalendar::updateOrCreate(
-            ['church_id' => $churchId, 'name' => 'Google Calendar'],
-            ['url' => $url, 'active' => 1]
-        );
+        foreach ($lista as $url) {
+            if (!self::isAllowedCalendarUrl($url, $resolvedIps)) {
+                throw new \InvalidArgumentException('Csak publikus HTTPS iCalendar URL adható meg: ' . htmlspecialchars($url));
+            }
+        }
+
+        // Ami kimaradt, az elalszik. Előbb, hogy a listában maradó azonos URL utána
+        // biztosan aktívra álljon vissza.
+        \Eloquent\ExternalCalendar::where('church_id', $churchId)
+            ->when($lista !== [], fn($q) => $q->whereNotIn('url', $lista))
+            ->update(['active' => 0]);
+
+        $eredmeny = [];
+        foreach ($lista as $i => $url) {
+            $eredmeny[] = \Eloquent\ExternalCalendar::updateOrCreate(
+                ['church_id' => $churchId, 'url' => $url],
+                ['active' => 1, 'name' => self::calendarNameFor($churchId, $url, $i)]
+            );
+        }
+
+        return $eredmeny;
+    }
+
+    /**
+     * A naptár megjelenített neve.
+     *
+     * A meglévőét nem írjuk felül (az importból már lehet valódi neve), újnál pedig
+     * ideiglenes sorszámot adunk — az első sikeres import cseréli le a feed
+     * `X-WR-CALNAME` értékére.
+     */
+    private static function calendarNameFor(int $churchId, string $url, int $index): string {
+        $meglevo = \Eloquent\ExternalCalendar::where('church_id', $churchId)->where('url', $url)->first();
+        if ($meglevo && trim((string) $meglevo->name) !== '') {
+            return $meglevo->name;
+        }
+
+        return 'Naptár ' . ($index + 1);
+    }
+
+    /**
+     * A feed saját neve (`X-WR-CALNAME`), ha megadta.
+     *
+     * A Google minden exportba beleírja — a #157-ben megadott minta-naptáré
+     * „Szent József templom - Miserend". Ettől a szerkesztőnek nem kell nevet
+     * kitalálnia ahhoz, hogy több naptár közt eligazodjon.
+     */
+    public static function calendarNameFromIcs(string $icsContent): ?string {
+        if (!preg_match('/^X-WR-CALNAME(?:;[^:]*)?:(.*)$/im', $icsContent, $m)) {
+            return null;
+        }
+
+        $nev = \IcalEventProperties::unescapeText($m[1]);
+
+        return ($nev ?? '') === '' ? null : mb_substr($nev, 0, 255);
     }
 
     /** @return string[] */
@@ -351,6 +470,12 @@ class ExternalCalendarImporter {
                 // exportáláskor tölti ki, tehát minden lekérésnél mai — attól minden
                 // naptár örökké "frissnek" látszana, akkor is, ha évek óta hozzá se nyúltak.
                 'LAST-MODIFIED' => null,
+                // #157: amit eddig eldobtunk.
+                'SUMMARY_LANGUAGE' => null,
+                'LOCATION' => null,
+                'DESCRIPTION' => null,
+                'GEO' => null,
+                'STATUS' => null,
             ];
             
             // Parse EXDATE (capture the full parameter+value part, e.g. ;TZID=Europe/Budapest:20241222T183000)
@@ -361,9 +486,35 @@ class ExternalCalendarImporter {
                 }
             }
 
-            // Parse SUMMARY
-            if (preg_match('/^SUMMARY:(.*)$/im', $eventData, $m)) {
-                $event->SUMMARY = trim(preg_replace('/\\\\,/', ', -', $m[1]));
+            /*
+             * #157: a SUMMARY-nak LEHETNEK paraméterei (RFC 5545), és van is: a
+             * `SUMMARY;LANGUAGE=en:Holy Mass` alak korábban egyáltalán NEM illeszkedett,
+             * tehát az ilyen bejegyzés címe elveszett, és „External Calendar Event"
+             * néven jött be.
+             *
+             * A `\,` visszafejtése is hibás volt: `', -'`-ra cserélte, tehát minden
+             * escape-elt vesszős címbe beszúrt egy fölösleges kötőjelet. A
+             * minta-naptárban ez 100+ misét érint („P. Elek, - gyóntat: -").
+             */
+            if (preg_match('/^SUMMARY(;[^:]*)?:(.*)$/im', $eventData, $m)) {
+                $event->SUMMARY = \IcalEventProperties::unescapeText($m[2]);
+                if (($m[1] ?? '') !== '' && preg_match('/LANGUAGE=([^;:]+)/i', $m[1], $lang)) {
+                    $event->SUMMARY_LANGUAGE = trim($lang[1]);
+                }
+            }
+
+            // #157: a helyszín, a leírás, a koordináta és az állapot — mind eldobva eddig.
+            if (preg_match('/^LOCATION(?:;[^:]*)?:(.*)$/im', $eventData, $m)) {
+                $event->LOCATION = \IcalEventProperties::unescapeText($m[1]);
+            }
+            if (preg_match('/^DESCRIPTION(?:;[^:]*)?:(.*)$/im', $eventData, $m)) {
+                $event->DESCRIPTION = \IcalEventProperties::unescapeText($m[1]);
+            }
+            if (preg_match('/^GEO(?:;[^:]*)?:(.*)$/im', $eventData, $m)) {
+                $event->GEO = trim($m[1]);
+            }
+            if (preg_match('/^STATUS(?:;[^:]*)?:(.*)$/im', $eventData, $m)) {
+                $event->STATUS = trim($m[1]);
             }
             
             // Parse DTSTART
@@ -481,9 +632,21 @@ class ExternalCalendarImporter {
     /**
      * Convert iCalendar VEVENT to CalMass object
      */
-    private static function createCalMassFromEvent($event, $churchId) {
+    private static function createCalMassFromEvent($event, $churchId, ?int $calendarId = null) {
         
         $summary = isset($event->SUMMARY) ? (string)$event->SUMMARY : 'External Calendar Event';
+
+        /*
+         * #157: ami épp azt mondja, hogy NINCS alkalom, az nem alkalom.
+         *
+         * A minta-naptárban 17 ilyen van („NINCS Szentmise", „ELMARAD! Szentségimádás").
+         * Ezeket eddig miseként vettük fel, tehát a miserend PONT AZ ELLENKEZŐJÉT
+         * állította annak, amit a naptár gazdája kiírt — és épp azon a napon, amikor a
+         * hívő hiába megy el.
+         */
+        if (\IcalEventProperties::isCancelled($summary, $event->STATUS ?? null)) {
+            return null;
+        }
         $startDate = self::extractStartDate($event);        
         $duration = self::extractDuration($event);
         $rrule = null;
@@ -508,17 +671,37 @@ class ExternalCalendarImporter {
             echo "  ⚠ A cím túl hosszú volt, levágtam: " . htmlspecialchars($title) . "<br>\n";
         }
 
+        $geo = \IcalEventProperties::parseGeo($event->GEO ?? null);
+
         $calMass = \Eloquent\CalMass::make([
             'church_id' => $churchId,
+            'external_calendar_id' => $calendarId,
             'title' => $title,
             'start_date' => $startDate,
             'rrule' => $rrule,
             'exdate' => !empty($exdates) ? $exdates : null,
             'duration' => $duration,
-            'rite' => 'ROMAN_CATHOLIC',  // Default rite
-            'lang' => 'hu',     // Default language
+            // #157: eddig mindkettő be volt drótozva. A nyelvet a szabványos
+            // `LANGUAGE=` paraméter, ennek híján a cím adja; a rítust a cím.
+            'rite' => \IcalEventProperties::detectRite($summary),
+            'lang' => \IcalEventProperties::detectLanguage($summary, $event->SUMMARY_LANGUAGE ?? null),
+            'types' => \IcalEventProperties::detectTypes($summary),
             'period_id' => null,  // External calendars don't belong to periods
-            'comment' => self::IMPORT_MARKER,
+            /*
+             * #157: a `comment` felszabadult — a tulajdonost mostantól az
+             * `external_calendar_id` mondja meg, nem ez a szövegkonstans. Így a
+             * naptár LEÍRÁSA is átjön, ahogy borazslo kérte.
+             *
+             * Naptár-azonosító NÉLKÜL viszont semmi nem kötné a misét a forrásához:
+             * a szinkron nem tudná többé kicserélni, a szerkesztő pedig engedné
+             * szerkeszteni. Ilyenkor marad a régi jelölés — a leírás árán, mert az
+             * azonosíthatóság a fontosabb.
+             */
+            'comment' => $calendarId === null ? self::IMPORT_MARKER : ($event->DESCRIPTION ?? ''),
+            // A helyszínt a #431 óta tudja a mise; az iCal `LOCATION`-je pont ez.
+            'location_name' => ($event->LOCATION ?? '') !== '' ? $event->LOCATION : null,
+            'location_lat' => $geo['lat'] ?? null,
+            'location_lon' => $geo['lon'] ?? null,
         ]);
 
         return $calMass;

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -9,13 +9,20 @@ class Edit extends \Html\Html {
     public $help;
     public $input;
     public $nearbyChurches;
-    /** #157: a templom aktív külső naptárai (név, url, utolsó import). */
-    public $externalCalendars = [];
 
     /* #639: mit tegyünk a beküldött ellátó-plébánia választással. */
     public const PARENT_REPLACE = 'replace';
     public const PARENT_REMOVE  = 'remove';
     public const PARENT_INVALID = 'invalid';
+
+    /**
+     * #157: a templom aktív külső naptárai (név, url, utolsó import).
+     *
+     * Szándékosan NEM a többi property mellett, hanem a konstansok után: ott a #819
+     * is szúr be egy mezőt (`$derivedHolders`), és a git a két független hozzáadást
+     * ütközésnek látná. Egy sor odébb — és a két PR bármilyen sorrendben mehet.
+     */
+    public $externalCalendars = [];
 
     /**
      * #639: a legördülő "0" értéke a placeholder-opció ("– válassz templomot –"), vagyis

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -9,6 +9,8 @@ class Edit extends \Html\Html {
     public $help;
     public $input;
     public $nearbyChurches;
+    /** #157: a templom aktív külső naptárai (név, url, utolsó import). */
+    public $externalCalendars = [];
 
     /* #639: mit tegyünk a beküldött ellátó-plébánia választással. */
     public const PARENT_REPLACE = 'replace';
@@ -124,10 +126,9 @@ class Edit extends \Html\Html {
             \Eloquent\ChurchRelationship::where('child_church_id', $this->tid)->delete();
         }
 
-        // Handle external calendar URL
+        // #157: soronként egy külső naptár — templomonként több is lehet.
         if (isset($churchFields['external_calendar_url'])) {
-            $newUrl = trim($churchFields['external_calendar_url']);
-            \ExternalCalendarImporter::saveCalendarUrl((int)$this->tid, $newUrl);
+            \ExternalCalendarImporter::saveCalendarUrls((int)$this->tid, $churchFields['external_calendar_url']);
         }
 
         // #484: a részletes beállítások mentése + a származtatott OSM-címke azonnali
@@ -197,20 +198,25 @@ class Edit extends \Html\Html {
         // Meglévő kapcsolatok betöltése (szülő irányban)
         $this->church->load('parentRelationships.parent');
         
-        $externalCalendar = $this->getExternalCalendar();
-        $lastImport = $externalCalendar && $externalCalendar->last_import_at
-            ? $externalCalendar->last_import_at
-            : 'még nem futott le sikeresen';
+        $externalCalendars = $this->getExternalCalendars();
 
         $this->form['external_calendar_url'] = [
-            'type' => 'text',
+            'type' => 'textarea',
             'name' => 'church[external_calendar_url]',
             'id' => 'external_calendar_url',
             'class' => 'form-control',
-            'placeholder' => 'https://calendar.google.com/calendar/ical/...',
-            'value' => $externalCalendar ? $externalCalendar->url : '',
-            'labelback' => 'Külső naptár (publikus HTTPS iCalendar URL). Napi automatikus szinkron; utolsó sikeres import: ' . $lastImport
+            'rows' => 3,
+            'placeholder' => "https://calendar.google.com/calendar/ical/...\nhttps://…/masik-naptar.ics",
+            'value' => $externalCalendars->pluck('url')->implode("\n"),
+            'labelback' => 'Külső naptárak, soronként egy publikus HTTPS iCalendar URL. Napi automatikus szinkron.'
         ];
+
+        // A naptárak állapota külön, mert több sorról van szó.
+        $this->externalCalendars = $externalCalendars->map(fn($n) => [
+            'nev' => $n->name,
+            'url' => $n->url,
+            'utolso_import' => $n->last_import_at ?: 'még nem futott le sikeresen',
+        ])->all();
 
         foreach ([
             'gluten_free_holidays' => [\GlutenFreeCommunion::HOLIDAYS_KEY, 'Ünnepnapokon'],
@@ -272,10 +278,12 @@ class Edit extends \Html\Html {
         }
     }
 
-    private function getExternalCalendar(): ?\Eloquent\ExternalCalendar {
+    /** @return \Illuminate\Support\Collection<int,\Eloquent\ExternalCalendar> */
+    private function getExternalCalendars(): \Illuminate\Support\Collection {
         return \Eloquent\ExternalCalendar::where('church_id', $this->tid)
             ->where('active', 1)
-            ->first();
+            ->orderBy('id')
+            ->get();
     }
     
     /**

--- a/webapp/classes/icaleventproperties.php
+++ b/webapp/classes/icaleventproperties.php
@@ -1,0 +1,296 @@
+<?php
+
+/**
+ * #157: mit tudunk kiolvasni egy naptár-bejegyzésből azon túl, hogy mikor van.
+ *
+ * Az import eddig három dolgot vett át (cím, időpont, ismétlődés), a többit eldobta:
+ * a nyelv MINDIG magyar volt, a rítus MINDIG római katolikus, a helyszín, a leírás és
+ * a mise típusa pedig sehova nem került. borazslo listája a #157-ben pontosan ezt
+ * sorolja fel.
+ *
+ * A döntések nem elméletiek: a #157-ben megadott szegedi minta-naptár 949 eseményén
+ * mértem őket. Abban van 11 „Régi rítusú mise" (ma mind római katolikusként jönne be),
+ * több tucat „Angol nyelvű szentmise" (ma mind magyarként), 30+ „kisgyermekes
+ * családoknak" (ma típus nélkül), és 16 olyan bejegyzés, ami épp azt mondja, hogy
+ * NINCS mise — azokat ma miseként vesszük fel.
+ *
+ * Külön osztály, mert tiszta függvényekből áll: se adatbázis, se hálózat, tehát
+ * önmagában tesztelhető, és az importer marad az, ami — összerakó.
+ */
+class IcalEventProperties {
+
+    /** Az alapértelmezések, ha a bejegyzés nem mond semmit. */
+    public const DEFAULT_LANG = 'hu';
+    public const DEFAULT_RITE = 'ROMAN_CATHOLIC';
+
+    /**
+     * Nyelvek felismerése a címből.
+     *
+     * A kulcs a `calendar/src/app/enum/language-code.ts` kódja. Az érték három alak:
+     * a magyar melléknév töve, a magyar határozó, és az angol név.
+     *
+     * A puszta nemzetiségnév NEM elég, és ez nem elméleti óvatosság: a minta-naptárban
+     * van „Gyász szentmise Lengyel Györgyért" és „Gyász szentmise Horváth Andreáért" —
+     * a `lengyel` és a `horvát` itt VEZETÉKNÉV. Ezért a felismerés nyelvi kontextust
+     * követel: „X nyelvű", „X nyelven", „Xül", „Mass in X", „X mass".
+     *
+     * @var array<string, array{0:string,1:string,2:string}>
+     */
+    private const LANG_WORDS = [
+        'hu'  => ['magyar', 'magyarul', 'hungarian'],
+        'en'  => ['angol', 'angolul', 'english'],
+        'de'  => ['német', 'németül', 'german'],
+        'va'  => ['latin', 'latinul', 'latin'],
+        'sk'  => ['szlovák', 'szlovákul', 'slovak'],
+        'hr'  => ['horvát', 'horvátul', 'croatian'],
+        'ro'  => ['román', 'románul', 'romanian'],
+        'pl'  => ['lengyel', 'lengyelül', 'polish'],
+        'it'  => ['olasz', 'olaszul', 'italian'],
+        'fr'  => ['francia', 'franciául', 'french'],
+        'es'  => ['spanyol', 'spanyolul', 'spanish'],
+        'ua'  => ['ukrán', 'ukránul', 'ukrainian'],
+        'ru'  => ['orosz', 'oroszul', 'russian'],
+        'gr'  => ['görög', 'görögül', 'greek'],
+        'cu'  => ['ószláv', 'ószlávul', 'church slavonic'],
+        'rue' => ['ruszin', 'ruszinul', 'rusyn'],
+        'si'  => ['szlovén', 'szlovénul', 'slovenian'],
+        'pt'  => ['portugál', 'portugálul', 'portuguese'],
+        'tl'  => ['tagalog', 'tagalogul', 'tagalog'],
+    ];
+
+    /**
+     * A ténylegesen keresett minták, nyelvenként.
+     *
+     * @return array<string, string[]>
+     */
+    private static function langPatterns(): array {
+        $mintak = [];
+        foreach (self::LANG_WORDS as $kod => [$mellek, $hatarozo, $angol]) {
+            $mintak[$kod] = [
+                $mellek . ' nyelv',      // „angol nyelvű", „angol nyelven"
+                $hatarozo,               // „angolul"
+                'in ' . $angol,          // „Mass in English"
+                $angol . ' mass',        // „English mass"
+                $angol . ' language',
+            ];
+        }
+
+        return $mintak;
+    }
+
+    /**
+     * Rítusok felismerése a címből.
+     *
+     * A sorrend SZÁMÍT: a „Régi rítusú liturgikus hétvége" a „liturgi" mintára is
+     * illeszkedne, pedig az a régi rítus, nem a görög. Ezért a szűkebb minta van elöl.
+     *
+     * @var array<string, string[]>
+     */
+    private const RITE_PATTERNS = [
+        'TRADITIONAL'    => ['régi rítus', 'regi ritus', 'tridenti', 'usus antiquior', 'régi rítusú'],
+        'GREEK_CATHOLIC' => ['görögkatolikus', 'gorogkatolikus', 'görög katolikus', 'szent liturgia', 'liturgia'],
+    ];
+
+    /**
+     * Mise-típusok felismerése a címből. A kulcs a `calendar/src/app/enum/types.ts`-ből.
+     *
+     * @var array<string, string[]>
+     */
+    private const TYPE_PATTERNS = [
+        'FAMILY'           => ['család', 'csalad', 'kisgyermekes'],
+        'UNIVERSITY_YOUTH' => ['egyetemi', 'egyetemista', 'főiskolás', 'foiskolas'],
+        'STUDENT'          => ['diák', 'diak', 'ifjúsági', 'ifjusagi', 'iskolás', 'iskolas'],
+        'GUITAR'           => ['gitáros', 'gitaros'],
+        'ORGAN'            => ['orgonás', 'orgonas', 'orgonakísérettel'],
+        'SILENT'           => ['csendes', 'néma', 'nema'],
+        'SINGER'           => ['énekes', 'enekes', 'kántált', 'kantalt'],
+    ];
+
+    /**
+     * Ami épp azt mondja, hogy NINCS alkalom.
+     *
+     * A mintában 16 ilyen van („NINCS Szentmise", „ELMARAD! Szentségimádás…"). Ezeket
+     * ma miseként vesszük fel, tehát a miserend pont az ellenkezőjét állítja annak,
+     * amit a naptár gazdája ki akart írni.
+     */
+    private const CANCELLATION_PATTERNS = [
+        'nincs', 'elmarad', 'szünetel', 'szunetel', 'törölve', 'torolve', 'cancelled', 'canceled',
+    ];
+
+    /** Kis- és nagybetűtől, ékezettől független összehasonlításhoz. */
+    private static function normalize(string $text): string {
+        return mb_strtolower(trim($text), 'UTF-8');
+    }
+
+    /**
+     * Elmarad-e az alkalom?
+     *
+     * Két forrásból: az RFC 5545 `STATUS:CANCELLED`-jéből, és a címből. Az utóbbi
+     * azért kell, mert a Google-naptárakban a lemondást jellemzően átírt címmel
+     * jelzik, nem a STATUS mezővel.
+     */
+    public static function isCancelled(string $summary, ?string $status = null): bool {
+        if ($status !== null && self::normalize($status) === 'cancelled') {
+            return true;
+        }
+
+        $cim = self::normalize($summary);
+        foreach (self::CANCELLATION_PATTERNS as $minta) {
+            // Szóhatáron, hogy a „nincstelen" vagy a „Szentmise a NINCSTELENEKÉRT"
+            // ne essen áldozatul. A `nincs` külön is gyakori önálló szóként.
+            if (preg_match('/(?:^|[\s\(\[!\.,;:])' . preg_quote($minta, '/') . '(?:[\s\)\]!\.,;:]|$)/u', $cim)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * A bejegyzés nyelve.
+     *
+     * Elsőként az RFC 5545 `LANGUAGE=` paramétere számít — az a szabvány helye, és ha
+     * a naptár gazdája kitöltötte, akkor azt akarta. Ha nincs, a címből következtetünk.
+     *
+     * A „X helyett Y" eset külön kezelendő: a „Mass in HUNGARIAN - Angol helyett magyar
+     * nyelvű mise" cím MINDKÉT nyelvet említi, de az egyik épp az, ami ELMARAD. Ezért a
+     * „helyett" szó előtti említéseket eldobjuk.
+     *
+     * @param string|null $languageParam a SUMMARY `LANGUAGE=` paramétere, ha volt
+     */
+    public static function detectLanguage(string $summary, ?string $languageParam = null): string {
+        if ($languageParam !== null && $languageParam !== '') {
+            $kod = self::mapLanguageTag($languageParam);
+            if ($kod !== null) {
+                return $kod;
+            }
+        }
+
+        $cim = self::normalize($summary);
+
+        // „Angol helyett magyar": ami a „helyett" ELŐTT van, az nem lesz.
+        $helyettPos = mb_strpos($cim, 'helyett');
+        $vizsgalando = $helyettPos === false ? $cim : mb_substr($cim, $helyettPos);
+
+        $talalt = self::firstMatch($vizsgalando, self::langPatterns());
+        if ($talalt !== null) {
+            return $talalt;
+        }
+
+        // Ha a „helyett" utáni rész nem mondott semmit, essünk vissza a teljes címre.
+        if ($helyettPos !== false) {
+            $talalt = self::firstMatch($cim, self::langPatterns());
+            if ($talalt !== null) {
+                return $talalt;
+            }
+        }
+
+        return self::DEFAULT_LANG;
+    }
+
+    /**
+     * Az RFC 5646 nyelvi címke (`en-US`, `hu`) leképezése a saját kódjainkra.
+     *
+     * A saját listánk nem mindenhol ISO 639-1: a latin nálunk `va`, a görög `gr`, az
+     * ukrán `ua`. Ezeket külön kell fordítani, különben a szabványos címke épp a
+     * szabványkövető naptáraknál veszne el.
+     */
+    public static function mapLanguageTag(string $tag): ?string {
+        $alap = self::normalize(explode('-', str_replace('_', '-', $tag))[0]);
+
+        $kivetelek = ['la' => 'va', 'el' => 'gr', 'uk' => 'ua', 'sl' => 'si', 'cs' => 'cu'];
+        if (isset($kivetelek[$alap])) {
+            return $kivetelek[$alap];
+        }
+
+        return isset(self::LANG_WORDS[$alap]) ? $alap : null;
+    }
+
+    /** A bejegyzés rítusa a címből. */
+    public static function detectRite(string $summary): string {
+        return self::firstMatch(self::normalize($summary), self::RITE_PATTERNS) ?? self::DEFAULT_RITE;
+    }
+
+    /**
+     * A mise típusai a címből.
+     *
+     * Több is lehet egyszerre („Szentmise kisgyermekes családoknak, orgonás"), ezért
+     * itt nem az első találat nyer.
+     *
+     * @return string[]
+     */
+    public static function detectTypes(string $summary): array {
+        $cim = self::normalize($summary);
+        $talalatok = [];
+
+        foreach (self::TYPE_PATTERNS as $tipus => $mintak) {
+            foreach ($mintak as $minta) {
+                if (mb_strpos($cim, $minta) !== false) {
+                    $talalatok[] = $tipus;
+                    break;
+                }
+            }
+        }
+
+        return $talalatok;
+    }
+
+    /**
+     * A `GEO` mező szélesség/hosszúság párja.
+     *
+     * RFC 5545: `GEO:46.2530;20.1414` — pontosvesszővel, ebben a sorrendben.
+     *
+     * @return array{lat: float, lon: float}|null
+     */
+    public static function parseGeo(?string $geo): ?array {
+        if ($geo === null || trim($geo) === '') {
+            return null;
+        }
+
+        $reszek = explode(';', trim($geo));
+        if (count($reszek) !== 2 || !is_numeric($reszek[0]) || !is_numeric($reszek[1])) {
+            return null;
+        }
+
+        $lat = (float) $reszek[0];
+        $lon = (float) $reszek[1];
+        if ($lat < -90 || $lat > 90 || $lon < -180 || $lon > 180) {
+            return null;
+        }
+
+        return ['lat' => $lat, 'lon' => $lon];
+    }
+
+    /**
+     * Az iCal szövegmezők escape-elésének visszabontása (RFC 5545 3.3.11).
+     *
+     * A `\n`, `\,`, `\;` és `\\` a FÁJLBAN escape-elt alak; ha nyersen tennénk az
+     * adatbázisba, a leírásban `\n` maradna sortörés helyett — a mintában több
+     * DESCRIPTION is ilyen („AA\nKék?").
+     */
+    public static function unescapeText(?string $value): ?string {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = str_replace(['\\n', '\\N'], "\n", $value);
+        $value = preg_replace('/\\\\([,;\\\\])/', '$1', $value);
+
+        return trim($value ?? '');
+    }
+
+    /**
+     * @param array<string, string[]> $patterns
+     */
+    private static function firstMatch(string $haystack, array $patterns): ?string {
+        foreach ($patterns as $ertek => $mintak) {
+            foreach ($mintak as $minta) {
+                if (mb_strpos($haystack, $minta) !== false) {
+                    return $ertek;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/webapp/classes/search.php
+++ b/webapp/classes/search.php
@@ -216,6 +216,29 @@ class Search {
             $bool['should'][] = ['terms' => [$prefix . 'boundaries' => $boundaryIds, 'boost' => 16]];
         }
 
+        /*
+         * #157: misére keresve MAGÁT A MISÉT is nézzük, ne csak a templomát.
+         *
+         * Eddig a kulcsszó kizárólag templom-mezőkre ment (`names`, `varos`,
+         * `alternative_names`), tehát az esemény CÍME sehol nem számított. Aki
+         * „Rorate"-ra vagy „angol nyelvű misé"-re keresett, nulla találatot kapott —
+         * pedig a külső naptárakból épp ilyen, beszédes címek jönnek be.
+         *
+         * borazslo listáján ez így szerepel: „A keresőt fel kell készíteni, hogy ne
+         * csak pontos egyezésnél találjon rá egy eseményre."
+         *
+         * A `match` az elemzett mezőn szótöredék helyett SZAVAKRA illeszt, tehát a
+         * „szentmise angol" is megtalálja az „Angol nyelvű szentmise (P. Elek)"-et. A
+         * `wildcard` mellette a szó belsejét is engedi, gyengébb súllyal. A boost a
+         * városnév-egyezés (64/18) ALATT van: aki egy települést ír be, továbbra is a
+         * települést kapja, a cím csak bővíti a találatokat.
+         */
+        if ($this->massOrChurch === 'mass') {
+            $bool['should'][] = ['match'    => ['title'   => ['query' => $keyword, 'boost' => 14]]];
+            $bool['should'][] = ['wildcard' => ['title'   => ['value' => '*' . mb_strtolower($keyword) . '*', 'boost' => 6]]];
+            $bool['should'][] = ['match'    => ['comment' => ['query' => $keyword, 'boost' => 3]]];
+        }
+
         $this->query['bool']['must'][] = ['bool' => $bool ];
     }
 

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -247,6 +247,12 @@
           "default": null,
           "extra": ""
         },
+        "external_calendar_id": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
         "period_id": {
           "type": "int(11)",
           "nullable": true,
@@ -367,6 +373,12 @@
           "unique": true,
           "columns": [
             "id"
+          ]
+        },
+        "external_calendar_id": {
+          "unique": false,
+          "columns": [
+            "external_calendar_id"
           ]
         }
       }

--- a/webapp/templates/church/edit.twig
+++ b/webapp/templates/church/edit.twig
@@ -204,10 +204,18 @@
             {{ _self.helptr(6,help) }}
             
             <tr>
-                <td bgcolor=#F0E6D2 class=kiscim align=right>Külső naptár (iCalendar):</td>
+                <td bgcolor=#F0E6D2 class=kiscim align=right>Külső naptárak (iCalendar):</td>
                 <td bgcolor=#F0E6D2>
-                    {{ forms.input(form.external_calendar_url) }}
-                    <small><i>Google Calendar vagy más iCalendar-kompatibilis naptár URL. Az importálást naponta automatikusan végezzük. Maximum 1 naptár templomként. Ürítse a mezőt az importálás leállításához.</i></small>
+                    {{ forms.textarea(form.external_calendar_url) }}
+                    <small><i>Google Calendar vagy más iCalendar-kompatibilis naptár URL-je, <b>soronként egy</b>. Az importálást naponta automatikusan végezzük. A naptár nevét magából a naptárból vesszük át. Ürítse a mezőt az importálás leállításához.</i></small>
+                    {% if externalCalendars %}
+                    <table class="table table-sm" style="margin-top:.5em">
+                        <tr><th>Naptár</th><th>Utolsó sikeres import</th></tr>
+                        {% for naptar in externalCalendars %}
+                        <tr><td>{{ naptar.nev }}</td><td>{{ naptar.utolso_import }}</td></tr>
+                        {% endfor %}
+                    </table>
+                    {% endif %}
                 </td>
                 <td>{{ _self.helplink(60, ICONS_INFO ) }}</td>
             </tr>

--- a/webapp/templates/forms.twig
+++ b/webapp/templates/forms.twig
@@ -45,6 +45,7 @@
     {% if array.style %} style="{{array.style}}" {% else %} style="width:100%" {% endif %}
     {% if array.cols %} cols="{{array.cols}}" {% else %} cols="50" {% endif %}
     {% if array.rows %} rows="{{array.rows}}" {% else %} rows="10" {% endif %}
+    {% if array.placeholder %} placeholder="{{array.placeholder}}" {% endif %}
     >
     {% if array.value %}{{ array.value }}{% endif %}
     </textarea>

--- a/webapp/tests/Integration/ExternalCalendarImporterTest.php
+++ b/webapp/tests/Integration/ExternalCalendarImporterTest.php
@@ -68,7 +68,7 @@ class ExternalCalendarImporterTest extends TestCase
         ExternalCalendarImporter::replaceFromIcs($ics, 1);
 
         $mass = Eloquent\CalMass::where('church_id', 1)
-            ->where('comment', ExternalCalendarImporter::IMPORT_MARKER)
+            ->imported()
             ->firstOrFail();
         $this->assertSame('Magyar nyelvű vasárnapi szentmise', $mass->title);
         $this->assertSame('2026-08-09T12:00:00', $mass->start_date);
@@ -88,7 +88,7 @@ class ExternalCalendarImporterTest extends TestCase
             . "END:VCALENDAR\r\n";
 
         $modifiedOn = null;
-        ExternalCalendarImporter::replaceFromIcs($ics, 1, $modifiedOn);
+        ExternalCalendarImporter::replaceFromIcs($ics, 1, null, $modifiedOn);
 
         $this->assertSame('2026-02-14', $modifiedOn);
     }
@@ -105,7 +105,7 @@ class ExternalCalendarImporterTest extends TestCase
             . "END:VEVENT\r\nEND:VCALENDAR\r\n";
 
         $modifiedOn = null;
-        ExternalCalendarImporter::replaceFromIcs($ics, 1, $modifiedOn);
+        ExternalCalendarImporter::replaceFromIcs($ics, 1, null, $modifiedOn);
 
         $this->assertNull($modifiedOn);
     }
@@ -119,7 +119,7 @@ class ExternalCalendarImporterTest extends TestCase
             . "END:VEVENT\r\nEND:VCALENDAR\r\n";
 
         $modifiedOn = null;
-        ExternalCalendarImporter::replaceFromIcs($ics, 1, $modifiedOn);
+        ExternalCalendarImporter::replaceFromIcs($ics, 1, null, $modifiedOn);
 
         $this->assertNull($modifiedOn);
     }
@@ -208,7 +208,7 @@ class ExternalCalendarImporterTest extends TestCase
         ExternalCalendarImporter::replaceFromIcs($ics, 1);
 
         $mass = Eloquent\CalMass::where('church_id', 1)
-            ->where('comment', ExternalCalendarImporter::IMPORT_MARKER)
+            ->imported()
             ->firstOrFail();
         $this->assertSame('2026-03-29T18:00:00', $mass->start_date);
         $this->assertSame('2026-03-29T18:00:00', $mass->rrule['dtstart']);
@@ -239,25 +239,106 @@ class ExternalCalendarImporterTest extends TestCase
         }
     }
 
-    public function testSavingCalendarUrlReactivatesTheExistingCalendar(): void
+    /**
+     * #157: az azonos URL-t visszakapcsoljuk, nem hozunk létre másodpéldányt.
+     *
+     * A naptárt mostantól az URL azonosítja, nem a neve. Korábban templomonként
+     * EGYETLEN sor volt („Google Calendar"), aminek az URL-jét felülírtuk — az volt
+     * a több naptár akadálya.
+     */
+    public function testSavingTheSameUrlReactivatesTheExistingCalendar(): void
     {
+        $url = 'https://calendar.google.com/calendar/ical/example/public/basic.ics';
         $calendar = Eloquent\ExternalCalendar::create([
             'church_id' => 1,
-            'name' => 'Google Calendar',
-            'url' => 'https://calendar.google.com/old.ics',
+            'name' => 'Szent József templom - Miserend',
+            'url' => $url,
             'active' => 0,
         ]);
 
-        ExternalCalendarImporter::saveCalendarUrl(
-            1,
-            'https://calendar.google.com/calendar/ical/example/public/basic.ics',
-            ['142.250.74.78']
-        );
+        ExternalCalendarImporter::saveCalendarUrls(1, $url, ['142.250.74.78']);
 
         $calendar->refresh();
         $this->assertSame(1, $calendar->active);
-        $this->assertSame('https://calendar.google.com/calendar/ical/example/public/basic.ics', $calendar->url);
         $this->assertSame(1, Eloquent\ExternalCalendar::where('church_id', 1)->count());
+        $this->assertSame('Szent József templom - Miserend', $calendar->name,
+            'a meglévő nevet nem írjuk felül');
+    }
+
+    /** Másik URL = másik naptár: a régi elalszik, nem tűnik el. */
+    public function testReplacingTheUrlDeactivatesTheOldCalendar(): void
+    {
+        $regi = Eloquent\ExternalCalendar::create([
+            'church_id' => 1,
+            'name' => 'Régi naptár',
+            'url' => 'https://calendar.google.com/calendar/ical/regi/public/basic.ics',
+            'active' => 1,
+        ]);
+
+        ExternalCalendarImporter::saveCalendarUrls(
+            1,
+            'https://calendar.google.com/calendar/ical/uj/public/basic.ics',
+            ['142.250.74.78']
+        );
+
+        $regi->refresh();
+        $this->assertSame(0, $regi->active, 'a régi naptár elalszik');
+        $this->assertSame(1, Eloquent\ExternalCalendar::where('church_id', 1)->where('active', 1)->count());
+    }
+
+    /**
+     * A jegy lényege: templomonként több naptár.
+     *
+     * borazslo példája: „Pl. Szegeden a szentségimádásosat vagy a kápolnát."
+     */
+    public function testTobbNaptarEgyTemplomhoz(): void
+    {
+        ExternalCalendarImporter::saveCalendarUrls(
+            1,
+            "https://calendar.google.com/calendar/ical/miserend/public/basic.ics\n"
+            . "https://calendar.google.com/calendar/ical/szentsegimadas/public/basic.ics",
+            ['142.250.74.78']
+        );
+
+        $aktiv = Eloquent\ExternalCalendar::where('church_id', 1)->where('active', 1)->get();
+
+        $this->assertCount(2, $aktiv);
+        $this->assertSame(['Naptár 1', 'Naptár 2'], $aktiv->pluck('name')->all(),
+            'ideiglenes név, amit az első import cserél le a feed X-WR-CALNAME-jére');
+    }
+
+    /** Az üres sorok és az ismétlődések nem hoznak létre naptárat. */
+    public function testAzUresEsIsmetlodoSorokatKiszurjuk(): void
+    {
+        $url = 'https://calendar.google.com/calendar/ical/egy/public/basic.ics';
+
+        ExternalCalendarImporter::saveCalendarUrls(1, "\n  $url  \n\n$url\n", ['142.250.74.78']);
+
+        $this->assertSame(1, Eloquent\ExternalCalendar::where('church_id', 1)->where('active', 1)->count());
+    }
+
+    /** Egyetlen rossz URL az egész mentést visszautasítja — ne fél-jó állapot maradjon. */
+    public function testEgyRosszUrlVisszautasitjaAMentest(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ExternalCalendarImporter::saveCalendarUrls(
+            1,
+            "https://calendar.google.com/calendar/ical/jo/public/basic.ics\nhttp://192.168.0.1/belso.ics",
+            ['142.250.74.78']
+        );
+    }
+
+    /** #157: a feed saját neve. A Google minden exportba beleírja. */
+    public function testANaptarNeveAFeedbolJon(): void
+    {
+        $ics = "BEGIN:VCALENDAR\r\nX-WR-CALNAME:Szent József templom - Miserend\r\nEND:VCALENDAR\r\n";
+
+        $this->assertSame(
+            'Szent József templom - Miserend',
+            ExternalCalendarImporter::calendarNameFromIcs($ics)
+        );
+        $this->assertNull(ExternalCalendarImporter::calendarNameFromIcs("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"));
     }
 
     public function testMissingImportCronIsRegisteredForExistingDatabases(): void

--- a/webapp/tests/Integration/ExternalCalendarPropertiesEndToEndTest.php
+++ b/webapp/tests/Integration/ExternalCalendarPropertiesEndToEndTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #157: a naptár-import a bejegyzés minden tulajdonságát átveszi — végponttól végpontig.
+ *
+ * Az `IcalEventPropertiesTest` a felismerést méri önmagában; itt az a kérdés, hogy a
+ * teljes úton — ICS → parser → CalMass → adatbázis — tényleg megérkezik-e.
+ *
+ * A fixtúra a #157-ben megadott szegedi minta-naptár ALAKJÁT követi: onnan valók a
+ * címek, a `LOCATION:templom`, a folytatósoros DESCRIPTION és a `\,` escape is.
+ * A valódi feeden mérve ez 949 eseményből 37 nem magyar, 14 nem római katolikus,
+ * 43 típusos és 12 helyszínes misét eredményez — mindezt eddig eldobtuk.
+ */
+final class ExternalCalendarPropertiesEndToEndTest extends TestCase {
+
+    private const TID = 1;
+
+    private int $naptarId;
+
+    protected function setUp(): void {
+        parent::setUp();
+        DB::beginTransaction();
+
+        $naptar = \Eloquent\ExternalCalendar::create([
+            'church_id' => self::TID,
+            'name' => 'Naptár 1',
+            'url' => 'https://calendar.google.com/calendar/ical/e2e/public/basic.ics',
+            'active' => 1,
+        ]);
+        $this->naptarId = (int) $naptar->id;
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        parent::tearDown();
+    }
+
+    private function esemeny(string $uid, string $summary, array $extra = []): string {
+        $sorok = ["BEGIN:VEVENT", "UID:$uid@example.test", "SUMMARY:$summary",
+                  "DTSTART:20260809T100000Z", "DURATION:PT1H"];
+        foreach ($extra as $kulcs => $ertek) {
+            $sorok[] = "$kulcs:$ertek";
+        }
+        $sorok[] = "END:VEVENT";
+
+        return implode("\r\n", $sorok) . "\r\n";
+    }
+
+    private function importal(string ...$esemenyek): void {
+        $ics = "BEGIN:VCALENDAR\r\nX-WR-CALNAME:Szent József templom - Miserend\r\n"
+             . implode('', $esemenyek) . "END:VCALENDAR\r\n";
+
+        \ExternalCalendarImporter::replaceFromIcs($ics, self::TID, $this->naptarId);
+    }
+
+    private function mise(string $cimReszlet): \Eloquent\CalMass {
+        return \Eloquent\CalMass::where('external_calendar_id', $this->naptarId)
+            ->where('title', 'LIKE', "%$cimReszlet%")
+            ->firstOrFail();
+    }
+
+    /** Ahol a részlet másik címre is illeszkedne (a LIKE nem érzékeny a kis/nagybetűre). */
+    private function pontosMise(string $cim): \Eloquent\CalMass {
+        return \Eloquent\CalMass::where('external_calendar_id', $this->naptarId)
+            ->where('title', $cim)
+            ->firstOrFail();
+    }
+
+    /** A nyelv eddig MINDIG magyar volt. */
+    public function testAnyelvAcimbolJon(): void {
+        $this->importal(
+            $this->esemeny('a', 'Mass in English - Angol nyelvű szentmise (P. Elek)'),
+            $this->esemeny('b', 'Szentmise (P. Elek)')
+        );
+
+        self::assertSame('en', $this->mise('English')->lang);
+        self::assertSame('hu', $this->pontosMise('Szentmise (P. Elek)')->lang);
+    }
+
+    public function testAszabvanyosLanguageParaméterIsMegerkezik(): void {
+        $ics = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:c@example.test\r\n"
+             . "SUMMARY;LANGUAGE=de:Heilige Messe\r\n"
+             . "DTSTART:20260809T100000Z\r\nDURATION:PT1H\r\n"
+             . "END:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        \ExternalCalendarImporter::replaceFromIcs($ics, self::TID, $this->naptarId);
+
+        $mise = $this->mise('Heilige');
+        self::assertSame('de', $mise->lang);
+        // A paraméteres SUMMARY korábban egyáltalán nem illeszkedett: a cím elveszett.
+        self::assertSame('Heilige Messe', $mise->title);
+    }
+
+    /** A rítus eddig MINDIG római katolikus volt. */
+    public function testAritusAcimbolJon(): void {
+        $this->importal(
+            $this->esemeny('d', '(Régi rítusú mise)'),
+            $this->esemeny('e', 'Szentmise (P. Elek)')
+        );
+
+        self::assertSame('TRADITIONAL', $this->mise('Régi rítusú')->rite);
+        self::assertSame('ROMAN_CATHOLIC', $this->pontosMise('Szentmise (P. Elek)')->rite);
+    }
+
+    /** A helyszín, a leírás és a típus eddig sehova nem került. */
+    public function testAhelyszinAleirasEsAtipusMegerkezik(): void {
+        $this->importal($this->esemeny(
+            'f',
+            'Szentmise kisgyermekes családoknak (P. SZŐCS)',
+            ['LOCATION' => 'Hittanterem', 'DESCRIPTION' => 'Kapcsolat: Csepi László', 'GEO' => '46.2530;20.1414']
+        ));
+
+        $mise = $this->mise('kisgyermekes');
+        self::assertSame('Hittanterem', $mise->location_name);
+        self::assertSame('Kapcsolat: Csepi László', $mise->comment);
+        self::assertSame(['FAMILY'], (array) $mise->types);
+        self::assertEquals(46.2530, (float) $mise->location_lat);
+        self::assertEquals(20.1414, (float) $mise->location_lon);
+    }
+
+    /**
+     * Ami épp azt mondja, hogy NINCS mise, abból nem lesz mise.
+     *
+     * A valódi feedben 17 ilyen van. Eddig mind bekerült, tehát a miserend pont az
+     * ellenkezőjét állította annak, amit a naptár gazdája kiírt.
+     */
+    public function testAzElmaradtAlkalombolNemLeszMise(): void {
+        $this->importal(
+            $this->esemeny('g', 'NINCS Szentmise'),
+            $this->esemeny('h', 'ELMARAD! Szentségimádás és gyóntatás'),
+            $this->esemeny('i', 'Szentmise (P. Elek)')
+        );
+
+        self::assertSame(1, \Eloquent\CalMass::where('external_calendar_id', $this->naptarId)->count());
+        self::assertSame('Szentmise (P. Elek)', $this->pontosMise('Szentmise (P. Elek)')->title);
+    }
+
+    /** A `\,` visszafejtése: eddig egy fölösleges kötőjelet szúrt a címbe. */
+    public function testAzEscapeltVesszoNemRontjaElAcimet(): void {
+        $this->importal($this->esemeny('j', 'Szentmise (P. Elek\\, gyóntat: -)'));
+
+        self::assertSame('Szentmise (P. Elek, gyóntat: -)', $this->mise('gyóntat')->title);
+    }
+
+    /**
+     * A jegy lényege: a MÁSIK naptár importja nem törli ezt.
+     *
+     * Eddig a templom minden importált miséje ment, tehát templomonként egyetlen
+     * naptár működhetett.
+     */
+    public function testAmasikNaptarImportjaNemTorliEzt(): void {
+        $this->importal($this->esemeny('k', 'Szentmise (P. Elek)'));
+
+        $masik = \Eloquent\ExternalCalendar::create([
+            'church_id' => self::TID, 'name' => 'Naptár 2',
+            'url' => 'https://calendar.google.com/calendar/ical/masik/public/basic.ics', 'active' => 1,
+        ]);
+        \ExternalCalendarImporter::replaceFromIcs(
+            "BEGIN:VCALENDAR\r\n" . $this->esemeny('l', 'Szentségimádás') . "END:VCALENDAR\r\n",
+            self::TID,
+            (int) $masik->id
+        );
+
+        self::assertSame(1, \Eloquent\CalMass::where('external_calendar_id', $this->naptarId)->count(),
+            'az első naptár miséje megmaradt');
+        self::assertSame(1, \Eloquent\CalMass::where('external_calendar_id', $masik->id)->count());
+    }
+
+    /** A saját naptár újraimportja viszont cserél, nem halmoz. */
+    public function testAsajatUjraimportCserel(): void {
+        $this->importal($this->esemeny('m', 'Régi szentmise'));
+        $this->importal($this->esemeny('n', 'Új szentmise'));
+
+        $misek = \Eloquent\CalMass::where('external_calendar_id', $this->naptarId)->get();
+        self::assertCount(1, $misek);
+        self::assertSame('Új szentmise', $misek->first()->title);
+    }
+
+    /** Az importált mise a szerkesztő számára továbbra is felismerhető. */
+    public function testAzImportaltMiseJeloltMarad(): void {
+        $this->importal($this->esemeny('o', 'Szentmise (P. Elek)'));
+
+        $mise = $this->pontosMise('Szentmise (P. Elek)');
+        self::assertTrue($mise->imported, 'a jelölés mostantól az external_calendar_id');
+        self::assertSame([$mise->id], \Eloquent\CalMass::importedIdsAmong([$mise->id]));
+    }
+}

--- a/webapp/tests/Unit/IcalEventPropertiesTest.php
+++ b/webapp/tests/Unit/IcalEventPropertiesTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #157: a naptár-bejegyzés tulajdonságainak felismerése.
+ *
+ * A példák NEM kitaláltak: mind a #157-ben megadott szegedi minta-naptárból valók.
+ */
+final class IcalEventPropertiesTest extends TestCase {
+
+    // ── nyelv ───────────────────────────────────────────────────
+
+    public function testAlapertelmezesbenMagyar(): void {
+        self::assertSame('hu', IcalEventProperties::detectLanguage('Szentmise (P. Elek)'));
+    }
+
+    public function testAngolNyelvuMiseAngol(): void {
+        self::assertSame('en', IcalEventProperties::detectLanguage('Mass in English - Angol nyelvű szentmise (P. Elek)'));
+        self::assertSame('en', IcalEventProperties::detectLanguage('Szentmise ANGOL nyelven (P. Elek)'));
+        self::assertSame('en', IcalEventProperties::detectLanguage('English mass / Angol nyelvű szentmise (P. Elek)'));
+    }
+
+    /**
+     * A legcifrább valódi cím: mindkét nyelvet említi, de az egyik épp az, ami ELMARAD.
+     */
+    public function testAHelyettUtaniNyelvSzamit(): void {
+        self::assertSame(
+            'hu',
+            IcalEventProperties::detectLanguage('Mass in HUNGARIAN - Angol helyett magyar nyelvű mise (P. SZŐCS)')
+        );
+    }
+
+    public function testASzabvanyosLanguageParameterEroesebb(): void {
+        // A cím magyarul van, de a naptár gazdája kitöltötte a szabványos mezőt.
+        self::assertSame('de', IcalEventProperties::detectLanguage('Szentmise', 'de-AT'));
+    }
+
+    /** A saját kódjaink nem mindenhol ISO 639-1: a latin `va`, a görög `gr`. */
+    public function testANyelviCimkeLekepezese(): void {
+        self::assertSame('va', IcalEventProperties::mapLanguageTag('la'));
+        self::assertSame('gr', IcalEventProperties::mapLanguageTag('el-GR'));
+        self::assertSame('ua', IcalEventProperties::mapLanguageTag('uk'));
+        self::assertSame('hu', IcalEventProperties::mapLanguageTag('hu-HU'));
+        self::assertNull(IcalEventProperties::mapLanguageTag('klingon'));
+    }
+
+    /**
+     * A puszta nemzetiségnév nem elég — VEZETÉKNÉV is lehet.
+     *
+     * Mindkettő valódi cím a minta-naptárból. A kontextus-követelmény nélkül ezek
+     * lengyel, illetve horvát nyelvű misének látszanának.
+     */
+    public function testANemzetisegNevuVezeteknevNemNyelv(): void {
+        self::assertSame('hu', IcalEventProperties::detectLanguage('Gyász szentmise Lengyel Györgyért (P. Szőcs)'));
+        self::assertSame('hu', IcalEventProperties::detectLanguage('Gyász szentmise Horváth Andreáért (P. SZŐCS)'));
+    }
+
+    /** Kontextussal viszont felismeri. */
+    public function testANyelvKontextussalFelismerheto(): void {
+        self::assertSame('pl', IcalEventProperties::detectLanguage('Lengyel nyelvű szentmise'));
+        self::assertSame('hr', IcalEventProperties::detectLanguage('Szentmise horvátul'));
+        self::assertSame('de', IcalEventProperties::detectLanguage('German mass'));
+    }
+
+    // ── rítus ───────────────────────────────────────────────────
+
+    public function testAlapertelmezesbenRomaiKatolikus(): void {
+        self::assertSame('ROMAN_CATHOLIC', IcalEventProperties::detectRite('Szentmise (P. Elek)'));
+    }
+
+    public function testARegiRitusFelismerese(): void {
+        self::assertSame('TRADITIONAL', IcalEventProperties::detectRite('(Régi rítusú mise)'));
+        self::assertSame('TRADITIONAL', IcalEventProperties::detectRite('(Régi rítusú katolikus mise)'));
+        self::assertSame('TRADITIONAL', IcalEventProperties::detectRite('(Régi rítusú mise: Uhel Péter primíciája)'));
+    }
+
+    /**
+     * A sorrend számít: ez a cím a „liturgi" mintára is illeszkedne, pedig régi rítus.
+     */
+    public function testARegiRitusEroesebbMintALiturgia(): void {
+        self::assertSame('TRADITIONAL', IcalEventProperties::detectRite('Régi rítusú liturgikus hétvége'));
+    }
+
+    public function testAGorogKatolikusFelismerese(): void {
+        self::assertSame('GREEK_CATHOLIC', IcalEventProperties::detectRite('Szent Liturgia'));
+        self::assertSame('GREEK_CATHOLIC', IcalEventProperties::detectRite('Görögkatolikus szentmise'));
+    }
+
+    // ── típus ───────────────────────────────────────────────────
+
+    public function testACsaladosMiseTipusa(): void {
+        self::assertSame(['FAMILY'], IcalEventProperties::detectTypes('Szentmise kisgyermekes családoknak (P. SZŐCS)'));
+        self::assertSame(['FAMILY'], IcalEventProperties::detectTypes('Családi mise (P. ELEK)'));
+    }
+
+    public function testAzEgyetemiMiseTipusa(): void {
+        self::assertSame(
+            ['UNIVERSITY_YOUTH'],
+            IcalEventProperties::detectTypes('Szentmise az Egyetemilelkészség évnyitójával (P. ELEK)')
+        );
+    }
+
+    /** Egyszerre több típus is lehet. */
+    public function testTobbTipusEgyszerre(): void {
+        $tipusok = IcalEventProperties::detectTypes('Szentmise kisgyermekes családoknak (P. Szőcs, orgonás)');
+
+        self::assertContains('FAMILY', $tipusok);
+        self::assertContains('ORGAN', $tipusok);
+    }
+
+    public function testTipusJelzesNelkulUres(): void {
+        self::assertSame([], IcalEventProperties::detectTypes('Szentmise (P. Elek)'));
+    }
+
+    // ── elmaradás ───────────────────────────────────────────────
+
+    /**
+     * A mintában 16 ilyen van. Ma miseként vesszük fel őket, tehát a miserend pont az
+     * ellenkezőjét állítja annak, amit a naptár gazdája kiírt.
+     */
+    public function testANincsMiseNemMise(): void {
+        self::assertTrue(IcalEventProperties::isCancelled('NINCS Szentmise'));
+        self::assertTrue(IcalEventProperties::isCancelled('NINCS SZENTMISE'));
+        self::assertTrue(IcalEventProperties::isCancelled('NINCS MÁR Taizei imaóra'));
+        self::assertTrue(IcalEventProperties::isCancelled('ELMARAD! Szentségimádás és gyóntatás'));
+    }
+
+    public function testASzabvanyosCancelledStatuszIsSzamit(): void {
+        self::assertTrue(IcalEventProperties::isCancelled('Szentmise', 'CANCELLED'));
+        self::assertFalse(IcalEventProperties::isCancelled('Szentmise', 'CONFIRMED'));
+    }
+
+    /** A szóhatár miatt a szó BELSEJÉBEN lévő egyezés nem számít. */
+    public function testASzoBelsejebenNemIllik(): void {
+        self::assertFalse(IcalEventProperties::isCancelled('Szentmise a nincstelenekért'));
+        self::assertFalse(IcalEventProperties::isCancelled('Szentmise (P. Elek)'));
+    }
+
+    // ── GEO ─────────────────────────────────────────────────────
+
+    public function testAGeoMezoFeldolgozasa(): void {
+        self::assertSame(['lat' => 46.253, 'lon' => 20.1414], IcalEventProperties::parseGeo('46.2530;20.1414'));
+    }
+
+    public function testARosszGeoNemDoblHibat(): void {
+        self::assertNull(IcalEventProperties::parseGeo(null));
+        self::assertNull(IcalEventProperties::parseGeo(''));
+        self::assertNull(IcalEventProperties::parseGeo('46.25'));
+        self::assertNull(IcalEventProperties::parseGeo('abc;def'));
+        self::assertNull(IcalEventProperties::parseGeo('200;300'), 'a tartományon kívüli koordináta sem jó');
+    }
+
+    // ── szöveg-visszafejtés ─────────────────────────────────────
+
+    /** RFC 5545 3.3.11: a `\n` a fájlban escape-elt sortörés. */
+    public function testAzEscapeltSzovegVisszabontasa(): void {
+        self::assertSame("AA\nKék?", IcalEventProperties::unescapeText('AA\\nKék?'));
+        self::assertSame('Elek, gyóntat: -', IcalEventProperties::unescapeText('Elek\\, gyóntat: -'));
+        self::assertNull(IcalEventProperties::unescapeText(null));
+    }
+}


### PR DESCRIPTION
Closes: #157
@borazslo a #157-es checklistádon öt pont maradt nyitva. Mind az öt megvan. A döntéseket nem találtam ki: az általad megadott szegedi minta-naptár **949 valódi eseményén** mértem őket.

## 1–2. Nyelv és rítus

Eddig mindkettő be volt drótozva a kódba (`'lang' => 'hu'`, `'rite' => 'ROMAN_CATHOLIC'`). Mostantól a nyelvet a szabványos `LANGUAGE=` paraméter adja, ennek híján a cím; a rítust a cím.

A valódi feeden mérve:

| | eddig | mostantól |
|---|---|---|
| nem magyar nyelvű mise | 0 | **37** |
| nem római katolikus | 0 | **14** |

Példák a te naptáradból: „Mass in English - Angol nyelvű szentmise (P. Elek)" → `en`; „(Régi rítusú mise)" → `TRADITIONAL`.

**A puszta nemzetiségnév nem elég.** Van a naptáradban „Gyász szentmise Lengyel Györgyért" és „Gyász szentmise Horváth Andreáért" — ott a `lengyel` és a `horvát` VEZETÉKNÉV. Ezért nyelvi kontextust követelek: „X nyelvű", „Mass in X", „Xül". Az első változatom mindkettőt félreértette; a mérés fogta meg.

A legcifrább valódi címed: „Mass in HUNGARIAN - Angol helyett magyar nyelvű mise" — mindkét nyelvet említi, de az egyik épp az, ami elmarad. A „helyett" előtti említést eldobom.

## 3. A többi tulajdonság

A helyszín, a leírás, a koordináta és a mise típusa eddig sehova nem került. Most megérkeznek: **43 mise kap típust, 12 helyszínt, 17 leírást.**

Ehhez fel kellett szabadítani a `comment` mezőt, amit az importált mise JELÖLÉSE foglalt (`comment = 'External calendar import'`). A jelölés mostantól külön oszlop: `cal_masses.external_calendar_id`. Ezt a lépést egyébként a kód saját megjegyzése jelezte előre: *„a jelölés módja (később: külön DB-oszlop, több naptár támogatásához) egy helyen legyen cserélhető"*.

## 4. Kereső

A kulcsszó eddig **kizárólag templom-mezőkre** ment (`names`, `varos`, `alternative_names`) — az esemény CÍME sehol nem számított. Ezt kérted: *„A keresőt fel kell készíteni, hogy ne csak pontos egyezésnél találjon rá egy eseményre."*

Éles Elasticsearch ellen mérve:

| keresés | eddig | mostantól |
|---|---|---|
| „Rorate" | **0** | 1135 |
| „gyóntatás" | **0** | 1194 |
| „szentségimádás" | **0** | 9882 |

A súly a városnév-egyezés alatt van, tehát aki települést ír be, továbbra is a települést kapja — a cím csak bővíti a találatokat.

## 5. Több naptár templomonként

*„Több külső naptárat is meg lehessen vele etetni. Pl. Szegeden a szentségimádásosat vagy a kápolnát."*

A tábla eddig is engedte, a kód nem: az import a templom ÖSSZES jelölt miséjét törölte, tehát a második naptár importja **kitörölte az elsőét**. Mostantól naptáranként cserél.

A szerkesztőben soronként egy URL. A naptár nevét nem kell kitalálni: a feed `X-WR-CALNAME` mezőjéből vesszük — a tiéd például „Szent József templom - Miserend".

## Amit menet közben találtam

**A `SUMMARY;LANGUAGE=en:` alakú sor egyáltalán nem illeszkedett.** A regex csak a paraméter nélküli `SUMMARY:`-t fogadta el, tehát az ilyen bejegyzés címe elveszett, és „External Calendar Event" néven jött be.

**A `\,` visszafejtése rossz volt:** `', -'`-ra cserélte, tehát minden escape-elt vesszős címbe beszúrt egy fölösleges kötőjelet. A te naptáradban 100+ misét érint — „Szentmise (P. Elek, - gyóntat: -)".

**És a legkomolyabb: a „NINCS Szentmise" és az „ELMARAD!" kezdetű bejegyzésekből MISE lett.** A miserendünk pont az ellenkezőjét állította annak, amit a naptár gazdája kiírt — épp azon a napon, amikor a hívő hiába megy el. A te naptáradban **17 ilyen van**.

## Teszt

- `IcalEventPropertiesTest` (21) — a felismerés önmagában, valódi címekkel a naptáradból
- `ExternalCalendarPropertiesEndToEndTest` (9) — ICS → parser → CalMass → adatbázis
- `ExternalCalendarImporterTest` (20) — a több-naptáras viselkedés
- a teljes böngészős (Panther) sor: 80 teszt, zöld

Az éles importot a te naptáradon is végigfuttattam (949 esemény), tranzakcióban, rollbackkel — a fenti számok onnan valók.

## Deploy

**Kézi migráció kell**, mert a `cal_masses` új oszlopot kap: `docker/mysql/migrations/157-mise-kulso-naptar.sql`. Ellenőrző lekérdezéssel együtt a `docs/deploy-lepesek.md`-ben. Adatvesztés nincs, csak hozzáad; a meglévő importált misék a következő cron-futáskor gazdagodnak a leírással és a helyszínnel.

Egy dolog nem fér ebbe a PR-be: a séma-ujjlenyomat (`schema-reference.json` `_meta`) a konténerben lévő `docker/mysql/initdb.d`-ből számolódik, az viszont az IMAGE tartalma, nem a repóé — ezért a 08-as fájl óta amúgy is elavult. Nem nyúltam hozzá, hogy ne keverjem ide.
