### PR TITLE
A maradék három térképen is a tiltott OSM-csempeszerver van

### DIFF
--- a/webapp/js/church-map.js
+++ b/webapp/js/church-map.js
@@ -112,15 +112,15 @@
         }
 
         //https://leaflet-extras.github.io/leaflet-providers/preview/
-        var CartoDB_Voyager = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-            subdomains: 'abcd',
-            maxZoom: 19
-        });
-    	var OpenStreetMap_Mapnik = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    		maxZoom: 19,
-    		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    	});
+        // #817: a konfiguráció a /js/map-tiles.js-ben van, egy helyen. Itt eddig helyes
+        // volt, három másik hívóhelyen viszont nem — ezért került közösbe.
+        var CartoDB_Voyager = L.tileLayer(window.MISEREND_CSEMPE.url, window.MISEREND_CSEMPE.beallitas);
+        /*
+         * #817: az `OpenStreetMap_Mapnik` réteg innen KIKERÜLT. Halott kód volt — a lenti
+         * `control.layers` baseLayers-e null, tehát sosem lehetett kiválasztani —, viszont
+         * pont azt a forrást mutatta példaként, amit nem szabad használni. Ugyanez a döntés
+         * született a #653-ban a szintén halott Stamen-rétegre.
+         */
         /*
          * #653: a Stamen Terrain réteg innen KIKERÜLT. A Stamen 2023-ban a Stadia Mapshez
          * költözött, a régi végpont (stamen-tiles-*.a.ssl.fastly.net) mérve HTTP 503-at ad,
@@ -132,12 +132,12 @@
          * hozzá. Ha valaha kell egy terep-alapréteg, az külön döntés (és külön kulcs-kezelés).
          */
 
-        // #376: a direkt tile.openstreetmap.org az OSM Tile Usage Policy szerint
-        // produkciós forgalomra tiltott → intermittensen „Access blocked" csempe
-        // (van akinek megy, van akinek nem, Referer/IP/forgalom alapján). A CARTO
-        // Voyager basemap (ingyenes, produkcióra való) a default — böngészőben mérve
-        // minden csempe 200-zal jön. Az OpenStreetMap_Mapnik fentebb definiálva
-        // marad, de nincs a réteg-választóban (baseLayers=null a lenti control.layers-nél).
+        // #376/#817: a direkt tile.openstreetmap.org az OSM Tile Usage Policy szerint
+        // produkciós forgalomra tiltott. A blokkolást NEM hibakóddal jelzi: HTTP 200-at ad
+        // és egy valódi PNG-t „Access blocked" felirattal (mérve: 6987 bájt, x-blocked
+        // fejléc), amit a Leaflet szabályos csempeként rak ki — a térkép nem hibázik,
+        // hanem foltos lesz. A CARTO Voyager basemap (ingyenes, produkcióra való) a
+        // default; a konfiguráció a /js/map-tiles.js-ben van.
         CartoDB_Voyager.addTo(mymap);
     
     

--- a/webapp/js/map-tiles.js
+++ b/webapp/js/map-tiles.js
@@ -1,0 +1,35 @@
+/**
+ * #817: a projekt kanonikus csempeforrása, EGY helyen.
+ *
+ * MIÉRT NEM A DIREKT OSM. Az OpenStreetMap önkéntesekből fenntartott csempeszervere
+ * produkciós forgalomra tiltott (Tile Usage Policy), és a blokkolást NEM hibakóddal
+ * jelzi: HTTP 200-at ad és egy valódi 256×256-os PNG-t, amire az van írva, hogy
+ * „403 — Access blocked". Mérve (2026-08-20):
+ *
+ *   curl https://a.tile.openstreetmap.org/16/36000/22800.png
+ *     -> HTTP 200, 6987 B, fejléc: x-blocked: Access denied
+ *   ugyanaz böngésző-UA-val és Refererrel
+ *     -> HTTP 200, 1473 B, nincs x-blocked
+ *
+ * A Leaflet ezt nem tudja megkülönböztetni egy csempétől: kirakja. A térkép ilyenkor
+ * nem hibázik, hanem FOLTOS lesz — és se konzolhiba, se `tileerror` nem szól róla.
+ * A #376 ezt a döntést a főtérképnél már meghozta, csak nem mindenhol futott át rajta.
+ *
+ * SIMA ADATOBJEKTUM, nem Leaflet-hívás: a `nearby-map-search.js` szándékosan lustán
+ * tölti be a Leafletet, tehát egy Leaflet-függő factory itt betöltési sorrend-csapda
+ * lenne. Így mindegy, hol szerepel a `<script>`.
+ *
+ * PÁRJA AZ ANGULAR-OLDALON: `calendar/src/app/map-tiles.ts`. A kettőt KÉZZEL kell
+ * szinkronban tartani — a naptár külön npm-csomag, nem tud innen importálni, és
+ * futásidejű globálisra sem támaszkodhat (a szerkesztő-oldal a Leafletet magát is csak
+ * menet közben tölti be). Ha itt módosítasz, módosítsd ott is.
+ */
+window.MISEREND_CSEMPE = {
+    /** A `{r}` a retina-változatot kéri; a Leaflet 1.9 magától kezeli. */
+    url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+    beallitas: {
+        subdomains: 'abcd',
+        maxZoom: 19,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+    }
+};

--- a/webapp/js/nearby-map-search.js
+++ b/webapp/js/nearby-map-search.js
@@ -204,10 +204,10 @@
 
         function buildMap(L) {
             state.map = L.map(canvas, { scrollWheelZoom: false });
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                maxZoom: 19,
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-            }).addTo(state.map);
+            // #817: a kanonikus csempeforrás (/js/map-tiles.js). A direkt OSM-szerver
+            // produkciós forgalomra tiltott, és a blokkolt csempét HTTP 200-zal, valódi
+            // PNG-ként adja vissza — a Leaflet kirakja, a térkép foltos lesz.
+            L.tileLayer(window.MISEREND_CSEMPE.url, window.MISEREND_CSEMPE.beallitas).addTo(state.map);
 
             var point = currentPoint();
             state.map.setView(point || DEFAULT_CENTER, point ? 14 : DEFAULT_ZOOM);

--- a/webapp/templates/_map_leaflet.twig
+++ b/webapp/templates/_map_leaflet.twig
@@ -112,4 +112,5 @@
         autoGeoLocation: {% if enableAutoGeoLocation is defined and enableAutoGeoLocation %}true{% else %}false{% endif %}
     };
 </script>
+<script src="/js/map-tiles.js"></script>
 <script src="/js/church-map.js"></script>

--- a/webapp/templates/church/create.twig
+++ b/webapp/templates/church/create.twig
@@ -117,6 +117,7 @@
     <script language="javascript" type="text/javascript" src="/js/tiny_mce_init.js"></script>
     
     <script src="/node_modules/leaflet/dist/leaflet.js"></script>
+    <script src="/js/map-tiles.js"></script>
     <link rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css"/>
 
     <script>
@@ -258,12 +259,9 @@
     // Térkép inicializálása
     var map = L.map('map').setView([defaultLat, defaultLon], 15);
 
-    // #376: CARTO Voyager basemap (a direkt tile.openstreetmap.org produkcióra tiltott).
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
-        subdomains: 'abcd',
-        maxZoom: 19,
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
-    }).addTo(map);
+    // #376/#817: CARTO Voyager basemap (a direkt tile.openstreetmap.org produkcióra
+    // tiltott). A konfiguráció a /js/map-tiles.js-ben van, egy helyen.
+    L.tileLayer(window.MISEREND_CSEMPE.url, window.MISEREND_CSEMPE.beallitas).addTo(map);
 
     // Marker inicializálása
     var marker = L.marker([defaultLat, defaultLon], { draggable: true }).addTo(map);

--- a/webapp/templates/home.twig
+++ b/webapp/templates/home.twig
@@ -938,6 +938,7 @@
             {# #733: a térkép-modul ELŐBB tölt be, mert a kereső-szkript indulásakor
                kérdezi meg, van-e. A Leafletet viszont egyik sem hozza magával —
                azt csak a térkép megnyitása tölti le. #}
+            <script src="/js/map-tiles.js"></script>
             <script src="/js/nearby-map-search.js"></script>
             <script src="/js/nearby-mass-search.js"></script>
             

--- a/webapp/templates/search/resultsmasses.twig
+++ b/webapp/templates/search/resultsmasses.twig
@@ -14,6 +14,7 @@
            kockázat — a keresőoldal egy idegen CDN elérhetőségén múlott. #}
         <link rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css"/>
         <script src="/node_modules/leaflet/dist/leaflet.js"></script>
+        <script src="/js/map-tiles.js"></script>
     {% endif %}
     <script>
         window.boundaryDataFromUrl = {{ boundaryDataJson|raw|default('[]') }};
@@ -112,10 +113,9 @@
                     var radiusKm = {{ nearbyRadius|json_encode|raw }};
                     var churches = {{ nearbyMapJson|raw }};
                     var map = L.map('nearby-masses-map').setView([origin.lat, origin.lon], 12);
-                    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                        maxZoom: 19,
-                        attribution: '&copy; OpenStreetMap közreműködők'
-                    }).addTo(map);
+                    {# #817: a kanonikus csempeforrás. A korábbi direkt OSM-hívás nemcsak
+                       policy-sértés volt, de az attribúcióban egyetlen link sem szerepelt. #}
+                    L.tileLayer(window.MISEREND_CSEMPE.url, window.MISEREND_CSEMPE.beallitas).addTo(map);
                     var bounds = L.latLngBounds([[origin.lat, origin.lon]]);
                     function escapeHtml(value) {
                         var node = document.createElement('div');

--- a/webapp/tests/Unit/MapTileProviderTest.php
+++ b/webapp/tests/Unit/MapTileProviderTest.php
@@ -1,0 +1,210 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #817: senki ne írhasson be újra direkt OpenStreetMap-csempét.
+ *
+ * Az OSM önkéntes csempeszervere produkciós forgalomra tiltott (Tile Usage Policy), és
+ * a blokkolást NEM hibakóddal jelzi. Mérve (2026-08-20):
+ *
+ *   curl https://a.tile.openstreetmap.org/16/36000/22800.png
+ *     -> HTTP 200, 6987 B, fejléc: x-blocked: Access denied
+ *
+ * Az a 6987 bájt egy valódi 256×256-os PNG „403 — Access blocked" felirattal. A Leaflet
+ * ezt nem tudja megkülönböztetni egy csempétől: kirakja. A térkép tehát nem hibázik,
+ * hanem FOLTOS lesz — se konzolhiba, se `tileerror`. Ilyet futásidőben nem lehet
+ * elkapni, ezért őrizzük forrás-szinten.
+ *
+ * A #376 ezt a döntést a főtérképnél már meghozta, de három másik hívóhelyen nem futott
+ * át: `nearby-map-search.js`, `search/resultsmasses.twig`, és a naptár helyszínválasztója
+ * (#816/#817). Ez a teszt azt őrzi, hogy ne lehessen negyedik.
+ */
+class MapTileProviderTest extends TestCase
+{
+    private const CSEMPE_FAJL = 'js/map-tiles.js';
+
+    private static function webapp(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+
+    /**
+     * Minden saját forrásfájl, ahol csempeforrás megjelenhet.
+     *
+     * A `js/mcal` KIMARAD: az a naptár lefordított csomagja, nem szerkesztjük — a
+     * forrása a `calendar/` alatt van, és annak saját Angular-tesztje van
+     * (`location-picker.component.spec.ts`, „csempeforrás (#817)").
+     *
+     * @return string[]
+     */
+    private static function forrasok(): array
+    {
+        $ki = [];
+
+        foreach (['templates', 'js'] as $konyvtar) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator(self::webapp() . '/' . $konyvtar)
+            );
+
+            foreach ($iterator as $fajl) {
+                if (!$fajl->isFile()) {
+                    continue;
+                }
+                $ut = (string) $fajl->getPathname();
+                if (str_contains($ut, '/js/mcal/')) {
+                    continue;
+                }
+                if (str_ends_with($ut, '.twig') || str_ends_with($ut, '.js')) {
+                    $ki[] = $ut;
+                }
+            }
+        }
+
+        return $ki;
+    }
+
+    private static function rovid(string $ut): string
+    {
+        return str_replace(self::webapp() . '/', '', $ut);
+    }
+
+    /**
+     * A tiltott forrás sehol nem szerepelhet — HASZNÁLATKÉNT.
+     *
+     * A puszta említés (komment, magyarázat, mérési kimenet) rendben van, sőt kell:
+     * a döntés indoklása pont ezekben a kommentekben él. Ezért idézőjelbe zárt
+     * URL-literált keresünk, nem a hosztnevet.
+     */
+    public function testNoSourceUsesTheDirectOsmTileServer(): void
+    {
+        $talalatok = [];
+
+        foreach (self::forrasok() as $ut) {
+            $tartalom = (string) file_get_contents($ut);
+            if (preg_match('#[\'"`]https?://[^\'"`]*tile\.openstreetmap\.org#', $tartalom)) {
+                $talalatok[] = self::rovid($ut);
+            }
+        }
+
+        self::assertSame([], $talalatok,
+            "Direkt OSM-csempeszerver: " . implode(', ', $talalatok)
+            . ". Az OSM a blokkolt csempét HTTP 200-zal és valódi PNG-vel adja vissza, "
+            . "amit a Leaflet kirak — a térkép foltos lesz, hibaüzenet nélkül. "
+            . "Használd a " . self::CSEMPE_FAJL . " kanonikus konfigurációját.");
+    }
+
+    /**
+     * Csempeforrás-URL csak a közös fájlban lehet beégetve.
+     *
+     * Enélkül maradna négy igazságforrás, és a következő módosító megint csak az egyiket
+     * írná át — pontosan ez történt a #376 után.
+     */
+    public function testTileUrlsLiveInOneFileOnly(): void
+    {
+        $talalatok = [];
+
+        foreach (self::forrasok() as $ut) {
+            if (str_ends_with($ut, self::CSEMPE_FAJL)) {
+                continue;
+            }
+
+            $tartalom = (string) file_get_contents($ut);
+            // Beégetett csempe-URL: olyan literál, amiben ott a Leaflet {z}/{x}/{y} mintája.
+            if (preg_match('#[\'"]https?://[^\'"]*\{z\}/\{x\}/\{y\}#', $tartalom)) {
+                $talalatok[] = self::rovid($ut);
+            }
+        }
+
+        self::assertSame([], $talalatok,
+            'Beégetett csempe-URL: ' . implode(', ', $talalatok)
+            . '. A konfiguráció helye a ' . self::CSEMPE_FAJL . '.');
+    }
+
+    /** A közös fájl a kanonikus CARTO Voyager forrást adja. */
+    public function testTheSharedFileHoldsTheCanonicalProvider(): void
+    {
+        $tartalom = (string) file_get_contents(self::webapp() . '/' . self::CSEMPE_FAJL);
+
+        self::assertStringContainsString(
+            'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+            $tartalom);
+        self::assertStringContainsString("subdomains: 'abcd'", $tartalom);
+    }
+
+    /** Az ODbL-attribúció mindkét kötelező linkje legyen ott. */
+    public function testTheAttributionCreditsBothParties(): void
+    {
+        $tartalom = (string) file_get_contents(self::webapp() . '/' . self::CSEMPE_FAJL);
+
+        self::assertStringContainsString('openstreetmap.org/copyright', $tartalom,
+            'az OSM-adat forrását fel kell tüntetni');
+        self::assertStringContainsString('carto.com/attributions', $tartalom,
+            'a csempeszolgáltatót is fel kell tüntetni');
+    }
+
+    /**
+     * Aki a közös konstanst használja, annak be is kell töltenie.
+     *
+     * Ha kimarad a `<script src>`, a `window.MISEREND_CSEMPE` undefined, és a térkép
+     * FEHÉR marad — az rosszabb, mint a foltos. Ezért itt kötjük össze a kettőt.
+     */
+    public function testEveryUserOfTheSharedConfigAlsoLoadsIt(): void
+    {
+        // Melyik JS-fájl használja a globálist?
+        $hasznalok = [];
+        foreach (self::forrasok() as $ut) {
+            if (str_ends_with($ut, self::CSEMPE_FAJL) || !str_ends_with($ut, '.js')) {
+                continue;
+            }
+            if (str_contains((string) file_get_contents($ut), 'MISEREND_CSEMPE')) {
+                $hasznalok[] = basename($ut);
+            }
+        }
+
+        self::assertNotEmpty($hasznalok, 'legalább egy térkép használja a közös konfigurációt');
+
+        // Minden ilyen JS-hez tartozzon olyan sablon, ami MINDKETTŐT betölti.
+        foreach ($hasznalok as $js) {
+            $megvan = false;
+
+            foreach (self::forrasok() as $ut) {
+                if (!str_ends_with($ut, '.twig')) {
+                    continue;
+                }
+                $tartalom = (string) file_get_contents($ut);
+                if (str_contains($tartalom, '/js/' . $js) && str_contains($tartalom, '/' . self::CSEMPE_FAJL)) {
+                    $megvan = true;
+                    break;
+                }
+            }
+
+            self::assertTrue($megvan,
+                $js . ' használja a MISEREND_CSEMPE globálist, de nincs olyan sablon, '
+                . 'ami mellé a ' . self::CSEMPE_FAJL . '-t is betöltené.');
+        }
+    }
+
+    /** A közös konstanst használó SABLONOK is töltsék be a fájlt. */
+    public function testEveryTemplateUsingTheConfigLoadsIt(): void
+    {
+        $hianyzik = [];
+
+        foreach (self::forrasok() as $ut) {
+            if (!str_ends_with($ut, '.twig')) {
+                continue;
+            }
+            $tartalom = (string) file_get_contents($ut);
+            if (!str_contains($tartalom, 'MISEREND_CSEMPE')) {
+                continue;
+            }
+            if (!str_contains($tartalom, '/' . self::CSEMPE_FAJL)) {
+                $hianyzik[] = self::rovid($ut);
+            }
+        }
+
+        self::assertSame([], $hianyzik,
+            'Ezek a sablonok használják a MISEREND_CSEMPE globálist, de nem töltik be: '
+            . implode(', ', $hianyzik));
+    }
+}


### PR DESCRIPTION
Closes #851

A #817 nyomozásából derült ki, hogy ugyanaz a hiba még két helyen ott van. Ez a PR a webapp-oldal; a naptár helyszínválasztója a #817-ben megy.

## A hiba, amit nem lehet észrevenni

Az OpenStreetMap önkéntes csempeszervere produkciós forgalomra tiltott, és a blokkolást **nem hibakóddal jelzi**. Mérve:

```
curl https://a.tile.openstreetmap.org/16/36000/22800.png
  -> HTTP 200, 6987 bájt, fejléc: x-blocked: Access denied
```

Az a 6987 bájt egy **valódi 256×256-os PNG**, sárga-fekete sávos kerettel, rajta: *„403 — Access blocked."* A Leaflet ezt nem tudja megkülönböztetni egy csempétől: kirakja. A térkép tehát nem hibázik, hanem **foltos** lesz — se konzolhiba, se `tileerror`.

Ugyanaz a kérés böngésző-fejlécekkel: HTTP 200, 1473 bájt, `x-blocked` nélkül. Innen a #376 megjegyzésében szereplő „van akinek megy, van akinek nem".

## Hol maradt bent

A #376-ban a főtérképnél átálltunk CARTO Voyagerre, de a döntés három helyen nem futott át:

| hely | mi volt |
|---|---|
| `webapp/js/nearby-map-search.js:207` | direkt OSM |
| `webapp/templates/search/resultsmasses.twig:115` | direkt OSM, ráadásul **egyetlen link nélküli attribúcióval** (ODbL-hiányosság) |
| a naptár helyszínválasztója | direkt OSM — **#817** |

## Mit csinálok

A konfiguráció egyetlen fájlba kerül (`webapp/js/map-tiles.js`), sima adatobjektumként — nem Leaflet-hívásként, mert a `nearby-map-search.js` szándékosan lustán tölti a Leafletet, és egy Leaflet-függő factory ott betöltési sorrend-csapda lenne. Mind a négy hívóhely erre áll át, a két eddig is helyes is: négy igazságforrás mellett a következő módosítás megint csak az egyiket írná át, pontosan ahogy a #376 után történt.

Törlöm a `church-map.js` halott `OpenStreetMap_Mapnik` rétegét. Sosem lehetett kiválasztani (a rétegválasztó `baseLayers`-e `null`), viszont pont a tiltott forrást mutatta példaként — ugyanez a döntés született a #653-ban a szintén halott Stamen-rétegre.

Az Angular-oldalon külön párja van (`calendar/src/app/map-tiles.ts`, a #817-ben), mert az külön npm-csomag: nem tud innen importálni, és futásidejű globálisra sem támaszkodhat. A két fájl fejléce kereszthivatkozik egymásra.

## Miért statikus teszt

Ilyen hibát futásidőben nem lehet elkapni — a szolgáltató 200-at ad. Az őrzés ezért forrás-szintű: nincs idézőjeles OSM-csempe URL, csempe-URL csak a közös fájlban él, benne mindkét kötelező attribúció, és aki a konstanst használja, az be is tölti (különben `undefined`, és a térkép **fehér** marad — az rosszabb, mint a foltos).

A puszta *említés* továbbra is szabad: a döntés indoklása épp ezekben a kommentekben él.

## Mérés

E2E-ben, a dev konténerben:

| oldal | `map-tiles.js` | direkt OSM-csempe |
|---|---|---|
| `/terkep` | ✔ | 0 |
| főoldal | ✔ | 0 |
| misekereső (`q=searchresultsmasses`) | ✔ | 0 |

CARTO-csempék: mind a négy aldomain HTTP 200, Refererrel és anélkül is.

PHP: a teljes futam zöld a két, ettől független, környezeti bukást leszámítva (elavult lokális séma-referencia — a CI-ban zöld).