### PR TITLE
Reflected XSS a bemenet-ellenőrzőben: ottfelejtett printr() (#860)

### DIFF
--- a/webapp/classes/eloquent/photo.php
+++ b/webapp/classes/eloquent/photo.php
@@ -193,7 +193,9 @@ class Photo extends \Illuminate\Database\Eloquent\Model {
                     $exception .= " Because ".$target_path." already exists.";
             if(!is_writable(dirname($target_path)))
                     $exception .= " Because ".dirname($target_path)." is not writable.";
-            \printr($inputFile);
+            // #860: itt egy `\printr($inputFile)` állt, ami a nyers $_FILES bejegyzést —
+            // benne a szerver ideiglenes útvonalával — a válaszba echózta. A konkrét okot
+            // az $exception fentebb amúgy is tartalmazza, ez csak szivárgás volt.
             throw new \Exception($exception);
         }
 

--- a/webapp/classes/request.php
+++ b/webapp/classes/request.php
@@ -133,7 +133,18 @@ class Request {
         
         foreach ($value as $item) {
             if (!is_numeric($item)) {
-                printr($item);
+                /*
+                 * #860: itt egy `printr($item)` állt — a NYERS, escape-eletlen felhasználói
+                 * bemenetet echózta a válaszba, a kivétel eldobása ELŐTT. Három baj egyszerre:
+                 *
+                 *   1. reflected XSS, `text/html` válaszban, bejelentkezés nélkül, sima GET-tel;
+                 *   2. a JSON-válasz szemét-prefixet kapott, tehát a kliens `JSON.parse`-a
+                 *      elhasalt — pont a „mindig tiszta JSON hibaválasz" szabályt ütötte ki;
+                 *   3. a státusz 200 lett 400 helyett, mert a fejléc a kimenettel már elment.
+                 *
+                 * Hogy hibakeresés-maradék volt és nem szándék: az iker metódus, az
+                 * `IntegerArray()` fentebb BETŰRE ugyanez — csak `printr` nélkül.
+                 */
                 throw new Exception("Required Array '$name' contains non-integer values.");
             }
         }

--- a/webapp/functions.php
+++ b/webapp/functions.php
@@ -262,9 +262,21 @@ function file_exists_ci($fileName) {
     return false;
 }
 
+/**
+ * #860: hibakereső kiírás — HTML-be ESCAPE-elve.
+ *
+ * A függvény korábban nyersen echózta a `print_r()` kimenetét. Ez addig ártalmatlan,
+ * amíg saját adatot ír ki, de a `Request::IntegerArrayRequired()`-ben ottfelejtett
+ * hívás a FELHASZNÁLÓ bemenetét adta vissza — reflected XSS lett belőle, bejelentkezés
+ * nélkül, sima GET-tel.
+ *
+ * A hívásokat kivettük, de a függvény maga is legyen védett: hibakereséskor az ember
+ * pont nem arra figyel, honnan jött az adat. Escape-elve ugyanúgy olvasható, csak nem
+ * futtatható.
+ */
 function printr($variable) {
 
-    echo"<pre>" . print_r($variable, 1) . "</pre>";
+    echo "<pre>" . htmlspecialchars(print_r($variable, 1), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "</pre>";
 }
 
 function configurationSetEnvironment($env) {

--- a/webapp/tests/Request/IntegerArrayRequiredTest.php
+++ b/webapp/tests/Request/IntegerArrayRequiredTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #860: a bemenet-ellenőrzőben ottfelejtett `printr()` visszaechózta a felhasználó
+ * nyers bemenetét — a kivétel eldobása ELŐTT.
+ *
+ * Reprodukálva, bejelentkezés nélkül, sima GET-tel:
+ *
+ *   GET /ajax/calendar/generate?tids[]=<img src=x onerror=alert(1)>&years[]=2026
+ *   -> HTTP 200, Content-Type: text/html
+ *      <pre><img src=x onerror=alert(1)></pre>{"error":true,...,"code":400}
+ *
+ * Három baj egyszerre:
+ *   1. reflected XSS, `text/html` válaszban;
+ *   2. a JSON-válasz szemét-prefixet kapott, tehát a kliens `JSON.parse`-a elhasalt —
+ *      pont a „mindig tiszta JSON hibaválasz" szabályt ütötte ki;
+ *   3. a státusz 200 lett 400 helyett, mert a fejléc a kimenettel már elment.
+ *
+ * Hogy hibakeresés-maradék volt: az iker metódus, az `IntegerArray()` betűre ugyanez,
+ * csak `printr` nélkül. Tesztje egyiknek sem volt — a `RequestTest` kizárólag a
+ * `printr` nélküli változatot hívta.
+ */
+final class IntegerArrayRequiredTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_REQUEST = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_REQUEST = [];
+    }
+
+    /** A LÉNYEG: az ellenőrző NE írjon semmit a kimenetre. */
+    public function testItPrintsNothingOnInvalidInput(): void
+    {
+        $_REQUEST['tids'] = ['<img src=x onerror=alert(1)>'];
+
+        ob_start();
+        try {
+            \Request::IntegerArrayRequired('tids');
+            $dobott = false;
+        } catch (\Exception $e) {
+            $dobott = true;
+        }
+        $kimenet = ob_get_clean();
+
+        self::assertTrue($dobott, 'a hibas bemenetre kivetelt kell dobni');
+        self::assertSame('', $kimenet,
+            'a bemenet-ellenorzo NEM irhat a kimenetre: XSS-t okoz, elrontja a JSON-t, '
+            . 'es a fejlecet is elkuldi, tehat a statuszkod is rossz lesz');
+    }
+
+    /** A felhasználó bemenete a kivétel ÜZENETÉBE se kerüljön bele. */
+    public function testTheUserInputIsNotEchoedInTheMessage(): void
+    {
+        $_REQUEST['tids'] = ['<script>alert(1)</script>'];
+
+        try {
+            \Request::IntegerArrayRequired('tids');
+            self::fail('kivetelt kellett volna dobnia');
+        } catch (\Exception $e) {
+            self::assertStringNotContainsString('<script>', $e->getMessage());
+        }
+    }
+
+    /* A védelem ne rontsa el a rendes működést. */
+
+    public function testItAcceptsAValidArray(): void
+    {
+        $_REQUEST['tids'] = ['1', '2', '3'];
+
+        self::assertSame(['1', '2', '3'], \Request::IntegerArrayRequired('tids'));
+    }
+
+    public function testItRejectsAMissingParameter(): void
+    {
+        $this->expectException(\Exception::class);
+
+        \Request::IntegerArrayRequired('tids');
+    }
+
+    public function testItRejectsANonArray(): void
+    {
+        $_REQUEST['tids'] = '5';
+
+        $this->expectException(\Exception::class);
+
+        \Request::IntegerArrayRequired('tids');
+    }
+
+    /** Az iker metódus is hallgasson — ma is így van, de ne csússzon szét a kettő. */
+    public function testTheTwinMethodIsSilentToo(): void
+    {
+        $_REQUEST['tids'] = ['<img src=x onerror=alert(1)>'];
+
+        ob_start();
+        try {
+            \Request::IntegerArray('tids');
+        } catch (\Exception $e) {
+            // várt
+        }
+        self::assertSame('', ob_get_clean());
+    }
+
+    /**
+     * A `printr()` maga is escape-eljen.
+     *
+     * A hívásokat kivettük, de a függvény legyen védett: hibakereséskor az ember pont
+     * nem arra figyel, honnan jött az adat.
+     */
+    public function testThePrintrHelperEscapesHtml(): void
+    {
+        ob_start();
+        printr('<img src=x onerror=alert(1)>');
+        $kimenet = ob_get_clean();
+
+        self::assertStringNotContainsString('<img', $kimenet);
+        self::assertStringContainsString('&lt;img', $kimenet);
+    }
+}


### PR DESCRIPTION
Closes #860

## A hiba

A `Request::IntegerArrayRequired()`-ben egy `printr($item)` maradt, ami a felhasználó **nyers, escape-eletlen** bemenetét echózza a válaszba — a kivétel eldobása **előtt**.

Reprodukálva, bejelentkezés nélkül, sima GET-tel:

```
GET /ajax/calendar/generate?tids[]=<img src=x onerror=alert(1)>&years[]=2026

HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8

<pre><img src=x onerror=alert(1)></pre>{"error":true,"message":"Hiányzó vagy érvénytelen templom ID.","code":400}
```

**Három baj egyszerre:**

1. **Reflected XSS** `text/html` válaszban, azonosítás nélkül. Bejelentkezett gondnoknál vagy adminnál ez munkamenet-átvétel.
2. **A JSON-válasz szemét-prefixet kap** — a kliens `JSON.parse`-a elhasal. Pont a #392 „mindig tiszta JSON hibaválasz" szabályát üti ki.
3. **A státusz 200 lesz 400 helyett**, mert a fejléc a kimenettel már elment.

## Hogy hibakeresés-maradék volt

Az iker metódus, az `IntegerArray()` **betűre ugyanez** — csak `printr` nélkül. Tesztje egyiknek sem volt: a `RequestTest` kizárólag a `printr` nélküli változatot hívta, tehát a hiba bekerülhetett és bent maradhatott zöld futam mellett.

## A javítás után, e2e

Ugyanaz a támadó kérés:

```
Content-Type: application/json
{"error":true,"message":"Hiányzó vagy érvénytelen templom ID.","code":400}
```

`JSON.parse` rendben. Nincs HTML, nincs szemét-prefix.

## Két további helyen ugyanez

- **`photo.php`** — a nyers `$_FILES` bejegyzést szivárogtatta, benne a szerver ideiglenes útvonalával. A konkrét okot a kivétel üzenete amúgy is tartalmazza, ez csak szivárgás volt.
- **`printr()` maga** — escape nélkül írt. A hívásokat kivettem, de a függvény legyen **védett**: hibakereséskor az ember pont nem arra figyel, honnan jött az adat. Escape-elve ugyanúgy olvasható, csak nem futtatható.

## Teszt

Visszaméréssel ellenőrizve: a javítás nélkül elbukik. Külön őrzöm azt is, hogy az **iker metódus** is hallgasson — ma is így van, de ne csússzon szét a kettő.

PHP: a teljes futam zöld a két, ettől független környezeti bukást leszámítva.
