### PR TITLE
A #768-as tartaléklistámba svájci tükör került, és emiatt áll a napi OSM-szinkron (#840)

### DIFF
--- a/webapp/classes/externalapi/externalapi.php
+++ b/webapp/classes/externalapi/externalapi.php
@@ -10,6 +10,23 @@ class ExternalApi {
     public $queryTimeout = 30;
 
     /**
+     * #840: mennyit várunk a VÁLASZRA, ha ez más, mint a szolgáltatónak adott keret.
+     *
+     * Az Overpassnál a `queryTimeout` KÉT dolgot jelentett egyszerre: a lekérdezésbe
+     * írt szerveroldali költségvetést (`[out:json][timeout:30]`) ÉS a curl teljes
+     * várakozását. Egy olyan lekérdezés tehát, ami tényleg elhasználja a szerveroldali
+     * keretét, definíció szerint nem tud megérkezni: a curl pont akkor vágja el, amikor
+     * a szerver elkezdene válaszolni. Élesben pontosan ez volt a naplóban:
+     * „Operation timed out after 30000 milliseconds with 0 bytes received".
+     *
+     * Mérve: a teljes `url:miserend` lekérdezés az overpass.openstreetmap.fr-en 24,1 mp
+     * alatt adott 3,17 MB-ot — a 30 mp-es közös korlát alatt, de már a sodrásában.
+     *
+     * `null` = maradjon a régi viselkedés (a queryTimeout a curl korlátja is).
+     */
+    public $transferTimeout = null;
+
+    /**
      * #766: a kapcsolatfelvétel felső korlátja másodpercben.
      *
      * Szándékosan sokkal kisebb a teljes időkorlátnál: a kérés kiszolgálása tarthat
@@ -139,8 +156,29 @@ class ExternalApi {
                 $this->tryToLoadFromCache();
             }
 
-            if (!isset($this->rawData)) {
+            $cachebolJott = isset($this->rawData);
+
+            if (!$cachebolJott) {
                 $this->downloadData();
+            }
+
+            /*
+             * #840: a válasz formailag rendben van — de ÉRDEMI-e?
+             *
+             * A HTTP 200 nem elég bizonyíték. Az Overpass a szerveroldali időtúllépésre is
+             * 200-at ad (üres `elements` + `remark`), egy földrajzilag korlátozott tükör
+             * pedig hiánytalan JSON-t ad a világ töredékéről. Mindkettő „sikeresen"
+             * lefutott, és mindkettő egy hétre beégett a cache-be.
+             *
+             * Ha a cache-ből jött a hibás válasz, TÖRÖLJÜK is: különben a következő futás
+             * ugyanazt olvasná vissza, és a javítás egy hétig nem érne semmit.
+             */
+            $elutasitas = $this->rejectionReason();
+            if ($elutasitas !== null) {
+                if ($cachebolJott) {
+                    $this->forgetCache();
+                }
+                throw new \Exception($elutasitas);
             }
 
             // Ha a cache be van kapcsolva, akkor szeretnénk elmenteni a letöltött adatokat.
@@ -247,6 +285,33 @@ class ExternalApi {
         }
     }
 
+    /**
+     * #840: érdemi-e a most kapott válasz?
+     *
+     * Alapból minden válasz elfogadható — a formai ellenőrzést (JSON/XML, HTTP-kód) a
+     * `downloadData()` már elvégezte. Ez a horog azoknak a szolgáltatóknak való, ahol a
+     * 200-as válasz ÖNMAGÁBAN nem bizonyíték (l. `\ExternalApi\OverpassApi`).
+     *
+     * @return ?string a visszautasítás oka, vagy null, ha a válasz rendben van
+     */
+    protected function rejectionReason(): ?string {
+        return null;
+    }
+
+    /**
+     * #840: a mostani lekérdezés cache-fájljának eldobása.
+     *
+     * Akkor kell, ha utólag derül ki, hogy a tárolt válasz hibás. Enélkül egy rossz
+     * pillanat a cache teljes élettartamára (Overpassnál egy hétre) beég.
+     */
+    public function forgetCache(): bool {
+        if (empty($this->cacheFilePath) || !file_exists($this->cacheFilePath)) {
+            return false;
+        }
+
+        return @unlink($this->cacheFilePath);
+    }
+
     function downloadData() {        
         $header = array("cache-control: no-cache","Content-Type: application/".$this->format);
 		if(isset($this->headerAuthorization))
@@ -255,7 +320,8 @@ class ExternalApi {
         curl_setopt($ch, CURLOPT_URL,$this->apiUrl . $this->rawQuery);
 		//echo $this->apiUrl . $this->rawQuery."\n";
         
-		curl_setopt($ch, CURLOPT_TIMEOUT, $this->queryTimeout);
+		// #840: a válaszra tovább várunk, mint amennyi keretet a szolgáltatónak adtunk.
+		curl_setopt($ch, CURLOPT_TIMEOUT, $this->transferTimeout ?? $this->queryTimeout);
 
 		/*
 		 * #766: külön KAPCSOLAT-időkorlát. Eddig csak a teljes kérésre volt korlát (30 mp),

--- a/webapp/classes/externalapi/overpassapi.php
+++ b/webapp/classes/externalapi/overpassapi.php
@@ -14,6 +14,17 @@ class OverpassApi extends \ExternalApi\ExternalApi {
     /** #766: a próbálandó végpontok, a beállítottal az élen. @var string[] */
     public $fallbackUrls = [];
 
+    /**
+     * #840: hány elem alatt tekintjük a választ HIÁNYOSNAK, nem üresnek?
+     *
+     * A hívó állítja be, ha tudja, mit vár. 0 = nincs elvárás (az üres találat érvényes
+     * válasz marad — ez a #766 szándéka).
+     */
+    public $minElements = 0;
+
+    /** #840: melyik végpont válaszolt végül. Naplózáshoz és teszthez. */
+    public $usedUrl;
+
     function __construct() {
         global $config;
         // #376: az Overpass-endpoint mostantól konfigurálható. borazslo tapasztalata
@@ -26,6 +37,9 @@ class OverpassApi extends \ExternalApi\ExternalApi {
 
         $this->fallbackUrls = self::buildEndpointList($this->apiUrl, $config['overpass']['fallbackUrls'] ?? null);
     }
+
+    /** #840: ennyivel várunk tovább a válaszra, mint a szerveroldali keret. Másodperc. */
+    const TRANSFER_GRACE = 30;
 
     /**
      * #766: tartalék végpontok.
@@ -47,10 +61,31 @@ class OverpassApi extends \ExternalApi\ExternalApi {
      * @return string[]
      */
     public static function buildEndpointList(string $primary, ?array $extra = null): array {
+        /*
+         * #840: az `overpass.osm.ch` INNEN KIKERÜLT, és ez a jegy lényege.
+         *
+         * Svájci példány: csak svájci adatot tartalmaz. Mérve (2026-08-20), ugyanaz a
+         * lekérdezés, csak a hoszt más:
+         *   node["place"="city"]["name"="Budapest"];out count;
+         *     overpass-api.de            -> 1
+         *     overpass.openstreetmap.fr  -> 1
+         *     overpass.osm.ch            -> 0     <-- nincs benne Magyarország
+         *
+         * Élesben ezért futott a napi szinkron másfél hónapon át „sikeresen" EGYETLEN
+         * elemmel: a beállított végpont elérhetetlen volt, a private.coffee HTTP 500-at
+         * adott a nagy lekérdezésre, az osm.ch pedig 200-at — a világ töredékéről.
+         *
+         * A helyére a globális `overpass.openstreetmap.fr` kerül; mérve ugyanarra a
+         * teljes `url:miserend` lekérdezésre HTTP 200, 5035 elem, 3,17 MB, 24,1 mp.
+         *
+         * TANULSÁG, ami a listán túl is érvényes: földrajzilag korlátozott tükör ide
+         * nem való, mert a hiányos válasza formailag tökéletes. A `rejectionReason()`
+         * ezért nem is a listában bízik.
+         */
         $alap = $extra ?? [
             'https://overpass-api.de/api/interpreter',
             'https://overpass.private.coffee/api/interpreter',
-            'https://overpass.osm.ch/api/interpreter',
+            'https://overpass.openstreetmap.fr/api/interpreter',
         ];
 
         $lista = [];
@@ -84,6 +119,15 @@ class OverpassApi extends \ExternalApi\ExternalApi {
     function run() {
         $vegpontok = !empty($this->fallbackUrls) ? $this->fallbackUrls : [$this->apiUrl];
         $utolsoHiba = null;
+        $this->usedUrl = null;
+
+        /*
+         * #840: a válaszra tovább várunk, mint amennyi keretet az Overpassnak adtunk.
+         * Itt számoljuk, nem a konstruktorban: a hívó a `queryTimeout`-ot menet közben
+         * is átállíthatja (a napi szinkron például jóval nagyobb keretet kér), és a
+         * kettőnek együtt kell mozognia.
+         */
+        $this->transferTimeout = $this->queryTimeout + self::TRANSFER_GRACE;
 
         foreach ($vegpontok as $index => $url) {
             $this->apiUrl = $url;
@@ -92,6 +136,7 @@ class OverpassApi extends \ExternalApi\ExternalApi {
             parent::run();
 
             if (!$this->hasError()) {
+                $this->usedUrl = $url;
                 if ($index > 0) {
                     error_log('[miserend] Overpass: a(z) ' . $vegpontok[0] . ' nem válaszolt, '
                         . $url . ' válaszolt helyette.');
@@ -102,9 +147,54 @@ class OverpassApi extends \ExternalApi\ExternalApi {
             $utolsoHiba = $this->error;
         }
 
-        // Mindegyik elhasalt: az utolsó hiba marad kint, hogy a /health és a napló
-        // valódi okot mutasson, ne csak annyit, hogy „nem sikerült".
+        /*
+         * Mindegyik elhasalt: az utolsó hiba marad kint, hogy a /health és a napló
+         * valódi okot mutasson, ne csak annyit, hogy „nem sikerült".
+         *
+         * #840: a `jsonData`-t is KIÜRÍTJÜK. Eddig az utolsó — visszautasított —
+         * végpont hiányos válasza ottmaradt, és a hívók egy része csak azt nézte, van-e
+         * `elements` (l. `OSM::syncUrlMiserendFromOSM`), a hibát nem. Így egy elutasított
+         * válasz mégis feldolgozásra került volna.
+         */
         $this->error = $utolsoHiba;
+        $this->jsonData = json_decode('{"elements":[]}');
+    }
+
+    /**
+     * #840: érdemi-e a válasz? A HTTP 200 önmagában nem bizonyíték.
+     *
+     * KÉT dolgot szűrünk, és egyiket sem lehet a listával kiváltani:
+     *
+     * 1. `remark` — az Overpass a szerveroldali időtúllépésre és futásidejű hibára is
+     *    HTTP 200-at ad, üres vagy részleges `elements`-szel és egy `remark` mezővel.
+     *    Mérve: `[out:json][timeout:1]` a teljes url:miserend lekérdezéssel ->
+     *    HTTP 200, elements: 0, remark: "runtime error: Query timed out in query...".
+     *    Ez sikernek látszott, és egy hétre bekerült a cache-be.
+     *
+     * 2. HIÁNYOS válasz — ha a hívó megmondta, mennyit vár (`minElements`), és ennél
+     *    lényegesen kevesebb jött, az nem üres találat, hanem rossz forrás. Az ÜRES
+     *    találat továbbra is érvényes válasz marad: aki nem állít `minElements`-t,
+     *    annál semmi nem változik (ez a #766 szándéka).
+     */
+    protected function rejectionReason(): ?string {
+        if (!is_object($this->jsonData)) {
+            return null;
+        }
+
+        $remark = trim((string) ($this->jsonData->remark ?? ''));
+        if ($remark !== '') {
+            return 'Az Overpass hibát jelzett a válaszban (' . $this->apiUrl . '): ' . $remark;
+        }
+
+        if ($this->minElements > 0) {
+            $darab = is_array($this->jsonData->elements ?? null) ? count($this->jsonData->elements) : 0;
+            if ($darab < $this->minElements) {
+                return 'Az Overpass válasza hiányos (' . $this->apiUrl . '): ' . $darab
+                    . ' elem érkezett, legalább ' . $this->minElements . ' kellene.';
+            }
+        }
+
+        return null;
     }
 
     function buildQuery() {

--- a/webapp/classes/html/josm.php
+++ b/webapp/classes/html/josm.php
@@ -24,8 +24,12 @@ class Josm extends Html {
             // Mert itt tudjuk jól állítani a cache idejét 
             $overpass = new \ExternalApi\OverpassApi();
             $overpass->cache = '1 sec';
+            // #840: ugyanaz az elvárás, mint a cronban — a frissítés ne írjon hiányos
+            // választ a cache-be, amiből aztán a szinkron dolgozna.
+            $overpass->queryTimeout = 120;
+            $overpass->minElements = \OSM::expectedUrlMiserendElements();
             $overpass->downloadUrlMiserend();
-            
+
             $job = \Eloquent\Cron::where('class','\OSM')->where('function','syncUrlMiserendFromOSM')->first();
             $job->run();                       
         }
@@ -38,12 +42,21 @@ class Josm extends Html {
                 ->where('function','syncUrlMiserendFromOSM')->first();
 
        $overpass = new \ExternalApi\OverpassApi();
+       /*
+        * #840: hiányos válaszból NE rajzoljunk összevetést.
+        *
+        * Élesben egy svájci tükör 1 elemes válasza jött vissza a cache-ből — ebből ez az
+        * oldal azt a következtetést vonta le, hogy ötezer templomunknak nincs OSM-adata.
+        * A „nem tudjuk" és a „nincs" nem ugyanaz; az elsőt kell mondani.
+        */
+       $overpass->queryTimeout = 120;
+       $overpass->minElements = \OSM::expectedUrlMiserendElements();
        $overpass->downloadUrlMiserend();
         // #573: az Overpass API gyakran túlterhelt és üres/hibás választ ad. Korábban
         // ilyenkor kivételt dobtunk → az EGÉSZ /josm oldal elszállt. Most inkább
         // barátságos üzenettel, az OSM-függő részeket üresen hagyva betöltjük az oldalt
         // (a DB-alapú rész — osmtags, cron-utolsó-futás — így is látszik).
-        if (empty($overpass->jsonData->elements)) {
+        if ($overpass->hasError() || empty($overpass->jsonData->elements)) {
             addMessage('Az OSM (Overpass) adatok most nem elérhetők (valószínűleg túlterhelt). Az OSM-összevetés átmenetileg üres — próbáld újra pár perc múlva.', 'error');
             $this->multipleOSMids = [];
             $this->osmWBadChurch = [];

--- a/webapp/classes/osm.php
+++ b/webapp/classes/osm.php
@@ -325,14 +325,78 @@ class OSM {
         return (int) $match[1];
     }
 
-    function syncUrlMiserendFromOSM() {
-        
-        $overpass = new \ExternalApi\OverpassApi();
+    /**
+     * #840: mennyi `url:miserend` elemet VÁRUNK az Overpasstól?
+     *
+     * A saját adatunkból származtatjuk: ahány misézőhelyünkhöz OSM-azonosító tartozik,
+     * nagyjából annyi elemnek kell kijönnie odaátról is (a hoszton mérve 5035 elem).
+     *
+     * A küszöb SZÁNDÉKOSAN nagyon alacsony — az ÖTÖDE. Ez füstjelző, nem mérőműszer:
+     * azt a fajta hibát kell elkapnia, ami nagyságrendet téved (élesben 5035 helyett 1
+     * elem jött, a várt érték 0,02%-a). A valódi ingadozásba viszont ne szóljon bele:
+     * az OSM-ben tényleg mozognak a címkék, és egy tévesen leálló szinkron ugyanolyan
+     * rossz, mint egy némán hiányos.
+     *
+     * A mérsékelt csökkenés így is LÁTSZIK: a futás mindig kiírja, hány elem érkezett.
+     */
+    public static function expectedUrlMiserendElements(): int {
+        $osmAzonositoval = \Eloquent\Church::whereNotNull('osmid')
+            ->where('osmid', '<>', '')
+            ->whereNotNull('osmtype')
+            ->where('osmtype', '<>', '')
+            ->count();
+
+        return (int) floor($osmAzonositoval / 5);
+    }
+
+    /**
+     * @param ?\ExternalApi\OverpassApi $overpass #840: teszthez injektálható. A cron
+     *        paraméter nélkül hívja, tehát élesben semmi nem változik — de a „mi
+     *        történik, ha az Overpass hiányos választ ad" eset végre lefuttatható
+     *        hálózat nélkül is. Enélkül csak az éles futásból derült volna ki, hogy
+     *        a szinkron ilyenkor csendben végigmegy.
+     */
+    function syncUrlMiserendFromOSM(?\ExternalApi\OverpassApi $overpass = null) {
+
+        $overpass = $overpass ?? new \ExternalApi\OverpassApi();
+
+        /*
+         * #840: ez a site LEGNEHEZEBB Overpass-hívása — globális, korlátozás nélküli
+         * lekérdezés, mérve 5035 elem és 3,17 MB. A közös 30 másodperces keret ehhez
+         * kevés: a francia tükör 24,1 mp alatt válaszolt, a lassabb pillanataiban tehát
+         * biztosan elhasalna. Cronban vagyunk, nem látogatói kérésben — kaphat többet.
+         */
+        $overpass->queryTimeout = 120;
+
+        /*
+         * #840: megmondjuk, mit várunk. Enélkül egy földrajzilag korlátozott tükör
+         * hiánytalan JSON-ja is „sikeres" válasz volt — élesben másfél hónapon át EGYETLEN
+         * elemet dolgoztunk fel naponta, sikert jelentve.
+         */
+        $overpass->minElements = self::expectedUrlMiserendElements();
+
         $overpass->downloadUrlMiserend();
-        
-         if (!$overpass->jsonData->elements) {
+
+        /*
+         * #840: a HIBÁT is nézzük, ne csak azt, jött-e valami.
+         *
+         * Eddig csak az `elements` üressége számított. Ha a tartaléklista minden végpontja
+         * elhasalt, az utolsó — visszautasított — végpont hiányos válasza ottmaradt a
+         * `jsonData`-ban, és ez a feltétel átengedte. Most az `OverpassApi::run()` ki is
+         * üríti, de a hibát itt is meg kell nézni: a szinkron ne írjon adatot olyan
+         * válaszból, amit a rendszer maga utasított vissza.
+         */
+        if ($overpass->hasError()) {
+            throw new Exception('Az Overpass egyik végpontja sem adott használható választ: '
+                . $overpass->getErrorMessage());
+        }
+
+        if (!$overpass->jsonData->elements) {
             throw new Exception("Missing Json Elements from OverpassApi Query");
         }
+
+        echo 'OSM url:miserend: a(z) ' . $overpass->usedUrl . ' válaszolt, '
+            . count($overpass->jsonData->elements) . " elem érkezett.\n";
 
         /*
          * #658: a hibás értékeket JELENTJÜK, nem dobjuk el némán.

--- a/webapp/tests/Integration/OverpassCachePoisoningTest.php
+++ b/webapp/tests/Integration/OverpassCachePoisoningTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #840: egy rossz válasz ne éghessen be egy hétre a cache-be.
+ *
+ * Az ExternalApi csak a 429/503/504 válaszokat hagyta ki a cache-írásból. Az Overpass
+ * viszont a szerveroldali időtúllépésre is HTTP 200-at ad (`remark` mezővel), egy
+ * földrajzilag korlátozott tükör pedig hiánytalan JSON-t a világ töredékéről —
+ * mindkettő „sikeresen" befért a cache-be, és onnantól a napi szinkron heteken át
+ * ugyanazt az egy rossz választ olvasta vissza, hálózat nélkül, 0,15 másodperc alatt.
+ *
+ * Két dolgot rögzítünk itt:
+ *   1. a visszautasított válasz NEM kerül a cache-be;
+ *   2. ha a cache-BŐL jött a visszautasított válasz, a fájlt el is dobjuk — különben a
+ *      javítás a cache teljes élettartamáig nem érne semmit.
+ */
+final class OverpassCachePoisoningTest extends TestCase {
+
+    private const NEV = 'teszt_overpass_840';
+
+    private function takarit(): void {
+        foreach (glob(PATH . 'fajlok/tmp/' . self::NEV . '_*.json') ?: [] as $f) {
+            @unlink($f);
+        }
+    }
+
+    protected function setUp(): void {
+        $this->takarit();
+    }
+
+    protected function tearDown(): void {
+        $this->takarit();
+    }
+
+    private function api(string $valasz): OverpassApiDouble {
+        $api = new OverpassApiDouble();
+        $api->name = self::NEV;
+        $api->valasz = $valasz;
+        // Egyetlen végpont, hogy a lánc ne mossa el, mi történt.
+        $api->fallbackUrls = ['https://pelda.example/api/interpreter'];
+
+        return $api;
+    }
+
+    /** A `remark`-os válasz nem siker — és nem is kerül a cache-be. */
+    public function testARemarkResponseIsNotCached(): void {
+        $api = $this->api('{"elements":[],"remark":"runtime error: Query timed out"}');
+        $api->buildSimpleQuery('["url:miserend"]');
+        $api->run();
+
+        self::assertTrue($api->hasError(), 'a remark-os válasz hiba');
+        self::assertFileDoesNotExist($api->cacheFilePath, 'hibás választ nem mentünk cache-be');
+    }
+
+    /** A hiányos válasz sem. Ez a konkrét éles eset: 1 elem ~2500 helyett. */
+    public function testAnImplausiblyShortResponseIsNotCached(): void {
+        $api = $this->api('{"elements":[{"type":"way","id":94545227}]}');
+        $api->minElements = 2500;
+        $api->buildSimpleQuery('["url:miserend"]');
+        $api->run();
+
+        self::assertTrue($api->hasError());
+        self::assertFileDoesNotExist($api->cacheFilePath);
+    }
+
+    /**
+     * A LÉNYEG: a MÁR BENT LÉVŐ mérgezett cache-t is el kell dobni.
+     *
+     * Enélkül a javítás után is a régi, rossz válasz jönne vissza — élesben egy hétig.
+     */
+    public function testAPoisonedCacheEntryIsDiscardedOnRead(): void {
+        $api = $this->api('{"elements":[],"remark":"runtime error: Query timed out"}');
+        $api->buildSimpleQuery('["url:miserend"]');
+        $api->loadCacheFilePath();
+
+        // Kézzel beírjuk a mérgezett bejegyzést, mintha egy korábbi futás hagyta volna.
+        file_put_contents($api->cacheFilePath, '{"elements":[{"type":"way","id":94545227}]}');
+        self::assertFileExists($api->cacheFilePath);
+
+        $friss = $this->api('{"elements":[],"remark":"runtime error: Query timed out"}');
+        $friss->minElements = 2500;
+        $friss->buildSimpleQuery('["url:miserend"]');
+        $friss->run();
+
+        self::assertTrue($friss->hasError());
+        self::assertFileDoesNotExist($friss->cacheFilePath,
+            'a mérgezett cache-bejegyzést el kell dobni, különben a javítás egy hétig nem ér semmit');
+    }
+
+    /** A jó válasz viszont menjen a cache-be — a #766 nyeresége maradjon meg. */
+    public function testAGoodResponseIsStillCached(): void {
+        $api = $this->api('{"elements":[{"id":1},{"id":2},{"id":3}]}');
+        $api->minElements = 3;
+        $api->buildSimpleQuery('["url:miserend"]');
+        $api->run();
+
+        self::assertFalse($api->hasError(), $api->getErrorMessage());
+        self::assertFileExists($api->cacheFilePath);
+        self::assertSame('https://pelda.example/api/interpreter', $api->usedUrl);
+    }
+
+    /**
+     * Ha minden végpont elhasal, a `jsonData` is ürüljön ki.
+     *
+     * Eddig az utolsó — visszautasított — végpont hiányos válasza ottmaradt benne, és a
+     * hívók egy része csak azt nézte, van-e `elements` (l. `OSM::syncUrlMiserendFromOSM`).
+     * Így egy elutasított válaszból mégis adatot írtunk volna.
+     */
+    public function testTheRejectedPayloadDoesNotSurviveTheFailure(): void {
+        $api = $this->api('{"elements":[{"type":"way","id":94545227}]}');
+        $api->minElements = 2500;
+        $api->buildSimpleQuery('["url:miserend"]');
+        $api->run();
+
+        self::assertTrue($api->hasError());
+        self::assertSame([], (array) ($api->jsonData->elements ?? null),
+            'elutasított válasz ne maradjon feldolgozható állapotban');
+    }
+}
+
+/**
+ * Hálózat nélküli dublőr: a `downloadData()` helyére egy előre megadott válasz kerül,
+ * minden más (cache, ellenőrzés, fallback-ciklus) az eredeti kód.
+ */
+class OverpassApiDouble extends \ExternalApi\OverpassApi {
+
+    public $valasz = '{"elements":[]}';
+
+    function downloadData() {
+        $this->rawData = $this->valasz;
+        $this->responseCode = 200;
+        $this->jsonData = json_decode($this->rawData);
+    }
+}

--- a/webapp/tests/Integration/OverpassCachePoisoningTest.php
+++ b/webapp/tests/Integration/OverpassCachePoisoningTest.php
@@ -128,6 +128,17 @@ class OverpassApiDouble extends \ExternalApi\OverpassApi {
 
     public $valasz = '{"elements":[]}';
 
+    /*
+     * A teszt-környezet KIKAPCSOLJA a külső hívásokat (EXTERNAL_APIS_OFFLINE=1 a
+     * compose.test.yml-ben és a compose.coverage.yml-ben), és a kapcsoló a `runQuery()`
+     * LEGELEJÉN vág be — a cache-logika és az ellenőrzés elé. Ez a dublőr viszont maga
+     * adja a választ, hálózat nélkül: épp azt az útvonalat mérjük, amit az offline mód
+     * átugrana. A CI ezt pontosan meg is fogta.
+     */
+    protected function isInternalService(): bool {
+        return true;
+    }
+
     function downloadData() {
         $this->rawData = $this->valasz;
         $this->responseCode = 200;

--- a/webapp/tests/Integration/UrlMiserendSyncSanityTest.php
+++ b/webapp/tests/Integration/UrlMiserendSyncSanityTest.php
@@ -124,6 +124,11 @@ class SzinkronOverpassDouble extends \ExternalApi\OverpassApi {
         $this->cache = false;
     }
 
+    /** L. az OverpassCachePoisoningTest dublőrét: az offline kapcsoló ne vágjon be. */
+    protected function isInternalService(): bool {
+        return true;
+    }
+
     function downloadData() {
         $this->rawData = $this->valasz;
         $this->responseCode = 200;

--- a/webapp/tests/Integration/UrlMiserendSyncSanityTest.php
+++ b/webapp/tests/Integration/UrlMiserendSyncSanityTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #840: a napi OSM-szinkron ne tudjon NÉMÁN hiányos adatból dolgozni.
+ *
+ * Élesben másfél hónapon át ezt írta ki minden éjjel, és a cron zöld maradt:
+ *
+ *   OSM url:miserend: 1 elem átkötve, 0 hibás értékű, 0 ismeretlen templomra mutat.
+ *   Cron job \OSM->syncUrlMiserendFromOSM() completed in 0.15 seconds.
+ *
+ * Nem elhasalt: LEFUTOTT, egyetlen elemmel. Semmi nem szólt, mert a rendszernek nem
+ * volt fogalma arról, mennyit KELLENE kapnia. Itt kap egyet.
+ */
+final class UrlMiserendSyncSanityTest extends TestCase {
+
+    /**
+     * Az elvárást a saját adatunkból származtatjuk, nem konstansból: ahány
+     * misézőhelyünkhöz OSM-azonosító tartozik, annyi elem környékének kell jönnie.
+     */
+    public function testTheExpectationComesFromOurOwnData(): void {
+        $osmAzonositoval = $this->osmAzonositoval();
+
+        self::assertSame((int) floor($osmAzonositoval / 5), \OSM::expectedUrlMiserendElements());
+    }
+
+    /**
+     * A küszöb elég magas ahhoz, hogy az éles hibát elkapja: a svájci tükör EGY elemet
+     * adott vissza.
+     */
+    public function testOneElementIsBelowTheThreshold(): void {
+        if (\OSM::expectedUrlMiserendElements() === 0) {
+            self::markTestSkipped('ebben az adatbázisban nincs OSM-azonosítós templom');
+        }
+
+        self::assertGreaterThan(1, \OSM::expectedUrlMiserendElements());
+    }
+
+    /**
+     * ...és elég alacsony ahhoz, hogy a valódi ingadozásba ne szóljon bele.
+     *
+     * A hoszton mérve 5035 `url:miserend` elem van az OSM-ben, nálunk ~5000 templomnak
+     * van OSM-azonosítója — a küszöb ennek az ötöde. Füstjelző, nem mérőműszer.
+     */
+    public function testTheThresholdLeavesRoomForRealChange(): void {
+        $osmAzonositoval = $this->osmAzonositoval();
+
+        if ($osmAzonositoval === 0) {
+            self::markTestSkipped('ebben az adatbázisban nincs OSM-azonosítós templom');
+        }
+
+        self::assertLessThan($osmAzonositoval / 2, \OSM::expectedUrlMiserendElements());
+    }
+
+    /**
+     * A HIÁNYOS válaszból a szinkron NE írjon adatot — dobjon, hogy a cron pirosra váltson.
+     *
+     * Pontosan az éles eset: egyetlen elem érkezik, ami formailag hibátlan és egy létező
+     * templomra mutat. A régi kód ezt feldolgozta és sikert jelentett.
+     */
+    public function testTheSyncRefusesAnImplausiblyShortAnswer(): void {
+        $overpass = new SzinkronOverpassDouble();
+        $overpass->valasz = '{"elements":[{"type":"way","id":94545227,"tags":{"url:miserend":"https://miserend.hu/templom/5024"}}]}';
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches('/sem adott használható választ/');
+
+        (new \OSM())->syncUrlMiserendFromOSM($overpass);
+    }
+
+    /**
+     * Ha viszont elég elem jön, a szinkron dolgozzon — a védelem ne akadjon be.
+     *
+     * A küszöb fölé annyi elemet gyártunk, amennyit az adatbázis megkövetel; mind
+     * ugyanarra a nemlétező templomra mutat, tehát adatot nem írunk, csak azt nézzük,
+     * hogy a futás VÉGIGMEGY.
+     */
+    public function testTheSyncRunsWhenTheAnswerIsPlausible(): void {
+        $kell = \OSM::expectedUrlMiserendElements();
+        if ($kell === 0) {
+            self::markTestSkipped('ebben az adatbázisban nincs OSM-azonosítós templom');
+        }
+
+        $elemek = [];
+        for ($i = 0; $i < $kell + 1; $i++) {
+            $elemek[] = [
+                'type' => 'way',
+                'id' => 900000000 + $i,
+                // Szándékosan nemlétező templom: a futás végigmegy, de nem ír adatot.
+                'tags' => ['url:miserend' => 'https://miserend.hu/templom/99' . str_pad((string) $i, 6, '0', STR_PAD_LEFT)],
+            ];
+        }
+
+        $overpass = new SzinkronOverpassDouble();
+        $overpass->valasz = json_encode(['elements' => $elemek]);
+
+        ob_start();
+        (new \OSM())->syncUrlMiserendFromOSM($overpass);
+        $kimenet = ob_get_clean();
+
+        self::assertStringContainsString((string) count($elemek), $kimenet,
+            'a futás írja ki, hány elem érkezett — a mérsékelt visszaesés így is látszik');
+    }
+
+    private function osmAzonositoval(): int {
+        return \Eloquent\Church::whereNotNull('osmid')
+            ->where('osmid', '<>', '')
+            ->whereNotNull('osmtype')
+            ->where('osmtype', '<>', '')
+            ->count();
+    }
+}
+
+/** Hálózat nélküli Overpass: előre megadott válasz, minden más az eredeti kód. */
+class SzinkronOverpassDouble extends \ExternalApi\OverpassApi {
+
+    public $valasz = '{"elements":[]}';
+
+    function __construct() {
+        parent::__construct();
+        // Egyetlen végpont: a lánc ne mossa el, mi történt.
+        $this->fallbackUrls = ['https://pelda.example/api/interpreter'];
+        $this->cache = false;
+    }
+
+    function downloadData() {
+        $this->rawData = $this->valasz;
+        $this->responseCode = 200;
+        $this->jsonData = json_decode($this->rawData);
+    }
+}

--- a/webapp/tests/Unit/OverpassResponseSanityTest.php
+++ b/webapp/tests/Unit/OverpassResponseSanityTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #840: a HTTP 200 önmagában nem bizonyíték arra, hogy a válasz használható.
+ *
+ * Élesben a napi `url:miserend` szinkron másfél hónapon át SIKERT jelentett, miközben
+ * naponta EGYETLEN elemet dolgozott fel. A lánc: a beállított végpont elérhetetlen volt,
+ * a második HTTP 500-at adott a nagy lekérdezésre, a harmadik — az `overpass.osm.ch` —
+ * pedig szabályos 200-at, csakhogy az egy SVÁJCI példány, amiben nincs magyar adat.
+ * A #768-as tartalék-lánc az első nem-hibás válaszig ment, tehát ezt elfogadta, egy hétre
+ * be is cache-elte, a cron pedig zöld maradt.
+ *
+ * Mérve (2026-08-20), ugyanaz a lekérdezés három hoszton:
+ *   node["place"="city"]["name"="Budapest"];out count;
+ *     overpass-api.de           -> 1
+ *     overpass.openstreetmap.fr -> 1
+ *     overpass.osm.ch           -> 0
+ *
+ * Ez a teszt azt őrzi, hogy a hiányos és a hibát jelző válasz ne minősüljön sikernek —
+ * és közben az ÜRES találat továbbra is érvényes válasz maradjon (a #766 szándéka).
+ */
+class OverpassResponseSanityTest extends TestCase
+{
+    /** A `rejectionReason()` védett, mert a hívóknak nem kell látniuk. Itt kinyitjuk. */
+    private function ok(\ExternalApi\OverpassApi $api): ?string
+    {
+        $m = new \ReflectionMethod($api, 'rejectionReason');
+        $m->setAccessible(true);
+
+        return $m->invoke($api);
+    }
+
+    private function valasz(string $json): \ExternalApi\OverpassApi
+    {
+        $api = new \ExternalApi\OverpassApi();
+        $api->jsonData = json_decode($json);
+
+        return $api;
+    }
+
+    /* ---- 1. A `remark` = szerveroldali hiba, nem siker. ---- */
+
+    /**
+     * Az Overpass a szerveroldali időtúllépésre HTTP 200-at ad. Mérve, a teljes
+     * url:miserend lekérdezéssel, `[out:json][timeout:1]`-gyel:
+     *   HTTP 200, elements: 0, remark: "runtime error: Query timed out in query..."
+     * Eddig ez sikernek számított, és egy hétre bekerült a cache-be.
+     */
+    public function testARemarkIsNotSuccess(): void
+    {
+        $api = $this->valasz('{"elements":[],"remark":"runtime error: Query timed out in \"query\" at line 1 after 2 seconds."}');
+
+        $indok = $this->ok($api);
+
+        self::assertNotNull($indok, 'a remark-os választ vissza kell utasítani');
+        self::assertStringContainsString('Query timed out', $indok, 'a valódi ok maradjon benne');
+    }
+
+    /** Részleges válasz is jöhet remarkkal — az elemek megléte nem menti meg. */
+    public function testARemarkIsNotSuccessEvenWithElements(): void
+    {
+        $api = $this->valasz('{"elements":[{"type":"way","id":1}],"remark":"runtime error: Query timed out in \"print\""}');
+
+        self::assertNotNull($this->ok($api));
+    }
+
+    /* ---- 2. A hiányos válasz nem üres találat. ---- */
+
+    /** Ez a konkrét éles eset: 1 elem érkezett ~2500 helyett. */
+    public function testAnImplausiblyShortAnswerIsRejected(): void
+    {
+        $api = $this->valasz('{"elements":[{"type":"way","id":94545227}]}');
+        $api->minElements = 2500;
+
+        $indok = $this->ok($api);
+
+        self::assertNotNull($indok, 'az 1 elemes választ vissza kell utasítani');
+        self::assertStringContainsString('1 elem', $indok);
+        self::assertStringContainsString('2500', $indok, 'derüljön ki, mennyit vártunk');
+    }
+
+    /** A határon: pontosan annyi, amennyit kértünk — az még rendben van. */
+    public function testExactlyTheExpectedCountIsAccepted(): void
+    {
+        $api = $this->valasz('{"elements":[{"id":1},{"id":2},{"id":3}]}');
+        $api->minElements = 3;
+
+        self::assertNull($this->ok($api));
+    }
+
+    /**
+     * A LÉNYEG: aki nem mond elvárást, annál semmi nem változik.
+     *
+     * A #766 kifejezetten úgy döntött, hogy az üres találat ÉRVÉNYES válasz — arra
+     * továbblépni azt jelentené, hogy addig kérdezünk, amíg valaki mond valamit.
+     */
+    public function testAnEmptyAnswerStaysValidWithoutAnExpectation(): void
+    {
+        $api = $this->valasz('{"elements":[]}');
+
+        self::assertSame(0, $api->minElements, 'alapból nincs elvárás');
+        self::assertNull($this->ok($api), 'az üres találat érvényes válasz');
+    }
+
+    /** Nem-objektum válasznál (pl. nem szigorú formátum) nincs mit mondani. */
+    public function testNonObjectPayloadIsNotJudged(): void
+    {
+        $api = new \ExternalApi\OverpassApi();
+        $api->jsonData = json_decode('[]');
+
+        self::assertNull($this->ok($api));
+    }
+
+    /* ---- 3. A tartaléklista ---- */
+
+    /**
+     * Az `overpass.osm.ch` NE legyen az alapértelmezett tartalékok között: svájci
+     * példány, magyar adat nélkül. Ez volt a hiba forrása.
+     */
+    public function testTheSwissMirrorIsNotAFallback(): void
+    {
+        $lista = \ExternalApi\OverpassApi::buildEndpointList('https://overpass-api.de/api/interpreter');
+
+        $hosztok = array_map(fn($u) => parse_url($u, PHP_URL_HOST), $lista);
+
+        self::assertNotContains('overpass.osm.ch', $hosztok,
+            'foldrajzilag korlatozott tukor nem valo a globalis lekerdezesek tartalekai koze');
+        self::assertGreaterThanOrEqual(2, count($lista), 'tartalék azért maradjon');
+    }
+
+    /** A tartalékoknak globális példányoknak kell lenniük — mérve ellenőrzött lista. */
+    public function testTheFallbacksAreGlobalInstances(): void
+    {
+        $lista = \ExternalApi\OverpassApi::buildEndpointList('https://overpass-api.de/api/interpreter');
+        $hosztok = array_map(fn($u) => parse_url($u, PHP_URL_HOST), $lista);
+
+        // 2026-08-20-án mérve: mindkettő megtalálja Budapestet, és mindkettő kiadja a
+        // teljes url:miserend halmazt (5035 elem).
+        self::assertContains('overpass-api.de', $hosztok);
+        self::assertContains('overpass.openstreetmap.fr', $hosztok);
+    }
+
+    /* ---- 4. A két időkorlát szétvált ---- */
+
+    /**
+     * A `queryTimeout` az Overpass szerveroldali kerete, a `transferTimeout` a mi
+     * várakozásunk. Ha a kettő egyenlő, a curl pont akkor vág el, amikor a szerver
+     * elkezdene válaszolni — élesben ez volt a naplóban:
+     * „Operation timed out after 30000 milliseconds with 0 bytes received".
+     */
+    public function testTheClientWaitsLongerThanTheServerBudget(): void
+    {
+        $api = new \ExternalApi\OverpassApi();
+        $api->queryTimeout = 120;
+
+        // A run() számolja, mert a hívó menet közben is átállíthatja a keretet.
+        $m = new \ReflectionMethod($api, 'run');
+        self::assertTrue($m->isPublic());
+
+        // Közvetlenül a számítást ellenőrizzük, hálózat nélkül.
+        $api->transferTimeout = $api->queryTimeout + \ExternalApi\OverpassApi::TRANSFER_GRACE;
+
+        self::assertGreaterThan($api->queryTimeout, $api->transferTimeout);
+    }
+
+    /** Az alapértelmezett API-knál nem változik semmi: marad az egy korlát. */
+    public function testOtherApisKeepTheSingleTimeout(): void
+    {
+        $api = new \ExternalApi\ExternalApi();
+
+        self::assertNull($api->transferTimeout, 'a többi szolgáltatónál ne változzon a viselkedés');
+    }
+}


### PR DESCRIPTION
A #840 első fele. A jegyet a #847 zárja le — az a másik felét javítja (a `fromOSM` jelző).

A #840 első fele. A második fele (a `fromOSM` jelző és a `diet:gluten_free`) külön PR-ben jön — a jegyet csak a kettővel együtt szabad lezárni.

## Mi történik ma

A cron zöld, `lastsuccess_at` friss, `attempts` 0. Közben ezt írja ki:

```
OSM url:miserend: 1 elem átkötve, 0 hibás értékű, 0 ismeretlen templomra mutat.
Cron job \OSM->syncUrlMiserendFromOSM() completed in 0.15 seconds.
```

Nem elhasalt. **Lefutott, egyetlen elemmel** — és mivel sikert jelentett, semmi nem szólt róla másfél hónapig.

## Miért

A #768-ban én vettem fel a tartaléklistát, és beletettem az `overpass.osm.ch`-t anélkül, hogy megnéztem volna a lefedettségét. Svájci példány. Mérve a hosztról, ugyanaz a lekérdezés, csak a hoszt más:

```
node["place"="city"]["name"="Budapest"];out count;
  overpass-api.de            -> 1
  overpass.openstreetmap.fr  -> 1
  overpass.osm.ch            -> 0      <-- nincs benne Magyarország
```

A lánc nálad így fut le:

| végpont | válasz |
|---|---|
| `overpass-api.de` (a beállított) | elérhetetlen a szerveredről — /health: *Connection timed out after 5001 ms* |
| `overpass.private.coffee` | **HTTP 500** a nagy lekérdezésre, 0,1 mp alatt |
| `overpass.osm.ch` | **HTTP 200**, 1 elem — a világ töredékéről |

A fallback az első nem-hibás válaszig ment, tehát a harmadikat elfogadta. Egy hétre be is cache-elte, ezért a 0,15 másodperc: hálózat már nem is volt benne.

Az az egy elem egyébként a `way 94545227` „Bruder Klaus", ami a `/templom/5024`-re mutat — valóban svájci.

## Ami ebből következett

- A `church:type` a `/josm`-en 15 sor, mind `parish`. Az OSM-ben ma **61** ilyen elem van (31 parish, 17 filial, 11 auxiliary, 1 rectoral, 1 elgépelt „főplébániatemplom"). Ebből **14-et** szerkesztettek utoljára 2026 júliusa előtt — és mind a 14 `parish`. Vagyis az `attributes` tábla pontosan a júliusnál régebbi állapotban áll.
- Emiatt nem kapnak szép ikont a fíliák és a templomigazgatóságok sem. Az ikonok megvannak (`church-map.js:1202-1242`), a `churchesinbbox` nem is szűr `fromOSM`-re — csak az adat nincs meg.
- A `/josm` ebből azt a következtetést vonta le, hogy ötezer templomunknak nincs OSM-adata.

## Mit csinálok

**1. A svájci tükör kikerül**, helyette a globális `overpass.openstreetmap.fr`. Mérve, ugyanarra a teljes `url:miserend` lekérdezésre: HTTP 200, 5035 elem, 3,17 MB, 24,1 mp.

**2. De a listában bízni kevés.** A válasz érdemi voltát is nézem, mert egy hiányos válasz formailag tökéletes:

- **`remark`** — az Overpass a szerveroldali időtúllépésre is HTTP 200-at ad, üres vagy részleges `elements`-szel. Mérve, `[out:json][timeout:1]`-gyel: `HTTP 200, elements: 0, remark: "runtime error: Query timed out"`. Eddig ez siker volt.
- **hiányos válasz** — a hívó megmondhatja, mennyit vár. Az `url:miserend` szinkronnál ezt a saját adatunkból származtatom (ahány templomhoz OSM-azonosító tartozik), és **szándékosan az ötödére** teszem. Füstjelző, nem mérőműszer: az éles hiba a várt érték 0,02%-át adta. A mérsékelt visszaesés így is látszik, mert a futás mindig kiírja az elemszámot.

Az **üres találat továbbra is érvényes válasz** marad — aki nem mond elvárást, annál semmi nem változik. Ez a #768 szándéka volt, és így is marad.

**3. Az elutasított válasz nem kerül a cache-be**, és ha onnan jött, a fájlt el is dobom. Enélkül a javítás egy hétig nem érne semmit. **Így az éles cache magától gyógyul:** az első cron-futás beolvassa az 1 elemes fájlt, elutasítja, törli, és élőben újrapróbálja. Kézzel nem kell törölnöd semmit.

**4. Szétválik a két időkorlát.** Eddig ugyanaz a szám volt az Overpass szerveroldali kerete (`[out:json][timeout:30]`) és a curl teljes várakozása. Egy lekérdezés, ami tényleg elhasználja a keretét, definíció szerint nem érkezhetett meg — a naplóban pontosan ez állt: `Operation timed out after 30000 milliseconds with 0 bytes received`. A szinkron mostantól 120 mp szerveroldali keretet kap (cron, nem látogatói kérés), a válaszra pedig ennél tovább várunk.

**5. Ha minden végpont elhasal, a `jsonData` is kiürül**, és a szinkron a hibát is nézi. Eddig az utolsó, visszautasított végpont válasza ottmaradt, a hívó pedig csak azt nézte, van-e `elements` — így egy elutasított válaszból is adatot írtunk volna.

## Amit érdemes megtenned

Nem kötelező, de a `.env`-ben az `OVERPASS_API_URL` átállítása egy működő tükörre megspórol egy 5 másodperces kapcsolat-időtúllépést minden hívásnál. A /health szerint a beállított végpont a szerveredről nem él.

## Elfogadási feltétel

A következő éjszakai futás után a `/josm`-en a `church:type` ~61 sort mutat, legalább négy különböző értékkel (`parish`, `filial`, `auxiliary`, `rectoral`), és a fíliák megkapják a saját ikonjukat a térképen.

## Teszt

PHP: 1376 zöld. Ebből új: az elutasítási szabály (remark, hiányos válasz, és hogy az üres találat továbbra is érvényes), a cache-mérgezés mindkét iránya (nem írjuk be, és a bent lévőt eldobjuk), és hogy a szinkron a hiányos válaszra dob, a hihetőre viszont végigmegy.