### PR TITLE
to Prod

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -109,7 +109,28 @@ jobs:
         env:
           COVERAGE_IMAGE_TAG: ${{ steps.tag.outputs.TAG }}
         run: |
-            docker compose $COMPOSE_FILES cp scripts/check-undefined-methods.php miserend:/tmp/check-undefined-methods.php
+            # #888: az ellenőrző szkript a REPÓ eszköze, nem a vizsgált kód.
+            #
+            # A futás a nyers PR-fejet checkoutolja (l. fentebb a REF-et), tehát egy
+            # néhány hetes ágon a szkript egyszerűen nincs ott — a `cp` `lstat ... no such
+            # file`-lal elhasal, és a PR a TARTALMÁTÓL FÜGGETLENÜL piros lesz, még mielőtt
+            # egyetlen teszt lefutna. Pontosan ez történt a #879-cel.
+            #
+            # Ezért: ha az ágon nincs, a bázisról vesszük elő. Ha ott sincs, kihagyjuk —
+            # a hiányzó ellenőrző nem hiba, csak nem alkalmazható.
+            SCRIPT=scripts/check-undefined-methods.php
+            if [ ! -f "$SCRIPT" ]; then
+              BASE="${{ github.base_ref || 'master' }}"
+              echo "A(z) $SCRIPT nincs ezen az ágon; a(z) $BASE példányát próbálom."
+              if git fetch --depth=1 origin "$BASE" \
+                 && git show FETCH_HEAD:"$SCRIPT" > /tmp/check-undefined-methods.php 2>/dev/null; then
+                SCRIPT=/tmp/check-undefined-methods.php
+              else
+                echo "::notice title=Metódus-ellenőrzés kihagyva::A szkript sem az ágon, sem a(z) $BASE ágon nem érhető el."
+                exit 0
+              fi
+            fi
+            docker compose $COMPOSE_FILES cp "$SCRIPT" miserend:/tmp/check-undefined-methods.php
             docker compose $COMPOSE_FILES exec -T miserend php /tmp/check-undefined-methods.php /miserend/webapp
 
       - name: Run PHPUnit tests

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -15,7 +15,14 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     use \Illuminate\Database\Eloquent\SoftDeletes;
     
     protected $table = 'templomok';
-    protected $appends = array('names', 'alternative_names', 'fullName','location','links','fullNetwork');
+    /*
+     * #881: a `varos` azért van itt, mert a kereső-találatok nem a modellt adják a
+     * sablonnak, hanem `$church->toArray()`-t (`searchresultsmasses.php:408`, `:475`) —
+     * oda az accessor önmagában nem jut el. Az `orszag`/`megye` szándékosan marad ki:
+     * azokat csak a /josm sablonja használja, ott viszont modellobjektumon, tehát az
+     * accessor elég. Minden fölösleges append ára egy lekérdezés soronként.
+     */
+    protected $appends = array('names', 'alternative_names', 'fullName','location','links','fullNetwork','varos');
     protected $fillable = [
         'nev', 'cim', 'orszag', 'megye', 'varos', 'plebania', 'pleb_eml', 'leiras',
         'lat', 'lon', 'miseaktiv', 'ok', 'frissites', 'misemegj','osmid','osmtype',
@@ -1905,16 +1912,88 @@ class Church extends \Illuminate\Database\Eloquent\Model {
             . " ORDER BY FIELD(b.admin_level, $lista) LIMIT 1)";
     }
 
+    /** #881: a templom közigazgatási határai, egyszer lekérve. `null` = még nem kértük le. */
+    private ?array $kozigHatarokCache = null;
+
+    /**
+     * #881: EGY lekérdezés templomonként, szintenkénti helyett.
+     *
+     * Eddig minden szint-kérés külön `SELECT`-et indított, és a `locationCityName()`
+     * ebből 1–4-et hív. Amíg ezt csak az API-tömbök használták (templomonként egyszer),
+     * ez elfért. A `varos` accessorral viszont MINDEN listasor meghívja — egy 50 soros
+     * katalógus 100+ lekérdezés lenne, holott a régi `varos` oszlop kiolvasása ingyen
+     * volt. Ezért egyszer lekérjük a templom összes közigazgatási határát (jellemzően
+     * 4-6 sor), és utána PHP-ben válogatunk.
+     *
+     * Ha a `boundaries` reláció már be van töltve (eager loading), lekérdezés sincs.
+     */
+    private function kozigHatarok(): array {
+        if ($this->kozigHatarokCache !== null) {
+            return $this->kozigHatarokCache;
+        }
+
+        $sorok = $this->relationLoaded('boundaries')
+            ? $this->boundaries->where('boundary', 'administrative')
+            : $this->boundaries()->where('boundary', 'administrative')->get();
+
+        $this->kozigHatarokCache = [];
+        foreach ($sorok as $hatar) {
+            $szint = (int) $hatar->admin_level;
+            $nev = trim((string) $hatar->name);
+            // Egy szinten több sor is lehet; az elsőt tartjuk meg, ahogy a régi
+            // `orderBy('admin_level','desc')` + `first()` is egyet adott vissza.
+            if ($nev !== '' && !isset($this->kozigHatarokCache[$szint])) {
+                $this->kozigHatarokCache[$szint] = $nev;
+            }
+        }
+
+        return $this->kozigHatarokCache;
+    }
+
     private function adminBoundaryName(array $szintek): ?string {
-        $talalat = $this->boundaries()
-                ->where('boundary', 'administrative')
-                ->whereIn('admin_level', $szintek)
-                ->orderBy('admin_level', 'desc')
-                ->first();
+        $hatarok = $this->kozigHatarok();
 
-        $nev = trim((string) ($talalat->name ?? ''));
+        // A régi lekérdezés a megadott szintek közül a LEGMAGASABBAT vette
+        // (`orderBy('admin_level','desc')`), ezért itt is csökkenő sorrendben keresünk.
+        rsort($szintek);
+        foreach ($szintek as $szint) {
+            if (isset($hatarok[$szint])) {
+                return $hatarok[$szint];
+            }
+        }
 
-        return $nev !== '' ? $nev : null;
+        return null;
+    }
+
+    /**
+     * #881: `varos` — a régi oszlop neve alatt, a határokból számolva.
+     *
+     * A #496/#497/#498 eldobta a `templomok.varos` oszlopot, és a helyére a
+     * `locationCityName()` lépett. Az API-tömbök át is álltak rá — a FELÜLET viszont
+     * nem: tizenhét sablon hivatkozik `church.varos`-ra. Oszlop és accessor híján az
+     * Eloquent üres értéket adott, és a település egyszerűen eltűnt:
+     *
+     *   /templom/list        ->  <strong>Szent Anna-templom</strong> ()
+     *   /egyhazmegye/list    ->  a „város" oszlop üres
+     *   /home                ->  a javaslat-lista templomneve mögött üres zárójel
+     *   mise-keresés         ->  ugyanaz
+     *
+     * Az accessor a legkisebb javítás, ami MINDET megfogja egyszerre, és a sablonokat
+     * nem kell egyenként átírni. A név szándékosan marad `varos`: az API-ban, a v5
+     * sqlite-ban és a mobilappban is ez a mező neve.
+     */
+    public function getVarosAttribute(): string {
+        return $this->locationCityName();
+    }
+
+    /** #881: `orszag` — ugyanaz a történet, a /josm oldal két táblázata használja. */
+    public function getOrszagAttribute(): string {
+        return $this->locationCountryName();
+    }
+
+    /** #881: `megye` — a teljesség kedvéért, ugyanabból a forrásból. */
+    public function getMegyeAttribute(): string {
+        return $this->locationCountyName();
     }
 
     /**

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -242,7 +242,14 @@ class Health extends Html {
 		}
 
 		$ids = $elastic->churchIdsWithMassesInPeriod(date('Y-01-01'), date('Y-12-31'));
-		$this->churchesWithNoElasticMasses = \Eloquent\Church::whereNotIn('id', $ids)->has('massrules')->get()->toArray();
+		/*
+		 * #881: `with('boundaries')` — a `toArray()` a `varos`-t is kiszámolja, az pedig a
+		 * határokból jön. Eager loading nélkül soronként egy külön lekérdezés lenne, és ez
+		 * a lista pont akkor hosszú (ELSŐSORBAN üres Elasticsearch-nél), amikor a /health
+		 * a legfontosabb — ezerszám indított lekérdezéssel maga a diagnosztika állna meg.
+		 */
+		$this->churchesWithNoElasticMasses = \Eloquent\Church::whereNotIn('id', $ids)->has('massrules')
+			->with('boundaries')->get()->toArray();
 		$this->churchesWithNoElasticMassesCount = count($this->churchesWithNoElasticMasses);
 
 		/*

--- a/webapp/tests/Integration/ChurchCityAttributeTest.php
+++ b/webapp/tests/Integration/ChurchCityAttributeTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #881: a település a felületen.
+ *
+ * A #496/#497/#498 eldobta a `templomok.varos` oszlopot, és a helyére a határokból
+ * számolt `locationCityName()` lépett. Az API-tömbök átálltak rá — a FELÜLET viszont
+ * nem: tizenhét sablon hivatkozik `church.varos`-ra. Oszlop és accessor híján az
+ * Eloquent üres értéket adott, és a település eltűnt a listákból:
+ *
+ *   /templom/list        ->  <strong>Szent Anna-templom</strong> ()
+ *   /egyhazmegye/list    ->  a „város" oszlop üres
+ *   /home                ->  a javaslat-lista templomneve mögött üres zárójel
+ *   mise-keresés         ->  ugyanaz
+ *
+ * Ez a teszt a `varos` HÁROM útját fogja: az accessort, a `toArray()`-t (a
+ * kereső-találatok azt adják a sablonnak), és a lekérdezésszámot — mert egy
+ * listaoldalon soronkénti lekérdezés-lavina ugyanolyan hiba lenne, mint az üres érték.
+ */
+final class ChurchCityAttributeTest extends TestCase {
+
+    private int $churchId;
+
+    protected function setUp(): void {
+        DB::beginTransaction();
+        $this->churchId = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Település teszt', 'ok' => 'i', 'lat' => 47.0, 'lon' => 19.0,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+    }
+
+    /** Egy közigazgatási határ hozzákötése a teszt-templomhoz. */
+    private function hatart(int $szint, string $nev, string $tipus = 'administrative'): void {
+        $id = (int) DB::table('boundaries')->insertGetId([
+            'boundary' => $tipus, 'admin_level' => $szint, 'name' => $nev,
+        ]);
+        DB::table('lookup_boundary_church')->insert([
+            'boundary_id' => $id, 'church_id' => $this->churchId,
+        ]);
+    }
+
+    private function church(): \Eloquent\Church {
+        return \Eloquent\Church::findOrFail($this->churchId);
+    }
+
+    /** A LÉNYEG: a `varos` a határokból jön, nem üres. */
+    public function testTheCityComesFromTheBoundaries(): void {
+        $this->hatart(8, 'Szentendre');
+
+        self::assertSame('Szentendre', $this->church()->varos);
+    }
+
+    /** Nagyvárosnál a kerülettel együtt — ahogy a régi oszlopban is volt. */
+    public function testInABigCityTheDistrictIsAppended(): void {
+        $this->hatart(8, 'Budapest');
+        $this->hatart(9, 'XI. kerület');
+
+        self::assertSame('Budapest XI. kerület', $this->church()->varos);
+    }
+
+    /**
+     * Nincs 8-as szint (pl. német kreisfreie Stadt): a 6-os a település, és a 9-es
+     * kerületet ilyenkor NEM fűzzük hozzá — ott már másfajta felosztás.
+     */
+    public function testWithoutLevelEightTheCountyLevelIsTheCity(): void {
+        $this->hatart(6, 'Köln');
+        $this->hatart(9, 'Innenstadt');
+
+        self::assertSame('Köln', $this->church()->varos);
+    }
+
+    /** Nem közigazgatási határ (pl. egyházmegye) nem település. */
+    public function testANonAdministrativeBoundaryIsNotACity(): void {
+        $this->hatart(8, 'Egyházmegye', 'religious_administration');
+
+        self::assertSame('', $this->church()->varos);
+    }
+
+    /**
+     * A `toArray()`-ben is ott kell lennie: a kereső-találatok nem a modellt adják a
+     * sablonnak, hanem a tömbjét (`searchresultsmasses.php:408`).
+     */
+    public function testTheArrayFormAlsoCarriesTheCity(): void {
+        $this->hatart(8, 'Eger');
+
+        $tomb = $this->church()->toArray();
+        self::assertArrayHasKey('varos', $tomb, 'a kereső-találat ezt a kulcsot olvassa');
+        self::assertSame('Eger', $tomb['varos']);
+    }
+
+    /**
+     * EGY lekérdezés templomonként, akárhányszor kérdezzük.
+     *
+     * A `varos` minden listasorra meghívódik. Ha szintenként külön `SELECT` menne
+     * (a javítás előtti állapot), egy 50 soros katalógus 100+ lekérdezést indítana —
+     * a régi oszlop kiolvasása ehhez képest ingyen volt.
+     */
+    public function testTheBoundariesAreQueriedOnlyOnce(): void {
+        $this->hatart(8, 'Budapest');
+        $this->hatart(9, 'XI. kerület');
+
+        $church = $this->church();
+
+        $kapcsolat = DB::connection();
+        $kapcsolat->flushQueryLog();
+        $kapcsolat->enableQueryLog();
+
+        $church->varos;
+        $church->varos;
+        $church->locationCountryName();
+
+        $lekerdezesek = $kapcsolat->getQueryLog();
+        $kapcsolat->disableQueryLog();
+
+        $hatarLekerdezesek = array_filter(
+            $lekerdezesek,
+            fn($l) => str_contains($l['query'], 'lookup_boundary_church')
+        );
+
+        self::assertCount(1, $hatarLekerdezesek,
+            'A határokat egyszer kérjük le és megjegyezzük; kaptunk: '
+            . count($hatarLekerdezesek));
+    }
+
+    /** Eager loading esetén lekérdezés sincs — a betöltött relációból dolgozunk. */
+    public function testWithEagerLoadingThereIsNoQueryAtAll(): void {
+        $this->hatart(8, 'Pécs');
+
+        $church = \Eloquent\Church::with('boundaries')->findOrFail($this->churchId);
+
+        $kapcsolat = DB::connection();
+        $kapcsolat->flushQueryLog();
+        $kapcsolat->enableQueryLog();
+
+        $varos = $church->varos;
+
+        $lekerdezesek = $kapcsolat->getQueryLog();
+        $kapcsolat->disableQueryLog();
+
+        self::assertSame('Pécs', $varos);
+        self::assertCount(0, array_filter(
+            $lekerdezesek,
+            fn($l) => str_contains($l['query'], 'lookup_boundary_church')
+        ), 'betöltött relációnál nem kellene lekérdeznünk');
+    }
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A javítás</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: 600;">1. Accessor a régi név alatt.</strong><span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">getVarosAttribute()</code><span> </span>→<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">locationCityName()</code>. Egyetlen ponton javítja mind a tizenhetet, a sablonokat nem kell egyenként átírni. A név szándékosan marad<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">varos</code>: az API-ban, a v5 sqlite-ban és a mobilappban is ez a mező neve. Mellé<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">orszag</code><span> </span>és<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">megye</code><span> </span>is, mert a /josm két táblázata azokat használja.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: 600;">2.<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">varos</code><span> </span>az<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">$appends</code>-be.</strong><span> </span>A kereső-találatok nem a modellt adják a sablonnak, hanem<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">$church-&gt;toArray()</code>-t (<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">searchresultsmasses.php:408</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">:475</code>) — oda az accessor önmagában nem jut el. Az<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">orszag</code>/<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">megye</code><span> </span>szándékosan<span> </span><strong style="box-sizing: border-box; font-weight: 600;">nem</strong><span> </span>kerül az appends-be: azokat csak a /josm használja, ott viszont modellobjektumon.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: 600;">3. Egy lekérdezés templomonként, nem szintenként.</strong><span> </span>Ez a fontos rész. Eddig<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">adminBoundaryName()</code><span> </span>minden szint-kérésre külön<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">SELECT</code>-et indított, és a<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">locationCityName()</code><span> </span>ebből 1–4-et hív. Amíg ezt csak az API használta (templomonként egyszer), elfért. A<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">varos</code><span> </span>accessorral viszont<span> </span><strong style="box-sizing: border-box; font-weight: 600;">minden listasor</strong><span> </span>meghívja: egy 50 soros katalógus 100+ lekérdezés lenne, holott a régi oszlop kiolvasása ingyen volt.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Most egyszer kérem le a templom összes közigazgatási határát (jellemzően 4-6 sor), és PHP-ben válogatok. Ha a<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">boundaries</code><span> </span>reláció be van töltve, lekérdezés sincs — a /health listáját ezért<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">with('boundaries')</code>-szal kérem, mert az a lista pont üres Elasticsearch mellett a leghosszabb, vagyis akkor, amikor a diagnosztika a legfontosabb.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Mérés</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Ugyanaz a négy hely, a javítás után:</p><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
hely | előtte | utána
-- | -- | --
/templom/list | Loyolai Szent Ignác bencés templom () | … (Győr)
/egyhazmegye/list?ehm=3 | varos='' | Budapest XI. kerület, Budapest V. kerület, Budapest XII. kerület, Budapest XVII. kerület
mise-keresés | () | (Budapest XI. kerület)
/home | Jézus Szíve templom () | a határral rendelkező templomoknál kiírja

</markdown-accessiblity-table><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Visszaméréssel is: az accessort kivéve mindkét oldal újra<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">()</code>-t ad, visszatéve újra a települést.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: 600;">A fejlesztői adatbázisomban csak 12 templomnak van 6/8/9/10-es közigazgatási határa</strong><span> </span>(a helyi OSM-import részleges), ezért a többi sor ott továbbra is üres marad. Élesen ez nem így van — de ha valahol mégis üres maradna, az onnantól<span> </span><strong style="box-sizing: border-box; font-weight: 600;">adathiány</strong>, nem ez a hiba: a<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">/health</code><span> </span>„határ nélküli templomok" listája mutatja meg.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Teszt</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ChurchCityAttributeTest</code>, 7 eset. A<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">varos</code><span> </span>három útját fogja:</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">az accessort (8-as szint; 8+9 → „Budapest XI. kerület"; 8 nélkül a 6-os a település és a 9-est<span> </span><strong style="box-sizing: border-box; font-weight: 600;">nem</strong><span> </span>fűzzük hozzá — a kölni eset; nem közigazgatási határ nem település),</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">a<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">toArray()</code>-t (ezt olvassa a kereső-találat),</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">és a<span> </span><strong style="box-sizing: border-box; font-weight: 600;">lekérdezésszámot</strong>: kétszeri<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">varos</code><span> </span>+ egy<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">locationCountryName()</code><span> </span>együtt is pontosan<span> </span><strong style="box-sizing: border-box; font-weight: 600;">egy</strong><span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">lookup_boundary_church</code><span> </span>lekérdezés, eager loadingnál pedig<span> </span><strong style="box-sizing: border-box; font-weight: 600;">nulla</strong>.</li></ul><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Visszamérve: az accessort kivéve 7-ből 6 bukik, visszatéve zöld.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">PHP: 1480 teszt, a két ismert környezeti bukást leszámítva zöld.</p><!--EndFragment-->
</body>
</html>