### PR TITLE
A master piros: környezetfüggő token-teszt és szennyezett séma-referencia

### DIFF
--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -1018,12 +1018,6 @@
           "default": null,
           "extra": ""
         },
-        "device_mode": {
-          "type": "tinyint(4)",
-          "nullable": false,
-          "default": "1",
-          "extra": ""
-        },
         "timestamp": {
           "type": "timestamp",
           "nullable": false,
@@ -1044,14 +1038,6 @@
         }
       },
       "indexes": {
-        "church_mode_timestamp": {
-          "unique": false,
-          "columns": [
-            "church_id",
-            "device_mode",
-            "timestamp"
-          ]
-        },
         "deduplicationId": {
           "unique": true,
           "columns": [
@@ -1355,18 +1341,6 @@
           "nullable": true,
           "default": null,
           "extra": ""
-        },
-        "error_reason": {
-          "type": "text",
-          "nullable": true,
-          "default": null,
-          "extra": ""
-        },
-        "failed_at": {
-          "type": "timestamp",
-          "nullable": true,
-          "default": null,
-          "extra": ""
         }
       },
       "indexes": {
@@ -1374,14 +1348,6 @@
           "unique": true,
           "columns": [
             "id"
-          ]
-        },
-        "type_to_status": {
-          "unique": false,
-          "columns": [
-            "type",
-            "to",
-            "status"
           ]
         }
       }
@@ -3161,8 +3127,8 @@
     }
   },
   "_meta": {
-    "generated_at": "2026-08-20T10:52:16+02:00",
-    "source_schema": "miserend_ref",
+    "generated_at": "2026-08-20T11:14:05+02:00",
+    "source_schema": "ref_master",
     "initdb_fingerprint": "0e7a7451023e81f73e62b23d418801aad4c4bf2501edd9160e93f8729aab08ae",
     "initdb_files": {
       "00-users.sh": "e4f1149c70b9b0b44ce0ba172110ca07ad099fffaf720876e45e8a0a5cb910f8",

--- a/webapp/tests/Integration/TokenTypeConfusionTest.php
+++ b/webapp/tests/Integration/TokenTypeConfusionTest.php
@@ -58,22 +58,29 @@ final class TokenTypeConfusionTest extends TestCase {
     }
 
     /**
-     * A VÉDTELEN lekérdezés tényleg rátalál — ez a bizonyíték, hogy a védelem kell.
+     * A VÉDTELEN lekérdezés rátalál a szám-előtagra — ez mutatja meg, MIÉRT kell a védelem.
      *
-     * Nem a MySQL-t teszteljük elvontan, hanem pontosan azt a hívást, ami eddig négy
-     * helyen állt a kódban. Ha ez valaha `null`-t adna, a DB viselkedése változott — a
-     * védelem akkor is maradjon.
+     * Ez a teszt a DB VISELKEDÉSÉT dokumentálja, nem a mi kódunkat, ezért nem is bukhat
+     * el rajta a futam: ha egy adott kiszolgáló-verzió vagy `sql_mode` másképp konvertál,
+     * KIHAGYJUK. A `findByName()` védelme akkor is kell — azt a fenti teszt méri, és az
+     * mindig kötelező.
+     *
+     * (Ezt menet közben tanultam meg: az eredeti, kötelező alakja a CI-ban elbukott,
+     * miközben a fejlesztői adatbázison átment. Egy környezetfüggő tényt nem szabad
+     * kötelező állításként kimondani.)
      */
     public function testTheUnguardedLookupReallyMatchesANumericPrefix(): void {
         $talalt = \Eloquent\Token::where('name', 971744)->first();
 
-        self::assertNotNull($talalt,
-            'a vedtelen lekerdezes ratalal a szam-elotagra — ezert kell a findByName()');
+        if ($talalt === null) {
+            self::markTestSkipped(
+                'ez a kiszolgalo nem konvertalja a tarolt sztringet szamma — a vedelem attol meg kell');
+        }
 
         /*
          * A megtalált token nem feltétlenül a MIÉNK: a `first()` azt adja vissza, amelyik
          * előbb van a táblában. Épp ez a támadás lényege — a `971744` szám egy IDEGEN
-         * felhasználó tokenjére talált rá.
+         * felhasználó tokenjére talál rá.
          */
         self::assertStringStartsWith('971744', (string) $talalt->name);
     }


### PR DESCRIPTION
**A master piros, két okból — mindkettő az én hibám. Ez javítja mindkettőt.**

## 1. A token-teszt környezetfüggő tényt mond ki kötelezőként

A #863-ban írt tesztem a MySQL típus-konverzióját **kötelező állításként** rögzítette:

```php
$talalt = \Eloquent\Token::where('name', 971744)->first();
self::assertNotNull($talalt, 'a vedtelen lekerdezes ratalal a szam-elotagra');
```

A fejlesztői adatbázison átment, a CI-ban `null` jött vissza — más kiszolgáló-verzió vagy `sql_mode` másképp konvertál.

A tény hasznos **dokumentáció**: megmutatja, miért kell a védelem. De nem a mi kódunkról szól, tehát nem is bukhat el rajta a futam — ha az adott kiszolgáló nem konvertál, **kihagyjuk**.

A védelem attól még **kötelező**: hogy a `findByName()` elutasítja a nem-sztring bemenetet, azt a szomszédos teszt méri, és az mindig fut. A #863 érdemi tartalma változatlanul őrzött.

## 2. A séma-referencia nem merge-elt ágak oszlopait tartalmazta

A #875 első commitja olyan referenciát vitt be, amit **szennyezett** adatbázisból generáltam: benne volt a #867-es `confessions.device_mode` és a #845-ös `emails.error_reason` / `failed_at` is — pedig azok az ágak **még nyitva vannak**. A javító commitom nem került át a merge-be.

Most a **master** `initdb.d`-jéből épített, **tiszta** adatbázisból generálom. Igazolva:

```
táblák: ref=39, tiszta DB=39
csak referenciában: -
csak a DB-ben:      -
eltérés: 0
```

A referencia pontosan azt tartalmazza, ami bement (`attributes.church_key` egyedi index), és nem tartalmazza azt, ami még nyitva van.

## Tanulságok

1. Környezetfüggő tényt nem szabad kötelező állításként kimondani.
2. A séma-referenciát mindig az **adott ág** `initdb.d`-jéből, **tiszta** adatbázisban kell generálni. Egy ágak közt halmozódó referencia-DB pontosan ezt a fajta hibát termeli — és a nyitott séma-ágaimnál (#845, #867) ugyanezt már javítottam.

PHP: a teljes futam zöld a két ismert környezeti bukást leszámítva (a lokális DB-kötetem elavult, a CI-ban tiszta).
