### PR TITLE
Az ellenőrző szkriptet a bázisról veszem, ha az ág régebbi nála (#888)

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -109,7 +109,28 @@ jobs:
         env:
           COVERAGE_IMAGE_TAG: ${{ steps.tag.outputs.TAG }}
         run: |
-            docker compose $COMPOSE_FILES cp scripts/check-undefined-methods.php miserend:/tmp/check-undefined-methods.php
+            # #888: az ellenőrző szkript a REPÓ eszköze, nem a vizsgált kód.
+            #
+            # A futás a nyers PR-fejet checkoutolja (l. fentebb a REF-et), tehát egy
+            # néhány hetes ágon a szkript egyszerűen nincs ott — a `cp` `lstat ... no such
+            # file`-lal elhasal, és a PR a TARTALMÁTÓL FÜGGETLENÜL piros lesz, még mielőtt
+            # egyetlen teszt lefutna. Pontosan ez történt a #879-cel.
+            #
+            # Ezért: ha az ágon nincs, a bázisról vesszük elő. Ha ott sincs, kihagyjuk —
+            # a hiányzó ellenőrző nem hiba, csak nem alkalmazható.
+            SCRIPT=scripts/check-undefined-methods.php
+            if [ ! -f "$SCRIPT" ]; then
+              BASE="${{ github.base_ref || 'master' }}"
+              echo "A(z) $SCRIPT nincs ezen az ágon; a(z) $BASE példányát próbálom."
+              if git fetch --depth=1 origin "$BASE" \
+                 && git show FETCH_HEAD:"$SCRIPT" > /tmp/check-undefined-methods.php 2>/dev/null; then
+                SCRIPT=/tmp/check-undefined-methods.php
+              else
+                echo "::notice title=Metódus-ellenőrzés kihagyva::A szkript sem az ágon, sem a(z) $BASE ágon nem érhető el."
+                exit 0
+              fi
+            fi
+            docker compose $COMPOSE_FILES cp "$SCRIPT" miserend:/tmp/check-undefined-methods.php
             docker compose $COMPOSE_FILES exec -T miserend php /tmp/check-undefined-methods.php /miserend/webapp
 
       - name: Run PHPUnit tests


### PR DESCRIPTION
Closes #888

## Az ok

A `phpunit.yml` a **nyers PR-fejet** checkoutolja (`github.event.pull_request.head.sha`) — tudatos döntés, jó indoklással. A következménye viszont, hogy a futás a PR ágának saját, régi repóállapotát látja.

A „Nemlétező metódushívások" lépés pedig egy repó-szintű eszközt másol be. A `scripts/check-undefined-methods.php` `1f04a04d`-vel került a masterre (2026-08-17); a #879 ága `335e8d04`-ről indul, tehát nincs rajta:

```
lstat …/scripts/check-undefined-methods.php: no such file or directory
##[error]Process completed with exit code 1.
```

A futás 2 perc alatt elhal, **egyetlen teszt lefutása előtt**. A hozzájárulónak azt üzenjük, hogy elrontott valamit — pedig egy sort törölt a compose-ból, aminek ehhez semmi köze.

## A javítás

Az ellenőrző szkript a **repó eszköze**, nem a vizsgált kód — a verziója sem a PR-é kell legyen. Ha nincs az ágon, a bázisról vesszük elő; ha ott sincs, a lépést kihagyjuk figyelmeztetéssel. Hiányzó ellenőrző nem hiba, csak nem alkalmazható.

## Mérés

Lefuttattam a bash-logikát pontosan a #879 ágának állapotán (`335e8d04`, külön worktree-ben):

```
van-e a szkript ezen az ágon? -> NEM
A(z) scripts/check-undefined-methods.php nincs ezen az ágon; a(z) master példányát próbálom.
-> megvan a bázisról: 4542 bájt
használt szkript: /tmp/check-undefined-methods.php
No syntax errors detected
```

Olyan ágon, ahol a szkript ott van (mint ez a PR), a `if [ ! -f ]` ág be sem fut — a viselkedés változatlan.

## Amit szándékosan NEM változtatok

A `head.sha` checkoutot. Az indoklása ott van a workflow-ban (a `refs/pull/<id>/merge` eltűnik merge/close után, a head commit viszont marad), és az átállás külön mérlegelést kíván. Ez a PR csak azt orvosolja, hogy egy repó-szintű eszköz hiánya ne legyen a hozzájáruló hibája.

Ettől a #879 még nem lesz zöld magától — a javítás a **master** workflow-ját érinti, a PR-ek a saját águkról futnak. Merge után újraindítva viszont már átmegy, és minden ezutáni régebbi ág is.
