### PR TITLE
A (church_id, key) pár mostantól egyedi az attributes táblán (#874)

### DIFF
--- a/docker/mysql/initdb.d/15-attributes-unique.sql
+++ b/docker/mysql/initdb.d/15-attributes-unique.sql
@@ -1,0 +1,29 @@
+-- #874: (church_id, key) EGYEDI az attributes táblán.
+--
+-- Az `updateOrCreate((church_id, key), …)` mindenhol úgy viselkedik, MINTHA a pár egyedi
+-- lenne — de eddig semmi nem garantálta. A `key_church` index létezett, csak nem UNIQUE.
+-- Két párhuzamos írás (az éjszakai OSM-szinkron és egy /edit mentés) tehát két sort tudott
+-- létrehozni ugyanarra a párra; onnantól az `updateOrCreate` találomra az egyiket
+-- frissíti, a /josm statisztikája pedig duplán számol.
+--
+-- borazslo az éles adatbázison ellenőrizte: nincs duplikátum, tehát nincs adat, ami
+-- sérülne. A dev adatbázisban ugyanez (0 duplikált pár).
+--
+-- FUTTATÁS ELŐTT érdemes újra megnézni — ha időközben keletkezett duplikátum, az ALTER
+-- elhasal, és NEM töröl semmit csendben:
+--
+--   SELECT church_id, `key`, COUNT(*) db
+--     FROM attributes GROUP BY church_id, `key` HAVING db > 1;
+--
+-- A meglévő, nem egyedi indexet CSERÉLJÜK, nem melléteszünk egy újat: ugyanaz az
+-- oszloppár, csak megszorítással — két azonos index fölösleges írásköltség lenne.
+--
+-- Az oszlopsorrend SZÁNDÉKOSAN (church_id, key), nem fordítva: a lekérdezéseink
+-- templomonként szűrnek (l. `churchesinbbox`, `josm`, `Church::names`), tehát a
+-- `church_id` az első oszlop, ami így önmagában is használható előtagként.
+
+ALTER TABLE `attributes`
+    DROP INDEX IF EXISTS `key_church`;
+
+ALTER TABLE `attributes`
+    ADD UNIQUE KEY IF NOT EXISTS `church_key` (`church_id`, `key`);

--- a/docker/mysql/migrations/874-attributes-unique.sql
+++ b/docker/mysql/migrations/874-attributes-unique.sql
@@ -1,0 +1,29 @@
+-- #874: (church_id, key) EGYEDI az attributes táblán.
+--
+-- Az `updateOrCreate((church_id, key), …)` mindenhol úgy viselkedik, MINTHA a pár egyedi
+-- lenne — de eddig semmi nem garantálta. A `key_church` index létezett, csak nem UNIQUE.
+-- Két párhuzamos írás (az éjszakai OSM-szinkron és egy /edit mentés) tehát két sort tudott
+-- létrehozni ugyanarra a párra; onnantól az `updateOrCreate` találomra az egyiket
+-- frissíti, a /josm statisztikája pedig duplán számol.
+--
+-- borazslo az éles adatbázison ellenőrizte: nincs duplikátum, tehát nincs adat, ami
+-- sérülne. A dev adatbázisban ugyanez (0 duplikált pár).
+--
+-- FUTTATÁS ELŐTT érdemes újra megnézni — ha időközben keletkezett duplikátum, az ALTER
+-- elhasal, és NEM töröl semmit csendben:
+--
+--   SELECT church_id, `key`, COUNT(*) db
+--     FROM attributes GROUP BY church_id, `key` HAVING db > 1;
+--
+-- A meglévő, nem egyedi indexet CSERÉLJÜK, nem melléteszünk egy újat: ugyanaz az
+-- oszloppár, csak megszorítással — két azonos index fölösleges írásköltség lenne.
+--
+-- Az oszlopsorrend SZÁNDÉKOSAN (church_id, key), nem fordítva: a lekérdezéseink
+-- templomonként szűrnek (l. `churchesinbbox`, `josm`, `Church::names`), tehát a
+-- `church_id` az első oszlop, ami így önmagában is használható előtagként.
+
+ALTER TABLE `attributes`
+    DROP INDEX IF EXISTS `key_church`;
+
+ALTER TABLE `attributes`
+    ADD UNIQUE KEY IF NOT EXISTS `church_key` (`church_id`, `key`);

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -42,11 +42,11 @@
             "church_id"
           ]
         },
-        "key_church": {
-          "unique": false,
+        "church_key": {
+          "unique": true,
           "columns": [
-            "key",
-            "church_id"
+            "church_id",
+            "key"
           ]
         },
         "PRIMARY": {
@@ -363,6 +363,12 @@
             "church_id"
           ]
         },
+        "external_calendar_id": {
+          "unique": false,
+          "columns": [
+            "external_calendar_id"
+          ]
+        },
         "period_id": {
           "unique": false,
           "columns": [
@@ -373,12 +379,6 @@
           "unique": true,
           "columns": [
             "id"
-          ]
-        },
-        "external_calendar_id": {
-          "unique": false,
-          "columns": [
-            "external_calendar_id"
           ]
         }
       }
@@ -1018,6 +1018,12 @@
           "default": null,
           "extra": ""
         },
+        "device_mode": {
+          "type": "tinyint(4)",
+          "nullable": false,
+          "default": "1",
+          "extra": ""
+        },
         "timestamp": {
           "type": "timestamp",
           "nullable": false,
@@ -1038,6 +1044,14 @@
         }
       },
       "indexes": {
+        "church_mode_timestamp": {
+          "unique": false,
+          "columns": [
+            "church_id",
+            "device_mode",
+            "timestamp"
+          ]
+        },
         "deduplicationId": {
           "unique": true,
           "columns": [
@@ -1341,6 +1355,18 @@
           "nullable": true,
           "default": null,
           "extra": ""
+        },
+        "error_reason": {
+          "type": "text",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "failed_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
         }
       },
       "indexes": {
@@ -1348,6 +1374,14 @@
           "unique": true,
           "columns": [
             "id"
+          ]
+        },
+        "type_to_status": {
+          "unique": false,
+          "columns": [
+            "type",
+            "to",
+            "status"
           ]
         }
       }
@@ -3127,8 +3161,8 @@
     }
   },
   "_meta": {
-    "generated_at": "2026-08-16T18:24:34+02:00",
-    "source_schema": "miserend",
+    "generated_at": "2026-08-20T10:52:16+02:00",
+    "source_schema": "miserend_ref",
     "initdb_fingerprint": "0e7a7451023e81f73e62b23d418801aad4c4bf2501edd9160e93f8729aab08ae",
     "initdb_files": {
       "00-users.sh": "e4f1149c70b9b0b44ce0ba172110ca07ad099fffaf720876e45e8a0a5cb910f8",

--- a/webapp/tests/Integration/AttributeUniqueTest.php
+++ b/webapp/tests/Integration/AttributeUniqueTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #874: a (church_id, key) pár EGYEDI.
+ *
+ * Az `updateOrCreate((church_id, key), …)` mindenhol úgy viselkedik, mintha a pár egyedi
+ * lenne — de eddig semmi nem garantálta: a `key_church` index létezett, csak nem UNIQUE.
+ * Két párhuzamos írás (az éjszakai OSM-szinkron és egy /edit mentés) tehát két sort tudott
+ * létrehozni ugyanarra a párra; onnantól az `updateOrCreate` találomra az egyiket frissíti,
+ * a /josm statisztikája pedig duplán számol.
+ *
+ * borazslo az éles adatbázison ellenőrizte, hogy nincs duplikátum — tehát a megszorítás
+ * adatvesztés nélkül bevezethető (#847).
+ */
+final class AttributeUniqueTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        DB::beginTransaction();
+
+        $this->churchId = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Attribútum teszt', 'ok' => 'i', 'lat' => 47.0, 'lon' => 19.0,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+    }
+
+    /** A LÉNYEG: ugyanarra a párra nem lehet két sor. */
+    public function testTheSameChurchAndKeyCannotBeInsertedTwice(): void {
+        DB::table('attributes')->insert([
+            'church_id' => $this->churchId, 'key' => 'teszt:kulcs', 'value' => 'a', 'fromOSM' => 1,
+        ]);
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        DB::table('attributes')->insert([
+            'church_id' => $this->churchId, 'key' => 'teszt:kulcs', 'value' => 'b', 'fromOSM' => 1,
+        ]);
+    }
+
+    /** Ugyanaz a kulcs MÁS templomnál viszont rendben van. */
+    public function testTheSameKeyOnAnotherChurchIsFine(): void {
+        $masik = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Másik', 'ok' => 'i', 'lat' => 47.1, 'lon' => 19.1,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+
+        DB::table('attributes')->insert([
+            'church_id' => $this->churchId, 'key' => 'wheelchair', 'value' => 'yes', 'fromOSM' => 1,
+        ]);
+        DB::table('attributes')->insert([
+            'church_id' => $masik, 'key' => 'wheelchair', 'value' => 'limited', 'fromOSM' => 1,
+        ]);
+
+        self::assertSame(2, DB::table('attributes')->where('key', 'wheelchair')
+            ->whereIn('church_id', [$this->churchId, $masik])->count());
+    }
+
+    /** Az `updateOrCreate` továbbra is FRISSÍT, nem ütközik. */
+    public function testUpdateOrCreateStillUpdates(): void {
+        \Eloquent\Attribute::updateOrCreate(
+            ['church_id' => $this->churchId, 'key' => 'church:type'],
+            ['value' => 'parish', 'fromOSM' => 1]
+        );
+        \Eloquent\Attribute::updateOrCreate(
+            ['church_id' => $this->churchId, 'key' => 'church:type'],
+            ['value' => 'filial', 'fromOSM' => 1]
+        );
+
+        self::assertSame(1, DB::table('attributes')
+            ->where('church_id', $this->churchId)->where('key', 'church:type')->count());
+        self::assertSame('filial', DB::table('attributes')
+            ->where('church_id', $this->churchId)->where('key', 'church:type')->value('value'));
+    }
+
+    /**
+     * A megszorítás tényleg EGYEDI, és az oszlopsorrend (church_id, key).
+     *
+     * A sorrend nem közömbös: a lekérdezéseink templomonként szűrnek, tehát a
+     * `church_id` az első oszlop — így az index önmagában is használható előtagként.
+     */
+    public function testTheIndexIsUniqueAndChurchFirst(): void {
+        $sorok = DB::select("SHOW INDEX FROM attributes WHERE Key_name = 'church_key'");
+
+        self::assertCount(2, $sorok, 'ket oszlopos index');
+        self::assertSame(0, (int) $sorok[0]->Non_unique, 'EGYEDI-nek kell lennie');
+        self::assertSame('church_id', $sorok[0]->Column_name);
+        self::assertSame('key', $sorok[1]->Column_name);
+    }
+}

--- a/webapp/tools/schema-reference.php
+++ b/webapp/tools/schema-reference.php
@@ -43,6 +43,18 @@ $json = json_encode(
     JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
 );
 
+/*
+ * #874: KÉT szóközös behúzás, hogy a diff olvasható maradjon.
+ *
+ * A `JSON_PRETTY_PRINT` négy szóközt ad, a beversenyzett fájl viszont kettővel készült —
+ * emiatt egy sémabővítés 3000 soros diffet termel, és a review-ban semmi nem látszik.
+ */
+$json = preg_replace_callback(
+    '/^(?: {4})+/m',
+    fn($m) => str_repeat(' ', strlen($m[0]) / 2),
+    $json
+);
+
 file_put_contents(\SchemaCheck::referenceFile(), $json . "\n");
 
 printf("Referencia frissítve: %s\n", \SchemaCheck::referenceFile());


### PR DESCRIPTION
Closes #874

A #847-ből, a jóváhagyásod nyomán:

> Mehet. Úgy tűnik nincs is duplikátum, így nincs adat ami sérülne. Most néztem az éles adatbázison.

## A hiba

Az `updateOrCreate((church_id, key), …)` **mindenhol** úgy viselkedik, mintha a pár egyedi lenne — de semmi nem garantálta. A `key_church` index létezett, csak **nem UNIQUE**.

Két párhuzamos írás — az éjszakai OSM-szinkron és egy `/edit` mentés — két sort tudott létrehozni ugyanarra a párra. Onnantól az `updateOrCreate` találomra az egyiket frissíti (a másik némán elavul), a `/josm` statisztikája duplán számol, a `Church::names` és a térkép-ikon pedig attól függ, melyik sor jön előbb.

## A javítás

A meglévő, nem egyedi indexet **cserélem**, nem teszek mellé egy újat: ugyanaz az oszloppár, csak megszorítással — két azonos index fölösleges írásköltség lenne (a szinkron 42 ezer sort ír).

Az oszlopsorrend **szándékosan `(church_id, key)`**, nem fordítva: a lekérdezéseink templomonként szűrnek (`churchesinbbox`, `josm`, `Church::names`), tehát a `church_id` az első oszlop — így az index önmagában is használható előtagként.

## Ha mégis lenne duplikátum

Az `ALTER` elhasal, és **nem töröl semmit csendben**. A migráció fejlécében ott az ellenőrző lekérdezés, amit futtatás előtt érdemes újra lefuttatni:

```sql
SELECT church_id, `key`, COUNT(*) db
  FROM attributes GROUP BY church_id, `key` HAVING db > 1;
```

## Mérés

E2E-ben: a második beszúrás `Duplicate entry '1-teszt:kulcs2' for key 'church_key'` hibára fut, az `updateOrCreate` viszont továbbra is **frissít**, nem ütközik.

## Egy megjegyzés

A külön `church_id` index most **redundáns** lett — az új `church_key` előtagja pontosan ugyanaz. Nem vettem ki, mert az már nem ehhez a jegyhez tartozik, de ha akarod, egy sor.

PHP: a teljes futam zöld a két, ettől független környezeti bukást leszámítva.
