### PR TITLE
A főoldal saját ajax-végpontot kap a nyilvános API helyett (#854)

### DIFF
--- a/webapp/classes/api/nearby.php
+++ b/webapp/classes/api/nearby.php
@@ -91,26 +91,22 @@ class NearBy extends Api {
 		// (error:0-val, mintha érvényes találat lenne). A 0,0 a Guineai-öbölben
 		// van, ott nincs katolikus misézőhely; kezeljük „nincs érvényes helyzet"-
 		// ként és adjunk vissza hibát a szemét 5000 km-es lista helyett.
-		if ((float) $this->input['lat'] === 0.0 && (float) $this->input['lon'] === 0.0) {
+		if (!\Eloquent\Church::isUsablePosition((float) $this->input['lat'], (float) $this->input['lon'])) {
 			$this->return['error'] = 1;
 			$this->return['text'] = 'Érvénytelen helyzet (0,0) — nem sikerült meghatározni a pozíciót.';
 			$this->return['templomok'] = [];
 			return;
 		}
 
-		$this->return['templomok'] = \Eloquent\Church::select()
-				->addSelect(DB::raw("ST_distance_sphere( ST_GeomFromText('POINT ( ".$this->input['lat']." ".$this->input['lon']." )', 4326), ST_GeomFromText(CONCAT('POINT ( ',lat,' ', lon, ')'), 4326) ) as distance"))
-                ->where('ok','i')
-				// #94 (másodlagos, defenzív): a koordináta nélküli templomok a
-				// templomok.lat/lon DEFAULT 0.0/0.0 értékén ülnek. Ezeket a meglévő
-				// `lat <> ''` szűrő DECIMAL-coercion révén (''→0) már kizárja, de ez
-				// törékeny/rejtett — explicit `NOT (lat=0 AND lon=0)`-val biztosítjuk,
-				// hogy egy 0,0 templom akkor se szivárogjon be, ha a szűrő változik.
-				->where('lat','<>','')
-				->where('lon','<>','')
-				->whereRaw('NOT (lat = 0 AND lon = 0)')
-                ->orderBy('distance', 'ASC')
-				->limit($limit)
+		/*
+		 * #854: a lekérdezés a `Church::nearestQuery()`-be került, mert a főoldali doboz
+		 * (`Html\Ajax\NearBy`) is ezt használja. A két FELÜLET szétvált — az API-t nem
+		 * kötheti a saját oldalunk —, de a távolságszámítás és a kizárások egyek maradnak.
+		 * A #94-es (0,0)-védelem is ott van, egy helyen.
+		 */
+		$this->return['templomok'] = \Eloquent\Church::nearestQuery(
+					(float) $this->input['lat'], (float) $this->input['lon'], (int) $limit
+				)
                 ->get()->map->toAPIArray(
 					isset($this->input['response_length']) ? $this->input['response_length'] : (  $this->fields['response_length']['default'] ? $this->fields['response_length']['default'] : false ), 
 					isset($this->input["whenMass"]) ? $this->input["whenMass"] : (  $this->fields['whenMass']['default'] ? $this->fields['whenMass']['default'] : false ),

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1820,6 +1820,48 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * @param string $churchIdColumn a templom azonosítója a külső lekérdezésben
      *                               (pl. `templomok.id` vagy `t.id`)
      */
+    /**
+     * #854: a legközelebbi misézőhelyek egy koordinátához.
+     *
+     * KÖZÖS lekérdezés a nyilvános API (`Api\NearBy`) és a főoldali „mi van a
+     * közelemben" doboz (`Html\Ajax\NearBy`) között. A kettő SZÉTVÁLT — borazslo kérése:
+     * a főoldal ne a nyilvános API-t hívja, mert az torzítja az API-statisztikát, és a
+     * publikus szerződést sem lehet szabadon alakítani, amíg a saját oldalunk függ tőle.
+     * A LEKÉRDEZÉS viszont maradjon egy: a távolságszámítás és a kizárások pontosan
+     * ugyanazok, és nem szabad, hogy szétcsússzanak.
+     *
+     * A `(0,0)` KIZÁRÁSA szándékos, és nem elméleti: a #94-ben a mobilalkalmazás
+     * GPS-fix nélkül (0,0)-t küldött, és erre minden magyar templom ~5000 km-re jött
+     * vissza — érvényes találatnak látszó szemétként. A koordináta nélküli templomok
+     * ugyanezen a nulla-ponton ülnek (a `lat`/`lon` DEFAULT 0.0), ezért őket is kizárjuk.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder a `distance` mezővel (méter)
+     */
+    public static function nearestQuery(float $lat, float $lon, int $limit = 10) {
+        return self::select()
+            ->addSelect(DB::raw(
+                "ST_distance_sphere( ST_GeomFromText('POINT ( " . (float) $lat . " " . (float) $lon . " )', 4326),"
+                . " ST_GeomFromText(CONCAT('POINT ( ',lat,' ', lon, ')'), 4326) ) as distance"
+            ))
+            ->where('ok', 'i')
+            ->where('lat', '<>', '')
+            ->where('lon', '<>', '')
+            ->whereRaw('NOT (lat = 0 AND lon = 0)')
+            ->orderBy('distance', 'ASC')
+            ->limit($limit);
+    }
+
+    /**
+     * #854/#94: van-e egyáltalán értelmes helyzetünk?
+     *
+     * A (0,0) a Guineai-öbölben van; ott nincs katolikus misézőhely. Ha ez jön be, a
+     * hívó nem helyzetet küldött, hanem a GPS-fix hiányát — és jobb ezt megmondani,
+     * mint egy ötezer kilométeres listát adni érvényes válaszként.
+     */
+    public static function isUsablePosition(float $lat, float $lon): bool {
+        return !($lat === 0.0 && $lon === 0.0);
+    }
+
     public static function citySubquerySql(string $churchIdColumn = 'templomok.id'): string {
         return self::boundaryNameSubquerySql([8, 9, 10], $churchIdColumn);
     }

--- a/webapp/classes/html/ajax/nearby.php
+++ b/webapp/classes/html/ajax/nearby.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Html\Ajax;
+
+/**
+ * #854: a főoldali „mi van a közelemben" doboz saját végpontja.
+ *
+ * borazslo: „A /home használja az api/v4/nearby-t a közeli templomok kiírására. És ez
+ * egyáltalán nem elegáns. A statisztikát is torzítja, és másképp kell így figyelni az
+ * API alakításra is."
+ *
+ * Két külön baj volt vele:
+ *
+ * 1. A STATISZTIKA. Az `index.php` minden `api/` kezdetű útvonalat `kind = 'api'`-ként
+ *    számol (`Stats::countPageview`). A saját főoldalunk minden helymeghatározása tehát
+ *    API-használatnak látszott — a szám nem azt mérte, amire való: hogy mennyire
+ *    használják a mobilalkalmazást és a külső integrációkat.
+ *
+ * 2. A SZERZŐDÉS. Amíg a saját oldalunk a nyilvános API-n függ, annak az alakját nem
+ *    lehet szabadon alakítani: minden változás egyszerre kliens-változás is. Az `Api\NearBy`
+ *    ráadásul `requiredVersion = ['>=', 4]` — a főoldal így egy verziózott, kifelé
+ *    ígért felülethez volt kötve.
+ *
+ * A LEKÉRDEZÉS ettől függetlenül KÖZÖS marad (`Church::nearestQuery()`): a
+ * távolságszámítás és a kizárások pontosan ugyanazok, és nem szabad, hogy szétcsússzanak.
+ * Csak a felület vált szét, nem a logika.
+ *
+ * A válasz szándékosan SZŰK: pontosan az az öt mező, amit a doboz kiír. Nem `toAPIArray()`,
+ * mert az a nyilvános szerződés — épp attól szakadunk el.
+ */
+class NearBy extends Ajax {
+
+    /** Ennél többet a doboz úgysem ír ki; a felső korlát a védelem. */
+    const ALAP_LIMIT = 10;
+    const MAX_LIMIT = 50;
+
+    public function __construct() {
+        header('Content-Type: application/json; charset=utf-8');
+
+        /*
+         * A doboz JSON-törzsben POST-ol (így hívta az API-t is), de a GET-es alak is
+         * működjön: így böngészőből, kézzel is kipróbálható, és egy jövőbeli hívónak
+         * nem kell JSON-t gyártania.
+         */
+        $bemenet = self::bemenet();
+
+        if ($bemenet === false) {
+            echo json_encode([
+                'error' => 1,
+                'text' => 'Hiányzó vagy érvénytelen koordináta.',
+                'templomok' => [],
+            ], JSON_UNESCAPED_UNICODE);
+            exit;
+        }
+
+        [$lat, $lon, $limit] = $bemenet;
+
+        if (!\Eloquent\Church::isUsablePosition($lat, $lon)) {
+            echo json_encode([
+                'error' => 1,
+                'text' => 'Érvénytelen helyzet (0,0) — nem sikerült meghatározni a pozíciót.',
+                'templomok' => [],
+            ], JSON_UNESCAPED_UNICODE);
+            exit;
+        }
+
+        $templomok = \Eloquent\Church::nearestQuery($lat, $lon, $limit)->get()->map(function ($church) {
+            return [
+                'id' => (int) $church->id,
+                'nev' => (string) $church->nev,
+                'ismertnev' => (string) ($church->ismertnev ?? ''),
+                'varos' => (string) $church->locationCityName(),
+                // Méterben, ahogy a doboz várja (ott dől el a m/km megjelenítés).
+                'tavolsag' => (int) $church->distance,
+            ];
+        })->values();
+
+        echo json_encode([
+            'error' => 0,
+            'templomok' => $templomok,
+        ], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    /**
+     * A koordináta kiolvasása — JSON-törzsből vagy kérés-paraméterből.
+     *
+     * @return array{0:float,1:float,2:int}|false
+     */
+    private static function bemenet() {
+        /*
+         * SZÁNDÉKOSAN nem a `Request::FloatRequired()`-et hívjuk: az kivételt dob, és egy
+         * ajax-végponton a hiányzó paraméterre nem HTML hibaoldal jár, hanem JSON.
+         */
+        $lat = self::szam(\Request::get('lat'));
+        $lon = self::szam(\Request::get('lon'));
+        $limit = self::szam(\Request::get('limit'));
+
+        // JSON-törzs: a doboz így küldi.
+        if ($lat === null || $lon === null) {
+            $nyers = file_get_contents('php://input');
+            $json = $nyers === false ? null : json_decode($nyers, true);
+            if (is_array($json)) {
+                $lat = $lat ?? self::szam($json['lat'] ?? null);
+                $lon = $lon ?? self::szam($json['lon'] ?? null);
+                $limit = $limit ?? self::szam($json['limit'] ?? null);
+            }
+        }
+
+        if ($lat === null || $lon === null) {
+            return false;
+        }
+
+        $limit = $limit === null ? self::ALAP_LIMIT : $limit;
+
+        // A Föld szélein túli koordinátára nincs értelmes válasz.
+        if ($lat < -90 || $lat > 90 || $lon < -180 || $lon > 180) {
+            return false;
+        }
+
+        $limit = max(1, min(self::MAX_LIMIT, (int) $limit));
+
+        return [(float) $lat, (float) $lon, $limit];
+    }
+
+    /** Szám vagy null — üres sztringből, false-ból, szemétből NE legyen 0.0. */
+    private static function szam($ertek): ?float {
+        if ($ertek === null || $ertek === false || $ertek === '' || !is_numeric($ertek)) {
+            return null;
+        }
+
+        return (float) $ertek;
+    }
+}

--- a/webapp/js/nearby-churches.js
+++ b/webapp/js/nearby-churches.js
@@ -22,7 +22,11 @@
 		function fetchNearby(position) {
 			setStatus('Templomokat keresünk a környéken...', 'info');
 			$.ajax({
-				url: '/api/v4/nearby',
+				// #854: a SAJÁT ajax-végpontunk, nem a nyilvános API. Amíg a főoldal az
+				// api/v4/nearby-t hívta, minden helymeghatározásunk API-használatnak
+				// számított a statisztikában, és a publikus szerződést sem lehetett
+				// szabadon alakítani. A lekérdezés közös maradt (Church::nearestQuery).
+				url: '/ajax/nearby',
 				type: 'POST',
 				dataType: 'json',
 				data: JSON.stringify({'lat': position.coords.latitude, 'lon': position.coords.longitude}),

--- a/webapp/tests/Integration/AjaxNearByTest.php
+++ b/webapp/tests/Integration/AjaxNearByTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #854: a főoldali „mi van a közelemben" doboz saját végpontot kapott.
+ *
+ * borazslo: „A /home használja az api/v4/nearby-t a közeli templomok kiírására. És ez
+ * egyáltalán nem elegáns. A statisztikát is torzítja, és másképp kell így figyelni az
+ * API alakításra is."
+ *
+ * Két külön baj volt vele. A STATISZTIKA: az `index.php` minden `api/` kezdetű útvonalat
+ * `kind = 'api'`-ként számol, tehát a saját főoldalunk minden helymeghatározása
+ * API-használatnak látszott. És a SZERZŐDÉS: amíg a saját oldalunk a nyilvános,
+ * verziózott API-n függ, annak az alakját nem lehet szabadon alakítani.
+ *
+ * A felület vált szét, a LOGIKA nem: a lekérdezés közös (`Church::nearestQuery()`).
+ */
+final class AjaxNearByTest extends TestCase {
+
+    /* ---- A közös lekérdezés ---- */
+
+    /**
+     * A LÉNYEG: a két felület ugyanazt a lekérdezést használja, tehát nem tud szétcsúszni
+     * a távolságszámítás és a kizárás-halmaz.
+     */
+    public function testBothSurfacesShareTheSameQuery(): void {
+        $ajax = file_get_contents(dirname(__DIR__, 2) . '/classes/html/ajax/nearby.php');
+        $api = file_get_contents(dirname(__DIR__, 2) . '/classes/api/nearby.php');
+
+        self::assertStringContainsString('nearestQuery(', $ajax);
+        self::assertStringContainsString('nearestQuery(', $api);
+
+        // Az API-ban ne maradjon saját, kézzel írt távolság-lekérdezés.
+        self::assertStringNotContainsString('ST_distance_sphere', $api,
+            'a tavolsagszamitas egy helyen legyen: Church::nearestQuery()');
+    }
+
+    /** A (0,0) védelem (#94) is közös — a GPS-fix hiánya nem érvényes helyzet. */
+    public function testTheZeroPositionGuardIsShared(): void {
+        self::assertFalse(\Eloquent\Church::isUsablePosition(0.0, 0.0));
+        self::assertTrue(\Eloquent\Church::isUsablePosition(47.4979, 19.0402));
+    }
+
+    /** A koordináta nélküli templomok nem szivároghatnak be találatként. */
+    public function testChurchesWithoutCoordinatesAreExcluded(): void {
+        $sql = \Eloquent\Church::nearestQuery(47.4979, 19.0402, 5)->toSql();
+
+        self::assertStringContainsString('NOT (lat = 0 AND lon = 0)', $sql);
+        self::assertStringContainsString('order by `distance` asc', strtolower($sql));
+    }
+
+    /** A limit tényleg korlátoz. */
+    public function testTheLimitIsApplied(): void {
+        $templomok = \Eloquent\Church::nearestQuery(47.4979, 19.0402, 3)->get();
+
+        self::assertLessThanOrEqual(3, $templomok->count());
+    }
+
+    /** ...és növekvő távolság szerint jön. */
+    public function testTheResultIsOrderedByDistance(): void {
+        $tavok = \Eloquent\Church::nearestQuery(47.4979, 19.0402, 5)
+            ->get()->pluck('distance')->map('floatval')->all();
+
+        $rendezett = $tavok;
+        sort($rendezett);
+        self::assertSame($rendezett, $tavok);
+    }
+
+    /* ---- A szétválás ---- */
+
+    /**
+     * A saját felületünk NE hívja a nyilvános API-t.
+     *
+     * Ez az őrzés a jegy lényege: amíg egy JS-ünk az `api/`-t hívja, a statisztika
+     * torzít, és az API alakja a saját oldalunkhoz van kötve.
+     */
+    public function testOurOwnFrontendDoesNotCallThePublicApi(): void {
+        $talalatok = [];
+        $konyvtar = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(dirname(__DIR__, 2) . '/js')
+        );
+
+        foreach ($konyvtar as $fajl) {
+            if (!$fajl->isFile() || !str_ends_with((string) $fajl->getFilename(), '.js')) {
+                continue;
+            }
+            // A naptár lefordított csomagja nem a mi forrásunk.
+            if (str_contains((string) $fajl->getPathname(), '/mcal/')) {
+                continue;
+            }
+            if (preg_match('#[\'"]/api/v[0-9]+/#', (string) file_get_contents($fajl->getPathname()))) {
+                $talalatok[] = basename((string) $fajl->getPathname());
+            }
+        }
+
+        self::assertSame([], $talalatok,
+            'Ezek a sajat frontend-fajljaink a nyilvanos API-t hivjak: ' . implode(', ', $talalatok)
+            . '. Az api/ utvonalak kind=api-kent szamolodnak a statisztikaban, es a publikus '
+            . 'szerzodest is a sajat oldalunkhoz kotik. Hasznalj ajax/ vegpontot.');
+    }
+
+    /** A doboz az új végpontot hívja. */
+    public function testTheHomepageWidgetUsesTheAjaxEndpoint(): void {
+        $js = file_get_contents(dirname(__DIR__, 2) . '/js/nearby-churches.js');
+
+        self::assertStringContainsString("'/ajax/nearby'", $js);
+    }
+}


### PR DESCRIPTION
Closes #854

Igazad van mindkét pontban, és mindkettőt megmértem.

## A statisztika

Az `index.php` minden `api/` kezdetű útvonalat `kind = 'api'`-ként számol:

```php
\Stats::countPageview($path->url, str_starts_with($path->url, 'api/') ? 'api'
    : (str_starts_with($path->url, 'ajax') ? 'ajax' : 'html'));
```

Tehát a saját főoldalunk **minden** helymeghatározása API-használatnak látszott — a szám nem azt mérte, amire való (mennyire használják a mobilalkalmazást és a külső integrációkat).

Mérve, a javítás után, ugyanaz a két hívás:

```
route            kind   count
ajax/nearby      ajax   1
api/v4/nearby    api    1
```

## A szerződés

Az `Api\NearBy` `requiredVersion = ['>=', 4]` — a főoldal egy **verziózott, kifelé ígért** felülethez volt kötve. Amíg a saját oldalunk rajta függ, minden API-változás egyszerre kliens-változás is.

## Amit csináltam

A **felület** vált szét, a **logika** nem.

- Új `Html\Ajax\NearBy` (`/ajax/nearby`). A válasz szándékosan szűk: pontosan az az öt mező, amit a doboz kiír. **Nem** `toAPIArray()` — épp attól a szerződéstől szakadunk el.
- A lekérdezés a `Church::nearestQuery()`-be került, a #94-es (0,0)-védelemmel együtt. A távolságszámítás és a kizárás-halmaz **egy helyen** van, és nem tud szétcsúszni. Az API-ból eltűnik a kézzel írt `ST_distance_sphere`.
- A doboz (`nearby-churches.js`) az új végpontot hívja.

## Miért statikus teszt is

Egy őrzés arra, hogy a **saját frontendünk** ne hívjon `api/vN/` útvonalat. Enélkül a következő widget megint az API-ra menne, és a statisztika megint torzulna — csendben.

## Mérés

E2E-ben, a dev konténerben:

| eset | válasz |
|---|---|
| `GET /ajax/nearby?lat=…&lon=…&limit=3` | 3 templom, növekvő távolság szerint |
| JSON-POST (ahogy a doboz hívja) | 10 templom |
| koordináta nélkül | `{"error":1,"text":"Hiányzó vagy érvénytelen koordináta."}` |
| `lat=0&lon=0` | `{"error":1,"text":"Érvénytelen helyzet (0,0)…"}` |

A `varos` mező pontosan úgy viselkedik, mint az API-é (a dev adatbázisban mindkettőnél üres — hiányzó határadat, nem eltérés).

Hibánál **JSON** megy vissza, nem HTML hibaoldal: ezért nem a `Request::FloatRequired()`-et hívom, az ugyanis kivételt dob.

PHP: a teljes futam zöld a két, ettől független környezeti bukást leszámítva.
