### PR TITLE
Bárki, bejelentkezés nélkül átírhatta bármely észrevétel állapotát (#868)

### DIFF
--- a/.agents/scheduled_tasks.lock
+++ b/.agents/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"fa78c155-3884-4bb2-9186-f21666f19bd8","pid":85250,"procStart":"Thu Aug 20 04:16:50 2026","acquiredAt":1787213849075}

--- a/webapp/classes/html/remark.php
+++ b/webapp/classes/html/remark.php
@@ -37,29 +37,72 @@ class Remark extends Html {
         }
     }
     
+    /** #868: az észrevétel érvényes állapotai (l. `remarks.allapot` enum). */
+    const ALLAPOTOK = ['u', 'f', 'j'];
+
     function pageList() {
         if (\Request::Simpletext('remark') == 'modify') {
             $rid = \Request::IntegerRequired('rid');
             $remark = \Eloquent\Remark::find($rid);
-            
-            $remark->allapot = \Request::Simpletext('state');
-            $remark->admindatum = date('Y-m-d H:i:s');
-            
-            $remark->appendComment(\Request::Text('adminmegj'));
-            $remark->save();
-            
-            if($this->tid != $remark->church_id) { // Hogy ne lehessen csalni
+
+            /*
+             * #868: ELŐBB a jogosultság, AZTÁN a mentés.
+             *
+             * Itt korábban a `save()` a `writeAccess` őr ELŐTT futott le — az őr csak
+             * lentebb, a lista megjelenítése előtt állt. Következmény, mérve, sima
+             * GET-tel, bejelentkezés NÉLKÜL:
+             *
+             *   /index.php?q=remark/list/1&remark=modify&rid=3&state=f&adminmegj=…
+             *   -> HTTP 200, és az adatbázisban: allapot u -> f, admindatum frissült,
+             *      az adminmegj-be bekerült a támadó szövege.
+             *
+             * Vagyis bárki elrejthette a bejelentéseket a gondnokok elől („f" =
+             * feldolgozva), és tetszőleges tartalmat írhatott az admin-megjegyzésbe,
+             * amit a lista a gondnok böngészőjében jelenít meg.
+             *
+             * A jogot a MEGTALÁLT észrevétel templomához nézzük, nem az URL-ből jövő
+             * `tid`-hez: az utóbbi a támadó paramétere. (A régi kód ezt a mentés UTÁN
+             * javította ki — „hogy ne lehessen csalni" —, csak épp későn.)
+             */
+            if (!$remark) {
+                addMessage('Nincs ilyen észrevétel.', 'danger');
+                return;
+            }
+
+            if ($this->tid != $remark->church_id) {
                 $this->tid = $remark->church_id;
                 $this->church = \Eloquent\Church::find($this->tid);
             }
+
+            if (!$this->church || !$this->church->writeAccess) {
+                addMessage('Hiányzó jogosultság. Elnézést.', 'danger');
+                return;
+            }
+
+            /*
+             * #868: az állapot FEHÉRLISTÁS. A `Simpletext` bármit átenged, az oszlop
+             * viszont enum — egy ismeretlen érték némán üres stringgé válna, és az
+             * észrevétel besorolhatatlan állapotba kerülne.
+             */
+            $ujAllapot = \Request::Simpletext('state');
+            if (!in_array($ujAllapot, self::ALLAPOTOK, true)) {
+                addMessage('Érvénytelen állapot.', 'danger');
+                return;
+            }
+
+            $remark->allapot = $ujAllapot;
+            $remark->admindatum = date('Y-m-d H:i:s');
+
+            $remark->appendComment(\Request::Text('adminmegj'));
+            $remark->save();
         }
-       
+
         global $user;
         if (!$this->church->writeAccess) {
             addMessage("Hiányzó jogosultság. Elnézést.", "danger");
             return;
         }
-        
+
         $this->church->remarks;
 
         // Split adminmegj by line into adminmegjlist for each remark, and extract meta info if present

--- a/webapp/tests/Integration/RemarkModifyAuthTest.php
+++ b/webapp/tests/Integration/RemarkModifyAuthTest.php
@@ -1,0 +1,166 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #868: bárki, bejelentkezés nélkül átírhatta bármely észrevétel állapotát.
+ *
+ * A `Html\Remark::pageList()` a `?remark=modify` ágban betöltötte az észrevételt,
+ * állította az `allapot`-ot, az `admindatum`-ot, megjegyzést fűzött hozzá és MENTETT —
+ * mindezt azelőtt, hogy a `writeAccess` őr lefutott volna. Az őr csak lentebb, a lista
+ * megjelenítése előtt állt.
+ *
+ * Mérve, sima GET-tel, süti nélkül:
+ *
+ *   /index.php?q=remark/list/1&remark=modify&rid=3&state=f&adminmegj=ANONIM-INJEKCIO
+ *   -> HTTP 200, és az adatbázisban: allapot 'u' -> 'f', admindatum frissült,
+ *      az adminmegj-be bekerült a támadó szövege.
+ *
+ * Két kár egyszerre: a bejelentés eltűnik a gondnokok szeme elől (az „f" =
+ * feldolgozva), és a támadó tetszőleges tartalmat írhat az admin-megjegyzésbe, amit a
+ * lista a gondnok böngészőjében jelenít meg.
+ */
+final class RemarkModifyAuthTest extends TestCase {
+
+    private int $churchId;
+    private int $remarkId;
+
+    protected function setUp(): void {
+        DB::beginTransaction();
+
+        $this->churchId = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Észrevétel teszt', 'ok' => 'i', 'lat' => 47.0, 'lon' => 19.0,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+
+        $this->remarkId = (int) DB::table('remarks')->insertGetId([
+            'church_id' => $this->churchId,
+            'nev' => 'Teszt Bejelentő',
+            'login' => '',
+            'email' => 'bejelento@example.invalid',
+            'megbizhato' => '?',
+            'admin' => '',
+            'leiras' => 'Teszt bejelentés',
+            'allapot' => 'u',
+            'admindatum' => '0000-00-00 00:00:00',
+        ]);
+
+        // A vendég felhasználó: se bejelentkezés, se jogosultság.
+        $GLOBALS['user'] = new \User();
+        $_REQUEST = [];
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        $_REQUEST = [];
+    }
+
+    private function allapot(): string {
+        return (string) DB::table('remarks')->where('id', $this->remarkId)->value('allapot');
+    }
+
+    private function megjegyzes(): ?string {
+        return DB::table('remarks')->where('id', $this->remarkId)->value('adminmegj');
+    }
+
+    private function modositasKiserlet(string $state = 'f', string $megj = 'ANONIM-INJEKCIO'): void {
+        $_REQUEST = [
+            'remark' => 'modify',
+            'rid' => (string) $this->remarkId,
+            'state' => $state,
+            'adminmegj' => $megj,
+        ];
+
+        try {
+            new \Html\Remark(['list', (string) $this->churchId]);
+        } catch (\Throwable $e) {
+            // A jogosultság hiánya kivétellel is végződhet — a lényeg, hogy ne mentsen.
+        }
+    }
+
+    /** A LÉNYEG: a vendég ne tudja átállítani az állapotot. */
+    public function testAGuestCannotChangeTheState(): void {
+        $this->modositasKiserlet();
+
+        self::assertSame('u', $this->allapot(),
+            'bejelentkezes nelkul nem lehet a bejelentest feldolgozottra allitani');
+    }
+
+    /** ...és ne tudjon az admin-megjegyzésbe írni. */
+    public function testAGuestCannotInjectIntoTheAdminNote(): void {
+        $this->modositasKiserlet('f', 'ANONIM-INJEKCIO');
+
+        self::assertStringNotContainsString('ANONIM-INJEKCIO', (string) $this->megjegyzes(),
+            'a vendeg nem irhat az admin-megjegyzesbe, amit a gondnok bongeszoje jelenit meg');
+    }
+
+    /** Az `admindatum` sem mozdulhat — a lista abból számol „mikor foglalkoztak vele". */
+    public function testAGuestCannotTouchTheAdminTimestamp(): void {
+        $elotte = DB::table('remarks')->where('id', $this->remarkId)->value('admindatum');
+
+        $this->modositasKiserlet();
+
+        self::assertSame($elotte, DB::table('remarks')->where('id', $this->remarkId)->value('admindatum'));
+    }
+
+    /**
+     * Az URL-ből jövő `tid` NEM dönthet a jogosultságról.
+     *
+     * A régi kód a mentés UTÁN igazította a templomot („hogy ne lehessen csalni") —
+     * csak épp későn: a `save()` addigra megtörtént.
+     */
+    public function testTheChurchComesFromTheRemarkNotTheUrl(): void {
+        $masikChurch = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Másik templom', 'ok' => 'i', 'lat' => 47.1, 'lon' => 19.1,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+
+        $_REQUEST = [
+            'remark' => 'modify',
+            'rid' => (string) $this->remarkId,
+            'state' => 'f',
+            'adminmegj' => 'MASIK-TEMPLOMON-AT',
+        ];
+
+        try {
+            // A támadó a MÁSIK templom útvonalán próbálkozik.
+            new \Html\Remark(['list', (string) $masikChurch]);
+        } catch (\Throwable $e) {
+            // rendben
+        }
+
+        self::assertSame('u', $this->allapot());
+    }
+
+    /** Nemlétező azonosítóra ne szálljon el `null`-on. */
+    public function testAMissingRemarkDoesNotCrash(): void {
+        $_REQUEST = [
+            'remark' => 'modify',
+            'rid' => '99999999',
+            'state' => 'f',
+            'adminmegj' => 'nincs ilyen',
+        ];
+
+        try {
+            new \Html\Remark(['list', (string) $this->churchId]);
+            $hiba = null;
+        } catch (\Throwable $e) {
+            $hiba = $e;
+        }
+
+        self::assertNotInstanceOf(\Error::class, $hiba,
+            'a nemletezo eszrevetel ne okozzon null-on hivast');
+    }
+
+    /** Az állapot fehérlistás — az oszlop enum, az ismeretlen érték nem kerülhet bele. */
+    public function testTheStateIsWhitelisted(): void {
+        self::assertSame(['u', 'f', 'j'], \Html\Remark::ALLAPOTOK);
+    }
+}


### PR DESCRIPTION
Closes #868

**Ezt érdemes előre venni** — bejelentkezés nélkül, egyetlen linkkel kiváltható.

## A hiba

A `pageList()` a `?remark=modify` ágban betöltötte az észrevételt, állította az állapotot, az `admindatum`-ot, megjegyzést fűzött hozzá és **mentett** — mindezt azelőtt, hogy a `writeAccess` őr lefutott volna. Az őr csak lentebb, a lista megjelenítése előtt állt.

## Reprodukció

Sima GET, süti nélkül:

```
/index.php?q=remark/list/1&remark=modify&rid=3&state=f&adminmegj=ANONIM-INJEKCIO
```

`HTTP 200`, és az adatbázisban utána:

```
id  allapot  adminmegj                    admindatum
3   f        \n<img src='/img/edit.gif'…  2026-08-20 10:25:05
```

## Két kár

1. **A bejelentés eltűnik a gondnokok elől.** Az `f` = feldolgozva; a kezelendő észrevételek listája nem mutatja többé. Egy támadó **minden** bejelentést elrejthet.
2. **Tetszőleges tartalom az admin-megjegyzésbe**, amit a lista a **gondnok böngészőjében** jelenít meg.

GET-en megy és CSRF-token nincs, tehát egy beágyazott `<img src>` is kiváltja — nem kell hozzá, hogy a támadó maga nyissa meg a linket. Elég, ha a gondnok megnyit egy oldalt, ahova beágyazták.

## A javítás

A jogot a **megtalált észrevétel** templomához nézem, nem az URL-ből jövő `tid`-hez: az utóbbi a támadó paramétere. A régi kód ezt a mentés **után** javította ki — „hogy ne lehessen csalni" —, tehát a szándék megvolt, csak a sorrend volt rossz.

Mellette két apróság: az állapot **fehérlistás** lesz (a `Simpletext` bármit átenged, az oszlop viszont `enum('u','f','j')`, és ismeretlen érték némán üres stringgé válna), és a nemlétező azonosító sem okoz `null`-on hívást.

## Mérés

E2E-ben: ugyanaz a támadó kérés a javítás után nem mozdítja az adatot (`allapot` marad `u`, `adminmegj` üres).

Visszaméréssel: a javítás nélkül hat tesztből **öt bukik és egy hibára fut**.

PHP: a teljes futam zöld a két, ettől független környezeti bukást leszámítva.

## Amit külön érdemes átgondolnod

Az állapotváltás **GET**-en megy. Ez akkor is CSRF-sebezhető marad, ha a jogosultság rendben van: egy bejelentkezett gondnokot egy beágyazott képpel rá lehet venni, hogy „feldolgozottra" állítson egy bejelentést. A POST-ra kötés + token külön jegy — szólj, ha kéred.
