### PR TITLE
Írható könyvtár a képfeltöltésnél (#893)

### DIFF
--- a/webapp/classes/api/upload.php
+++ b/webapp/classes/api/upload.php
@@ -73,14 +73,12 @@ class Upload extends Api {
             
         } catch (\Exception $e) {
             // Set error response with detailed message
+            // #893: nincs `debug_info` a válaszban — a fájlnév, a sorszám és a hívási
+            // lánc a naplóba való, nem a hitelesítés nélkül hívható végpont válaszába.
+            // (L. #860: ugyanez a szivárgás már egyszer kikerült ebből a fájlból.)
             $this->return['error'] = '1';
             $this->return['text'] = $e->getMessage();
-            $this->return['debug_info'] = [
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
-                'trace' => $e->getTraceAsString()
-            ];
-            
+
             // Set HTTP status code to 400 (Bad Request) instead of 500
             http_response_code(400);
             

--- a/webapp/classes/eloquent/photo.php
+++ b/webapp/classes/eloquent/photo.php
@@ -156,18 +156,21 @@ class Photo extends \Illuminate\Database\Eloquent\Model {
          * véd; egyik sem hagyható el.
          */
         $safeExtension = self::safeExtensionFor($inputFile['tmp_name']);
+
+        /*
+         * #893: a templom könyvtárát ÉS a `kicsi/` alkönyvtárát külön-külön kell
+         * megkövetelni, még a fájl mozgatása előtt.
+         *
+         * Eddig a `kicsi/` csak akkor jött létre, ha a templom könyvtára is épp akkor
+         * született. Ha a könyvtár már megvolt, de a `kicsi/` nem, a feltöltés SIKERT
+         * jelentett: a nagy kép és az adatbázis-sor elkészült, a bélyegkép viszont nem.
+         * Kimértem — a válasz „Elmentettük", a naplóban meg
+         * `imagepng(.../kicsi/...): Failed to open stream: No such file or directory`.
+         * A templom oldalán ilyenkor törött kép áll, és senki nem tud róla.
+         */
         $konyvtar = $this->pathToPhotos . "/" . $this->church_id;
-        if (!is_dir("$konyvtar")) {
-            if (!mkdir("$konyvtar", 0775)) {
-                throw new \Exception("Could not create the folder.");
-            }
-            if (!mkdir("$konyvtar/kicsi", 0775)) {
-                throw new \Exception("Could not create the folder.");
-            }
-        }
-        if (!is_writable($konyvtar)) {
-            throw new \Exception("Upload directory is not writable.");            
-        }
+        self::keszenAllKonyvtar($konyvtar);
+        self::keszenAllKonyvtar($konyvtar . "/kicsi");
         // #709: a kiterjesztés a FELISMERT képtípusból jön, nem a kliens fájlnevéből.
         $Random_Number = rand(0, 9999999999); //Random number to be added to name.
         $this->filename = $Random_Number . $safeExtension; //new file name
@@ -231,6 +234,15 @@ class Photo extends \Illuminate\Database\Eloquent\Model {
         } catch (\Throwable $e) {
             @\unlink($kimenet);
             @\unlink($kimenet1);
+            /*
+             * #893: a valódi okot eddig elnyelte ez az ág — a `$e` felhasználatlan volt.
+             * A felhasználónak adott mondat („sérült vagy nem valódi képfájl") csak az
+             * esetek egy részére igaz: ha a bélyegkép azért nem készült el, mert nem
+             * lehetett kiírni, akkor a képére fogtuk a szerver hibáját. A napló mostantól
+             * megmondja, melyikről van szó.
+             */
+            error_log('[miserend] képfeldolgozás elhasalt (templom: ' . $this->church_id . ', fájl: '
+                . basename($kimenet) . '): ' . $e->getMessage());
             throw new \Exception("A képet nem sikerült feldolgozni, ezért nem mentettük el. "
                 . "Valószínűleg sérült vagy nem valódi képfájl.");
         }
@@ -355,15 +367,79 @@ class Photo extends \Illuminate\Database\Eloquent\Model {
         \imagecopyresampled($dst_img, $src_img, 0, 0, 0, 0, $new_w, $new_h, \imagesx($src_img), \imagesy($src_img));
 
         // Ugyanabban a formátumban írunk vissza, amilyen a forrás volt.
+        //
+        // #893: a GD `false`-szal jelzi, ha nem tudott írni (nincs meg a könyvtár, nem
+        // írható, betelt a lemez). Eddig ez a visszatérési érték elveszett, ezért a hívó
+        // sikeresnek látta a kicsinyítést akkor is, ha egyetlen bájt sem került ki.
         switch ($info[2]) {
-            case IMAGETYPE_PNG: \imagepng($dst_img, "$kimenet");  break;
-            case IMAGETYPE_GIF: \imagegif($dst_img, "$kimenet");  break;
-            default:            \imagejpeg($dst_img, "$kimenet"); break;
+            case IMAGETYPE_PNG: $sikerult = \imagepng($dst_img, "$kimenet");  break;
+            case IMAGETYPE_GIF: $sikerult = \imagegif($dst_img, "$kimenet");  break;
+            default:            $sikerult = \imagejpeg($dst_img, "$kimenet"); break;
         }
 
         // Free up memory
         \imagedestroy($src_img);
         \imagedestroy($dst_img);
+
+        if ($sikerult !== true) {
+            throw new \Exception("A képet nem sikerült kiírni: " . basename($kimenet));
+        }
+    }
+
+    /**
+     * #893: a képkönyvtár legyen meg és legyen írható — vagy derüljön ki, miért nem.
+     *
+     * A `webapp/kepek` az egyetlen hoszt-bind mount (`docker/compose.yml:180`), a
+     * konténer pedig `www-data`-ként fut (`compose.yml:187`): a jogosultság a HOSZTON
+     * dől el, és a kód nem tudja megjavítani — a `chown`-hoz tulajdonosnak kellene
+     * lenni. Amit tehetünk, az kettő: a felhasználó kapjon érthető mondatot, a napló
+     * pedig a tényeket. Enélkül a hiba egy angol félmondat egy gondnok észrevételében,
+     * és minden vizsgálat nulláról indul.
+     */
+    private static function keszenAllKonyvtar(string $ut): void {
+        /*
+         * A stat-gyorstár ürítése nem óvatoskodás: a fejlesztői példányon kimértem, hogy
+         * egy Apache-munkásfolyamat `is_dir()`-je IGAZ-at adott egy közben megszűnt
+         * könyvtárra. A `mkdir` így el sem indult, a hiba pedig csak három lépéssel
+         * később, a bélyegkép írásánál jött elő — pont abban a formában, amit ez a
+         * javítás meg akar szüntetni.
+         */
+        \clearstatcache(true, $ut);
+
+        // A harmadik feltétel nem felesleges: két párhuzamos feltöltés versenyezhet,
+        // és a vesztes `mkdir`-je azért ad `false`-t, mert a könyvtár közben elkészült.
+        if (!is_dir($ut) && !@mkdir($ut, 0775, true) && !is_dir($ut)) {
+            error_log('[miserend] képkönyvtár: nem hozható létre — ' . self::konyvtarAllapot($ut));
+            throw new \Exception("A képkönyvtár nem hozható létre a szerveren, ezért a kép most nem menthető. "
+                . "Jeleztük az üzemeltetésnek.");
+        }
+
+        if (!is_writable($ut)) {
+            error_log('[miserend] képkönyvtár: nem írható — ' . self::konyvtarAllapot($ut));
+            throw new \Exception("A képkönyvtár nem írható a szerveren, ezért a kép most nem menthető. "
+                . "Jeleztük az üzemeltetésnek; kérlek, próbáld meg később.");
+        }
+    }
+
+    /**
+     * #893: amit a naplóba írunk egy könyvtár-hibánál.
+     *
+     * Pontosan az, amiből eldönthető, hogy jogosultsági baj van-e vagy más: kié a
+     * könyvtár, mi a módja, ki futtat minket, és a szülőbe bele lehet-e írni.
+     */
+    private static function konyvtarAllapot(string $ut): string {
+        \clearstatcache(true, $ut);
+        $szulo = \dirname($ut);
+
+        return \json_encode([
+            'ut'           => $ut,
+            'letezik'      => \is_dir($ut),
+            'jogosultsag'  => \is_dir($ut) ? \substr(\sprintf('%o', \fileperms($ut)), -4) : null,
+            'tulajdonos'   => \is_dir($ut) ? (\fileowner($ut) . ':' . \filegroup($ut)) : null,
+            'szulo'        => $szulo,
+            'szulo_irhato' => \is_dir($szulo) ? \is_writable($szulo) : false,
+            'futo_uid'     => \function_exists('posix_geteuid') ? \posix_geteuid() : null,
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
 }

--- a/webapp/classes/html/uploadimage.php
+++ b/webapp/classes/html/uploadimage.php
@@ -135,16 +135,17 @@ class UploadImage extends Html {
             header('Content-Type: application/json');
             http_response_code(400); // Changed from 500 to 400 (Bad Request)
             
+            /*
+             * #893: a válaszban NINCS `debug_info`. Eddig a fájlnév, a sorszám és a
+             * TELJES hívási lánc kiment a böngészőbe — bárkinek, aki elő tud idézni egy
+             * hibát. Ugyanaz a szivárgás, mint amit a #860-ban kivettünk innen. Az ok
+             * továbbra is megvan, csak ott, ahol való: az alábbi naplósorban.
+             */
             $errorResponse = [
                 'success' => false,
                 'error' => true,
                 'text' => $e->getMessage(),
                 'message' => 'Hiba történt a feltöltés során: ' . $e->getMessage(),
-                'debug_info' => [
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                    'trace' => $e->getTraceAsString()
-                ]
             ];
             
             // Log the error for debugging

--- a/webapp/tests/Integration/PhotoUploadDirectoryTest.php
+++ b/webapp/tests/Integration/PhotoUploadDirectoryTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #893: a képfeltöltés és a könyvtárai.
+ *
+ * Egy gondnok azt jelezte, hogy nem tud képet feltölteni: „Upload directory is not
+ * writable". A vizsgálat két hibát hozott ki, és mindkettő itt van rögzítve:
+ *
+ *   1. A `kicsi/` alkönyvtár csak akkor jött létre, ha a templom könyvtára is épp
+ *      akkor született. Ha a könyvtár már megvolt (dockerizálás előtti képfa, mentés
+ *      visszaállítása), de a `kicsi/` nem, a feltöltés SIKERT jelentett — bélyegkép
+ *      nélkül. A `smallUrl` onnantól törött képre mutatott, és senki nem tudott róla.
+ *
+ *   2. A nem írható könyvtár a fájl MOZGATÁSA UTÁN derült ki, és a felhasználó egy
+ *      angol belső mondatot kapott.
+ *
+ * A képkönyvtár helye itt felül van írva egy ideiglenes könyvtárra: a teszt nem nyúl a
+ * valódi `kepek/` fához, és nem múlik azon, hogy az írható-e. (A CI-ban nem az — l. a
+ * PhotoUploadSecurityTest megjegyzését.)
+ */
+final class PhotoUploadDirectoryTest extends TestCase {
+
+    private string $gyoker;
+    private int $churchId;
+
+    protected function setUp(): void {
+        // A jogosultság-ellenőrzésnek nincs értelme rootként: a root a 0555-be is ír.
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            self::markTestSkipped('rootként a jogosultságok nem korlátoznak semmit');
+        }
+
+        DB::beginTransaction();
+
+        // A `photos.church_id` idegen kulcs, tehát kell egy valódi templom-sor.
+        $this->churchId = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Képfeltöltés teszt', 'ok' => 'i', 'lat' => 47.0, 'lon' => 19.0,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+
+        $this->gyoker = sys_get_temp_dir() . '/miserend-kepek-' . bin2hex(random_bytes(6));
+        mkdir($this->gyoker, 0775, true);
+        TesztKepkonyvtarPhoto::$gyoker = $this->gyoker;
+
+        // A Photo::uploadFile() ezt megköveteli.
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+        $this->torol($this->gyoker);
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+    }
+
+    /** A LÉNYEG (1): a `kicsi/` akkor is elkészül, ha a templom könyvtára már megvolt. */
+    public function testKicsiIsCreatedWhenTheChurchDirectoryAlreadyExists(): void {
+        $konyvtar = $this->gyoker . '/' . $this->churchId;
+        mkdir($konyvtar, 0775, true);   // `kicsi/` szándékosan nincs
+
+        $photo = $this->feltolt();
+
+        self::assertFileExists($konyvtar . '/' . $photo->filename, 'a nagy kép');
+        self::assertFileExists($konyvtar . '/kicsi/' . $photo->filename, 'a bélyegkép');
+        self::assertGreaterThan(0, filesize($konyvtar . '/kicsi/' . $photo->filename));
+    }
+
+    /** Ha egyik könyvtár sincs meg, mindkettőt létrehozzuk. */
+    public function testBothDirectoriesAreCreatedFromScratch(): void {
+        $photo = $this->feltolt();
+
+        $konyvtar = $this->gyoker . '/' . $this->churchId;
+        self::assertFileExists($konyvtar . '/' . $photo->filename);
+        self::assertFileExists($konyvtar . '/kicsi/' . $photo->filename);
+    }
+
+    /** A LÉNYEG (2): nem írható könyvtárnál érthető magyar mondat jön, nem belső szöveg. */
+    public function testUnwritableChurchDirectoryFailsWithAReadableMessage(): void {
+        $konyvtar = $this->gyoker . '/' . $this->churchId;
+        mkdir($konyvtar . '/kicsi', 0775, true);
+        chmod($konyvtar, 0555);
+
+        try {
+            $this->feltolt();
+            self::fail('a nem írható könyvtárnál kivételt vártunk');
+        } catch (\Exception $e) {
+            self::assertStringContainsString('nem írható', $e->getMessage());
+            self::assertStringNotContainsString('Upload directory', $e->getMessage());
+        } finally {
+            chmod($konyvtar, 0775);
+        }
+    }
+
+    /**
+     * A nem írható `kicsi/` MÉG A MOZGATÁS ELŐTT kiderül.
+     *
+     * Ez a régi sorrend valódi hibája volt: a nagy kép már kint volt a lemezen, amikor a
+     * bélyegkép írása elhasalt. Itt azt állítjuk, hogy a templom könyvtárában egyetlen
+     * fájl sem marad.
+     */
+    public function testUnwritableKicsiFailsBeforeTheFileIsMoved(): void {
+        $konyvtar = $this->gyoker . '/' . $this->churchId;
+        mkdir($konyvtar . '/kicsi', 0775, true);
+        chmod($konyvtar . '/kicsi', 0555);
+
+        try {
+            $this->feltolt();
+            self::fail('a nem írható kicsi/ könyvtárnál kivételt vártunk');
+        } catch (\Exception $e) {
+            self::assertStringContainsString('nem írható', $e->getMessage());
+            self::assertSame(
+                [],
+                glob($konyvtar . '/*.png'),
+                'a nagy képnek nem szabad kint maradnia'
+            );
+        } finally {
+            chmod($konyvtar . '/kicsi', 0775);
+        }
+    }
+
+    /** Egy valódi PNG feltöltése a Photo::uploadFile()-on keresztül. */
+    private function feltolt(): \Eloquent\Photo {
+        $forras = tempnam(sys_get_temp_dir(), 'miserend-teszt-kep');
+        $kep = imagecreatetruecolor(40, 30);
+        imagepng($kep, $forras);
+        imagedestroy($kep);
+
+        $photo = new TesztKepkonyvtarPhoto();
+        $photo->church_id = $this->churchId;
+        $photo->flag = 'n';
+        $photo->weight = 0;
+
+        try {
+            $photo->uploadFile([
+                'name'     => 'teszt.png',
+                'type'     => 'image/png',
+                'size'     => filesize($forras),
+                'error'    => UPLOAD_ERR_OK,
+                'tmp_name' => $forras,
+            ]);
+        } finally {
+            // A sikeres ág átnevezi (elmozgatja), a hibás ág ott hagyja.
+            if (is_file($forras)) @unlink($forras);
+        }
+
+        return $photo;
+    }
+
+    private function torol(string $ut): void {
+        if (!is_dir($ut)) {
+            return;
+        }
+        @chmod($ut, 0775);
+        foreach (scandir($ut) as $bejegyzes) {
+            if ($bejegyzes === '.' || $bejegyzes === '..') continue;
+            $teljes = $ut . '/' . $bejegyzes;
+            is_dir($teljes) ? $this->torol($teljes) : @unlink($teljes);
+        }
+        @rmdir($ut);
+    }
+}
+
+/** A képkönyvtár helyét felülíró változat — a valódi `kepek/` fához nem nyúlunk. */
+final class TesztKepkonyvtarPhoto extends \Eloquent\Photo {
+    public static string $gyoker = '';
+
+    public function getPathToPhotosAttribute($value) {
+        return self::$gyoker;
+    }
+}

--- a/webapp/tools/photo-dir-check.php
+++ b/webapp/tools/photo-dir-check.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * #893: mely templomok képkönyvtárába nem tudunk írni?
+ *
+ * Egy gondnok azt jelezte, hogy nem tud képet feltölteni („Upload directory is not
+ * writable"). A `webapp/kepek` az egyetlen hoszt-bind mount, a konténer pedig
+ * `www-data`-ként fut: a jogosultság a hoszton dől el, és a kód nem tudja megjavítani.
+ * Ez a szkript megmondja, HÁNY templomot érint — mert az dönti el, hogy egyetlen
+ * elrontott könyvtárról van szó, vagy az egész, dockerizálás előttről maradt képfáról.
+ *
+ * Két bajt keres:
+ *   - a templom könyvtára létezik, de nem írható  -> a feltöltés hibával elszáll;
+ *   - hiányzik a `kicsi/` alkönyvtár              -> a feltöltés SIKERT jelent,
+ *     de a bélyegkép némán elmarad (l. #893).
+ *
+ * CSAK OLVAS. A javítás a végén kiírt parancs, amit kézzel kell lefuttatni.
+ *
+ *   docker compose exec miserend php /miserend/webapp/tools/photo-dir-check.php
+ *
+ * Kilépési kód: 0 ha minden rendben, 1 ha talált hibát — így cronból is figyelhető.
+ */
+
+require __DIR__ . '/../load.php';
+
+$photo     = new \Eloquent\Photo();
+$photosDir = $photo->pathToPhotos;
+
+if (!is_dir($photosDir)) {
+    fwrite(STDERR, "Nincs meg a képkönyvtár: $photosDir\n");
+    exit(2);
+}
+
+$uid = function_exists('posix_geteuid') ? posix_geteuid() : null;
+$gid = function_exists('posix_getegid') ? posix_getegid() : null;
+
+printf("Képkönyvtár: %s\n", $photosDir);
+printf("Ez a folyamat: uid=%s gid=%s\n", $uid ?? '?', $gid ?? '?');
+printf("A szülő írható: %s\n\n", is_writable($photosDir) ? 'igen' : 'NEM');
+
+$nemIrhato   = [];
+$nincsKicsi  = [];
+$osszes      = 0;
+
+foreach (new DirectoryIterator($photosDir) as $bejegyzes) {
+    if ($bejegyzes->isDot() || !$bejegyzes->isDir()) {
+        continue;
+    }
+
+    $osszes++;
+    $ut    = $bejegyzes->getPathname();
+    $kicsi = $ut . '/kicsi';
+
+    $allapot = sprintf(
+        '%s (tulajdonos %d:%d, mód %s)',
+        $bejegyzes->getFilename(),
+        fileowner($ut),
+        filegroup($ut),
+        substr(sprintf('%o', fileperms($ut)), -4)
+    );
+
+    if (!is_writable($ut)) {
+        $nemIrhato[] = $allapot;
+        continue; // ha a szülő sem írható, a `kicsi/` hiánya már nem külön hír
+    }
+
+    if (!is_dir($kicsi)) {
+        $nincsKicsi[] = $allapot;
+    } elseif (!is_writable($kicsi)) {
+        $nemIrhato[] = $allapot . ' -> kicsi/';
+    }
+}
+
+printf("Átnézett templom-könyvtár: %d\n\n", $osszes);
+
+if ($nemIrhato) {
+    printf("NEM ÍRHATÓ (%d) — ezeknél a feltöltés hibával elszáll:\n", count($nemIrhato));
+    foreach ($nemIrhato as $sor) {
+        printf("  %s\n", $sor);
+    }
+    printf("\n");
+}
+
+if ($nincsKicsi) {
+    printf("HIÁNYZIK A kicsi/ (%d) — ezeknél a feltöltés sikert jelent, de bélyegkép nélkül:\n", count($nincsKicsi));
+    foreach ($nincsKicsi as $sor) {
+        printf("  %s\n", $sor);
+    }
+    printf("\n");
+}
+
+if (!$nemIrhato && !$nincsKicsi) {
+    printf("Minden könyvtár írható, és mindegyikben van kicsi/.\n");
+    exit(0);
+}
+
+printf(<<<SZOVEG
+Javítás a HOSZTON (nem a konténerben — ott nincs jogunk a chown-hoz), a
+docker-compose.yml könyvtárából:
+
+    sudo chown -R %s:%s ../webapp/kepek
+    sudo find ../webapp/kepek -type d -exec chmod 2775 {} +
+
+A `2775` a setgid: az ezután keletkező alkönyvtárak is a jó csoportot öröklik.
+A hiányzó `kicsi/` alkönyvtárakat a feltöltés a #893 után magától létrehozza,
+kézzel nem kell.
+
+SZOVEG, $uid ?? 33, $gid ?? 33);
+
+exit(1);


### PR DESCRIPTION
Closes #893

A #893-ra. Egy gondnok jelezte észrevételben, hogy nem tud képet feltölteni (Szent László-templom, Tállya):

> HTTP kód: 400 — Részletes hibaüzenet: Upload directory is not writable.

**A tényleges javítás nem itt van.** A könyvtár tulajdonosa a hoszton dől el (a `webapp/kepek` az egyetlen bind mount, a konténer `www-data`-ként fut), a `chown`-hoz pedig tulajdonosnak kell lenni — kódból nem megoldható. Ehhez a szerveren kell megnézni, mekkora a baj:

```
docker compose exec miserend php /miserend/webapp/tools/photo-dir-check.php
```

Ez a PR azt csinálja meg, amit kódból lehet.

## 1. A `kicsi/` akkor is elkészül, ha a templom könyvtára már megvolt

Eddig csak a szülővel EGYÜTT jött létre. Ha a könyvtár már megvolt (a dockerizálás előtti képfából), de a `kicsi/` nem, a feltöltés **sikert jelentett** — bélyegkép nélkül. Kimértem a javítás előtt:

```
válasz: {"text":"Köszönjük a képet. Elmentettük.","error":0}
napló:  PHP Warning: imagepng(.../kicsi/8954202679.png): Failed to open stream:
        No such file or directory
```

Az adatbázisban ott a sor, a templom oldalán törött kép, és senki nem tud róla. A `kicsinyites()` ezért nézi mostantól a GD visszatérési értékét is — ez volt a némaság oka.

## 2. A hiba a fájl mozgatása ELŐTT derül ki, érthető mondattal

Mindkét könyvtárat megköveteljük, mielőtt bármit mozgatnánk. A felhasználó ezt kapja:

> A képkönyvtár nem írható a szerveren, ezért a kép most nem menthető. Jeleztük az üzemeltetésnek; kérlek, próbáld meg később.

A napló pedig a tényeket:

```
[miserend] képkönyvtár: nem írható — {"ut":"/miserend/webapp/kepek/templomok/7",
"letezik":true,"jogosultsag":"0555","tulajdonos":"33:33",
"szulo_irhato":true,"futo_uid":33}
```

Ebből egy percben eldönthető, hogy jogosultsági baj van-e vagy más. Eddig egy angol félmondat volt egy gondnok észrevételében.

Egy dolog, amit menet közben mértem ki: egy Apache-munkásfolyamat `is_dir()`-je IGAZ-at adott egy közben megszűnt könyvtárra, ezért a `mkdir` el sem indult. Emiatt van `clearstatcache()` az ellenőrzés előtt — enélkül a javítás időnként nem javít.

## 3. A stack trace kikerül a hibaválaszból

`html/uploadimage.php` és `api/upload.php`: eddig a fájlnév, a sorszám és a teljes hívási lánc kiment a böngészőbe, az utóbbi hitelesítés nélkül hívható. Ugyanaz a szivárgás, mint amit a #860-ban kivettünk innen.

## Mérés

Négy teszt (`PhotoUploadDirectoryTest`), a valódi `kepek/` fához nem nyúlnak. A régi kódon **három bukik** belőlük, a javítottal mind a négy zöld. Kézzel is végigmértem a végponton mindhárom esetet (hiányzó `kicsi/`, nem írható templom-könyvtár, nem írható `kicsi/`).

A teljes tesztsor lefut. Két hiba marad a fejlesztői példányomon, mindkettő független ettől és a javítás nélkül is megvan.

## Deploy

Kódoldali lépés nincs. A szerveren viszont kell egy `chown`, különben a gondnok holnap sem tud képet feltölteni — a szkript kiírja a pontos parancsot.

---

Külön, nem ide tartozik, de látni kell: **a master CI most piros**, és nem ettől. A `BoundaryFreshnessTest::testTheBackfillSpreadsTheStampsOverTheWindow` bukik, „jövőbeli bélyeg nem lehet", pontosan **10799 másodperc** eltéréssel. Az a három óra a #890 — a MySQL `+05:00`-s session-zónája a PHP `Europe/Budapest`-jéhez képest. Vagyis a #890 nem elméleti: már pirosra festi a mastert.

