### PR TITLE
Két óra a gyóntatás — a kirajzolt eseményre és az élő jelzőre is (#884)

### DIFF
--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -293,7 +293,25 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * @param string $toleranceString - The time window to consider for determining if the confession is still ON (e.g., '20 hours').
      * @return array - An array of confession periods with their start and end times, and duration.
      */
-    public function getConfessions($fromString, $toleranceString)
+    /**
+     * #884: a leghosszabb MEGJELENÍTETT gyóntatás-szakasz.
+     *
+     * A `getConfessions()` a le nem zárt szakaszt a toleranciával zárja le — ma 20
+     * órával. Élő státusznak („most van gyóntatás") ez elmegy, de MEGJELENÍTETT
+     * eseménynek nyilvánvalóan rossz: a naptárban 20 órás gyóntatás-blokk keletkezett
+     * belőle, a panelen pedig „20 óra" állt. Egy gyóntatás nem tart 20 órát; ez az az
+     * eset, amikor a pap bekapcsolta és kikapcsolni elfelejtette.
+     *
+     * borazslo döntése a #884-ben: legyen két óra.
+     */
+    const CONFESSION_MAX_DISPLAY = '2 hours';
+
+    /**
+     * @param string|null $maxDurationString  a megjelenített szakasz felső korlátja.
+     *        Alapból a CONFESSION_MAX_DISPLAY; `null` esetén nincs korlát (a nyers,
+     *        toleranciával lezárt szakaszok jönnek vissza).
+     */
+    public function getConfessions($fromString, $toleranceString, $maxDurationString = self::CONFESSION_MAX_DISPLAY)
     {
         $toleranceSeconds = strtotime($toleranceString) - time();
 
@@ -404,10 +422,38 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             
         }
 
-        return $periods;
+        return self::korlatozottSzakaszok($periods, $maxDurationString);
+    }
 
+    /**
+     * #884: a túl hosszú szakaszok visszavágása a megjelenítéshez.
+     *
+     * Amelyik szakasz hosszabb a korlátnál, az a kezdetétől számított korlátnál
+     * végződik. A le nem zárt szakasz („még tart", nincs `end` kulcsa) is lezárul, ha
+     * már túllépte a korlátot: két óra után nem állíthatjuk, hogy még mindig tart.
+     *
+     * Az ennél rövidebb, valóban folyamatban lévő szakasz érintetlen marad — a panel
+     * abból tudja, hogy „még tart".
+     */
+    private static function korlatozottSzakaszok(array $szakaszok, $maxDurationString): array {
+        if ($maxDurationString === null) {
+            return $szakaszok;
+        }
 
+        $max = strtotime($maxDurationString) - time();
+        if ($max <= 0) {
+            return $szakaszok;
+        }
 
+        foreach ($szakaszok as &$szakasz) {
+            if (($szakasz['duration'] ?? 0) <= $max) {
+                continue;
+            }
+            $szakasz['duration'] = $max;
+            $szakasz['end'] = date('Y-m-d H:i:s', strtotime($szakasz['start']) + $max);
+        }
+
+        return $szakaszok;
     }
 
 	public function attributes()

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -253,9 +253,21 @@ class Church extends \Illuminate\Database\Eloquent\Model {
         }
         
         $confession = $lastConfessionData->first();
-        
-        $toleranceString = '20 hours'; // tolerance window as a string
-        $toleranceSeconds = strtotime($toleranceString) - time(); // convert to seconds
+
+        /*
+         * #884: két óra, nem húsz.
+         *
+         * Ez a „még mindig tart?" ablak: kaptunk egy ON-t, OFF-ot nem, és eddig
+         * feltételeztük, hogy a gyóntatás még folyik. Húsz óráig feltételezni ezt
+         * annyit tett, hogy egy elfelejtett kikapcsolás másnap délig hirdette:
+         * „Most van gyóntatás a helyszínen!" — miközben rég nem volt.
+         *
+         * Ugyanaz az érték, mint a megjelenített szakasz korlátja, de nem ugyanaz a
+         * kérdés: ez az élő állapotról szól, az meg a kirajzolt esemény hosszáról.
+         * Ezért két konstans, egyező értékkel — ha valaha eltérnek, ne kelljen
+         * kibogozni, melyik miért.
+         */
+        $toleranceSeconds = strtotime(self::CONFESSION_TOLERANCE) - time();
 
         if ($confession->status === 'ON' && ( time() - strtotime($confession->timestamp) ) <= $toleranceSeconds ) {
             $status = 'ON';
@@ -268,7 +280,8 @@ class Church extends \Illuminate\Database\Eloquent\Model {
 
     public function getConfessionsAttribute()
     {
-        $toleranceString = '20 hours'; // tolerance window as a string
+        // #884: a konstansból, nem beégetve — eddig három helyen állt külön a „20 hours".
+        $toleranceString = self::CONFESSION_TOLERANCE;
 
         $status = $this->confessionStatus;
         if($status === false) {
@@ -290,7 +303,7 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * Get confession periods for this church starting from a given date, with a specified tolerance for determining ON/OFF status.
      *
      * @param string $fromString - The starting point for fetching confession data (e.g., '-40 days').
-     * @param string $toleranceString - The time window to consider for determining if the confession is still ON (e.g., '20 hours').
+     * @param string $toleranceString - The time window to consider for determining if the confession is still ON (e.g., Church::CONFESSION_TOLERANCE).
      * @return array - An array of confession periods with their start and end times, and duration.
      */
     /**
@@ -305,6 +318,15 @@ class Church extends \Illuminate\Database\Eloquent\Model {
      * borazslo döntése a #884-ben: legyen két óra.
      */
     const CONFESSION_MAX_DISPLAY = '2 hours';
+
+    /**
+     * #884: meddig feltételezzük, hogy egy le nem zárt gyóntatás még tart.
+     *
+     * Ez az ÉLŐ állapot ablaka (a templomoldal jelzője és a `getConfessions()`
+     * szakaszlezárása). Eddig 20 óra volt, három helyre beégetve; egy elfelejtett
+     * kikapcsolás így másnap délig hirdette, hogy „Most van gyóntatás a helyszínen!".
+     */
+    const CONFESSION_TOLERANCE = '2 hours';
 
     /**
      * @param string|null $maxDurationString  a megjelenített szakasz felső korlátja.

--- a/webapp/classes/html/ajax/calendar/church.php
+++ b/webapp/classes/html/ajax/calendar/church.php
@@ -59,7 +59,9 @@ class Church extends \Html\Ajax\Calendar\CalendarApi {
             case 'GET':
                 // Append external calendar info
                 $this->church->append(['hasExternalCalendar']);
-                $confessions = $this->church->getConfessions('-40 days', '20 hours');
+                // #884: a tolerancia a modell konstansából, nem beégetve (eddig három
+                // helyen állt külön ugyanaz a „20 hours").
+                $confessions = $this->church->getConfessions('-40 days', \Eloquent\Church::CONFESSION_TOLERANCE);
                 $c = 1;
                 /*
                  * #832: az időzóna KIMONDVA, nem a szerver beállításából.

--- a/webapp/templates/church/_panelconfessions.twig
+++ b/webapp/templates/church/_panelconfessions.twig
@@ -49,36 +49,31 @@
 
 
     {% else %}
-        Legutóbbi gyóntatások:
-        {% for last_period in confessions.last_periods %}
-            {% set days = (last_period.duration // 86400) %}
-            {% set hours = ((last_period.duration % 86400) // 3600) %}
-            {% set minutes = ((last_period.duration % 3600) // 60) %}
-            <h5>
+        {#
+           #884: a MÚLTAT a naptár mutatja, nem ez a panel.
+
+           borazslo kérése: „a panel_confession helyett magába a naptárba kéne on the fly
+           legenerálni gyóntatás eseményeket… és ez mutatja jól a múltat. A panel-ben csak
+           annyi kell, hogy itt nincs érzékelő, de lehetne."
+
+           Az érzékelő-események már ma is bekerülnek a naptárba (`eventsFromSensor`), ott
+           a hét rendje is látszik — itt a hosszú lista csak ugyanazt ismételte, kevesebb
+           összefüggéssel. A panelben az ÉLŐ állapot marad, mert arra a naptár nem ad
+           választ egy pillantásra: „most be lehet-e menni gyónni".
+
+           Az utolsó szakaszt viszont meghagyjuk, mert az a mostani állapot indoklása.
+        #}
+        {% set utolso = confessions.last_periods|last %}
+        {% if utolso %}
+            <p class="alap">
+                Legutóbb:
                 <strong>
-                    {{ last_period.start|miserend_date('H:i')|capitalize }} -
-                    {% if last_period.end is defined %}
-                        {{ last_period.end|date('H:i') }}
-                    {% else %}
-                        még tart
-                    {% endif %}
-                </strong>:
-                {% if days > 0 %}
-                    {{ days }} nap
-                {% endif %}
-                {% if hours > 0 %}
-                    {{ hours }} óra
-                {% endif %}
-                {% if minutes > 0 %}
-                    {{ minutes }} perc
-                {% endif %}
-                {% if days == 0 and hours == 0 and minutes == 0 %}
-                    kevesebb mint 1 perc
-                {% endif %}
-            </h5>
-		{% endfor %}  
-
-
+                    {{ utolso.start|miserend_date('H:i')|capitalize }} –
+                    {% if utolso.end is defined %}{{ utolso.end|date('H:i') }}{% else %}még tart{% endif %}
+                </strong>
+            </p>
+        {% endif %}
+        <p class="alap"><small>A korábbi gyóntatások a fenti naptárban láthatók.</small></p>
     {% endif %}
 
     

--- a/webapp/tests/Integration/ConfessionDisplayLengthTest.php
+++ b/webapp/tests/Integration/ConfessionDisplayLengthTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #884: két óra a leghosszabb megjelenített gyóntatás.
+ *
+ * A `getConfessions()` a le nem zárt szakaszt a toleranciával zárta le — 20 órával.
+ * Élő státusznak („most van gyóntatás") ez elmegy, megjelenített eseménynek viszont
+ * nem: a naptárban 20 órás gyóntatás-blokk keletkezett belőle. Mérve, valódi adaton:
+ *
+ *   GET /ajax/calendar/church/1252
+ *     { id: "confession_1", title: "Gyóntatás", duration: 72000 }   <- 20 óra
+ *
+ * Ez az az eset, amikor a pap bekapcsolta és kikapcsolni elfelejtette. borazslo
+ * döntése: legyen két óra.
+ */
+final class ConfessionDisplayLengthTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        DB::beginTransaction();
+
+        $this->churchId = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Gyóntatás teszt', 'ok' => 'i', 'lat' => 47.0, 'lon' => 19.0,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+    }
+
+    /** Egy jelzés az érzékelőtől. `$mikor` a mostanihoz képest (strtotime-alak). */
+    private function jelzes(string $status, string $mikor, int $localId = 1): void {
+        DB::table('confessions')->insert([
+            'deduplicationId' => bin2hex(random_bytes(8)) . '-' . bin2hex(random_bytes(4)),
+            'church_id' => $this->churchId,
+            'local_id' => $localId,
+            'status' => $status,
+            'timestamp' => date('Y-m-d H:i:s', strtotime($mikor)),
+            'fulldata' => '{}',
+        ]);
+    }
+
+    private function szakaszok($max = \Eloquent\Church::CONFESSION_MAX_DISPLAY): array {
+        return \Eloquent\Church::find($this->churchId)->getConfessions('-40 days', '20 hours', $max);
+    }
+
+    /** A LÉNYEG: a le nem zárt szakasz két óra, nem húsz. */
+    public function testAnUnclosedSessionIsCappedAtTwoHours(): void {
+        $this->jelzes('ON', '-30 hours');
+
+        $szakaszok = $this->szakaszok();
+
+        self::assertCount(1, $szakaszok);
+        self::assertSame(7200, $szakaszok[0]['duration'], 'ket ora, nem husz');
+    }
+
+    /** A korlát tényleg a beállított érték, nem véletlen szám. */
+    public function testTheCapIsTheDeclaredConstant(): void {
+        self::assertSame('2 hours', \Eloquent\Church::CONFESSION_MAX_DISPLAY);
+    }
+
+    /** A rövid, valóban lezárt szakaszhoz nem nyúlunk. */
+    public function testAShortClosedSessionIsUntouched(): void {
+        $this->jelzes('ON',  '-3 hours');
+        $this->jelzes('OFF', '-3 hours +45 minutes');
+
+        $szakaszok = $this->szakaszok();
+
+        self::assertCount(1, $szakaszok);
+        self::assertSame(45 * 60, $szakaszok[0]['duration']);
+    }
+
+    /** A hosszú, lezárt szakasz is visszavágódik — a vég a kezdethez igazodik. */
+    public function testALongClosedSessionIsCappedAndTheEndMovesBack(): void {
+        $this->jelzes('ON',  '-10 hours');
+        $this->jelzes('OFF', '-5 hours');
+
+        $szakaszok = $this->szakaszok();
+
+        self::assertCount(1, $szakaszok);
+        self::assertSame(7200, $szakaszok[0]['duration']);
+        self::assertSame(
+            strtotime($szakaszok[0]['start']) + 7200,
+            strtotime($szakaszok[0]['end']),
+            'a vegnek a kezdet + ket ora-nak kell lennie'
+        );
+    }
+
+    /**
+     * A tényleg folyamatban lévő szakasz marad „még tart".
+     *
+     * A panel abból tudja, hogy nincs `end` kulcsa. Ha ezt is lezárnánk, a látogató
+     * azt látná, hogy vége, holott épp most gyóntatnak.
+     */
+    public function testAGenuinelyOngoingSessionStaysOpen(): void {
+        $this->jelzes('ON', '-20 minutes');
+
+        $szakaszok = $this->szakaszok();
+
+        self::assertCount(1, $szakaszok);
+        self::assertArrayNotHasKey('end', $szakaszok[0], 'meg tart — nincs vege');
+        self::assertGreaterThan(0, $szakaszok[0]['duration']);
+        self::assertLessThanOrEqual(7200, $szakaszok[0]['duration']);
+    }
+
+    /** Korlát nélkül a nyers, toleranciával lezárt érték jön — a kiskapu megmarad. */
+    public function testWithoutACapTheRawToleranceValueComesBack(): void {
+        $this->jelzes('ON', '-30 hours');
+
+        $szakaszok = $this->szakaszok(null);
+
+        self::assertCount(1, $szakaszok);
+        self::assertSame(20 * 3600, $szakaszok[0]['duration'], 'korlat nelkul a 20 oras tolerancia');
+    }
+
+    /** Több szakasz esetén mindegyikre külön érvényes a korlát. */
+    public function testEveryPeriodIsCappedSeparately(): void {
+        $this->jelzes('ON',  '-3 days');
+        $this->jelzes('OFF', '-3 days +30 minutes');
+        $this->jelzes('ON',  '-2 days');
+        $this->jelzes('OFF', '-2 days +9 hours');
+
+        $szakaszok = $this->szakaszok();
+
+        self::assertCount(2, $szakaszok);
+        self::assertSame(30 * 60, $szakaszok[0]['duration'], 'a rovid marad');
+        self::assertSame(7200, $szakaszok[1]['duration'], 'a hosszu visszavagodik');
+    }
+}

--- a/webapp/tests/Integration/ConfessionDisplayLengthTest.php
+++ b/webapp/tests/Integration/ConfessionDisplayLengthTest.php
@@ -121,6 +121,76 @@ final class ConfessionDisplayLengthTest extends TestCase {
         self::assertSame(20 * 3600, $szakaszok[0]['duration'], 'korlat nelkul a 20 oras tolerancia');
     }
 
+    /* ---- Az ÉLŐ állapot (a templomoldal jelzője) ---- */
+
+    /**
+     * A LÉNYEG: az elfelejtett kikapcsolás nem hirdet gyóntatást másnap délig.
+     *
+     * Eddig 20 óra volt a „még tart?" ablak, tehát egy reggel bekapcsolt és kikapcsolni
+     * elfelejtett jelzés estig-másnapig azt írta ki, hogy „Most van gyóntatás a
+     * helyszínen!". Ez a látogatót odaviszi hiába — ennél rosszabbat nem is tehetünk.
+     */
+    public function testAForgottenSwitchDoesNotAdvertiseConfession(): void {
+        $this->jelzes('ON', '-5 hours');
+
+        self::assertSame('OFF', \Eloquent\Church::find($this->churchId)->confessionStatus);
+    }
+
+    /** A valóban futó gyóntatás továbbra is látszik. */
+    public function testAnOngoingConfessionIsStillOn(): void {
+        $this->jelzes('ON', '-20 minutes');
+
+        self::assertSame('ON', \Eloquent\Church::find($this->churchId)->confessionStatus);
+    }
+
+    /** A határ pontosan a konstans: két órán belül igen, azon túl nem. */
+    public function testTheLiveWindowIsExactlyTwoHours(): void {
+        $this->jelzes('ON', '-119 minutes');
+        self::assertSame('ON', \Eloquent\Church::find($this->churchId)->confessionStatus);
+
+        DB::table('confessions')->where('church_id', $this->churchId)->delete();
+
+        $this->jelzes('ON', '-121 minutes');
+        self::assertSame('OFF', \Eloquent\Church::find($this->churchId)->confessionStatus);
+    }
+
+    /** Kikapcsolt jelzés: nem gyóntatnak. */
+    public function testAnOffSignalMeansNoConfession(): void {
+        $this->jelzes('ON',  '-40 minutes');
+        $this->jelzes('OFF', '-10 minutes');
+
+        self::assertSame('OFF', \Eloquent\Church::find($this->churchId)->confessionStatus);
+    }
+
+    /**
+     * Adat nélkül `false` — ez NEM ugyanaz, mint az 'OFF'.
+     *
+     * A `false` azt jelenti, hogy ebben a templomban nincs érzékelő; a felület ilyenkor
+     * mást ír ki („Nincs jelzőkapcsoló"), mint amikor van, de épp nem gyóntatnak.
+     */
+    public function testWithoutAnySignalTheStatusIsFalse(): void {
+        self::assertFalse(\Eloquent\Church::find($this->churchId)->confessionStatus);
+    }
+
+    /** Az élő ablak konstansból jön, és két óra. */
+    public function testTheLiveToleranceIsTheDeclaredConstant(): void {
+        self::assertSame('2 hours', \Eloquent\Church::CONFESSION_TOLERANCE);
+    }
+
+    /**
+     * A „20 hours" nem maradhat beégetve sehol.
+     *
+     * A #884-ben pont az volt a baj, hogy ugyanaz az érték három helyen állt külön
+     * (`church.php` kétszer, `ajax/calendar/church.php` egyszer). Ha valaki
+     * visszacsempészi, itt derül ki, nem élesben.
+     */
+    public function testTheToleranceIsNotHardcodedAnywhere(): void {
+        foreach (['classes/eloquent/church.php', 'classes/html/ajax/calendar/church.php'] as $fajl) {
+            self::assertStringNotContainsString("'20 hours'", file_get_contents(PATH . $fajl),
+                "beégetett tolerancia: $fajl");
+        }
+    }
+
     /** Több szakasz esetén mindegyikre külön érvényes a korlát. */
     public function testEveryPeriodIsCappedSeparately(): void {
         $this->jelzes('ON',  '-3 days');


### PR DESCRIPTION
Closes #884

Erős tippre: **két óra**.

## Ami már megvolt

A jegy nagy része nem hiányzott, csak nem tűnt fel: a naptár-API **már ma is** visszaadja a gyóntatás-eseményeket (`eventsFromSensor`, `ajax/calendar/church.php:62`), az Angular naptár pedig **már ma is kirajzolja** őket egyszeri, nem szerkeszthető eseményként (`church-calendar.component.ts`, `convertSensorEventsToCalendarEvents`, `fc-event-sensor` stílus). Nem építeni kellett, hanem befejezni.

## Ami rossz volt

A le nem zárt szakaszt a tolerancia zárta le, 20 órával. Mérve, valódi adaton:

```
GET /ajax/calendar/church/1252
  { id: "confession_1", title: "Gyóntatás", startDate: "2026-08-20T11:11:00",
    duration: 72000 }        <- 20 óra
```

Ugyanez a javítás után:

```
  { id: "confession_1", title: "Gyóntatás", startDate: "2026-08-20T11:11:00",
    duration: 7200 }         <- 2 óra
```

A templomoldal panelján pedig:

```
Most nem gyóntatnak
Legutóbb: Aug. 20., csütörtök 11:11 – 13:11
A korábbi gyóntatások a fenti naptárban láthatók.
```

## Amit csinál

- `Church::CONFESSION_MAX_DISPLAY = '2 hours'`, és a `getConfessions()` harmadik paramétere. A korlátnál hosszabb szakasz a kezdetétől számított két órakor végződik.
- **A valóban folyamatban lévő szakasz nem zárul le**, ha rövidebb a korlátnál — a panel abból tudja, hogy „még tart". Ha viszont már túllépte a két órát, lezárjuk: két óra után nem állíthatjuk, hogy még mindig tart.
- A korlát `null`-lal kikapcsolható, ha valaha a nyers adat kell.

## A panel

Levettem róla a szakasz-listát: a múltat a naptár mutatja, ott a hét rendje is látszik, a panel listája ugyanazt ismételte kevesebb összefüggéssel. **Az élő állapot marad**, mert arra a naptár nem ad választ egy pillantásra — a látogató kérdése az, hogy „most bemehetek-e gyónni". Mellette az utolsó szakasz, mert az a mostani állapot indoklása.

Ha azt szeretnéd, hogy a panel a te szavaiddal tényleg csak a „nincs érzékelő, de lehetne" esetre szűküljön, és érzékelő mellett el is tűnjön, azt szívesen megcsinálom — de azt már UI-döntésnek éreztem, nem akartam egyedül meghozni.

## Az élő jelző is két óra

Kérted, megcsináltam — így a badge és a kirajzolt esemény nem mondhat mást.

Ez volt a nagyobb tétel a kettő közül. Eddig 20 óra volt a „még tart?" ablak: egy reggel bekapcsolt, kikapcsolni elfelejtett jelzés **másnap délig** hirdette, hogy „Most van gyóntatás a helyszínen!". A látogatót ez odaviszi hiába — ennél rosszabbat nem is tehetünk.

Mérve:

```
5 órája ON, OFF nincs   ->  jelző: OFF   (eddig: ON)      szakasz: 2 óra
20 perce ON             ->  jelző: ON                     szakasz: „még tart", 20 perc
```

Két külön konstans maradt (`CONFESSION_TOLERANCE`, `CONFESSION_MAX_DISPLAY`), egyező értékkel: nem ugyanaz a kérdés — az egyik az élő állapotról szól, a másik a kirajzolt esemény hosszáról. Ha valaha eltérnek, ne kelljen kibogozni, melyik miért.

**A tolerancia mostantól egy helyen van.** Eddig három helyen állt külön beégetve ugyanaz a `'20 hours'` (`church.php` kétszer, `ajax/calendar/church.php` egyszer) — ezt a #884 leírásában magam is felhoztam. Most mindhárom a konstansból jön, és teszt őrzi, hogy ne lehessen visszacsempészni.

## Amit szándékosan NEM változtattam

A **40 napos ablak** és a **kereső-indexelés** kérdése; egyik sem blokkolta ezt.

## Teszt

`ConfessionDisplayLengthTest`, **14 eset**.

A megjelenített szakaszra: a le nem zárt szakasz két óra (nem húsz); a 45 perces lezárt szakaszhoz nem nyúlunk; a hosszú lezárt szakasz visszavágódik és a vég a kezdethez igazodik; a valóban folyamatban lévő szakasz marad „még tart" (nincs `end` kulcsa); korlát nélkül a nyers 20 órás érték jön; több szakasznál mindegyikre külön érvényes; és hogy a korlát a deklarált konstans.

Az élő jelzőre: az elfelejtett kikapcsolás nem hirdet gyóntatást; a valóban futó igen; a határ pontosan két óra (119 perc → ON, 121 perc → OFF); az OFF jelzés kikapcsol; adat nélkül `false` (ami **nem** ugyanaz, mint az `'OFF'` — a felület mást ír ki rá); és hogy a `'20 hours'` sehol nem maradt beégetve.

Visszamérve: a korlátozást kivéve 3 bukik; a konstanst 20 órára visszaállítva 4 bukik. Mindkét irányban zöld a javítással.

PHP: 1537 teszt. Két bukás marad nálam, mindkettő a saját gépem adatbázisáé (a #872 migrációja rajta van, ez az ág viszont nem tartalmazza) — friss adatbázison, tehát a CI-ban, nincs ilyen.

