### PR TITLE
Azonosítás-megkerülés: JSON-számmal küldött token idegen fiókra illeszkedik (#862)

### DIFF
--- a/webapp/classes/api/favorites.php
+++ b/webapp/classes/api/favorites.php
@@ -48,7 +48,9 @@ class Favorites extends Api {
         parent::run();
         $this->getInputJson();
 
-        $token = \Eloquent\Token::where('name',$this->input['token'])->first();
+        // #862: típusbiztos keresés — a JSON-ból szám is jöhet, és a MySQL olyankor a
+        // TÁROLT sztringet konvertálja számmá (l. Token::findByName()).
+        $token = \Eloquent\Token::findByName($this->input['token'] ?? null);
         if(!$token or !$token->isValid) {
             throw new \Exception("Invalid token.");
         }    

--- a/webapp/classes/api/report.php
+++ b/webapp/classes/api/report.php
@@ -84,7 +84,8 @@ class Report extends Api {
         }
     
         if (isset($this->input['token'])) {                    
-            $this->token = \Eloquent\Token::where('name',$this->input['token'])->first();
+            // #862: típusbiztos keresés — l. Token::findByName().
+            $this->token = \Eloquent\Token::findByName($this->input['token'] ?? null);
             if(!$this->token or !$this->token->isValid) {
                 throw new \Exception("Invalid token.");
             }            

--- a/webapp/classes/api/user.php
+++ b/webapp/classes/api/user.php
@@ -42,7 +42,8 @@ class User extends Api {
     public function run() {
         parent::run();
         $this->getInputJson();
-        $token = \Eloquent\Token::where('name',$this->input['token'])->first();
+        // #862: típusbiztos keresés — l. Token::findByName().
+        $token = \Eloquent\Token::findByName($this->input['token'] ?? null);
         if(!$token or !$token->isValid) {
             throw new \Exception("Invalid token.");
         }    

--- a/webapp/classes/eloquent/token.php
+++ b/webapp/classes/eloquent/token.php
@@ -8,7 +8,61 @@ class Token extends Model
 {
     protected $fillable = ['name','type','uid','timeout'];
     protected $appends = ['isValid'];
-    
+
+    /**
+     * #862: token keresése a nevéből — TÍPUSBIZTOSAN.
+     *
+     * A `tokens.name` `varchar(40)`, a token pedig 32 jegyű hexadecimális szám. Ha az
+     * összehasonlítás másik oldalára SZÁM kerül, a MySQL nem a számot alakítja
+     * sztringgé, hanem fordítva: a tárolt sztringet konvertálja számmá, a vezető
+     * számjegyekből. Mérve:
+     *
+     *     SELECT '971744af0e83941bffd19c110a5d2b28' = 971744;   ->  1
+     *
+     * Az API-k JSON-törzsből olvasnak, ahol a `{"token": 971744}` valódi PHP int lesz —
+     * tehát egy TÖREDÉK szám érvényes tokenre illeszkedett. A `/api/v4/favorites`
+     * végponton ez mérve is teljes azonosítás-megkerülés volt:
+     *
+     *     {"token": 971744}    ->  {"favorites":[],"error":0}      <-- beengedte
+     *     {"token": "971744"}  ->  {"error":"1","text":"Invalid token."}
+     *
+     * Vagyis bárki, token ismerete nélkül, rövid számokat próbálgatva idegen fiók
+     * adataihoz fért. A védelem itt van, a modellben, mert négy hívóhely használja
+     * ugyanezt a mintát (api/user.php, api/report.php, api/favorites.php, classes/user.php)
+     * — ha mindegyikben külön kellene megcsinálni, egy biztosan kimaradna.
+     *
+     * A NEM sztring bemenet elutasítás, nem konverzió: aki számot küld, az nem tokent
+     * küldött.
+     */
+    public static function findByName($name): ?self
+    {
+        if (!is_string($name) || $name === '') {
+            return null;
+        }
+
+        return self::where('name', $name)->first();
+    }
+
+    /**
+     * #862: token TÖRLÉSE a nevéből — típusbiztosan.
+     *
+     * Itt a típus-zavar még súlyosabb lenne, mint a keresésnél: a `where('name', <szám>)`
+     * TÖBB sorra is illeszkedhet (minden token, ami ugyanazokkal a számjegyekkel kezdődik),
+     * tehát egy törlés idegen felhasználókat is kiléptethetne.
+     *
+     * A süti értéke mindig sztring, tehát ma nem kiváltható — de a minta legyen egységes.
+     *
+     * @return int hány sort töröltünk
+     */
+    public static function deleteByName($name): int
+    {
+        if (!is_string($name) || $name === '') {
+            return 0;
+        }
+
+        return (int) self::where('name', $name)->delete();
+    }
+
     public function getIsValidAttribute($value) {
         if($this->timeout < date('Y-m-d H:i:s') ) 
             return false;

--- a/webapp/classes/token.php
+++ b/webapp/classes/token.php
@@ -6,7 +6,7 @@ class Token {
         global $config;
                 
         if(isset($_COOKIE['token'])) {
-                \Eloquent\Token::where('name',$_COOKIE['token'])->delete();
+                \Eloquent\Token::deleteByName($_COOKIE['token']);
         }
 
         $timeout = date('Y-m-d H:i:s', strtotime("+" . $config['token'][$type]));        
@@ -29,7 +29,7 @@ class Token {
    
     static function delete() {
         if(isset($_COOKIE['token'])) {
-            \Eloquent\Token::where('name',$_COOKIE['token'])->delete();
+            \Eloquent\Token::deleteByName($_COOKIE['token']);
             setcookie('token', "", strtotime("-1 year"),"/","", self::isHttps(), true);
             unset($_COOKIE['token']);
         }        

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -578,7 +578,9 @@ class User {
         if (!isset($_COOKIE['token'])) 
             return new \User();
                         
-        $token = \Eloquent\Token::where('name',$_COOKIE['token'])->first();
+        // #862: típusbiztos keresés. A süti értéke mindig sztring, tehát itt a hiba nem
+        // volt kiváltható — de a minta legyen egységes, hogy ne lehessen visszacsempészni.
+        $token = \Eloquent\Token::findByName($_COOKIE['token'] ?? null);
         if(!$token or !$token->isValid) {
             \Token::delete();
             return new \User();

--- a/webapp/tests/Integration/TokenTypeConfusionTest.php
+++ b/webapp/tests/Integration/TokenTypeConfusionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #862: azonosítás-megkerülés a token típus-konverziójával.
+ *
+ * A `tokens.name` `varchar(40)`, a token 32 jegyű hexadecimális szám. Ha az
+ * összehasonlítás másik oldalára SZÁM kerül, a MySQL nem a számot alakítja sztringgé,
+ * hanem fordítva: a TÁROLT sztringet konvertálja számmá, a vezető számjegyekből.
+ *
+ *     SELECT '971744af0e83941bffd19c110a5d2b28' = 971744;   ->  1
+ *
+ * Az API-k JSON-törzsből olvasnak, ahol a `{"token": 971744}` valódi PHP int lesz.
+ * Mérve, a `/api/v4/favorites` végponton:
+ *
+ *     {"token": 971744}    ->  {"favorites":[],"error":0}      <-- BEENGEDTE
+ *     {"token": "971744"}  ->  {"error":"1","text":"Invalid token."}
+ *
+ * Vagyis bárki, token ismerete nélkül, rövid számokat próbálgatva idegen fiók adataihoz
+ * fért — kiolvashatta és módosíthatta a kedvenc-templom listáját.
+ */
+final class TokenTypeConfusionTest extends TestCase {
+
+    private string $tokenNev;
+
+    protected function setUp(): void {
+        DB::beginTransaction();
+
+        /*
+         * A SZÁM-ELŐTAG a lényeg, nem a konkrét érték: a támadó a `971744`-et küldi, a
+         * tárolt token pedig ezzel KEZDŐDIK. A maradékot véletlenből tesszük hozzá, hogy
+         * a seedben lévő tokenekkel ne ütközzön (a `name` UNIQUE).
+         */
+        $this->tokenNev = '971744' . bin2hex(random_bytes(13));
+
+        DB::table('tokens')->insert([
+            'name' => $this->tokenNev,
+            'type' => 'api',
+            'uid' => 2,
+            'timeout' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+    }
+
+    /**
+     * A LÉNYEG: a szám-előtag NE találjon rá a tokenre.
+     *
+     * Ez a teszt a javítás előtt elbukik — a MySQL a tárolt sztringet konvertálja.
+     */
+    public function testANumericPrefixDoesNotMatchAToken(): void {
+        self::assertNull(\Eloquent\Token::findByName(971744),
+            'a 971744 szam nem token; a MySQL tipus-konverzioja miatt eddig ratalalt');
+    }
+
+    /**
+     * A VÉDTELEN lekérdezés tényleg rátalál — ez a bizonyíték, hogy a védelem kell.
+     *
+     * Nem a MySQL-t teszteljük elvontan, hanem pontosan azt a hívást, ami eddig négy
+     * helyen állt a kódban. Ha ez valaha `null`-t adna, a DB viselkedése változott — a
+     * védelem akkor is maradjon.
+     */
+    public function testTheUnguardedLookupReallyMatchesANumericPrefix(): void {
+        $talalt = \Eloquent\Token::where('name', 971744)->first();
+
+        self::assertNotNull($talalt,
+            'a vedtelen lekerdezes ratalal a szam-elotagra — ezert kell a findByName()');
+
+        /*
+         * A megtalált token nem feltétlenül a MIÉNK: a `first()` azt adja vissza, amelyik
+         * előbb van a táblában. Épp ez a támadás lényege — a `971744` szám egy IDEGEN
+         * felhasználó tokenjére talált rá.
+         */
+        self::assertStringStartsWith('971744', (string) $talalt->name);
+    }
+
+    /** A valódi token továbbra is működik. */
+    public function testAValidTokenStillResolves(): void {
+        $token = \Eloquent\Token::findByName($this->tokenNev);
+
+        self::assertNotNull($token);
+        self::assertSame(2, (int) $token->uid);
+    }
+
+    /** Nem sztring bemenet: elutasítás, nem konverzió. */
+    public static function nemSztringek(): array {
+        return [
+            'int' => [971744],
+            'float' => [971744.0],
+            'true' => [true],
+            'null' => [null],
+            'tomb' => [['971744']],
+        ];
+    }
+
+    /** @dataProvider nemSztringek */
+    public function testNonStringInputIsRejected($bemenet): void {
+        self::assertNull(\Eloquent\Token::findByName($bemenet));
+    }
+
+    /** Az üres sztring sem token. */
+    public function testAnEmptyStringIsRejected(): void {
+        self::assertNull(\Eloquent\Token::findByName(''));
+    }
+
+    /**
+     * MINDEN hívóhely a védett metódust használja.
+     *
+     * Négy helyen állt ugyanez a minta; ha bármelyik visszatér a nyers `where('name', …)`
+     * alakra, a hiba is visszatér — csak épp ott, ahol senki nem keresi.
+     */
+    public function testNoCallerUsesTheRawLookup(): void {
+        $talalatok = [];
+        $konyvtar = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(dirname(__DIR__, 2) . '/classes')
+        );
+
+        foreach ($konyvtar as $fajl) {
+            if (!$fajl->isFile() || !str_ends_with((string) $fajl->getFilename(), '.php')) {
+                continue;
+            }
+            // A modell maga tartalmazza a lekérdezést — az a védett hely.
+            if (str_ends_with((string) $fajl->getPathname(), '/eloquent/token.php')) {
+                continue;
+            }
+            $tartalom = (string) file_get_contents($fajl->getPathname());
+            if (preg_match('#Token::where\(\s*[\'"]name[\'"]#', $tartalom)) {
+                $talalatok[] = basename((string) $fajl->getPathname());
+            }
+        }
+
+        self::assertSame([], $talalatok,
+            'Ezek nyers Token::where(name, …)-t hasznalnak: ' . implode(', ', $talalatok)
+            . '. Hasznald a Token::findByName()-et — kulonben a szam-bemenet ratalal a tokenre.');
+    }
+}


### PR DESCRIPTION
Closes #862

## A hiba

A `tokens.name` `varchar(40)`, a token 32 jegyű hexadecimális szám. Ha az összehasonlítás másik oldalára **szám** kerül, a MySQL nem a számot alakítja sztringgé, hanem **fordítva** — a tárolt sztringet konvertálja számmá, a vezető számjegyekből:

```sql
SELECT '971744af0e83941bffd19c110a5d2b28' = 971744;   ->  1
```

Az API-k JSON-törzsből olvasnak, ahol a `{"token": 971744}` valódi PHP `int` lesz.

## Reprodukció

```
POST /api/v4/favorites   {"token": 971744}
->  {"favorites":[],"error":0}                     <-- BEENGEDTE

POST /api/v4/favorites   {"token": "971744"}
->  {"error":"1","text":"Invalid token."}
```

**Bárki, token ismerete nélkül**, rövid számokat próbálgatva idegen fiók adataihoz fért — kiolvashatta és módosíthatta a kedvenc-templom listáját. A próbálgatás olcsó: elég a token első néhány számjegyét eltalálni.

## A javítás

A védelem a **modellbe** kerül (`Token::findByName()`), mert négy hívóhely használja ugyanezt a mintát:

- `api/favorites.php`, `api/user.php`, `api/report.php`, `classes/user.php`

Ha mindegyikben külön kellene megcsinálni, egy biztosan kimaradna. A nem sztring bemenet **elutasítás, nem konverzió**: aki számot küld, az nem tokent küldött.

## A törlési út is

A `classes/token.php` két helyen `where('name', $_COOKIE['token'])->delete()`-et hív. Ott a típus-zavar **még súlyosabb** lenne: a `where('name', <szám>)` **több sorra** is illeszkedhet, tehát egy törlés idegen felhasználókat is kiléptethetne. A süti értéke mindig sztring, tehát ma nem kiváltható — de a minta legyen egységes, hogy ne lehessen visszacsempészni.

## A tesztről

A teszt a **védtelen** lekérdezéssel is mér, és ez a bizonyíték: a `971744` szám a seedben lévő **idegen** tokenre talál rá. Pontosan ez a támadás.

Külön őrzöm, hogy egyik hívóhely se térhessen vissza a nyers `Token::where('name', …)` alakra — különben a hiba visszatér, csak épp ott, ahol senki nem keresi.

## Mérés

E2E-ben: a támadás elutasítva (`Invalid token.`), a valódi token továbbra is működik (`error: 0`).

PHP: a teljes futam zöld a két, ettől független környezeti bukást leszámítva.
