### PR TITLE
Látszódjon, ha egy választható időszaknak nincs generált sora (#852)

### DIFF
--- a/calendar/src/app/util/generated-period-end-date.spec.ts
+++ b/calendar/src/app/util/generated-period-end-date.spec.ts
@@ -1,0 +1,29 @@
+import {DateTimeUtil} from './date-time-util';
+
+/**
+ * #837 kliensoldali ellenőrzés: a `cal_generated_periods.end_date` KIZÁRÓ vég.
+ *
+ * A PHP a #837 óta `subDay()`-t alkalmaz (calmass.php:459 és :506). A kliensnek
+ * ugyanezt kell tennie, különben a szerkesztő egy nappal többet mutat, mint az éles
+ * oldal — pontosan az a fajta eltérés, amit tombi bejelentett a 2405-ös templomnál.
+ */
+describe('generált időszak záró napja (#837)', () => {
+
+  it('a tárolt end_date NEM tartozik bele az időszakba', () => {
+    // Szenteste: egyetlen nap, 12-24. A generátor `addDay()`-jel tárolja, tehát 12-25.
+    const igazitott = DateTimeUtil.adjustEndDates([
+      {periodId: 1, startDate: '2026-12-24', endDate: '2026-12-25'} as any,
+    ]);
+
+    expect(igazitott[0].endDate.slice(0, 10)).toBe('2026-12-24');
+  });
+
+  it('a hónap-forduló sem csúszik el', () => {
+    // Május: 05-01 .. 05-31, tárolva 06-01-gyel.
+    const igazitott = DateTimeUtil.adjustEndDates([
+      {periodId: 2, startDate: '2026-05-01', endDate: '2026-06-01'} as any,
+    ]);
+
+    expect(igazitott[0].endDate.slice(0, 10)).toBe('2026-05-31');
+  });
+});

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -20,6 +20,8 @@ class Health extends Html {
     public $boundariesStats;
     public $schemaCheck;
     public $emails;
+    /** Választható, de nem generált időszakok — az oda tett mise sehol nem jelenne meg. */
+    public $periodsWithoutGenerated;
     public $mailing;
     public $foremail;
 
@@ -242,6 +244,29 @@ class Health extends Html {
 		$ids = $elastic->churchIdsWithMassesInPeriod(date('Y-01-01'), date('Y-12-31'));
 		$this->churchesWithNoElasticMasses = \Eloquent\Church::whereNotIn('id', $ids)->has('massrules')->get()->toArray();
 		$this->churchesWithNoElasticMassesCount = count($this->churchesWithNoElasticMasses);
+
+		/*
+		 * Választható, de nem generált időszakok.
+		 *
+		 * A miserend-szerkesztő minden `selectable = 1` időszakot felajánl. Ha egy
+		 * időszakhoz nincs `cal_generated_periods` sor, az oda tett mise SEHOL nem jelenik
+		 * meg — se a naptárban, se a keresőben —, és erről semmi nem szól. A szerkesztő azt
+		 * látja, hogy beírta, a látogató azt, hogy nincs ott.
+		 *
+		 * Nem hiba önmagában: a generálás a `\Crons::rollPeriodYears()` dolga, ami havonta
+		 * fut, tehát egy frissen felvett időszaknál ez átmeneti állapot. De LÁTSZÓDNIA kell,
+		 * mert magától nem derül ki. (A fejlesztői adatbázisban például a 43-as „Nyár"
+		 * ilyen.)
+		 */
+		$this->periodsWithoutGenerated = DB::table('cal_periods')
+			->where('cal_periods.selectable', 1)
+			->whereNotExists(function ($q) {
+				$q->select(DB::raw(1))
+					->from('cal_generated_periods')
+					->whereColumn('cal_generated_periods.period_id', 'cal_periods.id');
+			})
+			->orderBy('cal_periods.name')
+			->get(['cal_periods.id', 'cal_periods.name']);
 		
 		// Health of ExternalApis
 		$this->externalapis = [];		

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -217,6 +217,20 @@
 		</div>
 	{% endif %}
 
+	{% if periodsWithoutGenerated is not empty %}
+		<div class="alert alert-warning" style="margin-top: 15px;">
+			<strong>{{ periodsWithoutGenerated|length }} választható időszaknak nincs generált sora.</strong>
+			A szerkesztő felajánlja őket, de az oda tett mise <strong>sehol nem jelenik meg</strong> —
+			se a naptárban, se a keresőben —, és erről semmi nem szól.
+			A pótlás a <code>\Crons::rollPeriodYears()</code> dolga (havonta fut).
+			<ul class="mb-0">
+				{% for period in periodsWithoutGenerated %}
+					<li>#{{ period.id }} — {{ period.name }}</li>
+				{% endfor %}
+			</ul>
+		</div>
+	{% endif %}
+
 	<h3 id="externalapis">Külső szolgáltatók elérhetősége</h3>
 	<p><i>Olyanok mint mapqquest, openstreetmap, kozossegekapi, liturgiativ, nominatim, openinghapi, overpass</i></p> 
 


### PR DESCRIPTION
Closes #852

tombi bejelentése az admin-chatből (2026-08-15): *„templom/2405 másoltam júniust júliusra és csak július van."*

## Előbb utánanéztem, aztán javítottam

A bejelentett tünet-osztályt („átmásolom, és az eredeti eltűnik") a **#753** javította **2026-08-19-én** — a bejelentés **után**. A ma élesben futó commit már tartalmazza, és a **2405-ös templom mai adata ép**.

A konkrét pár ráadásul nem is az az eset: a Június (36) és a Július (37) is 10-es súlyú, és egyik sem fedi le a másikat — a javítás előtti súly-szabály mellett is megtartották mind a 30, illetve 31 napjukat. A #747 valódi párjai 2026-ban ezek: Nyári szünet ⊂ Nyári időszámítás, Március ⊂ Nagyböjt, Tavaszi óraátállítás ⊂ Nagyböjt.

**Tehát nem javítottam meg semmit, ami már nem volt elromolva.** De találtam mellette egy valódit.

## A néma állapot

A szerkesztő **minden** `selectable = 1` időszakot felajánl. Ha egy időszakhoz nincs `cal_generated_periods` sor, az oda tett mise **sehol nem jelenik meg** — se a naptárban, se a keresőben —, és erről **semmi nem szól**. A szerkesztő azt látja, hogy beírta; a látogató azt, hogy nincs ott.

A fejlesztői adatbázisban pontosan ilyen a **43-as „Nyár"**: `selectable = 1`, nulla generált sor.

Nem kódhiba — lefuttatva a generálás helyesen elő is állítja (`2026-06-01 .. 2026-08-31`), a `\Crons::rollPeriodYears()` havonta fut. De **magától nem derül ki**, és pont ez a baj: ez az állapot megkülönböztethetetlen attól, amit tombi jelentett. A /health mostantól kiírja, melyik időszak ilyen.

## Egy hiányzó őrzés

A generált időszak záró dátuma **kizáró** vég — a #837 óta a PHP így is olvassa (`calmass.php:459`, `:506`). A kliensen viszont **semmi nem őrizte** ezt a konvenciót.

Ellenőriztem, és a kliens **jól csinálja**: a `PeriodService` az adat beérkezésekor igazítja (`DateTimeUtil.adjustEndDates`). Teszt viszont nem volt rá, pedig ez a konvenció már kétszer okozott hibát (#832, #837). Most van: a Szenteste egyetlen nap marad, a május nem lóg át júniusra.

## Mérés

Angular: 443 zöld. PHP: a teljes futam zöld a két, ettől független környezeti bukást leszámítva.

## tombinak

Érdemes megnézetni vele, hogy a 08-19-i deploy után a 2405-ön a júniusi rend látszik-e a naptárban **és** a keresőben is — az éles iCal szerint igen (2026-06-06/13/20/27, 19:15).
