### PR TITLE
Napi/heti összefoglaló az esemény-értesítőkből (#872)

### DIFF
--- a/docker/mysql/initdb.d/16-notification-digest.sql
+++ b/docker/mysql/initdb.d/16-notification-digest.sql
@@ -1,0 +1,39 @@
+-- #872: értesítési gyakoriság és a napi/heti összefoglaló várólistája.
+--
+-- Az éles migrációt lásd: docker/mysql/migrations/872-ertesites-gyakorisag.sql
+
+USE `miserend`;
+
+/*
+ * Az alapérték SZÁNDÉKOSAN 'daily', a meglévő felhasználókra is.
+ *
+ * borazslo döntése a #872-ben: „Legyen rögtön a B (azonnal / napi / heti), és persze
+ * mindenki napira állítva. Ennyi késleltetése az adatok befutásának kb soha sem gond."
+ *
+ * A `notifications` oszlop marad, és erősebb: `0` esetén semmilyen értesítő nem megy,
+ * a gyakoriságtól függetlenül.
+ */
+ALTER TABLE `user`
+  ADD COLUMN IF NOT EXISTS `notification_frequency`
+    ENUM('instant','daily','weekly') NOT NULL DEFAULT 'daily' AFTER `notifications`;
+
+/*
+ * A halasztott értesítések. Nem a kész levelet tesszük félre, hanem az ESEMÉNYT:
+ * a digest egyetlen, templomonként csoportosított levél lesz, nem N levél egymás alá
+ * fűzve. A `sent_at` a kiküldés bélyege — a sorokat nem töröljük, mert a „mit küldtünk
+ * ki neki" kérdésre az `emails` tábla mellett ez a másik nyom.
+ */
+CREATE TABLE IF NOT EXISTS `notification_digest_items` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `uid` int(11) NOT NULL,
+  `email` varchar(100) NOT NULL,
+  `type` varchar(30) NOT NULL COMMENT 'remark | suggestion | image',
+  `church_id` int(11) DEFAULT NULL,
+  `title` varchar(255) NOT NULL,
+  `url` varchar(255) NOT NULL,
+  `created_at` timestamp NULL DEFAULT current_timestamp(),
+  `sent_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `uid_sent` (`uid`,`sent_at`),
+  KEY `sent_created` (`sent_at`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docker/mysql/migrations/872-ertesites-gyakorisag.sql
+++ b/docker/mysql/migrations/872-ertesites-gyakorisag.sql
@@ -1,0 +1,47 @@
+-- #872: értesítési gyakoriság és a napi/heti összefoglaló várólistája — ÉLES migráció.
+--
+--
+-- !!! ELŐTTE BACKUP:  bash docker/mysql/dump.sh > backup-PRE-872.sql
+--
+-- Futtatás:
+--    docker exec -i miserend-prod-mysql-1 mariadb -uuser -p"$MYSQL_PASSWORD" miserend \
+--      < docker/mysql/migrations/872-ertesites-gyakorisag.sql
+--
+-- Csak hozzáad, semmit nem ír felül. A meglévő felhasználók az oszlop alapértékét
+-- kapják: napi összefoglaló.
+
+USE `miserend`;
+
+/*
+ * Az alapérték SZÁNDÉKOSAN 'daily', a meglévő felhasználókra is.
+ *
+ * borazslo döntése a #872-ben: „Legyen rögtön a B (azonnal / napi / heti), és persze
+ * mindenki napira állítva. Ennyi késleltetése az adatok befutásának kb soha sem gond."
+ *
+ * A `notifications` oszlop marad, és erősebb: `0` esetén semmilyen értesítő nem megy,
+ * a gyakoriságtól függetlenül.
+ */
+ALTER TABLE `user`
+  ADD COLUMN IF NOT EXISTS `notification_frequency`
+    ENUM('instant','daily','weekly') NOT NULL DEFAULT 'daily' AFTER `notifications`;
+
+/*
+ * A halasztott értesítések. Nem a kész levelet tesszük félre, hanem az ESEMÉNYT:
+ * a digest egyetlen, templomonként csoportosított levél lesz, nem N levél egymás alá
+ * fűzve. A `sent_at` a kiküldés bélyege — a sorokat nem töröljük, mert a „mit küldtünk
+ * ki neki" kérdésre az `emails` tábla mellett ez a másik nyom.
+ */
+CREATE TABLE IF NOT EXISTS `notification_digest_items` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `uid` int(11) NOT NULL,
+  `email` varchar(100) NOT NULL,
+  `type` varchar(30) NOT NULL COMMENT 'remark | suggestion | image',
+  `church_id` int(11) DEFAULT NULL,
+  `title` varchar(255) NOT NULL,
+  `url` varchar(255) NOT NULL,
+  `created_at` timestamp NULL DEFAULT current_timestamp(),
+  `sent_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `uid_sent` (`uid`,`sent_at`),
+  KEY `sent_created` (`sent_at`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/webapp/classes/digestqueue.php
+++ b/webapp/classes/digestqueue.php
@@ -1,0 +1,200 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #872: napi/heti összefoglaló az esemény-értesítőkből.
+ *
+ * A gond, amit borazslo leírt: egyre több és többféle értesítőnk van, és aki több
+ * templomot gondnokol — a #819 óta a plébános a fíliáiét is —, azt elönti. Ha kikapcsolja
+ * az értesítést, csak rosszabb lesz, mert onnantól semmit nem tud.
+ *
+ * A számok az éles adatbázisból (borazslo mérése, 30 nap): a legterheltebb címek 157-162
+ * levelet kaptak, a legrosszabb napokon 21-et EGYETLEN nap alatt. 41 felhasználó már ki
+ * is kapcsolta az értesítést.
+ *
+ * MI TARTOZIK IDE. Csak a három esemény-értesítő: új észrevétel, új javaslat, új kép.
+ * Az emlékeztetők (`user_pleaseupdate`, `holder_bucsu_reminder`,
+ * `holder_holiday_reminder`) MÁR egy levél felhasználónként, az összes érintett
+ * templommal, és ritkítva is vannak — azokkal nincs teendő.
+ *
+ * MIT HALASZTUNK. Nem a kész levelet tesszük félre, hanem az ESEMÉNYT. Így a digest
+ * egyetlen, templomonként csoportosított levél lesz, nem N kész levél egymás alá fűzve
+ * (N köszöntéssel és N aláírással).
+ *
+ * A `notifications = 0` erősebb mindennél: az továbbra is „ne írj nekem".
+ */
+class DigestQueue {
+
+    const AZONNAL = 'instant';
+    const NAPI = 'daily';
+    const HETI = 'weekly';
+
+    const GYAKORISAGOK = [self::AZONNAL, self::NAPI, self::HETI];
+
+    /** A heti összefoglaló napja (1 = hétfő), és a legvégső határidő napokban. */
+    const HETI_NAP = 1;
+    const HETI_HATARIDO_NAP = 7;
+
+    /**
+     * Halasszuk-e ennek a címzettnek az értesítést?
+     *
+     * @return bool  true, ha a sor bekerült a várólistába — ilyenkor a hívó NE küldjön
+     *               azonnali levelet. false esetén marad a régi, azonnali kiküldés.
+     */
+    public static function halaszt($cimzett, string $tipus, ?int $churchId, string $cim, string $url): bool {
+        $uid = (int) ($cimzett->uid ?? 0);
+        $email = trim((string) ($cimzett->email ?? ''));
+
+        // Akit nem tudunk azonosítani, azt nem tudjuk összegezni sem: menjen azonnal,
+        // ahogy eddig. (Inkább kapjon levelet, mint hogy elvesszen az értesítés.)
+        if ($uid <= 0 || $email === '') {
+            return false;
+        }
+
+        if (self::gyakorisag($cimzett) === self::AZONNAL) {
+            return false;
+        }
+
+        DB::table('notification_digest_items')->insert([
+            'uid' => $uid,
+            'email' => $email,
+            'type' => $tipus,
+            'church_id' => $churchId,
+            // A cím a levélben egy sor lesz; a hosszú észrevétel-szövegek levágva.
+            'title' => mb_substr(trim(strip_tags($cim)), 0, 250),
+            'url' => mb_substr($url, 0, 250),
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        return true;
+    }
+
+    /**
+     * A címzett gyakorisága. Ismeretlen érték esetén a napi — az a beállított
+     * alapértelmezés, és sosem vezet elveszett értesítéshez, csak késleltetetthez.
+     */
+    public static function gyakorisag($cimzett): string {
+        $ertek = $cimzett->notification_frequency ?? null;
+
+        return in_array($ertek, self::GYAKORISAGOK, true) ? $ertek : self::NAPI;
+    }
+
+    /**
+     * Cron: kiküldi az esedékes összefoglalókat.
+     *
+     * Naponta fut. A napi gyakoriságúak minden futásnál sorra kerülnek, ha van mit
+     * küldeni; a hetiek a hét megadott napján — VAGY ha a legrégebbi tételük már
+     * túllépte a hét napot. Ez utóbbi azért kell, hogy egy kimaradt hétfői futás miatt
+     * ne csússzon a következő hétre az egész.
+     *
+     * @return int a kiküldött összefoglalók száma
+     */
+    public static function sendDue(): int {
+        $varakozok = DB::table('notification_digest_items')
+            ->select('uid')
+            ->selectRaw('MIN(created_at) AS legregebbi')
+            ->whereNull('sent_at')
+            ->groupBy('uid')
+            ->get();
+
+        $kuldott = 0;
+        foreach ($varakozok as $sor) {
+            if (self::kikuldheto((int) $sor->uid, $sor->legregebbi)) {
+                $kuldott += self::kuldEgynek((int) $sor->uid) ? 1 : 0;
+            }
+        }
+
+        return $kuldott;
+    }
+
+    private static function kikuldheto(int $uid, $legregebbi): bool {
+        $user = DB::table('user')->where('uid', $uid)->first();
+        if (!$user) {
+            return false;
+        }
+
+        // Ha időközben kikapcsolta az értesítést, a várólistája nem megy ki.
+        if ((int) ($user->notifications ?? 0) !== 1) {
+            return false;
+        }
+
+        $gyakorisag = self::gyakorisag($user);
+        if ($gyakorisag === self::AZONNAL) {
+            // Menet közben állt át azonnalira: a felgyűlt tételeket még kiküldjük
+            // egyben, mert azok már nem mennek ki külön levélben.
+            return true;
+        }
+        if ($gyakorisag === self::NAPI) {
+            return true;
+        }
+
+        return self::hetiEsedekes((int) date('N'), $legregebbi);
+    }
+
+    /**
+     * Esedékes-e a HETI összefoglaló?
+     *
+     * A hét megadott napján igen. Emellett akkor is, ha a legrégebbi tétel már túllépte
+     * a hét napot — enélkül egyetlen kimaradt hétfői futás miatt a következő hétre
+     * csúszna az egész, és a gondnok két hétig nem tudna a hozzá érkezett észrevételről.
+     *
+     * Kívülről is hívható, mert a „ma milyen nap van" nélkül nem lenne tesztelhető.
+     */
+    public static function hetiEsedekes(int $maiNap, $legregebbi): bool {
+        if ($maiNap === self::HETI_NAP) {
+            return true;
+        }
+
+        return strtotime((string) $legregebbi) < strtotime('-' . self::HETI_HATARIDO_NAP . ' days');
+    }
+
+    /** Egy címzett összefoglalója. */
+    private static function kuldEgynek(int $uid): bool {
+        $tetelek = DB::table('notification_digest_items')
+            ->where('uid', $uid)
+            ->whereNull('sent_at')
+            ->orderBy('created_at')
+            ->get();
+
+        if ($tetelek->isEmpty()) {
+            return false;
+        }
+
+        $user = new \User($uid);
+        if (!$user->uid) {
+            return false;
+        }
+
+        // Templomonként csoportosítva — a gondnok így egyben látja, melyik templomával
+        // mi történt, nem eseménytípusonként szétszórva.
+        $templomok = [];
+        foreach ($tetelek as $tetel) {
+            $kulcs = (int) $tetel->church_id;
+            if (!isset($templomok[$kulcs])) {
+                $templom = $kulcs > 0 ? \Eloquent\Church::find($kulcs) : null;
+                $templomok[$kulcs] = [
+                    'nev' => $templom ? $templom->fullName : 'Egyéb',
+                    'id' => $kulcs,
+                    'tetelek' => [],
+                ];
+            }
+            $templomok[$kulcs]['tetelek'][] = $tetel;
+        }
+
+        $user->digestChurches = array_values($templomok);
+        $user->digestCount = count($tetelek);
+
+        $mail = new \Eloquent\Email();
+        $mail->to = $user->email;
+        $mail->render('user_digest', $user);
+        $mail->addToQueue();
+
+        DB::table('notification_digest_items')
+            ->where('uid', $uid)
+            ->whereNull('sent_at')
+            ->update(['sent_at' => date('Y-m-d H:i:s')]);
+
+        return true;
+    }
+}

--- a/webapp/classes/eloquent/calsuggestionpackage.php
+++ b/webapp/classes/eloquent/calsuggestionpackage.php
@@ -115,6 +115,16 @@ class CalSuggestionPackage extends CalModel
         }
 
         foreach ($emails as $email) {
+            // #872: napi/heti összefoglalónál egy sor a várólistára, nem külön levél.
+            if (\DigestQueue::halaszt(
+                    $email[2],
+                    'suggestion',
+                    (int) $church->id,
+                    'Miserend-javaslat érkezett',
+                    '/templom/' . (int) $church->id . '/javaslatok')) {
+                continue;
+            }
+
             $this->sendMail($email[0], $email[1], $email[2]);
         }
 

--- a/webapp/classes/eloquent/remark.php
+++ b/webapp/classes/eloquent/remark.php
@@ -107,6 +107,20 @@ class Remark extends \Illuminate\Database\Eloquent\Model {
         }
         
         foreach($emails as $email) {
+            /*
+             * #872: akinek napi/heti összefoglalót kért a beállítása, annak nem külön
+             * levél megy, hanem egy sor a várólistára. Az azonnalit választóknál semmi
+             * nem változik.
+             */
+            if (\DigestQueue::halaszt(
+                    $email[2],
+                    'remark',
+                    (int) $this->church_id,
+                    (string) $this->leiras,
+                    '/templom/' . (int) $this->church_id . '/eszrevetelek')) {
+                continue;
+            }
+
             $this->sendMail($email[0], $email[1], $email[2]);            
         }
                 

--- a/webapp/classes/html/uploadimage.php
+++ b/webapp/classes/html/uploadimage.php
@@ -119,6 +119,16 @@ class UploadImage extends Html {
         }
         
         foreach($emails as $email) {
+            // #872: napi/heti összefoglalónál egy sor a várólistára, nem külön levél.
+            if (isset($email[2]) && \DigestQueue::halaszt(
+                    $email[2],
+                    'image',
+                    (int) $this->church->id,
+                    'Új kép érkezett',
+                    '/templom/' . (int) $this->church->id . '/editphotos')) {
+                continue;
+            }
+
             if(isset($email[2])) $this->addressee = $email[2];
             else $this->addressee = false;
             $mail = new \Eloquent\Email();                

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -40,6 +40,11 @@ class User {
     public $presaved;
     public $favorites;
     public $inactiveDays;
+    /** #872: az értesítési gyakoriság (instant/daily/weekly) — a `user` tábla oszlopa. */
+    public $notification_frequency;
+    /** #872: a napi/heti összefoglaló adatai a levélsablonnak. */
+    public $digestChurches;
+    public $digestCount;
 
     function __construct($uid = false) {
         if (isset($uid) AND $uid != false) {
@@ -197,6 +202,7 @@ class User {
             'volunteer' => 'Hibás értéke van az önkéntességnek!',
             'roles' => 'Hibás formátumú jogkörök!',
             'notifications' => 'Email értesítések engedélyezése körül hiba lépett fel!',
+            'notification_frequency' => 'Hibás értesítési gyakoriság!',
         );
 
         // #829: a mezőnkénti általános mondat helyett a KONKRÉT ok, ha tudjuk.
@@ -204,7 +210,7 @@ class User {
         // használatban van?"), így a felhasználó találgathatott, mit rontott el.
         $this->presaveErrors = [];
 
-        foreach (array('uid', 'username', 'nickname', 'name', 'email', 'volunteer', 'roles','notifications') as $input) {
+        foreach (array('uid', 'username', 'nickname', 'name', 'email', 'volunteer', 'roles','notifications','notification_frequency') as $input) {
             if (isset($vars[$input])) {
                 if (!$this->presave($input, $vars[$input])) {
                     $return = false;
@@ -389,6 +395,14 @@ class User {
         } elseif ($key == 'notifications') {
             if(!in_array($val,[0,1])) {
                 $this->presaveError($key, 'Az értesítés csak be- vagy kikapcsolt lehet.');
+                return false;
+            }
+            $this->presaved[$key] = $val;
+        } elseif ($key == 'notification_frequency') {
+            // #872: fehérlista. Ismeretlen érték az enum-oszlopon némán üres sztringgé
+            // válna, és onnantól a felhasználó besorolhatatlan gyakoriságon állna.
+            if (!in_array($val, \DigestQueue::GYAKORISAGOK, true)) {
+                $this->presaveError($key, 'Ilyen értesítési gyakoriság nincs.');
                 return false;
             }
             $this->presaved[$key] = $val;

--- a/webapp/fajlok/crons.php
+++ b/webapp/fajlok/crons.php
@@ -99,6 +99,9 @@ return [
     ['class' => '\Crons',                         'function' => 'cleanNotificationEmails',    'frequency' => '1 day'],
     ['class' => '\Crons',                         'function' => 'rollPeriodYears',            'frequency' => '1 month'],
     ['class' => '\Eloquent\Email',                'function' => 'sendQueued',                 'frequency' => '15 minutes', 'from' => '1am', 'until' => '6am'],
+    // #872: a napi/heti összefoglaló. A sendQueued ELŐTT kell futnia (az teszi sorba a
+    // levelet), ezért az ablak eleje felé — a `from` az 1 óra, a drainer utána ér rá.
+    ['class' => '\DigestQueue',                   'function' => 'sendDue',                    'frequency' => '1 day',      'from' => '1am', 'until' => '6am'],
     // #315: heti hét templom önkéntesség. Korábban a seed-dumpba (data/crons.sql) írtam
     // volna őket, de az a fájl azóta megszűnt — a #638 óta ez a lista az egyetlen forrás.
     // Mindkettő levelet küld, ezért — a többi levelező cronhoz igazodva — hajnalban fut.

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -1909,6 +1909,88 @@
         }
       }
     },
+    "notification_digest_items": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_uca1400_ai_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "uid": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "email": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "type": {
+          "type": "varchar(30)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "title": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "url": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "sent_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "sent_created": {
+          "unique": false,
+          "columns": [
+            "sent_at",
+            "created_at"
+          ]
+        },
+        "uid_sent": {
+          "unique": false,
+          "columns": [
+            "uid",
+            "sent_at"
+          ]
+        }
+      }
+    },
     "osm": {
       "engine": "InnoDB",
       "collation": "utf8mb4_unicode_ci",
@@ -3117,6 +3199,12 @@
           "default": "1",
           "extra": ""
         },
+        "notification_frequency": {
+          "type": "enum('instant','daily','weekly')",
+          "nullable": false,
+          "default": "daily",
+          "extra": ""
+        },
         "becenev": {
           "type": "varchar(50)",
           "nullable": false,
@@ -3147,8 +3235,8 @@
     }
   },
   "_meta": {
-    "generated_at": "2026-08-20T11:23:43+02:00",
-    "source_schema": "ref_845",
+    "generated_at": "2026-08-24T05:23:33+02:00",
+    "source_schema": "miserend_ref_872",
     "initdb_fingerprint": "0e7a7451023e81f73e62b23d418801aad4c4bf2501edd9160e93f8729aab08ae",
     "initdb_files": {
       "00-users.sh": "e4f1149c70b9b0b44ce0ba172110ca07ad099fffaf720876e45e8a0a5cb910f8",

--- a/webapp/templates/emails/user_digest.twig
+++ b/webapp/templates/emails/user_digest.twig
@@ -1,0 +1,53 @@
+{{ digestCount == 1 ? '1 újdonság a templomodnál' : digestCount ~ ' újdonság a templomaidnál' }}
+
+Kedves {% include 'emails/_megszolitas.twig' %}!<br/>
+<br/>
+{#
+    #872: napi/heti összefoglaló.
+
+    Ez a levél váltja ki az „új észrevétel / új javaslat / új kép érkezett" külön
+    leveleket. Templomonként csoportosítunk, nem eseménytípusonként: a gondnokot az
+    érdekli, hogy MELYIK templomával mi történt.
+#}
+Az utolsó értesítőnk óta {% if digestCount == 1 %}egy újdonság érkezett{% else %}{{ digestCount }} újdonság érkezett{% endif %} a hozzád tartozó
+templom{% if digestChurches|length > 1 %}okhoz{% else %}hoz{% endif %}:<br/>
+<br/>
+
+{% for templom in digestChurches %}
+	<div style="margin-bottom:18px;">
+		<strong>
+			{% if templom.id > 0 %}
+				<a href="{{ domain }}/templom/{{ templom.id }}">{{ templom.nev }}</a>
+			{% else %}
+				{{ templom.nev }}
+			{% endif %}
+		</strong>
+		<ul class="list-group" style="margin-top:6px;">
+			{% for tetel in templom.tetelek %}
+				<li class="list-group-item">
+					<small style="color:#666;">
+						{% if tetel.type == 'remark' %}Észrevétel
+						{% elseif tetel.type == 'suggestion' %}Miserend-javaslat
+						{% elseif tetel.type == 'image' %}Új kép
+						{% else %}{{ tetel.type }}
+						{% endif %}
+						· {{ tetel.created_at|date('Y. m. d. H:i') }}
+					</small><br/>
+					<a href="{{ domain }}{{ tetel.url }}">{{ tetel.title }}</a>
+				</li>
+			{% endfor %}
+		</ul>
+	</div>
+{% endfor %}
+
+<br/>
+{#
+    A beállítás helyét minden levélben megmutatjuk. Enélkül az marad a felhasználónak,
+    hogy az egészet kikapcsolja — pont ezt akartuk elkerülni.
+#}
+<small>
+	Ezt az összefoglalót azért kapod, mert a beállításod szerint
+	{% if notification_frequency == 'weekly' %}hetente{% else %}naponta{% endif %}
+	kérsz értesítést. A <a href="{{ domain }}/user/edit">beállításaid</a> között bármikor
+	átállíthatod azonnalira, ritkábbra, vagy kikapcsolhatod.
+</small>

--- a/webapp/templates/user/edit.twig
+++ b/webapp/templates/user/edit.twig
@@ -143,7 +143,27 @@
 	    			</label>
 	    			<p class="help-block">Leginkább a felelőssségi köreidbe tartozó templomokhoz érkező észrevételekről küldünk üzeneteket.</p>
 		    	</div>
-			</div>                    
+			</div>
+
+			{#
+			   #872: milyen sűrűn. Eddig csak „minden vagy semmi" volt, és aki több
+			   templomot gondnokol, az a sok levél miatt inkább az egészet kikapcsolta.
+			   Az alapérték a napi összefoglaló — a meglévő felhasználóknál is.
+			#}
+			<div class="form-group">
+				<label for="notification_frequency">Értesítések gyakorisága</label>
+				<select id="notification_frequency" name="edituser[notification_frequency]" class="form-control" style="max-width:22em;">
+					<option value="instant" {% if edituser.notification_frequency == 'instant' %}selected{% endif %}>Azonnal, eseményenként</option>
+					<option value="daily" {% if edituser.notification_frequency != 'instant' and edituser.notification_frequency != 'weekly' %}selected{% endif %}>Naponta egy összefoglaló</option>
+					<option value="weekly" {% if edituser.notification_frequency == 'weekly' %}selected{% endif %}>Hetente egy összefoglaló</option>
+				</select>
+				<p class="help-block">
+					Az új észrevételekről, miserend-javaslatokról és képekről szól. Az összefoglaló
+					templomonként csoportosítva sorolja fel, mi történt — így több templom mellett sem
+					kapsz naponta tucatnyi levelet. A búcsú- és ünnep-emlékeztetők ettől függetlenül,
+					a maguk idejében érkeznek.
+				</p>
+			</div>
                 {% endif %}
 
                 {% if user.roles is not empty %}

--- a/webapp/tests/Integration/NotificationDigestTest.php
+++ b/webapp/tests/Integration/NotificationDigestTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #872: napi/heti összefoglaló az esemény-értesítőkből.
+ *
+ * borazslo mérése az éles adatbázison (30 nap): a legterheltebb címek 157-162 értesítőt
+ * kaptak, a legrosszabb napokon 21-et EGYETLEN nap alatt, és 41 felhasználó már ki is
+ * kapcsolta az értesítést. A döntése: „Legyen rögtön a B (azonnal / napi / heti), és
+ * persze mindenki napira állítva."
+ *
+ * Amit ez a teszt rögzít: a halasztás nem veszít el értesítést, csak összevonja — és
+ * aki az azonnalit választja, annak semmi nem változik.
+ */
+final class NotificationDigestTest extends TestCase {
+
+    private int $uid;
+    private int $churchId;
+
+    protected function setUp(): void {
+        DB::beginTransaction();
+
+        $this->uid = (int) DB::table('user')->insertGetId([
+            'login' => 'digest' . bin2hex(random_bytes(3)),
+            'nev' => 'Digest Teszt',
+            'email' => 'digest' . bin2hex(random_bytes(3)) . '@example.invalid',
+            'jelszo' => 'x',
+            'notifications' => 1,
+            'notification_frequency' => 'daily',
+        ]);
+
+        $this->churchId = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Digest teszt templom', 'ok' => 'i', 'lat' => 47.0, 'lon' => 19.0,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+    }
+
+    private function cimzett(string $gyakorisag = 'daily'): stdClass {
+        DB::table('user')->where('uid', $this->uid)->update(['notification_frequency' => $gyakorisag]);
+
+        return DB::table('user')->where('uid', $this->uid)->first();
+    }
+
+    private function tetelek(): int {
+        return DB::table('notification_digest_items')->where('uid', $this->uid)->count();
+    }
+
+    /**
+     * A NEKÜNK szóló összefoglalók száma.
+     *
+     * A `sendDue()` szándékosan MINDENKINEK kiküldi az esedékes listáját, tehát a
+     * suite többi tesztje által keltett tételek is kimennek. Globális darabszámot
+     * számolni ezért félrevezető lenne — a saját címünkre szűkítünk.
+     */
+    private function nekemSzoloDigestek(): int {
+        return DB::table('emails')
+            ->where('type', 'user_digest')
+            ->where('to', DB::table('user')->where('uid', $this->uid)->value('email'))
+            ->count();
+    }
+
+    /** Az alapérték napi — a meglévő felhasználókra is, oszlop-alapértékkel. */
+    public function testTheDefaultIsTheDailyDigest(): void {
+        $user = DB::table('user')->where('uid', $this->uid)->first();
+
+        self::assertSame('daily', $user->notification_frequency);
+        self::assertSame('daily', \DigestQueue::gyakorisag($user));
+    }
+
+    /** A LÉNYEG: napi beállításnál nem megy külön levél, hanem sor kerül a listára. */
+    public function testWithTheDailySettingTheNotificationIsQueued(): void {
+        $halasztva = \DigestQueue::halaszt(
+            $this->cimzett('daily'), 'remark', $this->churchId, 'Rossz a miserend', '/templom/1/eszrevetelek');
+
+        self::assertTrue($halasztva, 'a hivonak NEM szabad azonnal kuldenie');
+        self::assertSame(1, $this->tetelek());
+    }
+
+    /** Aki az azonnalit választja, annál semmi nem változik. */
+    public function testWithTheInstantSettingNothingChanges(): void {
+        $halasztva = \DigestQueue::halaszt(
+            $this->cimzett('instant'), 'remark', $this->churchId, 'Rossz a miserend', '/x');
+
+        self::assertFalse($halasztva, 'azonnali beallitasnal a hivo kuld');
+        self::assertSame(0, $this->tetelek());
+    }
+
+    /**
+     * Akit nem tudunk azonosítani, annak inkább menjen a levél.
+     *
+     * Az összefoglaló felhasználóhoz kötött; uid nélkül nincs kihez kötni. Ilyenkor a
+     * régi, azonnali út a helyes válasz — az értesítés elvesztése sokkal rosszabb, mint
+     * egy fölös levél.
+     */
+    public function testAnUnidentifiableRecipientIsNotQueued(): void {
+        $nevtelen = (object) ['email' => 'valaki@example.invalid'];
+
+        self::assertFalse(\DigestQueue::halaszt($nevtelen, 'remark', $this->churchId, 'x', '/x'));
+    }
+
+    /** Ismeretlen gyakoriság-érték: napi. Nem veszíthet el értesítést, csak késleltet. */
+    public function testAnUnknownFrequencyFallsBackToDaily(): void {
+        self::assertSame('daily', \DigestQueue::gyakorisag((object) ['notification_frequency' => 'sohanapjan']));
+        self::assertSame('daily', \DigestQueue::gyakorisag((object) []));
+    }
+
+    /** A napi összefoglaló kimegy, és a tételek elkeltnek. */
+    public function testTheDailyDigestIsSentAndTheItemsAreMarked(): void {
+        \DigestQueue::halaszt($this->cimzett('daily'), 'remark', $this->churchId, 'Első', '/a');
+        \DigestQueue::halaszt($this->cimzett('daily'), 'image', $this->churchId, 'Második', '/b');
+
+        $elotte = $this->nekemSzoloDigestek();
+        \DigestQueue::sendDue();
+
+        self::assertSame($elotte + 1, $this->nekemSzoloDigestek(),
+            'ket esemenyre EGY levelet varunk');
+        self::assertSame(0, DB::table('notification_digest_items')
+            ->where('uid', $this->uid)->whereNull('sent_at')->count());
+    }
+
+    /** A levél mindkét eseményt felsorolja — az összevonás nem veszíthet el semmit. */
+    public function testTheDigestListsEveryEvent(): void {
+        \DigestQueue::halaszt($this->cimzett('daily'), 'remark', $this->churchId, 'Elveszett mise', '/a');
+        \DigestQueue::halaszt($this->cimzett('daily'), 'image', $this->churchId, 'Új fotó a toronyról', '/b');
+
+        \DigestQueue::sendDue();
+
+        $level = DB::table('emails')
+            ->where('type', 'user_digest')
+            ->where('to', DB::table('user')->where('uid', $this->uid)->value('email'))
+            ->orderByDesc('id')->first();
+
+        self::assertNotNull($level);
+        self::assertStringContainsString('Elveszett mise', $level->body);
+        self::assertStringContainsString('Új fotó a toronyról', $level->body);
+        self::assertStringContainsString('Digest teszt templom', $level->body);
+        self::assertStringContainsString('2 újdonság', $level->subject);
+    }
+
+    /** Aki közben kikapcsolta az értesítést, annak a felgyűlt lista sem megy ki. */
+    public function testASwitchedOffUserGetsNothing(): void {
+        \DigestQueue::halaszt($this->cimzett('daily'), 'remark', $this->churchId, 'x', '/a');
+        DB::table('user')->where('uid', $this->uid)->update(['notifications' => 0]);
+
+        $elotte = $this->nekemSzoloDigestek();
+        \DigestQueue::sendDue();
+
+        self::assertSame($elotte, $this->nekemSzoloDigestek());
+        self::assertSame(1, DB::table('notification_digest_items')
+            ->where('uid', $this->uid)->whereNull('sent_at')->count(), 'a tetel varakozzon tovabb');
+    }
+
+    /** A heti összefoglaló a hét megadott napján megy. */
+    public function testTheWeeklyDigestGoesOnTheChosenDay(): void {
+        $ma = date('Y-m-d H:i:s');
+
+        self::assertTrue(\DigestQueue::hetiEsedekes(\DigestQueue::HETI_NAP, $ma));
+        self::assertFalse(\DigestQueue::hetiEsedekes(\DigestQueue::HETI_NAP + 1, $ma));
+        self::assertFalse(\DigestQueue::hetiEsedekes(\DigestQueue::HETI_NAP + 3, $ma));
+    }
+
+    /**
+     * ...de egy kimaradt futás nem tolhatja a következő hétre.
+     *
+     * Enélkül egyetlen elmaradt hétfő azt jelentené, hogy a gondnok két hétig nem tud a
+     * hozzá érkezett észrevételről.
+     */
+    public function testAnOldItemGoesOutEvenOffDay(): void {
+        $regi = date('Y-m-d H:i:s', strtotime('-8 days'));
+
+        self::assertTrue(\DigestQueue::hetiEsedekes(\DigestQueue::HETI_NAP + 2, $regi));
+    }
+
+    /** A cím levágva, HTML nélkül kerül a listára — a levélben egy sor lesz belőle. */
+    public function testTheTitleIsStrippedAndTruncated(): void {
+        \DigestQueue::halaszt($this->cimzett('daily'), 'remark', $this->churchId,
+            '<b>Kalap</b> ' . str_repeat('a', 400), '/a');
+
+        $tetel = DB::table('notification_digest_items')->where('uid', $this->uid)->first();
+
+        self::assertStringStartsWith('Kalap a', $tetel->title);
+        self::assertLessThanOrEqual(250, mb_strlen($tetel->title));
+    }
+}


### PR DESCRIPTION
Closes #872

A B irány, ahogy kérted: **azonnal / napi / heti**, és **mindenki napira állítva** — a meglévő felhasználók is, az oszlop alapértékén keresztül. A D-t (a szóródás szűkítését) nem csinálom meg, ahogy írtad.

## Mi tartozik ide, és mi nem

Csak a három **esemény**-értesítő: új észrevétel, új miserend-javaslat, új kép. Az emlékeztetők (`user_pleaseupdate`, `holder_bucsu_reminder`, `holder_holiday_reminder`) már ma is egy levél felhasználónként az összes érintett templommal, és ritkítva is vannak — azokhoz nem nyúltam.

## Mit halasztunk

**Nem a kész levelet teszem félre, hanem az eseményt.** Ez a lényegi döntés: ha a rendelt leveleket fűznénk össze, N köszöntés és N aláírás kerülne egymás alá. Így viszont az összefoglaló egyetlen, **templomonként csoportosított** levél — a gondnokot az érdekli, hogy melyik templomával mi történt, nem az, hogy melyik eseménytípusból hány volt.

Új tábla: `notification_digest_items` (uid, email, típus, templom, cím, url, mikor, kiküldve). A `sent_at` a kiküldés bélyege; a sorokat nem töröljük, mert az `emails` mellett ez a másik nyom arról, mit küldtünk ki kinek.

## Mit nem lehet elrontani vele

- **`notifications = 0` erősebb mindennél.** Aki kikapcsolta, annak a felgyűlt lista sem megy ki — a tételek várakoznak tovább (ha visszakapcsolja, megkapja).
- **Ismeretlen gyakoriság-érték → napi.** A `presave` fehérlistás, de ha az adatbázisba mégis szemét kerülne, az nem értesítés-vesztés, csak késleltetés.
- **Azonosíthatatlan címzett → azonnali levél.** Az összefoglaló felhasználóhoz kötött; uid nélkül nincs kihez kötni. Ilyenkor a régi út a helyes válasz: egy fölös levél sokkal kisebb baj, mint egy elveszett értesítés.
- **A heti nem csúszhat két hétre.** A hét első napján megy, **de akkor is, ha a legrégebbi tétel túllépte a hét napot**. Enélkül egyetlen kimaradt futás miatt a gondnok két hétig nem tudna a hozzá érkezett észrevételről.

## Mérve, a fejlesztői példányon

Észrevétel beküldése ugyanarra a templomra, három értesítendő címzettel:

| beállítás | azonnali levelek | várólista | összefoglaló |
|---|---|---|---|
| `daily` | `remark%`: 4100 → **4100** (nem nőtt) | **3 tétel** | cron után **3 levél**, tételenként 0 maradt |
| `instant` | `remark%`: 4100 → **4103** | **0** (nem nőtt) | — |

A cron kimenete egy címzettre (két eseménnyel):

```
Tárgy: 2 újdonság a templomaidnál
Kedves Admin!
Az utolsó értesítőnk óta 2 újdonság érkezett a hozzád tartozó templomhoz:
  Péter-Pál-templom (Csiprovacska)
    Észrevétel · 2026. 08. 24. 05:19   -> Teszt eszrevetel …
    Új kép     · 2026. 08. 24. 05:20   -> Új fotó a toronyról
```

A levél alján ott a beállítás helye — enélkül a felhasználónak megint csak a teljes kikapcsolás marad, épp amit el akarunk kerülni.

## Felület

`/user/edit`: egy legördülő az „Email értesítések" kapcsoló alatt. A súgó kimondja, hogy mire vonatkozik és mire nem (a búcsú- és ünnep-emlékeztető ettől függetlenül érkezik).

## Teszt

`NotificationDigestTest`, 11 eset: az alapérték napi; napinál sorba kerül és nem megy levél; azonnalinál semmi nem változik; azonosíthatatlan címzett nem kerül sorba; ismeretlen érték napira esik; két eseményre **egy** levél megy; a levél **mindkét** eseményt felsorolja (az összevonás nem veszíthet el semmit); kikapcsolt értesítésnél semmi nem megy és a tétel vár; a heti a megadott napon megy; a nyolc napja várakozó tétel a hét közben is kimegy; a cím HTML nélkül, levágva kerül a listára.

Visszamérve: a halasztást kiiktatva 4 bukik + 1 hibára fut, visszatéve zöld.

PHP: 1534 teszt, egyetlen ismert környezeti bukással (`SzentsegimadasImportTest`, a seed-adat két majdnem azonos nevű temploma miatt).

## Deploy

```
docker exec -i miserend-prod-mysql-1 mariadb -uuser -p"$MYSQL_PASSWORD" miserend \
  < docker/mysql/migrations/872-ertesites-gyakorisag.sql
```

Csak hozzáad: egy oszlop a `user`-en (alapérték `daily`, tehát a meglévő felhasználók automatikusan napi összefoglalót kapnak) és egy új tábla. A cron (`\DigestQueue->sendDue()`) a `crons.php`-ból regisztrálódik a szokásos `cron_init=1`-gyel.

**Amire figyelni kell az első nap után:** a `notification_digest_items` sorai nem törlődnek. Ha sokat gyűlik, kell rá egy ritkító cron — de előbb hadd lássuk, mekkora a forgalom.