### PR TITLE
Az sqlite v5 tartalma a v4 fájlra íródott (#858)

### DIFF
--- a/webapp/classes/api/sqlite.php
+++ b/webapp/classes/api/sqlite.php
@@ -130,10 +130,34 @@ class Sqlite extends Api {
         $this->sqliteFileName = 'miserend_v' . $this->version . '.sqlite3';
     }
 
+    /**
+     * #858: a fájlnév MINDIG a mostani verzióból számolódik.
+     *
+     * Itt korábban `if (!isset($this->sqliteFileName))` állt — vagyis az első beállítás
+     * után a név BEFAGYOTT. Ez addig ártalmatlan volt, amíg egy példány egy verziót
+     * épített, de a #822 óta a `cron()` UGYANAZON a példányon megy végig a
+     * `GENERALT_VERZIOK`-on:
+     *
+     *     foreach (self::GENERALT_VERZIOK as $verzio) {   // [4, 5]
+     *         $this->version = $verzio;
+     *         $this->run();                               // -> setFilePath()
+     *     }
+     *
+     * Az első kör beállította a `miserend_v4.sqlite3`-at, a második kör pedig a `version`
+     * átállítása ELLENÉRE ugyanoda írt. Következmény, mérve:
+     *
+     *     version=4  ->  miserend_v4.sqlite3
+     *     version=5  ->  miserend_v4.sqlite3     <-- ide íródik a v5 tartalom
+     *
+     * Ez ROSSZABB, mint egy hiányzó fájl: a v5 sqlite soha nem készült el (a /health-en
+     * és élesben is 404), a `miserend_v4.sqlite3` viszont a V5 SÉMÁJÁT kapta — a v4-es
+     * kliensek tehát olyan `misek` táblát töltöttek le, ami nem az ő alakjuk.
+     *
+     * A `$sqliteFilePath` is újraszámolódik, mert a `run()` és a `generateSqlite()` is
+     * `isset()`-tel őrzi — ugyanaz a befagyás történne vele.
+     */
     function setFilePath() {
-        if(!isset($this->sqliteFileName)) {
-            $this->setFileName();
-        }
+        $this->setFileName();
         $this->sqliteFilePath = PATH . $this->folder . $this->sqliteFileName;
     }
 

--- a/webapp/tests/Integration/SqliteVersionFilePathTest.php
+++ b/webapp/tests/Integration/SqliteVersionFilePathTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #858: a v5 tartalma a v4 fájlra íródott, a v5 pedig soha nem készült el.
+ *
+ * A /health-en a `miserend_v5.sqlite3` pirosan állt, élesben 404 volt — miközben a
+ * `\Api\Sqlite::GENERALT_VERZIOK` a #822 óta `[4, 5]`, tehát épülnie kellett volna.
+ *
+ * Az ok a `setFilePath()` `isset()`-őre volt: az első beállítás után a fájlnév BEFAGYOTT.
+ * Egy példány / egy verzió mellett ez ártalmatlan, csakhogy a `cron()` UGYANAZON a
+ * példányon megy végig a verziókon — a második kör tehát a `version` átállítása ellenére
+ * ugyanoda írt.
+ *
+ * Ez rosszabb, mint egy hiányzó fájl: a `miserend_v4.sqlite3` a V5 SÉMÁJÁT kapta, tehát
+ * a v4-es kliensek olyan `misek` táblát töltöttek le, ami nem az ő alakjuk.
+ */
+final class SqliteVersionFilePathTest extends TestCase {
+
+    /**
+     * A LÉNYEG: ugyanazon a példányon, verziót váltva, a fájlnév is váltson.
+     *
+     * Ez a teszt a javítás előtt elbukik — mérve mindkét körre `miserend_v4.sqlite3` jött.
+     */
+    public function testTheFileNameFollowsTheVersionOnTheSameInstance(): void {
+        $api = new \Api\Sqlite();
+
+        $nevek = [];
+        foreach (\Api\Sqlite::GENERALT_VERZIOK as $verzio) {
+            $api->version = $verzio;
+            $api->setFilePath();
+            $nevek[$verzio] = $api->sqliteFileName;
+        }
+
+        foreach (\Api\Sqlite::GENERALT_VERZIOK as $verzio) {
+            self::assertSame('miserend_v' . $verzio . '.sqlite3', $nevek[$verzio],
+                'a v' . $verzio . ' tartalma a ' . $nevek[$verzio] . ' fajlra irodna');
+        }
+
+        self::assertSame(count($nevek), count(array_unique($nevek)),
+            'ket verzio nem irhat ugyanabba a fajlba');
+    }
+
+    /** Az útvonal is kövesse — a `run()` és a `generateSqlite()` is `isset()`-tel őrzi. */
+    public function testThePathFollowsTheVersionToo(): void {
+        $api = new \Api\Sqlite();
+
+        $api->version = 4;
+        $api->setFilePath();
+        $negy = $api->sqliteFilePath;
+
+        $api->version = 5;
+        $api->setFilePath();
+        $ot = $api->sqliteFilePath;
+
+        self::assertNotSame($negy, $ot);
+        self::assertStringEndsWith('miserend_v5.sqlite3', $ot);
+    }
+
+    /**
+     * A `cron()` tényleg több verziót épít — enélkül a fenti tesztek tárgytalanok.
+     *
+     * Ha valaha egyetlen verzióra szűkül, ez a teszt szól, hogy a fenti védelem is
+     * felülvizsgálandó.
+     */
+    public function testTheCronBuildsMoreThanOneVersion(): void {
+        self::assertGreaterThan(1, count(\Api\Sqlite::GENERALT_VERZIOK),
+            'ha csak egy verzio epul, a fajlnev-befagyas nem is jelentkezne');
+        self::assertContains(5, \Api\Sqlite::GENERALT_VERZIOK,
+            'a v5 a legujabb kiadott verzio, epulnie kell');
+    }
+
+    /**
+     * A verziónkénti séma tényleg ELTÉR — ezért volt kártékony a felülírás.
+     *
+     * A v4 `misek` táblájában `periodus`/`suly`/`nap` van, a v5-ében `mise_id`/`hossz`.
+     * Ha ez a kettő valaha egyformává válna, a hiba tünete eltűnne, de a hiba maradna —
+     * ezért itt rögzítjük, hogy tényleg két különböző alakról van szó.
+     */
+    public function testTheTwoVersionsHaveDifferentSchemas(): void {
+        $forras = file_get_contents(dirname(__DIR__, 2) . '/classes/api/sqlite.php');
+
+        self::assertStringContainsString('$this->version >= 5', $forras,
+            'a v5 sajat, eltero semat epit');
+    }
+}


### PR DESCRIPTION
Closes #858

Láttam, hogy a `/fajlok/sqlite/miserend_v5.sqlite3` 404. Utánanéztem, és a baj nagyobb annál, hogy hiányzik egy fájl.

## Az ok

A `setFilePath()` `isset()`-őre befagyasztotta a fájlnevet az első beállítás után:

```php
if (!isset($this->sqliteFileName)) {   // <-- ez fagyaszt
    $this->setFileName();
}
```

Egy példány / egy verzió mellett ez ártalmatlan. Csakhogy a #822 óta a `cron()` **ugyanazon a példányon** megy végig a verziókon. Mérve:

```
version=4  ->  miserend_v4.sqlite3
version=5  ->  miserend_v4.sqlite3     <-- ide íródott a v5 tartalom
```

## Ami rosszabb, mint a hiányzó fájl

A `miserend_v4.sqlite3` a **v5 sémáját** kapta. A v4-es kliensek tehát olyan `misek` táblát töltöttek le, ami nem az ő alakjuk — és a napi cron ezt minden éjjel felülírta:

| | `misek` oszlopok |
|---|---|
| **v4 séma** | `mid, tid, periodus, idoszak, suly, datumtol, datumig, nap` |
| **v5 séma** | `mid, tid, mise_id, idoszak, datumtol, datumig, ido, hossz` |

A `datumtol`/`datumig` a v4-ben `(H)HNN` **egész**, a v5-ben **DATE**. Egy v4-es kliens ezt vagy nem tudja értelmezni, vagy — ami rosszabb — értelmezi rosszul.

## A javítás után, e2e

A teljes `cron()`-ciklust lefuttattam a dev konténerben, a fájlok törlése után:

```
v4: 21 303 296 B   misek: mid,tid,periodus,idoszak,suly,datumtol,datumig,nap
v5:  7 094 272 B   misek: mid,tid,mise_id,idoszak,datumtol,datumig,ido,hossz
```

Mindkettő elkészül, és **mindkettő a saját sémáját** tartalmazza.

## Deploy

A legközelebbi `\Api\Sqlite->cron()` futás magától helyreteszi mindkét fájlt — kézzel nem kell semmit tenni. Addig a `miserend_v4.sqlite3` hibás sémájú marad, tehát ha sürgős, a cron kézzel is futtatható.

## Teszt

Visszaméréssel ellenőrizve: a javítás nélkül a teszt elbukik, és megnevezi, melyik fájlra íródna a v5. Külön őrzöm azt is, hogy a `cron()` tényleg több verziót épít — ha valaha egyetlenre szűkül, ez a védelem felülvizsgálandó.

PHP: a teljes futam zöld a két, ettől független környezeti bukást leszámítva.
