### PR TITLE
Platform jelölő törlése a Docker compose-ból a mysql konténernél

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -99,7 +99,6 @@ services:
       start_period: 30s
   mysql:
     image: mariadb:12
-    platform: linux/amd64
     volumes:
       - db_data:/var/lib/mysql
       - ./mysql/initdb.d:/docker-entrypoint-initdb.d


### PR DESCRIPTION
A `compose.yml` fájlban a `mysql` konténernél rögzítve volt a `linux/amd64` platform. Ezt töröltem, és így is működik megfelelően, immáron emuláció nélkül arm alatt.
Javaslat: az miserend-elasticsearch-data image-t lehetne buildelni Raspberry Pi 4 architektúrára is, nem tudom, hogy erre mennyire van igény és/vagy erőforrás a Github Actionsben, de így nem kellene emulátort telepíteni Raspberry Pi-re.