### PR TITLE
Megadom a release-jogot a heti Elasticsearch-workflow-nak (#886)

### DIFF
--- a/.github/workflows/elasticsearch-data.yaml
+++ b/.github/workflows/elasticsearch-data.yaml
@@ -13,7 +13,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # #886: a `Create GitHub Release` lépéshez `contents: write` kell. `read` mellett
+      # a lépés 403-mal elhasalt („Resource not accessible by integration"), és ezzel a
+      # futás pirosra váltott — nyolc hét óta minden hétfőn. A kép közben rendben
+      # elkészült és fel is került; csak a release nem jött létre hozzá.
+      contents: write
       packages: write
 
     steps:


### PR DESCRIPTION
Closes #886

## Az ok

```
👩‍🏭 Creating new GitHub release for tag elasticsearch-data-2026.08.24...
⚠️ GitHub release failed with status: 403
Resource not accessible by integration
Skip retry — your GitHub token/PAT does not have the required permission to create a release
```

A job `contents: read`-et kapott, a release létrehozása viszont `contents: write`-ot igényel. A `packages: write` csak az image-hez elég.

## Mi bukott el, és mi nem

Csak az utolsó lépés — a heti kép rendben elkészült és fel is került:

```
success  Export elasticsearch data from production
success  Build & push image
failure  Create GitHub Release
```

## Miért most vettem észre

Mert ma reggel is lefutott, és a `master` futáslistájában pirosan látszott. Visszanézve **nyolc egymás utáni hétfő** bukott el ugyanígy, legalább 2026-07-13 óta. Ütemezett munkafolyamat, senkinek nem szólt.

A tényleges kár nem a hiányzó release, hanem hogy nyolc hete piros: ha az `Export elasticsearch data from production` romlana el — az az egyetlen lépés, aminek a hibája tényleg számít —, az elveszne a zajban.

## A javítás

```diff
     permissions:
-      contents: read
+      contents: write
       packages: write
```

Végignéztem a többi munkafolyamatot is: release-t vagy taget más nem hoz létre, tehát ugyanez a hiba máshol nincs.

## Mérés

Ezt nem tudom helyben lefuttatni — a jogosultság a GitHub oldalán dől el. Amit ellenőriztem: a YAML érvényes és a `permissions` blokk a várt értéket adja, illetve hogy a 403 pontosan ennél a lépésnél és ezzel az indoklással jött. **A visszaigazolás a következő hétfői futás**, vagy egy kézi `workflow_dispatch` indítás merge után — érdemes egyet elindítani, ne várjunk vele egy hetet.
