### PR TITLE
CSRF-védelem: POST + token minden állapotváltáshoz (#873)

### DIFF
--- a/webapp/classes/csrf.php
+++ b/webapp/classes/csrf.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * #873: CSRF-védelem — POST + együtt utazó token.
+ *
+ * A gond, amiből a jegy indult (#869): az állapotváltásaink GET-en mennek, és
+ * kizárólag a süti azonosítja a kérést. A böngésző a sütit MINDEN kéréshez
+ * mellékeli, akkor is, ha a kérést egy idegen oldal indította — egy `<img
+ * src="https://miserend.hu/church/1/changeholders?uid=666&access=allowed">` a
+ * bejelentkezett adminunk nevében ad ki jogosultságot. A jogosultság-ellenőrzés
+ * ilyenkor hibátlanul lefut, és igent mond: tényleg az admin kérte, csak épp nem
+ * ő akarta.
+ *
+ * Két, egymást kiegészítő őr kell:
+ *
+ *   1. LEGYEN POST. Ez önmagában kizárja a `<img>`, `<script>`, `<link>` és a
+ *      puszta link alakú támadásokat — azok mind GET-et adnak ki. Rejtett űrlapot
+ *      viszont továbbra is lehet küldeni, ezért kell a második is.
+ *   2. LEGYEN TOKEN. Olyan érték, amit a támadó oldala nem tud kitalálni és nem
+ *      tud kiolvasni. A böngésző a sütinket automatikusan küldi, de a sütink
+ *      TARTALMÁT az idegen oldal nem látja (same-origin policy), tehát a
+ *      belőle számolt tokent sem tudja mellékelni.
+ *
+ * Miért külön süti, és miért nem a belépési token?
+ *
+ * borazslo felvetette (#873), hogy „egyszerűen a belépett user tokenjét küldjük
+ * át". A gondolat jó — de a belépési token a `token` sütiben él, és két gyakorlati
+ * baja lenne:
+ *
+ *   - A vendég is küld be űrlapot (észrevétel, javaslat, regisztráció), neki
+ *     viszont nincs belépési tokenje. Így minden ilyen űrlap kiesne a védelemből,
+ *     vagy külön ágat kapna.
+ *   - A belépés/kilépés lecseréli a tokent. A már megnyitott lapok űrlapjai
+ *     ilyenkor elavult tokent hordoznának, és a beküldés — látszólag ok nélkül —
+ *     elszállna.
+ *
+ * Ezért külön, kizárólag erre a célra szolgáló sütit használok. Ami a lapra kerül,
+ * az nem a süti értéke, hanem annak lenyomata: ha a token valaha kiszivárog (napló,
+ * Referer, képernyőkép), a süti értéke akkor sem derül ki belőle.
+ */
+class Csrf {
+
+    /** A süti neve. HttpOnly: a böngészőben futó szkriptnek sem kell látnia. */
+    const COOKIE = 'csrf';
+
+    /** Az űrlapmező és a JSON/ajax fejléc neve. */
+    const FIELD = 'csrf_token';
+    const HEADER = 'HTTP_X_CSRF_TOKEN';
+
+    /** A süti élettartama. Bőven túl a leghosszabb belépési tokenen (2 hét). */
+    const LIFETIME = '+1 year';
+
+    /** Teszt/CLI: ha nem tudunk sütit küldeni, ebben tartjuk a kérés erejéig. */
+    private static ?string $memoria = null;
+
+    /**
+     * A lapra kitehető token. Mellékhatása van: ha még nincs sütink, itt keletkezik.
+     * Ezért a sablonokba GLOBÁLISKÉNT kerül (l. buildTwigEnvironment) — így minden
+     * oldal legenerálja, még mielőtt bármit kiírnánk.
+     */
+    public static function token(): string {
+        return hash('sha256', 'miserend-csrf|' . self::titok());
+    }
+
+    /** A rejtett űrlapmező, kész HTML-ként. */
+    public static function field(): string {
+        return '<input type="hidden" name="' . self::FIELD . '" value="' . htmlspecialchars(self::token(), ENT_QUOTES, 'UTF-8') . '">';
+    }
+
+    /**
+     * Érvényes-e a beküldött token?
+     *
+     * Az összehasonlítás `hash_equals`: futásidő-független, tehát a token nem
+     * találgatható ki bájtonként a válaszidőből.
+     */
+    public static function valid(): bool {
+        $kuldott = self::submitted();
+        if ($kuldott === '') {
+            return false;
+        }
+        return hash_equals(self::token(), $kuldott);
+    }
+
+    /**
+     * Az őr: POST-ot és érvényes tokent követel.
+     *
+     * Kivételt dob, mert a hívási helyeken (Html\* konstruktorok) ez a bevett mód:
+     * az index.php elkapja, naplóz, és hibaoldalt/JSON-hibát ad. A 403-at előre
+     * kiírjuk, hogy a válasz státusza is beszédes legyen.
+     */
+    public static function guard(): void {
+        if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+            self::megtagad('Ez a művelet csak POST kéréssel indítható.');
+        }
+        if (!self::valid()) {
+            self::megtagad('Érvénytelen vagy hiányzó biztonsági token. Töltsd újra az oldalt, és próbáld meg ismét.');
+        }
+    }
+
+    private static function megtagad(string $uzenet): void {
+        if (!headers_sent()) {
+            http_response_code(403);
+        }
+        throw new \Exception($uzenet);
+    }
+
+    /** A beküldött token: űrlapmezőből vagy — ajax/JSON esetén — fejlécből. */
+    public static function submitted(): string {
+        if (isset($_POST[self::FIELD]) && is_string($_POST[self::FIELD])) {
+            return $_POST[self::FIELD];
+        }
+        if (isset($_SERVER[self::HEADER]) && is_string($_SERVER[self::HEADER])) {
+            return $_SERVER[self::HEADER];
+        }
+        return '';
+    }
+
+    /**
+     * A süti értéke — ha nincs, most keletkezik.
+     *
+     * SameSite=Lax: a süti keresztoldali POST-hoz el sem indul, tehát önmagában is
+     * megfogja a támadás javát. Nem hagyatkozom rá egyedül (régi böngészők,
+     * és a Lax a GET-es top-level navigációt átengedi), de ingyen van.
+     */
+    private static function titok(): string {
+        if (isset($_COOKIE[self::COOKIE]) && is_string($_COOKIE[self::COOKIE]) && $_COOKIE[self::COOKIE] !== '') {
+            return $_COOKIE[self::COOKIE];
+        }
+        if (self::$memoria !== null) {
+            return self::$memoria;
+        }
+
+        $ertek = bin2hex(random_bytes(32));
+        self::$memoria = $ertek;
+        $_COOKIE[self::COOKIE] = $ertek;
+
+        if (PHP_SAPI !== 'cli' && !headers_sent()) {
+            setcookie(self::COOKIE, $ertek, [
+                'expires' => strtotime(self::LIFETIME),
+                'path' => '/',
+                'secure' => \Token::isHttps(),
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ]);
+        }
+
+        return $ertek;
+    }
+
+    /** Csak tesztekhez: a kérésenkénti állapot eldobása. */
+    public static function reset(): void {
+        self::$memoria = null;
+        unset($_COOKIE[self::COOKIE]);
+    }
+}

--- a/webapp/classes/html/ajax/chat.php
+++ b/webapp/classes/html/ajax/chat.php
@@ -29,6 +29,10 @@ class Chat extends Ajax {
                 break;
 
             case 'save':
+                // #873: a chat-üzenet a mi nevünkben kerül be — POST + token. A `load` és
+                // a `getusers` marad őrizetlen: azok csak olvasnak.
+                \Csrf::guard();
+
                 $text = \Request::TextRequired('text');
                 if (preg_match('/^\$(\w+)/si', $text, $match)) {
                     $kinek = $match[1];

--- a/webapp/classes/html/ajax/churchlink.php
+++ b/webapp/classes/html/ajax/churchlink.php
@@ -5,7 +5,9 @@ namespace Html\Ajax;
 class ChurchLink extends Ajax {
 
     public function __construct() {
-        
+        // #873: hivatkozás felvétele és törlése is írás — POST + token.
+        \Csrf::guard();
+
         $action = \Request::InArrayRequired('action', ['delete','add']);
 
         header("Content-Type: text/plain");                         

--- a/webapp/classes/html/ajax/favorite.php
+++ b/webapp/classes/html/ajax/favorite.php
@@ -15,6 +15,10 @@ class Favorite extends Ajax {
             throw new \Exception("Hiányzó jogosultság: a kedvencekhez be kell jelentkezni.");
         }
 
+        // #873: a kedvenc felvétele/törlése írás — POST + token. Kis tét, de ugyanaz a
+        // szabály: ne lehessen idegen oldalról a felhasználónk nevében módosítani.
+        \Csrf::guard();
+
         $tid = \Request::IntegerRequired('tid');
         $method = \Request::SimpletextRequired('method');
         echo $tid."-".$method;

--- a/webapp/classes/html/ajax/osmkapcsolat.php
+++ b/webapp/classes/html/ajax/osmkapcsolat.php
@@ -12,6 +12,10 @@ class OSMKapcsolat extends Ajax {
         
 
         try {
+            // #873: az OSM-összeköttetés bontása törli az összes fromOSM attribútumot is
+            // — POST + token. (A hibát a lenti catch csomagolja JSON-ba.)
+            \Csrf::guard();
+
             $action = \Request::InArrayRequired('action', ['delete', 'add']);
             $tid = \Request::IntegerRequired('tid');
 

--- a/webapp/classes/html/ajax/switchreliable.php
+++ b/webapp/classes/html/ajax/switchreliable.php
@@ -5,6 +5,9 @@ namespace Html\Ajax;
 class SwitchReliable extends Ajax {
 
     public function __construct() {
+        // #873: az észrevétel megbízhatósági jelzőjének átállítása írás — POST + token.
+        \Csrf::guard();
+
         $rid = \Request::IntegerRequired('rid');
         $reliable = \Request::InArrayRequired('reliable', array('i', 'n', '?', 'e'));
         

--- a/webapp/classes/html/church/changeholders.php
+++ b/webapp/classes/html/church/changeholders.php
@@ -44,7 +44,11 @@ class ChangeHolders extends \Html\Html {
                 }
                 $this->holder = $churchHolder;
                            
-            } else {            
+            } else {
+                // #873: itt már írunk — POST + token. A fenti `confirmation == 'needed'`
+                // ág CSAK megjelenít (a megerősítő lapot), azt szándékosan nem őrizzük.
+                \Csrf::guard();
+
                 $churchHolder = \Eloquent\ChurchHolder::updateOrCreate($where,$data);
                 $churchHolder->sendEmails();
                 addMessage('A kérést köszönettel elmentettük.', 'info');
@@ -52,7 +56,15 @@ class ChangeHolders extends \Html\Html {
             }
         
         } else if($user->checkRole('miserend')) {
-           
+            /*
+             * #873: ez az ág adott ki és vont vissza szerkesztési jogot — GET-en, sima
+             * linkkel. Vagyis egy bejelentkezett miserend-adminnak elég volt megnéznie
+             * egy idegen oldalt (vagy egy beküldött észrevételben lévő képet), és a
+             * nevében kiosztódott a jog egy tetszőleges felhasználónak egy tetszőleges
+             * templomra. A jogosultság-ellenőrzés eközben hibátlanul lefutott.
+             */
+            \Csrf::guard();
+
 			if ( $data['status'] == 'toDelete') {
 				$churchHolder = \Eloquent\ChurchHolder::where('user_id',$where['user_id'])->where('church_id',$where['church_id'])->first()->delete();
 			} else {

--- a/webapp/classes/html/church/create.php
+++ b/webapp/classes/html/church/create.php
@@ -14,6 +14,8 @@ class Create extends \Html\Html {
 
         
         $isForm = \Request::Text('submit');
+        // #873: új templom felvétele — POST + token.
+        if ($isForm) { \Csrf::guard(); }
         if ($isForm) {
             $tid = $this->create();            
             if($tid) {

--- a/webapp/classes/html/church/delete.php
+++ b/webapp/classes/html/church/delete.php
@@ -22,7 +22,11 @@ class Delete extends \Html\Html {
         if (!$this->input['confirmation']) {
             $this->askConfirmation();
             return;
-        } else {            
+        } else {
+            // #873: a templom törlése (a misékkel, képekkel, kedvencekkel együtt)
+            // eddig GET-tel is kiadható volt — a megerősítő űrlap POST-ol ugyan, de a
+            // `?confirmation=confirmed` egy sima linkből is elég volt hozzá.
+            \Csrf::guard();
             $this->delete();
         }
     }

--- a/webapp/classes/html/church/edit.php
+++ b/webapp/classes/html/church/edit.php
@@ -61,6 +61,8 @@ class Edit extends \Html\Html {
         }
 
         $isForm = \Request::Text('submit');
+        // #873: a mentés POST + token. Eddig egy `?submit=1&church[...]=...` URL is elég volt.
+        if ($isForm) { \Csrf::guard(); }
         $isRelationshipAction = \Request::get('relationship[add]') !== false
             || \Request::get('relationship[delete]') !== false;
         if ($isForm || $isRelationshipAction) {

--- a/webapp/classes/html/church/editosm.php
+++ b/webapp/classes/html/church/editosm.php
@@ -120,6 +120,8 @@ class EditOsm extends \Html\Html {
 
 		// Ha beküldtünk adatokatt.
         $isForm = \Request::Text('submit');
+        // #873: a mentés OSM-be is visszaír — POST + token.
+        if ($isForm) { \Csrf::guard(); }
         if ($isForm AND $this->readingAccessOnly == false ) {
 			// Változtatunk, elmentünk, ilyenek.
             $this->modify();

--- a/webapp/classes/html/church/editphotos.php
+++ b/webapp/classes/html/church/editphotos.php
@@ -28,6 +28,8 @@ class EditPhotos extends \Html\Html {
 
 	
         $isForm = \Request::Text('submit');
+        // #873: fotó átnevezése, elrejtése, VÉGLEGES törlése — POST + token.
+        if ($isForm) { \Csrf::guard(); }
         if ($isForm) {
             $this->modify();
         }

--- a/webapp/classes/html/church/editschedule.php
+++ b/webapp/classes/html/church/editschedule.php
@@ -19,6 +19,10 @@ class EditSchedule extends \Html\Html {
 
         // Handle POST request to mark schedule as current
         if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['action'] === 'mark_current') {
+            // #873: POST-ot már eddig is követelt, tokent nem — egy rejtett űrlappal
+            // idegen oldalról is „naprakésszé" lehetett nyilvánítani a miserendet.
+            \Csrf::guard();
+
             $church = \Eloquent\Church::find($this->tid);
             if ($church && $church->writeAccess) {
                 $church->frissites = date('Y-m-d H:i:s');

--- a/webapp/classes/html/email/email.php
+++ b/webapp/classes/html/email/email.php
@@ -11,6 +11,9 @@ class Email extends \Html\Html {
 
         $this->mail = new \Eloquent\Email();        
         if (\Request::text('send') == 'Küldés') {
+            // #873: levélküldés a mi nevünkben, tetszőleges címzettnek és szöveggel —
+            // GET-tel is kiadható volt. POST + token.
+            \Csrf::guard();
             $this->send();
             $this->template = 'layout_simpliest.twig';
             $this->body = "Köszönjük, elküldtük.";

--- a/webapp/classes/html/remark.php
+++ b/webapp/classes/html/remark.php
@@ -42,6 +42,11 @@ class Remark extends Html {
 
     function pageList() {
         if (\Request::Simpletext('remark') == 'modify') {
+            // #873: POST + token. A #869-ben a jogosultság-ellenőrzést hoztam előre, de a
+            // művelet GET-en is indítható maradt — egy beágyazott kép a bejelentkezett
+            // gondnok nevében állította volna „feldolgozottra" a bejelentést.
+            \Csrf::guard();
+
             $rid = \Request::IntegerRequired('rid');
             $remark = \Eloquent\Remark::find($rid);
 

--- a/webapp/classes/html/uploadimage.php
+++ b/webapp/classes/html/uploadimage.php
@@ -16,6 +16,8 @@ class UploadImage extends Html {
 
         // #391: közvetlen $_REQUEST helyett a \Request:: olvasás.
         if (\Request::get('upload') !== false) {
+            // #873: a feltöltés fájlt ír a lemezre és sort a `photos` táblába — POST + token.
+            \Csrf::guard();
             $this->ajax();
             exit;
         }

--- a/webapp/classes/html/user/delete.php
+++ b/webapp/classes/html/user/delete.php
@@ -38,15 +38,20 @@ class Delete extends \Html\Html {
             return;
         }
 
+        // #873: a felhasználó törlése eddig egyetlen linken múlt
+        // (`/user/{uid}/delete?confirmation=confirmed`) — vagyis egy beágyazott kép
+        // a bejelentkezett adminunk nevében bárkit törölhetett.
+        \Csrf::guard();
+
         $this->user2delete->delete();
         header("Location: /user/catalogue");
     }
 
     /**
      * A saját fiók törlése visszafordíthatatlan, ezért nem elég egy linkre kattintani:
-     * POST kell hozzá és a saját jelszó. A jelszó nem csak elgépelés ellen véd — CSRF
-     * ellen is, mert egy idegen oldal el tudna küldeni egy formot a nevünkben, a
-     * jelszavunkat viszont nem tudja. (A projektben nincs CSRF-token mechanizmus.)
+     * POST kell hozzá, CSRF-token és a saját jelszó. A jelszó nem csak elgépelés ellen
+     * véd — a tokentől függetlenül is bizonyítja, hogy tényleg a fiók gazdája kérte.
+     * (#873 óta van CSRF-token mechanizmus; a jelszó marad, mert nem ugyanazt védi.)
      */
     private function deleteSelf() {
         global $user;

--- a/webapp/classes/html/user/edit.php
+++ b/webapp/classes/html/user/edit.php
@@ -10,6 +10,8 @@ class Edit extends \Html\Html {
         $this->uid = \Request::IntegerwDefault('uid', $user->uid);
 
         $isForm = \Request::Text('submit');
+        // #873: a felhasználói adatok (jelszó, email, értesítések) mentése — POST + token.
+        if ($isForm) { \Csrf::guard(); }
         if ($isForm) {
             if($this->modify()) {
                 /* Ha az aktuális felhasználót frissítettük, akkor be kell töltenünk újra a felhasználót a friss adatokkal */

--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -1254,3 +1254,16 @@ span.toggle.active {
   }
 
 } /* end @media (max-width: 575.98px) */
+/*
+ * #873: az ikon alakú, állapotváltó műveletek POST-űrlapok lettek (linkből gomb).
+ * Ez a szabály tünteti el a gomb saját megjelenését, hogy a felület ugyanaz maradjon,
+ * mint amikor még <a> volt.
+ */
+button.holder-action {
+    border: 0;
+    background: none;
+    padding: 0;
+    line-height: 1;
+    vertical-align: baseline;
+    cursor: pointer;
+}

--- a/webapp/js/csrf.js
+++ b/webapp/js/csrf.js
@@ -1,0 +1,44 @@
+/*
+ * #873: CSRF-token minden böngészőből induló írási kéréshez.
+ *
+ * A lap <head>-jében ott a token (<meta name="csrf-token">). Innen egyszer kiolvassuk,
+ * és a jQuery MINDEN nem-GET ajax-hívásához hozzátesszük X-CSRF-Token fejlécként. Így
+ * nem kell végigjárni és külön-külön kiegészíteni a meglévő $.ajax hívásokat, és a
+ * később írt hívások is védve lesznek anélkül, hogy bárkinek eszébe kellene jutnia.
+ *
+ * Csak SAJÁT eredetű kérésre teszünk fejlécet: a tokenünk nem tartozik idegen szerverre.
+ * (A jQuery crossDomain jelzője pont ezt mondja meg.)
+ *
+ * A GET kimarad: az olvasás nem állapotváltás, és a fölös fejléc csak preflightot
+ * provokálna ott, ahol eddig nem volt.
+ */
+(function ($) {
+    'use strict';
+
+    if (!$ || !$.ajaxPrefilter) {
+        return;
+    }
+
+    var meta = document.querySelector('meta[name="csrf-token"]');
+    var token = meta ? meta.getAttribute('content') : '';
+    if (!token) {
+        return;
+    }
+
+    // A jQuery-n kívüli (fetch/XHR) hívásoknak is legyen honnan elérni.
+    window.miserendCsrfToken = token;
+
+    $.ajaxPrefilter(function (options) {
+        var method = (options.type || options.method || 'GET').toUpperCase();
+        if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+            return;
+        }
+        if (options.crossDomain) {
+            return;
+        }
+        options.headers = options.headers || {};
+        if (!options.headers['X-CSRF-Token']) {
+            options.headers['X-CSRF-Token'] = token;
+        }
+    });
+})(window.jQuery);

--- a/webapp/load.php
+++ b/webapp/load.php
@@ -55,8 +55,24 @@ if (isset($_REQUEST['login'])) {
     }
 }
 if (isset($_REQUEST['logout']) AND $_REQUEST['logout'] != 'false') {
-    \User::logout();
-
+    /*
+     * #873: a kiléptetés is állapotváltás — POST + token kell hozzá, különben egy idegen
+     * oldal beágyazott képe kilépteti a látogatót. Kártétel nincs, bosszantás van.
+     *
+     * Itt nem `Csrf::guard()` van, hanem csendes kihagyás: a load.php az index.php
+     * try-blokkja ELŐTT fut, tehát egy kivétel itt nem hibaoldalt adna, hanem elkapatlan
+     * kivételt. Aki a régi `/?logout=true` linket használja (könyvjelző), az kapjon
+     * eligazítást ahelyett, hogy némán bejelentkezve maradna.
+     *
+     * A BELÉPÉS szándékosan marad GET-en is elérhető: az elfelejtett-jelszó levél egy
+     * `?login=...&passw=...` linket küld (l. emails/user_newpassword.twig), azt ez a
+     * változtatás nem törheti el. (Hogy a jelszó URL-ben utazik, az külön gond — nem ide.)
+     */
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST' AND \Csrf::valid()) {
+        \User::logout();
+    } else {
+        addMessage('A kilépéshez használd a menüben a „Kilépés" gombot.', 'warning');
+    }
 }
 $user = \User::load();
 

--- a/webapp/templates/church/_panelholders.twig
+++ b/webapp/templates/church/_panelholders.twig
@@ -36,17 +36,39 @@
                             </a>
 
                             <div style="float:right">
+                                {#
+                                   #873: a három művelet eddig sima link volt, tehát GET-tel is
+                                   kiadható. Egy bejelentkezett adminnak elég volt megnéznie egy
+                                   idegen oldalt, és a nevében kiosztódott a szerkesztési jog egy
+                                   tetszőleges felhasználónak. Ezért mind POST-űrlap lett, tokennel.
+                                   A gomb keret és háttér nélküli, hogy a felület ne változzon.
+                                #}
                                 {% if status in ['allowed'] %}
                                     <i class="{{ ICONS_GRANT_ACCESS}} green" title="A felhasználó tudja szerkeszteni a templom adatait."></i>
                                 {% else %}
-                                    <a href="/church/{{ church.id }}/changeholders?uid={{ holder.user.uid }}&access=allowed"><i class="{{ ICONS_GRANT_ACCESS}} grey" title="Az engedélyezéshez kattints ide."></i></a>
+                                    <form method="post" action="/church/{{ church.id }}/changeholders" style="display:inline">
+                                        <input type="hidden" name="uid" value="{{ holder.user.uid }}">
+                                        <input type="hidden" name="access" value="allowed">
+                                        {{ csrf_field() }}
+                                        <button type="submit" class="holder-action" title="Az engedélyezéshez kattints ide."><i class="{{ ICONS_GRANT_ACCESS}} grey"></i></button>
+                                    </form>
                                 {% endif %}
                                 {% if status in ['denied','revoked','left']  %}
                                     <i class="{{ ICONS_DENY_ACCESS}} red" title="A felhasználó nem szerkesztheti a templom adatait. És nem is kérheti újra ehhez a jogot."></i>
                                 {% else %}
-                                    <a href="/church/{{ church.id }}/changeholders?uid={{ holder.user.uid }}&access={% if status == 'asked' %}denied{% else %}revoked{% endif %}"><i class="{{ ICONS_DENY_ACCESS}} grey" title="A letiltáshoz kattints ide, így nem is kérheti többé a jogot a szerkesztéshez."></i></a>
+                                    <form method="post" action="/church/{{ church.id }}/changeholders" style="display:inline">
+                                        <input type="hidden" name="uid" value="{{ holder.user.uid }}">
+                                        <input type="hidden" name="access" value="{% if status == 'asked' %}denied{% else %}revoked{% endif %}">
+                                        {{ csrf_field() }}
+                                        <button type="submit" class="holder-action" title="A letiltáshoz kattints ide, így nem is kérheti többé a jogot a szerkesztéshez."><i class="{{ ICONS_DENY_ACCESS}} grey"></i></button>
+                                    </form>
                                 {% endif %}
-									<a href="/church/{{ church.id }}/changeholders?uid={{ holder.user.uid }}&access=toDelete"><i class="{{ ICONS_DELETE_ACCESS}} grey" title="A felelős (kérés) törlése. Ez után tiszta lappal indulunk."></i></a>
+                                <form method="post" action="/church/{{ church.id }}/changeholders" style="display:inline">
+                                    <input type="hidden" name="uid" value="{{ holder.user.uid }}">
+                                    <input type="hidden" name="access" value="toDelete">
+                                    {{ csrf_field() }}
+                                    <button type="submit" class="holder-action" title="A felelős (kérés) törlése. Ez után tiszta lappal indulunk."><i class="{{ ICONS_DELETE_ACCESS}} grey"></i></button>
+                                </form>
 
                             </div>
                         </td>
@@ -109,6 +131,7 @@
         {% endif %}
 
         <FORM ENCTYPE='multipart/form-data' action="/templom/{{ church.id }}/changeholders" method=post>
+        {{ csrf_field() }}
             <table class="table">
                 <tr class="bg-primary">
                     <td colspan="2" >Új felelős megadása</td>

--- a/webapp/templates/church/changeholders.twig
+++ b/webapp/templates/church/changeholders.twig
@@ -14,6 +14,7 @@
         <p><strong>Ha vállalod a gondoksággal járó felelősséget, akkor kattints lenn a „Kérés küldése” gombra.</strong></p>    
     
         <FORM ENCTYPE='multipart/form-data' action="/templom/{{ holder.church_id }}/changeholders" method=post>
+        {{ csrf_field() }}
         <table class="table table-striped align-middle">
             <tr>
                 <td>Templom:</td>

--- a/webapp/templates/church/create.twig
+++ b/webapp/templates/church/create.twig
@@ -14,6 +14,7 @@
 
 {% block content %}
     <FORM ENCTYPE='multipart/form-data' method=post>
+    {{ csrf_field() }}
 
         <style>
             td {

--- a/webapp/templates/church/delete.twig
+++ b/webapp/templates/church/delete.twig
@@ -14,6 +14,7 @@
         <form role="form" method="post" class="form"
                       action="/templom/{{ church2delete.id }}/delete">
             
+            {{ csrf_field() }}
             <div class="controls" class="form-group">            
                 <label for="comment">Indoklás:</label><br/>
                 <input type="text" name="comment" class="form-control">

--- a/webapp/templates/church/edit.twig
+++ b/webapp/templates/church/edit.twig
@@ -34,6 +34,7 @@
     {% include 'church/_adminlinks-section.twig' %}
     
     <FORM ENCTYPE='multipart/form-data' method=post>
+    {{ csrf_field() }}
         <input type=hidden name=church[id] value={{ church.id }}>
         <style>
             td {

--- a/webapp/templates/church/editosm.twig
+++ b/webapp/templates/church/editosm.twig
@@ -41,6 +41,7 @@
 	<div class="alert alert-warning">Az alábbi adatok közül honlapunkon még még nem használ fel minden adatot.</div>
 	
     <FORM ENCTYPE='multipart/form-data' method=post>
+    {{ csrf_field() }}
         <input type=hidden name=church[id] value={{ church.id }}>
 		<input type=hidden name=osmid value={{ church.osmid }}>
 		<input type=hidden name=osmtype value={{ church.osmtype }}>

--- a/webapp/templates/church/editphotos.twig
+++ b/webapp/templates/church/editphotos.twig
@@ -49,6 +49,7 @@
 		
 
     <FORM ENCTYPE='multipart/form-data' method=post>
+    {{ csrf_field() }}
         <input type=hidden name=church[id] value={{ church.id }}>
 			
 		{% for photo in church.photos %}

--- a/webapp/templates/church/editschedule.twig
+++ b/webapp/templates/church/editschedule.twig
@@ -53,6 +53,7 @@
                 <div>
                     <form method="POST" action="/templom/{{ church.id }}/editschedule" style="display: inline;">
                         <input type="hidden" name="action" value="mark_current">
+                        {{ csrf_field() }}
 
                     <p style="margin: 5px 0 0 0;">
                         {% if yearsSinceUpdate >= 1 %}

--- a/webapp/templates/email/email.twig
+++ b/webapp/templates/email/email.twig
@@ -5,6 +5,7 @@
 {% block content %}
     {% if mail %}
         <form method=post>
+        {{ csrf_field() }}
             {% block extraInput %}{% endblock %}
             <table class="table table-striped">
                 <tr>

--- a/webapp/templates/layout.twig
+++ b/webapp/templates/layout.twig
@@ -44,6 +44,9 @@
         <meta name="description" content="{{ teaser ? teaser : 'Magyarország és a Kárpát-medence katolikus templomainak miserendjei.' }}">
         <meta name="keywords" content="katolikus, római katolikus, görögkatolikus, szentmise, miserend, liturgia, ünnep">
         <meta name="author" content="miserend.hu">
+        {# #873: a CSRF-token a böngészőben futó ajax-hívásoknak. A jQuery innen olvassa
+           ki, és minden nem-GET kéréshez X-CSRF-Token fejlécként mellékeli (l. csrf.js). #}
+        <meta name="csrf-token" content="{{ csrf_token }}">
         <meta http-equiv="cleartype" content="on">
 
         <meta name="apple-itunes-app" content="app-id=967827488">
@@ -105,6 +108,9 @@
 -->
         <script src="/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
 
+        {# #873: a CSRF-fejléc beakasztása a miserend.js ELŐTT, hogy az ott regisztrált
+           ajax-hívások is védve legyenek. #}
+        <script src="/js/csrf.js"></script>
         <script src="/js/miserend.js"></script>
         
 

--- a/webapp/templates/navbar.twig
+++ b/webapp/templates/navbar.twig
@@ -35,7 +35,14 @@
 	   {% if user.loggedin %}
                 <div class="navbar-form navbar-right" role="search">
                     <a class="button btn btn-default" href="/user/edit">{{ user.username }}</a>
-                    <a class="button btn btn-default" href="/?logout=true" id="quit">Kilépés</a>
+                    {# #873: a kilépés eddig link volt, tehát bármelyik idegen oldal ki tudta
+                       léptetni a látogatót (egy `<img src="https://miserend.hu/?logout=true">`
+                       elég volt hozzá). Kártétel nincs, bosszantás van. POST-űrlap, tokennel. #}
+                    <form method="post" action="/" style="display:inline">
+                        <input type="hidden" name="logout" value="true">
+                        {{ csrf_field() }}
+                        <button type="submit" class="button btn btn-default" id="quit">Kilépés</button>
+                    </form>
                 </div>
             {% else %}
                 <form class="navbar-form navbar-right" role="search"  method="post">

--- a/webapp/templates/remark_list.twig
+++ b/webapp/templates/remark_list.twig
@@ -21,6 +21,7 @@
 		</td>
 		<td valign=top width="140" style="padding:3px">
                     <form method=post action='/templom/{{ remark.church_id }}/eszrevetelek'>
+                        {{ csrf_field() }}
                         <input type=hidden name=rid value="{{ remark.id }}">
                         <div class='form-group '>
                             <label for='my_dropdown'>Állapot</label>

--- a/webapp/templates/uploadimage.twig
+++ b/webapp/templates/uploadimage.twig
@@ -333,6 +333,7 @@
 
 {% block content %}
     <form method="post" enctype="multipart/form-data" id="MyUploadForm">
+    {{ csrf_field() }}
         <input type=hidden name=tid class="form-control" value='{{ church.id }}'>
         <input type=hidden name=upload class="form-control" value='true'>
 

--- a/webapp/templates/user/delete.twig
+++ b/webapp/templates/user/delete.twig
@@ -24,6 +24,7 @@
 		nem tudjuk visszaadni.</p>
 
 	<form method="post" action="/user/{{ user2delete.uid }}/delete">
+		{{ csrf_field() }}
 		<div class="form-group">
 			<label for="password">A megerősítéshez add meg a jelszavadat:</label>
 			<input type="password" class="form-control" id="password" name="password"
@@ -41,10 +42,16 @@
 	<p>Biztosan törölni akarod a következő felhasználót?</p>
 	<p><strong>{{ user2delete.username }}</strong> ({{ user2delete.nev }})</p>
 
-	<p>
-		<a href="/user/{{ user2delete.uid }}/delete?confirmation=confirmed" class="btn btn-danger">Igen</a>
+	{# #873: az „Igen" eddig link volt, tehát GET-tel is kiadható — egy beágyazott kép
+	   a bejelentkezett admin nevében törölhetett bárkit. Most POST-űrlap, tokennel. #}
+	<div>
+		<form method="post" action="/user/{{ user2delete.uid }}/delete" style="display:inline">
+			<input type="hidden" name="confirmation" value="confirmed">
+			{{ csrf_field() }}
+			<button type="submit" class="btn btn-danger">Igen</button>
+		</form>
 		<a href="/user/{{ user2delete.uid }}/edit" class="btn btn-secondary">Nem</a>
-	</p>
+	</div>
 {% endif %}
 
 {% endblock %}

--- a/webapp/templates/user/edit.twig
+++ b/webapp/templates/user/edit.twig
@@ -81,6 +81,7 @@
 {% block content %}
         {% if not newusercreated and not needtologin and not accessdenied %}
 	<form method="post">
+	{{ csrf_field() }}
 		<input type="hidden" name="q" value="user/edit">
 
 		{% if edit %}<input type="hidden" name="edituser[uid]" value="{{ edituser.uid }}">{% endif %}

--- a/webapp/tests/Integration/ChurchEditFormTest.php
+++ b/webapp/tests/Integration/ChurchEditFormTest.php
@@ -12,14 +12,12 @@ use Illuminate\Database\Capsule\Manager as DB;
  */
 class ChurchEditFormTest extends TestCase {
 
-    private string $baseUrl;
-    private ?string $cookie = null;
+    private CsrfFormClient $client;
     private ?int $churchId = null;
 
     protected function setUp(): void {
-        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
-        $this->login();
-        if ($this->cookie === null) {
+        $this->client = new CsrfFormClient();
+        if (!$this->client->login('admin', 'miserend')) {
             $this->markTestSkipped('Nem sikerült adminisztrátorként bejelentkezni.');
         }
         $this->churchId = $this->createChurch();
@@ -45,35 +43,13 @@ class ChurchEditFormTest extends TestCase {
         ]);
     }
 
-    /** Bejelentkezés; a session-sütit eltesszük a további kérésekhez. */
-    private function login(): void {
-        $ctx = stream_context_create(['http' => [
-            'method'        => 'POST',
-            'header'        => "Content-Type: application/x-www-form-urlencoded\r\n",
-            'content'       => http_build_query(['login' => 'admin', 'passw' => 'miserend', 'logout' => 'false']),
-            'timeout'       => 30,
-            'ignore_errors' => true,
-        ]]);
-        @file_get_contents($this->baseUrl . '/', false, $ctx);
-        foreach ($http_response_header ?? [] as $h) {
-            if (stripos($h, 'Set-Cookie:') === 0 && stripos($h, 'token=') !== false) {
-                $this->cookie = trim(explode(';', substr($h, 11))[0]);
-            }
-        }
-    }
-
+    /**
+     * #873: a beküldés a CsrfFormClient-en át megy, ami úgy viselkedik, mint a böngésző:
+     * betölti a szerkesztő lapot, elteszi a `csrf` sütit, és a POST-hoz mellékeli a
+     * lapról kiolvasott tokent. Enélkül a mentés — helyesen — meg sem történne.
+     */
     private function post(string $path, array $fields): string {
-        $header = "Content-Type: application/x-www-form-urlencoded\r\n";
-        if ($this->cookie) {
-            $header .= 'Cookie: ' . $this->cookie . "\r\n";
-        }
-        $ctx = stream_context_create(['http' => [
-            'method' => 'POST', 'header' => $header,
-            'content' => http_build_query($fields), 'timeout' => 60, 'ignore_errors' => true,
-        ]]);
-        $body = @file_get_contents($this->baseUrl . $path, false, $ctx);
-        $this->assertNotFalse($body, 'A kérés nem sikerült: ' . $path);
-        return $body;
+        return $this->client->post($path, $fields, true, '/templom/' . $this->churchId . '/edit');
     }
 
     private function churchRow() {

--- a/webapp/tests/Integration/UserEditFormTest.php
+++ b/webapp/tests/Integration/UserEditFormTest.php
@@ -14,11 +14,11 @@ use Illuminate\Database\Capsule\Manager as DB;
  */
 class UserEditFormTest extends TestCase {
 
-    private string $baseUrl;
+    private CsrfFormClient $client;
     private array $createdLogins = [];
 
     protected function setUp(): void {
-        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
+        $this->client = new CsrfFormClient();
     }
 
     protected function tearDown(): void {
@@ -36,18 +36,15 @@ class UserEditFormTest extends TestCase {
         return $login;
     }
 
-    /** POST az űrlap-feldolgozóra; a válasz HTML-je jön vissza. */
+    /**
+     * POST az űrlap-feldolgozóra; a válasz HTML-je jön vissza.
+     *
+     * #873: a beküldés úgy megy, mint a böngészőből — előbb betöltjük a regisztrációs
+     * lapot (onnan jön a `csrf` süti és a token), és azzal együtt küldünk. Nyers POST-tól
+     * ma már — helyesen — nem történne semmi.
+     */
     private function post(string $path, array $fields): string {
-        $ctx = stream_context_create(['http' => [
-            'method'        => 'POST',
-            'header'        => "Content-Type: application/x-www-form-urlencoded\r\n",
-            'content'       => http_build_query($fields),
-            'timeout'       => 30,
-            'ignore_errors' => true,
-        ]]);
-        $body = @file_get_contents($this->baseUrl . $path, false, $ctx);
-        $this->assertNotFalse($body, 'A kérés nem sikerült: ' . $path);
-        return $body;
+        return $this->client->post($path, $fields, true, $path);
     }
 
     private function userRow(string $login) {

--- a/webapp/tests/Support/CsrfFormClient.php
+++ b/webapp/tests/Support/CsrfFormClient.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * #873: űrlap-beküldő teszt-ügyfél, ami úgy viselkedik, mint egy böngésző.
+ *
+ * A CSRF-védelem bevezetése után egy nyers POST-tól már nem történik semmi — és ez így
+ * helyes. A böngésző viszont nem nyers POST-ot küld: előbb betölti az űrlap oldalát,
+ * megkapja a `csrf` sütit, kiolvassa a lapból a tokent, és a beküldéskor MINDKETTŐT
+ * mellékeli. A teszteknek pontosan ezt kell utánozniuk, különben nem a mentést mérnék,
+ * hanem az őrt.
+ *
+ * A sütiket kérésről kérésre visszük tovább, mert a token a `csrf` süti értékéből
+ * számolódik: ha elhagynánk, minden beküldés más tokent várna.
+ */
+final class CsrfFormClient {
+
+    private string $baseUrl;
+
+    /** name => value */
+    private array $sutik = [];
+
+    /** Az utolsó válasz státuszsora — hibakereséshez. */
+    public string $utolsoStatusz = '';
+
+    public function __construct(?string $baseUrl = null) {
+        $this->baseUrl = rtrim($baseUrl ?: (getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000'), '/');
+    }
+
+    /** Bejelentkezés; a kapott sütiket (token, csrf) megjegyezzük. */
+    public function login(string $nev, string $jelszo): bool {
+        $this->post('/', ['login' => $nev, 'passw' => $jelszo, 'logout' => 'false'], false);
+        return isset($this->sutik['token']);
+    }
+
+    public function beVagyunkLepve(): bool {
+        return isset($this->sutik['token']);
+    }
+
+    public function get(string $path): string {
+        return $this->keres($path, null);
+    }
+
+    /**
+     * Beküldés. Alapból előbb LEKÉRI az űrlap oldalát ($tokenLapja vagy maga a $path),
+     * hogy legyen érvényes tokenünk — pont úgy, ahogy a felhasználó is látja az űrlapot.
+     */
+    public function post(string $path, array $mezok, bool $tokennel = true, ?string $tokenLapja = null): string {
+        if ($tokennel) {
+            $mezok['csrf_token'] = $this->token($tokenLapja ?? $path);
+        }
+        return $this->keres($path, http_build_query($mezok));
+    }
+
+    /** A lapon lévő token. Mellékhatás: ha még nincs `csrf` sütink, itt keletkezik. */
+    public function token(string $path): string {
+        $html = $this->get($path);
+        if (preg_match('/<meta name="csrf-token" content="([0-9a-f]{64})">/', $html, $m)) {
+            return $m[1];
+        }
+        // Az oldal nem layout.twig-et használ (pl. layout_empty) — ilyenkor a rejtett mező segít.
+        if (preg_match('/name="csrf_token" value="([0-9a-f]{64})"/', $html, $m)) {
+            return $m[1];
+        }
+        throw new \RuntimeException("Nincs CSRF-token ezen a lapon: $path");
+    }
+
+    private function keres(string $path, ?string $torzs): string {
+        $fejlec = '';
+        if ($this->sutik) {
+            $parok = [];
+            foreach ($this->sutik as $nev => $ertek) {
+                $parok[] = $nev . '=' . $ertek;
+            }
+            $fejlec .= 'Cookie: ' . implode('; ', $parok) . "\r\n";
+        }
+
+        $opciok = ['timeout' => 60, 'ignore_errors' => true];
+        if ($torzs === null) {
+            $opciok['method'] = 'GET';
+        } else {
+            $opciok['method'] = 'POST';
+            $fejlec .= "Content-Type: application/x-www-form-urlencoded\r\n";
+            $opciok['content'] = $torzs;
+        }
+        $opciok['header'] = $fejlec;
+
+        $valasz = @file_get_contents($this->baseUrl . $path, false, stream_context_create(['http' => $opciok]));
+        $this->sutiketEltesz($http_response_header ?? []);
+        $this->utolsoStatusz = ($http_response_header ?? [''])[0];
+
+        return $valasz === false ? '' : $valasz;
+    }
+
+    private function sutiketEltesz(array $fejlecek): void {
+        foreach ($fejlecek as $sor) {
+            if (stripos($sor, 'Set-Cookie:') !== 0) {
+                continue;
+            }
+            $elso = trim(explode(';', substr($sor, 11))[0]);
+            if (!str_contains($elso, '=')) {
+                continue;
+            }
+            [$nev, $ertek] = explode('=', $elso, 2);
+            $nev = trim($nev);
+            if ($ertek === '' || $ertek === '""') {
+                unset($this->sutik[$nev]);   // törlő süti (pl. kilépés)
+            } else {
+                $this->sutik[$nev] = $ertek;
+            }
+        }
+    }
+}

--- a/webapp/tests/Unit/CsrfCoverageTest.php
+++ b/webapp/tests/Unit/CsrfCoverageTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #873: az állapotváltó belépési pontokon OTT KELL LENNIE az őrnek.
+ *
+ * Ez nem stílus-ellenőrzés. A CSRF-védelem pont attól ér valamit, hogy egy végpont sem
+ * marad ki: elég egyetlen őrizetlen írási út, és a támadás megint megvan. Ha valaki
+ * jóhiszeműen kiszedi a `\Csrf::guard()`-ot (mert „nem működik a tesztem"), erről itt
+ * kap hírt, nem élesben.
+ *
+ * A vizsgálat a PHP TOKENJEIT nézi, nem a nyers szöveget: egy kommentben említett
+ * `Csrf::guard()` nem számít teljesítésnek.
+ */
+final class CsrfCoverageTest extends TestCase {
+
+    /** Fájl => mit ír, ha nem őrizzük. */
+    private const ALLAPOTVALTOK = [
+        'classes/html/remark.php' => 'észrevétel állapota és admin-megjegyzése',
+        'classes/html/ajax/switchreliable.php' => 'észrevétel megbízhatósági jelzője',
+        'classes/html/ajax/churchlink.php' => 'templom-hivatkozás felvétele/törlése',
+        'classes/html/ajax/osmkapcsolat.php' => 'OSM-összeköttetés bontása',
+        'classes/html/church/changeholders.php' => 'gondnoki jogosultság kiosztása/visszavonása',
+        'classes/html/church/delete.php' => 'templom törlése',
+        'classes/html/church/edit.php' => 'templom adatainak mentése',
+        'classes/html/church/editosm.php' => 'templom adatainak visszaírása OSM-be',
+        'classes/html/church/editphotos.php' => 'fotó átnevezése/elrejtése/törlése',
+        'classes/html/church/editschedule.php' => 'miserend naprakészre jelölése',
+        'classes/html/church/create.php' => 'új templom felvétele',
+        'classes/html/user/delete.php' => 'felhasználó törlése',
+        'classes/html/user/edit.php' => 'felhasználói adatok mentése',
+        'classes/html/uploadimage.php' => 'kép feltöltése',
+        'classes/html/email/email.php' => 'levélküldés a nevünkben',
+        'classes/html/ajax/favorite.php' => 'kedvenc templom felvétele/törlése',
+        'classes/html/ajax/chat.php' => 'chat-üzenet beírása a nevünkben',
+    ];
+
+    public static function allapotvaltokProvider(): array {
+        $sorok = [];
+        foreach (self::ALLAPOTVALTOK as $fajl => $mit) {
+            $sorok[$fajl] = [$fajl, $mit];
+        }
+        return $sorok;
+    }
+
+    /**
+     * @dataProvider allapotvaltokProvider
+     */
+    public function testTheStateChangingEndpointIsGuarded(string $fajl, string $mit): void {
+        $ut = PATH . $fajl;
+        self::assertFileExists($ut, "Elmozdult a fájl? Ha átnevezted, a lista is frissítendő.");
+
+        self::assertTrue(
+            self::hivjaAzOrt(file_get_contents($ut)),
+            "Nincs \\Csrf::guard() ebben: $fajl — pedig ez írja: $mit. "
+            . "Enélkül egy idegen oldal a bejelentkezett felhasználónk nevében kiadhatja."
+        );
+    }
+
+    /** A load.php nem `guard()`-ol (kivétel nem fér el ott), de POST-ot és tokent követel. */
+    public function testTheLogoutRequiresPostAndAToken(): void {
+        $forras = file_get_contents(PATH . 'load.php');
+        self::assertStringContainsString("\\Csrf::valid()", $forras);
+        self::assertStringContainsString("REQUEST_METHOD", $forras);
+    }
+
+    /** A tokennek ott kell lennie a lapon, különben az ajax-hívások nem tudják mellékelni. */
+    public function testTheLayoutPublishesTheToken(): void {
+        $layout = file_get_contents(PATH . 'templates/layout.twig');
+        self::assertStringContainsString('name="csrf-token"', $layout);
+        self::assertStringContainsString('{{ csrf_token }}', $layout);
+        self::assertStringContainsString('/js/csrf.js', $layout);
+    }
+
+    /**
+     * Tokenekre bontva keressük a `Csrf::guard` hívást, hogy a kommentek és a
+     * sztringliterálok ne számítsanak bele.
+     */
+    private static function hivjaAzOrt(string $forras): bool {
+        $tokenek = token_get_all($forras);
+        $db = count($tokenek);
+
+        // PHP 8-ban a `\Csrf` EGY token (T_NAME_FULLY_QUALIFIED), a sima `Csrf` T_STRING.
+        // Mindkettőt el kell fogadni, különben a `\Csrf::guard()` alakot nem látjuk meg.
+        $osztalyNevek = [T_STRING, T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED];
+
+        for ($i = 0; $i < $db; $i++) {
+            $t = $tokenek[$i];
+            if (!is_array($t) || !in_array($t[0], $osztalyNevek, true)) {
+                continue;
+            }
+            if (strcasecmp(ltrim($t[1], '\\'), 'Csrf') !== 0) {
+                continue;
+            }
+            // Csrf :: guard  — a köztes whitespace-eket átlépve.
+            $j = self::kovetkezoErdemi($tokenek, $i + 1);
+            if ($j === null || !is_array($tokenek[$j]) || $tokenek[$j][0] !== T_DOUBLE_COLON) {
+                continue;
+            }
+            $k = self::kovetkezoErdemi($tokenek, $j + 1);
+            if ($k !== null && is_array($tokenek[$k]) && strcasecmp($tokenek[$k][1], 'guard') === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function kovetkezoErdemi(array $tokenek, int $tol): ?int {
+        for ($i = $tol; $i < count($tokenek); $i++) {
+            $t = $tokenek[$i];
+            if (is_array($t) && in_array($t[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+            return $i;
+        }
+        return null;
+    }
+}

--- a/webapp/tests/Unit/CsrfTest.php
+++ b/webapp/tests/Unit/CsrfTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #873: a CSRF-őr viselkedése.
+ *
+ * Amit itt rögzítek, az nem implementációs részlet, hanem a védelem ígérete:
+ * ami állapotot változtat, az CSAK POST-tal és CSAK érvényes tokennel indulhat el.
+ */
+final class CsrfTest extends TestCase {
+
+    protected function setUp(): void {
+        \Csrf::reset();
+        $_POST = [];
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        unset($_SERVER[\Csrf::HEADER]);
+    }
+
+    protected function tearDown(): void {
+        \Csrf::reset();
+        $_POST = [];
+        unset($_SERVER[\Csrf::HEADER]);
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+    }
+
+    /** Egy kérésen belül ugyanaz a token — különben az űrlap és az ellenőrzés elbeszélne egymás mellett. */
+    public function testTheTokenIsStableWithinOneRequest(): void {
+        $elso = \Csrf::token();
+        self::assertSame($elso, \Csrf::token());
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $elso);
+    }
+
+    /** Új látogató = új token. Enélkül egyetlen kitalált érték mindenkinél működne. */
+    public function testANewVisitorGetsADifferentToken(): void {
+        $elso = \Csrf::token();
+        \Csrf::reset();
+        self::assertNotSame($elso, \Csrf::token());
+    }
+
+    /** A lapra kitett érték NEM a süti értéke — ha kiszivárog, a süti akkor sem derül ki. */
+    public function testTheTokenIsNotTheCookieValue(): void {
+        $token = \Csrf::token();
+        self::assertNotSame($_COOKIE[\Csrf::COOKIE] ?? '', $token);
+    }
+
+    public function testWithoutATokenTheRequestIsInvalid(): void {
+        \Csrf::token();
+        self::assertFalse(\Csrf::valid());
+    }
+
+    public function testAWrongTokenIsInvalid(): void {
+        \Csrf::token();
+        $_POST[\Csrf::FIELD] = str_repeat('a', 64);
+        self::assertFalse(\Csrf::valid());
+    }
+
+    public function testTheRightTokenIsValid(): void {
+        $_POST[\Csrf::FIELD] = \Csrf::token();
+        self::assertTrue(\Csrf::valid());
+    }
+
+    /** Az ajax-hívások fejlécben küldik — ott is el kell fogadni. */
+    public function testTheTokenIsAcceptedFromTheHeaderToo(): void {
+        $_SERVER[\Csrf::HEADER] = \Csrf::token();
+        self::assertTrue(\Csrf::valid());
+    }
+
+    /** A LÉNYEG: GET-tel semmi nem indítható, akkor sem, ha a token stimmel. */
+    public function testGetIsRejectedEvenWithAValidToken(): void {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_POST[\Csrf::FIELD] = \Csrf::token();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('csak POST');
+        \Csrf::guard();
+    }
+
+    public function testPostWithoutATokenIsRejected(): void {
+        \Csrf::token();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('biztonsági token');
+        \Csrf::guard();
+    }
+
+    public function testPostWithAValidTokenPassesThrough(): void {
+        $_POST[\Csrf::FIELD] = \Csrf::token();
+
+        \Csrf::guard();
+        self::assertTrue(true, 'nem dobott kivetelt');
+    }
+
+    /** A rejtett mező kész HTML, és a token benne escape-elve szerepel. */
+    public function testTheHiddenFieldContainsTheToken(): void {
+        $mezo = \Csrf::field();
+        self::assertStringContainsString('name="' . \Csrf::FIELD . '"', $mezo);
+        self::assertStringContainsString(\Csrf::token(), $mezo);
+        self::assertStringStartsWith('<input type="hidden"', $mezo);
+    }
+}

--- a/webapp/tests/bootstrap.php
+++ b/webapp/tests/bootstrap.php
@@ -10,6 +10,11 @@ if (!@include PATH . 'vendor/autoload.php') {
 require_once PATH . 'functions.php';
 require_once PATH . 'twig_extras.php';
 
+// #873: az űrlapokat beküldő integrációs teszteknek CSRF-tokent kell szerezniük,
+// mint a böngészőnek. A közös ügyfél nem a `classes/` alatt van, tehát az app
+// autoloadere nem találja meg — itt töltjük be egyszer.
+require_once __DIR__ . '/Support/CsrfFormClient.php';
+
 // Load configuration for DB connection
 if (!function_exists('env')) {
     function env($key, $default = null) {

--- a/webapp/twig_extras.php
+++ b/webapp/twig_extras.php
@@ -277,5 +277,13 @@ function buildTwigEnvironment(?string $templatesPath = null): \Twig\Environment 
     // rájuk is érvényes.
     $twig->addGlobal('overpass_api_url', $config['overpass']['apiUrl'] ?? 'https://overpass-api.de/api/interpreter');
 
+    // #873: CSRF-token. Globálisként kell, nem szűrőként: a token LEKÉRÉSE hozza létre
+    // a sütit, és a sütit a kimenet előtt kell elküldeni. Twig-globálisként minden
+    // oldal-renderelés elején megtörténik, még a layout <head> kiírása előtt.
+    // CLI-ből (cron, teszt-bootstrap) is fut, ott a Csrf memóriában tartja az értéket.
+    $twig->addGlobal('csrf_token', \Csrf::token());
+    // A kész rejtett mező: `{{ csrf_field()|raw }}` — így az űrlapokba egy sor a beépítés.
+    $twig->addFunction(new \Twig\TwigFunction('csrf_field', ['Csrf', 'field'], ['is_safe' => ['html']]));
+
     return $twig;
 }


### PR DESCRIPTION
Closes #873

## A gond

Az állapotváltásaink GET-en mennek, és kizárólag a süti azonosítja a kérést. A böngésző a sütit MINDEN kéréshez mellékeli — akkor is, ha a kérést egy idegen oldal indította. A jogosultság-ellenőrzés ilyenkor hibátlanul lefut, és igent mond: tényleg az admin kérte, csak épp nem ő akarta.

Kimérve a fejlesztői példányon, bejelentkezett adminként:

```
GET /church/1/changeholders?uid=4&access=revoked     -> 200, a jogosultság átíródott
GET /user/{uid}/delete?confirmation=confirmed        -> 200, a felhasználó törölve
GET /index.php?q=remark/list/1&remark=modify&rid=1&state=f&adminmegj=…  -> 200, átírva
```

Mindhez elég volt egy `<img src="…">` egy tetszőleges oldalon (vagy egy beküldött észrevételben).

## A megoldás

**Két őr**, mert külön-külön egyik sem elég:

1. **Legyen POST.** Ez kizárja a `<img>`, `<script>`, `<link>` és a puszta link alakú támadásokat — azok mind GET-et adnak ki. Rejtett űrlapot viszont továbbra is lehet küldeni.
2. **Legyen token.** Olyan érték, amit a támadó oldala nem tud kitalálni és nem tud kiolvasni. A sütink automatikusan megy, de a sütink TARTALMÁT az idegen oldal nem látja, tehát a belőle számolt tokent sem tudja mellékelni.

`\Csrf::guard()` mindkettőt követeli, és 403-mal utasít vissza.

## Miért nem a belépési token?

Felvetetted a jegyben, hogy „egyszerűen a belépett user tokenjét küldjük át". A gondolat jó, de két gyakorlati baja lenne:

- **A vendég is küld be űrlapot** (észrevétel, javaslat, regisztráció), neki viszont nincs belépési tokenje. Minden ilyen űrlap kiesne a védelemből, vagy külön ágat kapna.
- **A belépés/kilépés lecseréli a tokent.** A már megnyitott lapok űrlapjai ilyenkor elavult tokent hordoznának, és a beküldés — látszólag ok nélkül — elszállna.

Ezért külön, kizárólag erre való süti van (`csrf`, HttpOnly, SameSite=Lax, 1 év). Ami a lapra kerül, az nem a süti értéke, hanem `sha256` lenyomata: ha a token valaha kiszivárog (napló, Referer, képernyőkép), a süti értéke akkor sem derül ki belőle.

## Mi került őrizet alá (17 belépési pont)

| Végpont | Mit írt őrizetlenül |
|---|---|
| `church/changeholders` | gondnoki jog kiosztása / visszavonása / törlése |
| `church/delete` | templom törlése (misékkel, képekkel, kedvencekkel) |
| `user/delete` | felhasználó törlése |
| `remark/list` (`remark=modify`) | észrevétel állapota és admin-megjegyzése (#869 folytatása) |
| `ajax/switchreliable` | észrevétel megbízhatósági jelzője |
| `ajax/churchlink` | hivatkozás felvétele / törlése |
| `ajax/osmkapcsolat` | OSM-összeköttetés bontása + minden `fromOSM` attribútum törlése |
| `ajax/favorite` | kedvenc felvétele / törlése |
| `ajax/chat` (`save`) | chat-üzenet a felhasználó nevében |
| `church/edit`, `editosm`, `editphotos`, `editschedule`, `create` | templomadatok, fotók, naprakészség |
| `user/edit` | jelszó, email, értesítések |
| `uploadimage` | kép feltöltése |
| `email/*` | levélküldés a mi nevünkben, tetszőleges címzettnek |
| kilépés (`load.php`) | kiléptetés idegen oldalról |

## Felület

- A három **gondnokság-ikon** és a **felhasználótörlés „Igen"** gombja linkből POST-űrlap lett. A megjelenés nem változik (`button.holder-action`: keret és háttér nélkül).
- A **kilépés** is űrlap. A régi `/?logout=true` link (könyvjelző) nem léptet ki némán, hanem kiírja, hogy a Kilépés gombot használd.
- Az **ajax-hívásokat nem kellett egyenként átírni**: a `csrf.js` egy `$.ajaxPrefilter`-rel minden saját eredetű, nem-GET jQuery-híváshoz hozzáteszi az `X-CSRF-Token` fejlécet. A később írt hívások is védve lesznek anélkül, hogy bárkinek eszébe kellene jutnia.

## Mérés

Bejelentkezett adminként, a fejlesztői példányon, minden esetben adatbázis-ellenőrzéssel:

| Kérés | Válasz | Adatbázis |
|---|---|---|
| `GET …/changeholders?uid=4&access=revoked` | **403** | változatlan (`allowed`, `updated_at` sem mozdult) |
| `POST …/changeholders` token nélkül | **403** | változatlan |
| `POST …/changeholders` a lapról vett tokennel | 302 | `revoked` — a jogos út működik |
| `GET /user/{uid}/delete?confirmation=confirmed` | **403** | a felhasználó megvan |
| `POST /user/{uid}/delete` token nélkül | **403** | a felhasználó megvan |
| `POST /user/{uid}/delete` tokennel | 302 | törölve |
| `GET …&remark=modify&state=f&adminmegj=…` | **403** | `allapot` maradt `u`, `adminmegj` `NULL` |
| `POST /ajax/switchreliable` token nélkül | 403 | `megbizhato` maradt |
| `POST /ajax/switchreliable` `X-CSRF-Token`-nel | `ok` | átírva |
| `POST /ajax/favorite` token nélkül / tokennel | 403 / 200 | 0 sor / 1 sor |
| kép-feltöltés token nélkül / tokennel | 403 / eljut a saját ellenőrzéséig | — |
| `GET /?logout=true` | eligazítás | a `token` süti megmarad |
| `POST /` + `logout=true` + token | — | a süti törlődik, kiléptünk |

## Tesztek

- `CsrfTest` (11 eset): a token stabil a kérésen belül, látogatónként más, nem egyenlő a süti értékével; hiányzó/rossz token elutasítva; fejlécből is elfogadva; **GET akkor is elutasítva, ha a token jó**.
- `CsrfCoverageTest`: a felsorolt 17 végpontról nem tűnhet el az őr. A vizsgálat a PHP **tokenjeit** nézi, nem a nyers szöveget — egy kommentben említett `Csrf::guard()` nem számít teljesítésnek. Visszamérve: az őrt kivéve a teszt bukik, visszatéve zöld.
- Az űrlapot beküldő integrációs tesztek (`ChurchEditFormTest`, `UserEditFormTest`) a közös `CsrfFormClient`-en át mennek, ami úgy viselkedik, mint a böngésző: betölti az űrlap lapját, elteszi a sütit, és a POST-hoz mellékeli a lapról olvasott tokent. Nyers POST-tól ma már — helyesen — nem történne semmi.

PHP: **1491 teszt**, a két ismert környezeti bukást (`SchemaReferenceTest`, `SzentsegimadasImportTest` — a helyi adatbázis-kötetem miatt) leszámítva zöld.

## Amit szándékosan nem csináltam

- **A belépés marad GET-en is elérhető.** Az elfelejtett-jelszó levél egy `?login=…&passw=…` linket küld (`emails/user_newpassword.twig`) — ezt nem törhettem el. Hogy a jelszó URL-ben utazik (access log, előzmények, Referer), az külön gond, külön jegybe való.
- **A naptár (Angular) írási végpontjai** kimaradtak: azok `application/json` törzzsel POST-olnak, ami előzetes CORS-kérést kényszerít, tehát űrlappal nem hamisíthatók. Ha egyszer űrlap-kódolásra váltanak, oda is kell a token.
- **Az `Api\*` végpontok** nem sütivel azonosítanak, tehát rájuk a CSRF fogalma nem alkalmazható.

## Amire deploy után figyelni kell

Az első oldallekérés `Set-Cookie: csrf=…`-t küld. Megosztott gyorsítótár (CDN) alapból nem tárol `Set-Cookie`-s választ, a Caddy pedig nem gyorsítótáraz — de ha valaha HTML-gyorsítótár kerül elé, a lapokat `private`-ként kell kezelnie, különben a látogatók egymás tokenjét kapnák, és az űrlapjaik elszállnának.