### PR TITLE
Egy helyre teszem a kategória-szótárt (#896)

### DIFF
--- a/calendar/src/app/data/mass-definitions-export.ts
+++ b/calendar/src/app/data/mass-definitions-export.ts
@@ -91,7 +91,10 @@ export function generateMassDefinitionsJson(): MassDefinitionsJsonOutput {
   // Build category index
   MASS_DEFINITIONS_DATA.categories.forEach((cat: CategoryDefinition) => {
     titlesByCategory[cat.key] = [];
-    aliasesByCategory[cat.key] = [];
+
+    // #896: a kategória saját aliasai (keresztelő, esküvő, temetés) — ezekhez nincs
+    // definíció, mert nem szabad felkínálni őket a naptárszerkesztőben.
+    aliasesByCategory[cat.key] = cat.aliases ? [...cat.aliases] : [];
   });
   
   // Build rite index
@@ -143,7 +146,9 @@ export function generateMassDefinitionsJson(): MassDefinitionsJsonOutput {
   return {
     _generator: 'mass-definitions-export.ts',
     _warning: 'Auto-generated from calendar/src/app/data/mass-definitions.ts during Angular build',
-    categories: MASS_DEFINITIONS_DATA.categories,
+    // A kategória-aliasok az `aliasesByCategory`-ban vannak; itt csak a kulcs és a szín,
+    // hogy ugyanaz az adat ne szerepeljen két helyen a kimenetben.
+    categories: MASS_DEFINITIONS_DATA.categories.map(({ key, color }) => ({ key, color })),
     rites: ritesWithMasstypes,
     definitions: exportDefinitions,
     titlesByCategory,

--- a/calendar/src/app/data/mass-definitions-export.ts
+++ b/calendar/src/app/data/mass-definitions-export.ts
@@ -12,6 +12,18 @@ export interface MassDefinitionJsonExport {
   defaultRite?: Rite;
   description: string;
   specialUsage?: 'EASTER' | 'CHRISTMAS' | null;
+  aliases?: string[];
+}
+
+/**
+ * #896: kategóriánként összefűzött aliasok — a szabad szöveges felismerés szótára.
+ *
+ * A PHP oldal ezt olvassa (`MassDefinitions::aliasesByCategory()`), és ugyanezt használja
+ * az Angular is. Azért kategória szerint csoportosítva, mert a felismerés kimenete a
+ * kategória; a definíció-kulcs ehhez nem kell.
+ */
+export interface AliasesByCategory {
+  [category: string]: string[];
 }
 
 /**
@@ -55,6 +67,7 @@ export interface MassDefinitionsJsonOutput {
   definitions: MassDefinitionJsonExport[];
   titlesByCategory: TitlesByCategory;
   titlesByRite: TitlesByRite;
+  aliasesByCategory: AliasesByCategory;
 }
 
 /**
@@ -68,6 +81,9 @@ export function generateMassDefinitionsJson(): MassDefinitionsJsonOutput {
   
   // Initialize category index
   const titlesByCategory: TitlesByCategory = {};
+
+  // #896: a szabad szöveges alakok ugyanígy, kategóriánként
+  const aliasesByCategory: AliasesByCategory = {};
   
   // Initialize rite index
   const titlesByRite: TitlesByRite = {};
@@ -75,6 +91,7 @@ export function generateMassDefinitionsJson(): MassDefinitionsJsonOutput {
   // Build category index
   MASS_DEFINITIONS_DATA.categories.forEach((cat: CategoryDefinition) => {
     titlesByCategory[cat.key] = [];
+    aliasesByCategory[cat.key] = [];
   });
   
   // Build rite index
@@ -89,6 +106,15 @@ export function generateMassDefinitionsJson(): MassDefinitionsJsonOutput {
     // Add to category index
     if (titlesByCategory[def.category]) {
       titlesByCategory[def.category].push(exportKey);
+    }
+
+    // #896: az aliasok kategóriánként, ismétlődés nélkül
+    if (aliasesByCategory[def.category] && def.aliases) {
+      def.aliases.forEach((alias) => {
+        if (!aliasesByCategory[def.category].includes(alias)) {
+          aliasesByCategory[def.category].push(alias);
+        }
+      });
     }
     
     // Add to rite index (for each rite this definition belongs to)
@@ -121,6 +147,7 @@ export function generateMassDefinitionsJson(): MassDefinitionsJsonOutput {
     rites: ritesWithMasstypes,
     definitions: exportDefinitions,
     titlesByCategory,
-    titlesByRite
+    titlesByRite,
+    aliasesByCategory
   };
 }

--- a/calendar/src/app/data/mass-definitions.ts
+++ b/calendar/src/app/data/mass-definitions.ts
@@ -23,6 +23,24 @@ export interface MassDefinition {
 
   /** Speciális felhasználás (pl. Easter, Christmas) */
   specialUsage?: 'EASTER' | 'CHRISTMAS' | null;
+
+  /**
+   * #896: a szabad szöveges alakok, ragozott formák és ismert elgépelések, amikről ez a
+   * definíció felismerhető egy naptárcímben.
+   *
+   * Eddig ez az adat egy PHP-osztály privát konstansában élt (`IcalEventProperties`),
+   * ezért a böngésző-oldal nem is látta: az Angular csak a lefordított kanonikus címekre
+   * tudott illeszteni, a PHP viszont ezekre is. Ugyanarra a címre így két válasz
+   * születhetett. Innentől egy helyen van, és mindkét oldal ezt olvassa.
+   *
+   * Szabályok:
+   *   - kisbetűvel, mert az illesztés kisbetűs címen fut;
+   *   - az ékezetes ÉS az ékezet nélküli alak is kell (a normalizálás nem ejt ékezetet);
+   *   - tő is lehet („szentségimád"), hogy a ragozott alakok is illeszkedjenek;
+   *   - de csak akkor, ha nem fog mást: a puszta „szertartás" például NEM szerepelhet,
+   *     mert a temetési szertartásból is misét csinálna.
+   */
+  aliases?: string[];
 }
 
 /**
@@ -76,6 +94,12 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'HOLY_MASS',
+      // A szóösszetételeknek saját alak kell: az illesztés SZÓ ELEJÉN keres, ezért az
+      // „újmiséje" végén álló „misé" magától nem illeszkedne.
+      aliases: ['szentmise', 'szentmisé', 'szentmsie', 'szentmse', 'sztmise', 'mise', 'misé',
+                'újmis', 'ujmis', 'gyászmis', 'gyaszmis', 'diákmis', 'diakmis', 'ifimis',
+                'emlékmis', 'emlekmis', 'aranymis', 'ezüstmis', 'ezustmis',
+                'szentáldozás', 'szentaldozas', 'mass', 'eucharist'],
       category: MassTitleCategory.MASS,
       rites: [Rite.ROMAN_CATHOLIC],
       description: 'Roman Catholic Sunday/weekday Mass',
@@ -84,6 +108,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'LITURGY_OF_THE_WORD',
+      aliases: ['igeliturgia', 'igeliturgi'],
       category: MassTitleCategory.MASS,
       rites: [Rite.ROMAN_CATHOLIC],
       description: 'Liturgy of the Word',
@@ -92,6 +117,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'DIVINE_LITURGY',
+      aliases: ['szent liturgia', 'liturgia'],
       category: MassTitleCategory.MASS,
       rites: [Rite.GREEK_CATHOLIC],
       defaultRite: Rite.GREEK_CATHOLIC,
@@ -101,6 +127,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'LITURGY_OF_THE_PRESANCTIFIED_GIFTS',
+      aliases: ['előre megszentelt', 'elore megszentelt'],
       category: MassTitleCategory.MASS,
       rites: [Rite.GREEK_CATHOLIC],
       description: 'Greek Catholic Liturgy of Presanctified Gifts',
@@ -109,6 +136,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'MASS_OF_THE_LORD_S_SUPPER',
+      aliases: ['nagycsütörtöki szertartás', 'nagycsutortoki szertartas', 'utolsó vacsora', 'utolso vacsora'],
       category: MassTitleCategory.MASS,
       rites: [
         Rite.ROMAN_CATHOLIC,
@@ -120,6 +148,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'GOOD_FRIDAY_LITURGY',
+      aliases: ['nagypénteki szertartás', 'nagypenteki szertartas'],
       category: MassTitleCategory.MASS,
       rites: [
         Rite.ROMAN_CATHOLIC,
@@ -131,6 +160,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'EASTER_VIGIL',
+      aliases: ['húsvét vigíliája', 'husvet vigiliaja', 'húsvéti vigília', 'husveti vigilia', 'feltámadási szertartás', 'feltamadasi szertartas', 'easter vigil', 'eastern vigil'],
       category: MassTitleCategory.MASS,
       rites: [
         Rite.ROMAN_CATHOLIC,
@@ -142,6 +172,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'TRADITIONAL_LATIN_MASS',
+      aliases: ['régi rítusú mise', 'regi ritusu mise', 'tridenti', 'usus antiquior'],
       category: MassTitleCategory.MASS,
       rites: [Rite.TRADITIONAL],
       defaultRite: Rite.TRADITIONAL,
@@ -154,6 +185,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'ADORATION',
+      aliases: ['szentségimád', 'szentsegimad', 'adorác', 'adorac', 'adoration'],
       category: MassTitleCategory.ADORATION,
       rites: [Rite.ROMAN_CATHOLIC],
       description: 'Eucharistic Adoration',
@@ -164,6 +196,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'CONFESSION',
+      aliases: ['gyóntat', 'gyontat', 'szentgyónás', 'szentgyonas', 'gyónás', 'gyonas', 'gyónási', 'gyonasi', 'confession'],
       category: MassTitleCategory.CONFESSION,
       rites: [
         Rite.ROMAN_CATHOLIC,
@@ -177,6 +210,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'BREVIARY',
+      aliases: ['zsolozsma', 'esti dicséret', 'esti dicseret', 'imaóra', 'imaora', 'breviárium', 'breviarium'],
       category: MassTitleCategory.OTHER,
       rites: [Rite.ROMAN_CATHOLIC],
       description: 'Liturgy of the Hours (Breviary)',
@@ -185,6 +219,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'ROSARY',
+      aliases: ['rózsafüzér', 'rozsafuzer'],
       category: MassTitleCategory.OTHER,
       rites: [Rite.ROMAN_CATHOLIC],
       description: 'Rosary recitation',
@@ -193,6 +228,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'LITANY',
+      aliases: ['litánia', 'litania'],
       category: MassTitleCategory.OTHER,
       rites: [Rite.ROMAN_CATHOLIC],
       description: 'Litany service',
@@ -204,6 +240,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
       // elvetette ("Jó lenne minél lejjebb tartani a szertartástípusok számát"), a
       // keresztutat viszont jóváhagyta.
       key: 'STATIONS_OF_THE_CROSS',
+      aliases: ['keresztút', 'keresztut'],
       category: MassTitleCategory.OTHER,
       rites: [Rite.ROMAN_CATHOLIC],
       description: 'Stations of the Cross (Way of the Cross) devotion',
@@ -212,6 +249,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'MATINS',
+      aliases: ['utrenye'],
       category: MassTitleCategory.OTHER,
       rites: [Rite.GREEK_CATHOLIC],
       description: 'Greek Catholic Matins service',
@@ -220,6 +258,7 @@ export const MASS_DEFINITIONS_DATA: MassDefinitionsData = {
 
     {
       key: 'VESPRES',
+      aliases: ['vecsernye'],
       category: MassTitleCategory.OTHER,
       rites: [Rite.GREEK_CATHOLIC],
       description: 'Greek Catholic Vespres service',

--- a/calendar/src/app/data/mass-definitions.ts
+++ b/calendar/src/app/data/mass-definitions.ts
@@ -50,6 +50,14 @@ export interface MassDefinition {
 export interface CategoryDefinition {
   key: MassTitleCategory;
   color: string;
+
+  /**
+   * #896: kategória-szintű aliasok — olyan alkalmak, amikhez nem tartozik definíció.
+   *
+   * Azért nem definíció, mert az megjelenne a naptárszerkesztő cím-választójában. L. a
+   * `MASS_CATEGORY_DEFINITIONS` megjegyzését.
+   */
+  aliases?: string[];
 }
 
 /**
@@ -57,9 +65,11 @@ export interface CategoryDefinition {
  * MASS_CATEGORY_DEFINITIONS az egyetlen hely az értékek definiálásához!
  */
 const generateCategories = (): CategoryDefinition[] => {
-  return MASS_CATEGORY_DEFINITIONS.map(({ key, color }) => ({
-    key: key as MassTitleCategory,
-    color
+  return MASS_CATEGORY_DEFINITIONS.map((def) => ({
+    key: def.key as MassTitleCategory,
+    color: def.color,
+    // `as const` miatt readonly a forrás; másolat kell, hogy a típus egyezzen.
+    aliases: 'aliases' in def ? [...(def.aliases as readonly string[])] : []
   }));
 };
 

--- a/calendar/src/app/enum/mass-categories.ts
+++ b/calendar/src/app/enum/mass-categories.ts
@@ -22,6 +22,25 @@ export const MASS_CATEGORY_DEFINITIONS = [
   {
     key: 'OTHER',
     color: '#A8B8D0',
+
+    /*
+     * #896: olyan alkalmak, amiket FEL kell ismerni, de NEM szabad felkínálni.
+     *
+     * borazslo döntése: a keresztelő, az esküvő és a temetés csak importból kerül be
+     * („a szerkesztő felületen keresztül nem akarunk ilyet állítani"), a keresőben
+     * viszont az „egyéb" jó nekik — a teljes elrejtésük már átverés lenne.
+     *
+     * Ezért KATEGÓRIA-szintű aliasok, nem definíciók: egy új definíció (BAPTISM,
+     * WEDDING, …) megjelenne a naptárszerkesztő cím-választójában is, tehát pont azt
+     * csinálná, amit nem akarunk. Így viszont a felismerés tud róluk, a szerkesztő nem.
+     */
+    aliases: [
+      'keresztel',            // keresztelő, keresztelõ, keresztelője, keresztelés
+      'esküvő', 'eskuvo',
+      'temetés', 'temetes',
+      'requiem',
+      'gyászszertartás', 'gyaszszertartas',
+    ],
   }
 ] as const;
 

--- a/calendar/src/app/util/mass-title-category-config.spec.ts
+++ b/calendar/src/app/util/mass-title-category-config.spec.ts
@@ -296,6 +296,49 @@ describe('MassTitleCategoryConfig', () => {
     });
   });
 
+  /**
+   * #896: a közös alias-szótár.
+   *
+   * A lényeg nem az, hogy több címet ismerünk fel, hanem hogy UGYANAZT ismerjük fel,
+   * mint a PHP oldal. A szótár egy helyen van (`mass-definitions.ts` -> `aliases`), és a
+   * szabály is közös: a szövegben legkorábban előforduló alias nyer.
+   */
+  describe('getCategoryByTitle – közös alias-szótár (#896)', () => {
+    it('a szöveg sorrendje dönt, nem a kategóriáké', () => {
+      // Ez a három a régi, kategória-sorrendes illesztéssel mind MASS lett volna.
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Szentmise, utána szentségimádás'))
+        .toBe(MassTitleCategory.MASS);
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Szentségimádás a szentmise után'))
+        .toBe(MassTitleCategory.ADORATION);
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Gyóntatás a szentmise előtt'))
+        .toBe(MassTitleCategory.CONFESSION);
+    });
+
+    it('felismeri a valódi adatból vett címeket, TranslateService nélkül is', () => {
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Nagypénteki szertartás (P. Szőcs)'))
+        .toBe(MassTitleCategory.MASS);
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Szentmsie'))
+        .toBe(MassTitleCategory.MASS);
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Kollégistáink szentmiséje (P. Szőcs)'))
+        .toBe(MassTitleCategory.MASS);
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Csendes szentségimádás'))
+        .toBe(MassTitleCategory.ADORATION);
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Keresztút a kálvárián'))
+        .toBe(MassTitleCategory.OTHER);
+    });
+
+    it('a szótár mind a négy kategóriára ad alakokat', () => {
+      const aliases = MassTitleCategoryConfig.CATEGORY_ALIASES;
+
+      for (const category of [MassTitleCategory.MASS, MassTitleCategory.ADORATION,
+                              MassTitleCategory.CONFESSION, MassTitleCategory.OTHER]) {
+        expect(aliases[category].length).toBeGreaterThan(0);
+      }
+      expect(aliases[MassTitleCategory.MASS]).toContain('szentmise');
+      expect(aliases[MassTitleCategory.CONFESSION]).toContain('gyóntat');
+    });
+  });
+
   describe('getAllCategories', () => {
     it('should return all category values', () => {
       const categories = MassTitleCategoryConfig.getAllCategories();

--- a/calendar/src/app/util/mass-title-category-config.spec.ts
+++ b/calendar/src/app/util/mass-title-category-config.spec.ts
@@ -327,6 +327,27 @@ describe('MassTitleCategoryConfig', () => {
         .toBe(MassTitleCategory.OTHER);
     });
 
+    it('#896: a keresztelő, esküvő, temetés EGYÉB — de nem választható cím', () => {
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Keresztelő (P. Vértesaljai)'))
+        .toBe(MassTitleCategory.OTHER);
+      expect(MassTitleCategoryConfig.getCategoryByTitle('Esküvő (Alácsi Ervin atya)'))
+        .toBe(MassTitleCategory.OTHER);
+      expect(MassTitleCategoryConfig.getCategoryByTitle('BOHAN BÉLA ATYA TEMETÉSE 12 ÓRAKOR'))
+        .toBe(MassTitleCategory.OTHER);
+
+      // A mise marad mise: a korábbi találat nyer.
+      expect(MassTitleCategoryConfig.getCategoryByTitle('10 misén keresztelő, Mária Teodóra'))
+        .toBe(MassTitleCategory.MASS);
+
+      // És egyikük sem jelenhet meg a szerkesztő cím-választójában.
+      const cimek = Object.values(MassTitleCategoryConfig.CATEGORY_TITLES).flat();
+      for (const kulcs of cimek) {
+        expect(kulcs.toLowerCase()).not.toContain('keresztel');
+        expect(kulcs.toLowerCase()).not.toContain('wedding');
+        expect(kulcs.toLowerCase()).not.toContain('funeral');
+      }
+    });
+
     it('a szótár mind a négy kategóriára ad alakokat', () => {
       const aliases = MassTitleCategoryConfig.CATEGORY_ALIASES;
 

--- a/calendar/src/app/util/mass-title-category-config.ts
+++ b/calendar/src/app/util/mass-title-category-config.ts
@@ -59,7 +59,9 @@ export class MassTitleCategoryConfig {
     const aliases: Record<MassTitleCategory, string[]> = {} as Record<MassTitleCategory, string[]>;
 
     for (const categoryDef of MASS_DEFINITIONS_DATA.categories) {
-      aliases[categoryDef.key as MassTitleCategory] = [];
+      // #896: a kategória saját aliasai (keresztelő, esküvő, temetés) — ezekhez nincs
+      // definíció, mert a naptárszerkesztőben nem szabad megjelenniük.
+      aliases[categoryDef.key as MassTitleCategory] = categoryDef.aliases ? [...categoryDef.aliases] : [];
     }
 
     for (const definition of MASS_DEFINITIONS_DATA.definitions) {

--- a/calendar/src/app/util/mass-title-category-config.ts
+++ b/calendar/src/app/util/mass-title-category-config.ts
@@ -48,6 +48,89 @@ export class MassTitleCategoryConfig {
     return titles;
   }
 
+  /**
+   * #896: kategóriánkénti szabad szöveges alakok — ugyanaz az adat, amit a PHP olvas.
+   *
+   * A szótár a definíciók mellett él (`mass-definitions.ts` -> `aliases`), az Angular
+   * build pedig ugyanezt exportálja a `webapp/mass-definitions.json`-ba. Egy forrás,
+   * két olvasó.
+   */
+  static get CATEGORY_ALIASES(): Record<MassTitleCategory, string[]> {
+    const aliases: Record<MassTitleCategory, string[]> = {} as Record<MassTitleCategory, string[]>;
+
+    for (const categoryDef of MASS_DEFINITIONS_DATA.categories) {
+      aliases[categoryDef.key as MassTitleCategory] = [];
+    }
+
+    for (const definition of MASS_DEFINITIONS_DATA.definitions) {
+      const category = definition.category as MassTitleCategory;
+      if (!aliases[category] || !definition.aliases) continue;
+
+      for (const alias of definition.aliases) {
+        if (!aliases[category].includes(alias)) {
+          aliases[category].push(alias);
+        }
+      }
+    }
+
+    return aliases;
+  }
+
+  /**
+   * #896: a címben LEGKORÁBBAN előforduló alias kategóriája.
+   *
+   * A magyar naptárcímek a főeseményt írják előre, ezért a SZÖVEG sorrendje dönt, nem a
+   * kategóriáké. Ez a különbség nem elméleti: a „Gyóntatás a szentmise előtt" a régi,
+   * kategória-sorrendes illesztéssel MASS lett, a PHP szerint viszont CONFESSION — a
+   * naptár tehát mást színezett, mint amit a kereső talált.
+   *
+   * Azonos pozíciónál a hosszabb alias nyer (az a szűkebb találat), így az eredmény nem
+   * függ a kategóriák felsorolási sorrendjétől. Ugyanez a szabály fut a PHP oldalon
+   * (`MassDefinitions::categoryForTitle()`).
+   */
+  private static matchByAliases(lowerTitle: string): MassTitleCategory | null {
+    let nyertes: MassTitleCategory | null = null;
+    let hol = -1;
+    let hossz = 0;
+
+    for (const [category, aliases] of Object.entries(this.CATEGORY_ALIASES)) {
+      for (const alias of aliases as string[]) {
+        const pozicio = this.aliasPozicio(lowerTitle, alias);
+        if (pozicio === -1) continue;
+
+        if (hol === -1 || pozicio < hol || (pozicio === hol && alias.length > hossz)) {
+          hol = pozicio;
+          hossz = alias.length;
+          nyertes = category as MassTitleCategory;
+        }
+      }
+    }
+
+    return nyertes;
+  }
+
+  /**
+   * #896: az alias első olyan előfordulása, ami SZÓ ELEJÉN áll.
+   *
+   * Szóhatár nélkül az „UnknownMassTitle"-ből a `mass` alias misét csinálna. Szó VÉGÉT
+   * nem kötünk ki: az aliasok egy része szándékosan tő („szentségimád"), hogy a ragozott
+   * alakok is illeszkedjenek. Ugyanez a szabály fut a PHP oldalon
+   * (`MassDefinitions::aliasPozicio()`).
+   */
+  private static aliasPozicio(cim: string, alias: string): number {
+    let tol = 0;
+
+    for (;;) {
+      const pozicio = cim.indexOf(alias, tol);
+      if (pozicio === -1) return -1;
+
+      const elozo = pozicio === 0 ? '' : cim.charAt(pozicio - 1);
+      if (elozo === '' || !/\p{L}/u.test(elozo)) return pozicio;
+
+      tol = pozicio + 1;
+    }
+  }
+
   // Lefordított szövegek a kategóriákhoz - dinamikusan generálva az i18n JSON alapján
   private static _translatedValuesCache: Record<MassTitleCategory, string[]> | null = null;
 
@@ -116,6 +199,15 @@ export class MassTitleCategoryConfig {
       if (titles.includes(title)) {
         return category as MassTitleCategory;
       }
+    }
+
+    const lowerTitleForAliases = title.toLowerCase();
+
+    // #896: a közös szótár. Ez fut a TranslateService nélkül is — eddig ilyenkor minden
+    // cím a default kategóriába esett, holott a felismeréshez a fordítás nem is kell.
+    const aliasTalalat = this.matchByAliases(lowerTitleForAliases);
+    if (aliasTalalat) {
+      return aliasTalalat;
     }
 
     // Lekérjük a lefordított értékeket

--- a/webapp/classes/icaleventproperties.php
+++ b/webapp/classes/icaleventproperties.php
@@ -279,77 +279,19 @@ class IcalEventProperties {
         return trim($value ?? '');
     }
 
-    /**
-     * #157: a bejegyzés KATEGÓRIÁJA a címből.
+    /*
+     * #896: a kategória-felismerés INNEN ELKERÜLT.
      *
-     * borazslo: „ha a keresőben filterként választom ki hogy misefélék vagy
-     * szentségimádások vagy gyóntatások vagy egyebek, akkor azok még nem fogják jól
-     * megtalálni az importált speciális miséinket."
+     * A `CATEGORY_PATTERNS` (a szabad szöveges alakok és elgépelések) ennek az osztálynak
+     * a privát konstansa volt, tehát csak a PHP látta. A böngésző-oldal ugyanarra a
+     * kérdésre a saját, gyengébb heurisztikájával felelt, és néha mást — a naptár tehát
+     * mást színezhetett, mint amit a kereső talált.
      *
-     * MINTA-CSAPDÁK, amiket nem szabad elfelejteni:
-     *
-     *   - „liturgia" TELJES szóként, nem „liturgi": a „Régi rítusú liturgikus hétvége"
-     *     különben misévé válna. Ugyanezt a döntést a `RITE_PATTERNS` már meghozta.
-     *   - „szentmise" és „mise" is kell: az előbbi a gyakori alak, az utóbbi a
-     *     „Régi rítusú mise"-hez.
-     *   - a „szentségimádás" nem tartalmazza a „mise" szót, tehát nincs átfedés.
-     *
-     * @var array<string, string[]>
+     * A szótár mostantól a definíciók mellett él (`mass-definitions.ts` -> `aliases`),
+     * a felismerő pedig `MassDefinitions::categoryForTitle()`. Ez az osztály maradt az,
+     * ami volt: tiszta függvények az ICS-mezőkhöz (nyelv, rítus, típus, lemondás). A
+     * kategória nem ICS-tulajdonság, hanem a miserend saját fogalma — nem is ide való.
      */
-    private const CATEGORY_PATTERNS = [
-        'CONFESSION' => ['gyóntat', 'gyontat', 'szentgyónás', 'szentgyonas', 'gyónási', 'gyonasi', 'confession'],
-        'ADORATION'  => ['szentségimád', 'szentsegimad', 'adorác', 'adorac', 'adoration'],
-        'MASS'       => ['szentmise', 'mise', 'liturgia', 'szentáldozás', 'szentaldozas', 'mass', 'eucharist'],
-        'OTHER'      => ['rózsafüzér', 'rozsafuzer', 'keresztút', 'keresztut', 'litánia', 'litania',
-                         'zsolozsma', 'vecsernye', 'utrenye', 'esti dicséret', 'esti dicseret', 'imaóra', 'imaora'],
-    ];
-
-    /**
-     * #157: melyik kategóriába tartozik ez a cím?
-     *
-     * A magyar naptárcímek a FŐESEMÉNYT írják előre, ezért a címben LEGKORÁBBAN
-     * előforduló minta nyer — nem a csoportok sorrendje:
-     *
-     *   „Szentmise, utána szentségimádás"      -> MASS
-     *   „Szentségimádás a szentmise után"      -> ADORATION
-     *   „Gyóntatás a szentmise előtt"          -> CONFESSION
-     *
-     * Csoport-sorrenddel mindhárom ugyanazt adná, tehát kettő rossz lenne.
-     *
-     * @return ?string a kategória kulcsa, vagy null, ha nem ismerjük fel
-     */
-    public static function detectCategory(string $summary): ?string {
-        return self::earliestMatch(self::normalize($summary), self::CATEGORY_PATTERNS);
-    }
-
-    /**
-     * A LEGKORÁBBAN előforduló minta csoportja.
-     *
-     * A `firstMatch()` a csoportok sorrendje szerint dönt — ott ez helyes (a rítusnál a
-     * szűkebb minta van elöl). Itt viszont a szöveg sorrendje a mérvadó, l. a
-     * `detectCategory()` példáit.
-     *
-     * @param array<string, string[]> $patterns
-     */
-    private static function earliestMatch(string $haystack, array $patterns): ?string {
-        $legkorabbi = null;
-        $hol = null;
-
-        foreach ($patterns as $ertek => $mintak) {
-            foreach ($mintak as $minta) {
-                $pozicio = mb_strpos($haystack, $minta);
-                if ($pozicio === false) {
-                    continue;
-                }
-                if ($hol === null || $pozicio < $hol) {
-                    $hol = $pozicio;
-                    $legkorabbi = $ertek;
-                }
-            }
-        }
-
-        return $legkorabbi;
-    }
 
     /**
      * @param array<string, string[]> $patterns

--- a/webapp/classes/massdefinitions.php
+++ b/webapp/classes/massdefinitions.php
@@ -110,10 +110,14 @@ final class MassDefinitions
      *      `aliases` szótára (#896), ami az importált és a kézzel írt egyedi címeket
      *      is besorolja.
      *
-     * ISMERETLEN CÍM -> NULL, NEM 'OTHER'. Az OTHER felületi neve „Egyéb imaalkalmak",
-     * tagjai a zsolozsma, rózsafüzér, litánia, keresztút. Ha minden felismeretlen szabad
-     * szöveg oda kerülne, a szűrő hazudna: a „Képviselőtestületi ülés" és a „Hittanóra"
+     * ISMERETLEN CÍM -> NULL, NEM 'OTHER'. Ha minden felismeretlen szabad szöveg az
+     * OTHER-be kerülne, a szűrő hazudna: a „Képviselőtestületi ülés" és a „Hittanóra"
      * imaalkalomként jelenne meg. A hiányzó mező őszinte, és mérhető is.
+     *
+     * #896: a keresztelő, az esküvő és a temetés viszont SZÁNDÉKOSAN OTHER — borazslo
+     * döntése. Ezek csak importból kerülnek be, keresni sem fog rájuk senki, de a teljes
+     * elrejtésük már átverés lenne. Kategória-aliasként szerepelnek (nem definícióként),
+     * hogy a naptárszerkesztő cím-választójában ne jelenjenek meg.
      */
     public function categoryForTitle(string $title): ?string
     {

--- a/webapp/classes/massdefinitions.php
+++ b/webapp/classes/massdefinitions.php
@@ -106,9 +106,9 @@ final class MassDefinitions
      *   1. PONTOS egyezés a kanonikus alakokra (a definíciókulcs vagy a magyar
      *      fordítása). Ez garantálja, hogy a mai viselkedés bitre ugyanaz maradjon a
      *      kanonikus címekre — nulla regresszió.
-     *   2. Ha nincs pontos találat, a szabad szöveges felismerő
-     *      (`\IcalEventProperties::detectCategory()`), ami az importált és a kézzel
-     *      írt egyedi címeket is besorolja.
+     *   2. Ha nincs pontos találat, a szabad szöveges felismerő — a definíciók
+     *      `aliases` szótára (#896), ami az importált és a kézzel írt egyedi címeket
+     *      is besorolja.
      *
      * ISMERETLEN CÍM -> NULL, NEM 'OTHER'. Az OTHER felületi neve „Egyéb imaalkalmak",
      * tagjai a zsolozsma, rózsafüzér, litánia, keresztút. Ha minden felismeretlen szabad
@@ -138,7 +138,99 @@ final class MassDefinitions
             }
         }
 
-        return \IcalEventProperties::detectCategory($title);
+        return $this->categoryByAliases($title);
+    }
+
+    /**
+     * #896: kategóriánkénti szabad szöveges alakok a generált JSON-ból.
+     *
+     * A mesterpéldány a `calendar/src/app/data/mass-definitions.ts` — ott, a definíciók
+     * mellett. Ez a metódus csak a kigenerált indexet adja vissza; ha üres (régi JSON,
+     * ami még az `aliasesByCategory` előtt készült), a felismerés egyszerűen nem talál
+     * semmit, és a kanonikus egyezés marad — nem hasal el.
+     *
+     * @return array<string, string[]>
+     */
+    public function aliasesByCategory(): array
+    {
+        $szotar = [];
+        foreach ($this->arrayValue('aliasesByCategory') as $category => $aliases) {
+            if (is_array($aliases)) {
+                $szotar[(string) $category] = array_values(array_filter(
+                    array_map('strval', $aliases),
+                    static fn(string $a): bool => $a !== ''
+                ));
+            }
+        }
+
+        return $szotar;
+    }
+
+    /**
+     * #157/#896: a címben LEGKORÁBBAN előforduló alias kategóriája.
+     *
+     * A magyar naptárcímek a FŐESEMÉNYT írják előre, ezért a szöveg sorrendje dönt, nem a
+     * kategóriáké:
+     *
+     *   „Szentmise, utána szentségimádás"      -> MASS
+     *   „Szentségimádás a szentmise után"      -> ADORATION
+     *   „Gyóntatás a szentmise előtt"          -> CONFESSION
+     *
+     * Kategória-sorrenddel mindhárom ugyanazt adná, tehát kettő rossz lenne. (Az Angular
+     * oldal pontosan ezt a hibát követte el a #896 előtt.)
+     *
+     * Azonos pozíciónál a HOSSZABB alias nyer: az a szűkebb, tehát a beszédesebb találat.
+     * Így az eredmény nem függ attól, milyen sorrendben soroljuk fel a kategóriákat.
+     */
+    private function categoryByAliases(string $title): ?string
+    {
+        $cim = mb_strtolower($title, 'UTF-8');
+
+        $nyertes = null;
+        $hol = null;
+        $hossz = 0;
+
+        foreach ($this->aliasesByCategory() as $category => $aliases) {
+            foreach ($aliases as $alias) {
+                $pozicio = self::aliasPozicio($cim, $alias);
+                if ($pozicio === null) {
+                    continue;
+                }
+
+                $aliasHossz = mb_strlen($alias);
+                if ($hol === null || $pozicio < $hol || ($pozicio === $hol && $aliasHossz > $hossz)) {
+                    $hol = $pozicio;
+                    $hossz = $aliasHossz;
+                    $nyertes = $category;
+                }
+            }
+        }
+
+        return $nyertes;
+    }
+
+    /**
+     * #896: az alias első olyan előfordulása, ami SZÓ ELEJÉN áll.
+     *
+     * Szóhatár nélkül az „UnknownMassTitle"-ből a `mass` alias misét csinál. Szó VÉGÉT
+     * viszont nem kötünk ki: az aliasok egy része szándékosan tő („szentségimád"), hogy
+     * a ragozott alakok — „szentségimádás", „szentségimádást" — is illeszkedjenek.
+     *
+     * Ugyanez a szabály fut az Angular oldalon (`MassTitleCategoryConfig`), különben a
+     * két felismerés megint elválna egymástól — pont attól, amiért a #896 megszületett.
+     */
+    private static function aliasPozicio(string $cim, string $alias): ?int
+    {
+        $tol = 0;
+        while (($pozicio = mb_strpos($cim, $alias, $tol)) !== false) {
+            $elozo = $pozicio === 0 ? '' : mb_substr($cim, $pozicio - 1, 1);
+            if ($elozo === '' || !preg_match('/\p{L}/u', $elozo)) {
+                return $pozicio;
+            }
+            $tol = $pozicio + 1;
+        }
+
+        return null;
     }
 
     /**

--- a/webapp/mass-definitions.json
+++ b/webapp/mass-definitions.json
@@ -430,6 +430,14 @@
       "confession"
     ],
     "OTHER": [
+      "keresztel",
+      "esküvő",
+      "eskuvo",
+      "temetés",
+      "temetes",
+      "requiem",
+      "gyászszertartás",
+      "gyaszszertartas",
       "zsolozsma",
       "esti dicséret",
       "esti dicseret",

--- a/webapp/mass-definitions.json
+++ b/webapp/mass-definitions.json
@@ -50,6 +50,31 @@
   "definitions": [
     {
       "key": "HOLY_MASS",
+      "aliases": [
+        "szentmise",
+        "szentmisé",
+        "szentmsie",
+        "szentmse",
+        "sztmise",
+        "mise",
+        "misé",
+        "újmis",
+        "ujmis",
+        "gyászmis",
+        "gyaszmis",
+        "diákmis",
+        "diakmis",
+        "ifimis",
+        "emlékmis",
+        "emlekmis",
+        "aranymis",
+        "ezüstmis",
+        "ezustmis",
+        "szentáldozás",
+        "szentaldozas",
+        "mass",
+        "eucharist"
+      ],
       "category": "MASS",
       "rites": [
         "ROMAN_CATHOLIC"
@@ -59,6 +84,10 @@
     },
     {
       "key": "LITURGY_OF_THE_WORD",
+      "aliases": [
+        "igeliturgia",
+        "igeliturgi"
+      ],
       "category": "MASS",
       "rites": [
         "ROMAN_CATHOLIC"
@@ -68,6 +97,10 @@
     },
     {
       "key": "DIVINE_LITURGY",
+      "aliases": [
+        "szent liturgia",
+        "liturgia"
+      ],
       "category": "MASS",
       "rites": [
         "GREEK_CATHOLIC"
@@ -78,6 +111,10 @@
     },
     {
       "key": "LITURGY_OF_THE_PRESANCTIFIED_GIFTS",
+      "aliases": [
+        "előre megszentelt",
+        "elore megszentelt"
+      ],
       "category": "MASS",
       "rites": [
         "GREEK_CATHOLIC"
@@ -87,6 +124,12 @@
     },
     {
       "key": "MASS_OF_THE_LORD_S_SUPPER",
+      "aliases": [
+        "nagycsütörtöki szertartás",
+        "nagycsutortoki szertartas",
+        "utolsó vacsora",
+        "utolso vacsora"
+      ],
       "category": "MASS",
       "rites": [
         "ROMAN_CATHOLIC",
@@ -97,6 +140,10 @@
     },
     {
       "key": "GOOD_FRIDAY_LITURGY",
+      "aliases": [
+        "nagypénteki szertartás",
+        "nagypenteki szertartas"
+      ],
       "category": "MASS",
       "rites": [
         "ROMAN_CATHOLIC",
@@ -107,6 +154,16 @@
     },
     {
       "key": "EASTER_VIGIL",
+      "aliases": [
+        "húsvét vigíliája",
+        "husvet vigiliaja",
+        "húsvéti vigília",
+        "husveti vigilia",
+        "feltámadási szertartás",
+        "feltamadasi szertartas",
+        "easter vigil",
+        "eastern vigil"
+      ],
       "category": "MASS",
       "rites": [
         "ROMAN_CATHOLIC",
@@ -117,6 +174,12 @@
     },
     {
       "key": "TRADITIONAL_LATIN_MASS",
+      "aliases": [
+        "régi rítusú mise",
+        "regi ritusu mise",
+        "tridenti",
+        "usus antiquior"
+      ],
       "category": "MASS",
       "rites": [
         "TRADITIONAL"
@@ -127,6 +190,13 @@
     },
     {
       "key": "ADORATION",
+      "aliases": [
+        "szentségimád",
+        "szentsegimad",
+        "adorác",
+        "adorac",
+        "adoration"
+      ],
       "category": "ADORATION",
       "rites": [
         "ROMAN_CATHOLIC"
@@ -136,6 +206,17 @@
     },
     {
       "key": "CONFESSION",
+      "aliases": [
+        "gyóntat",
+        "gyontat",
+        "szentgyónás",
+        "szentgyonas",
+        "gyónás",
+        "gyonas",
+        "gyónási",
+        "gyonasi",
+        "confession"
+      ],
       "category": "CONFESSION",
       "rites": [
         "ROMAN_CATHOLIC",
@@ -146,6 +227,15 @@
     },
     {
       "key": "BREVIARY",
+      "aliases": [
+        "zsolozsma",
+        "esti dicséret",
+        "esti dicseret",
+        "imaóra",
+        "imaora",
+        "breviárium",
+        "breviarium"
+      ],
       "category": "OTHER",
       "rites": [
         "ROMAN_CATHOLIC"
@@ -155,6 +245,10 @@
     },
     {
       "key": "ROSARY",
+      "aliases": [
+        "rózsafüzér",
+        "rozsafuzer"
+      ],
       "category": "OTHER",
       "rites": [
         "ROMAN_CATHOLIC"
@@ -164,6 +258,10 @@
     },
     {
       "key": "LITANY",
+      "aliases": [
+        "litánia",
+        "litania"
+      ],
       "category": "OTHER",
       "rites": [
         "ROMAN_CATHOLIC"
@@ -173,6 +271,10 @@
     },
     {
       "key": "STATIONS_OF_THE_CROSS",
+      "aliases": [
+        "keresztút",
+        "keresztut"
+      ],
       "category": "OTHER",
       "rites": [
         "ROMAN_CATHOLIC"
@@ -182,6 +284,9 @@
     },
     {
       "key": "MATINS",
+      "aliases": [
+        "utrenye"
+      ],
       "category": "OTHER",
       "rites": [
         "GREEK_CATHOLIC"
@@ -191,6 +296,9 @@
     },
     {
       "key": "VESPRES",
+      "aliases": [
+        "vecsernye"
+      ],
       "category": "OTHER",
       "rites": [
         "GREEK_CATHOLIC"
@@ -251,6 +359,92 @@
       "MASS_TITLE.GOOD_FRIDAY_LITURGY",
       "MASS_TITLE.EASTER_VIGIL",
       "MASS_TITLE.TRADITIONAL_LATIN_MASS"
+    ]
+  },
+  "aliasesByCategory": {
+    "MASS": [
+      "szentmise",
+      "szentmisé",
+      "szentmsie",
+      "szentmse",
+      "sztmise",
+      "mise",
+      "misé",
+      "újmis",
+      "ujmis",
+      "gyászmis",
+      "gyaszmis",
+      "diákmis",
+      "diakmis",
+      "ifimis",
+      "emlékmis",
+      "emlekmis",
+      "aranymis",
+      "ezüstmis",
+      "ezustmis",
+      "szentáldozás",
+      "szentaldozas",
+      "mass",
+      "eucharist",
+      "igeliturgia",
+      "igeliturgi",
+      "szent liturgia",
+      "liturgia",
+      "előre megszentelt",
+      "elore megszentelt",
+      "nagycsütörtöki szertartás",
+      "nagycsutortoki szertartas",
+      "utolsó vacsora",
+      "utolso vacsora",
+      "nagypénteki szertartás",
+      "nagypenteki szertartas",
+      "húsvét vigíliája",
+      "husvet vigiliaja",
+      "húsvéti vigília",
+      "husveti vigilia",
+      "feltámadási szertartás",
+      "feltamadasi szertartas",
+      "easter vigil",
+      "eastern vigil",
+      "régi rítusú mise",
+      "regi ritusu mise",
+      "tridenti",
+      "usus antiquior"
+    ],
+    "ADORATION": [
+      "szentségimád",
+      "szentsegimad",
+      "adorác",
+      "adorac",
+      "adoration"
+    ],
+    "CONFESSION": [
+      "gyóntat",
+      "gyontat",
+      "szentgyónás",
+      "szentgyonas",
+      "gyónás",
+      "gyonas",
+      "gyónási",
+      "gyonasi",
+      "confession"
+    ],
+    "OTHER": [
+      "zsolozsma",
+      "esti dicséret",
+      "esti dicseret",
+      "imaóra",
+      "imaora",
+      "breviárium",
+      "breviarium",
+      "rózsafüzér",
+      "rozsafuzer",
+      "litánia",
+      "litania",
+      "keresztút",
+      "keresztut",
+      "utrenye",
+      "vecsernye"
     ]
   }
 }

--- a/webapp/tests/Unit/MassCategoryDetectionTest.php
+++ b/webapp/tests/Unit/MassCategoryDetectionTest.php
@@ -89,12 +89,22 @@ final class MassCategoryDetectionTest extends TestCase
             'ragozott mise'           => ['Kollégistáink szentmiséje (P. Szőcs)', 'MASS'],
             'újmise'                  => ['P. Phamdinh Ngoc József SJ újmiséje', 'MASS'],
 
-            // Ezek TOVÁBBRA IS kategória nélkül maradnak, és ez a helyes: liturgiák, de
-            // egyik sem a négy kategória valamelyike. A „szertartás" önmagában ezért nem
-            // lehet alias — a temetésből is misét csinálna.
-            'temetés'                 => ['BOHAN BÉLA ATYA TEMETÉSE 12 ÓRAKOR', null],
-            'keresztelő'              => ['Keresztelő (P. Vértesaljai)', null],
-            'esküvő'                  => ['Esküvő (Alácsi Ervin atya)', null],
+            // #896: borazslo döntése szerint ezek EGYÉB-be tartoznak. Nem definícióként,
+            // hanem kategória-aliasként — így a kereső megtalálja őket, a naptárszerkesztő
+            // cím-választójában viszont nem jelennek meg.
+            'temetés'                 => ['BOHAN BÉLA ATYA TEMETÉSE 12 ÓRAKOR', 'OTHER'],
+            'keresztelő'              => ['Keresztelő (P. Vértesaljai)', 'OTHER'],
+            'ékezet nélküli keresztelő' => ['Keresztelõ, P. Szőcs', 'OTHER'],
+            'esküvő'                  => ['Esküvő (Alácsi Ervin atya)', 'OTHER'],
+            'requiem'                 => ['BOHAN BÉLA ATYA - REQUIEM, SZEGEDI SZENT JÓZSEF Templomban', 'OTHER'],
+
+            // De a MISE marad mise: a „10 misén keresztelő" elsősorban szentmise, és a
+            // korábbi találat nyer — a „misé" a 3. karakternél áll, a „keresztel" a 9-nél.
+            'keresztelő a misén'      => ['10 misén keresztelő, Mária Teodóra', 'MASS'],
+
+            // A „szertartás" önmagában továbbra sem lehet alias: abból a temetés is mise
+            // lenne. Csak a nagypénteki/nagycsütörtöki/feltámadási alak szerepel.
+            'lelkinap'                => ['Lelkinap', null],
         ];
     }
 

--- a/webapp/tests/Unit/MassCategoryDetectionTest.php
+++ b/webapp/tests/Unit/MassCategoryDetectionTest.php
@@ -58,7 +58,44 @@ final class MassCategoryDetectionTest extends TestCase
     /** @dataProvider cimek */
     public function testTheTitleDecidesTheCategory(string $cim, ?string $vart): void
     {
-        self::assertSame($vart, \IcalEventProperties::detectCategory($cim), $cim);
+        self::assertSame($vart, $this->md()->categoryForTitle($cim), $cim);
+    }
+
+    /**
+     * #896: amit a régi, szűk szótár NEM ismert fel.
+     *
+     * Mind a hat alak az éles adatból való — a fejlesztői adatbázis 12 505 sorából ezek
+     * maradtak kategória nélkül, pedig mind mise. A kanonikus cím önmagában kevés volt:
+     * a „Nagypénteki szertartás" pontosan egyezve felismerhető, de egy „(P. Szőcs)" a
+     * végén már kiejtette.
+     *
+     * @dataProvider valodiCimek
+     */
+    public function testTitlesFromTheRealDataAreRecognised(string $cim, ?string $vart): void
+    {
+        self::assertSame($vart, $this->md()->categoryForTitle($cim), $cim);
+    }
+
+    public static function valodiCimek(): array
+    {
+        return [
+            'nagypénteki szertartás'  => ['Nagypénteki szertartás (P. Szőcs)', 'MASS'],
+            'nagycsütörtöki'          => ['Nagycsütörtöki szertartás (P. Elek)', 'MASS'],
+            'húsvéti vigília'         => ['Húsvét vigíliája (P. Elek)', 'MASS'],
+            'feltámadási szertartás'  => ['Feltámadási szertartás (P. Elek)', 'MASS'],
+            'angol vigília elgépelve' => ['Eastern vigil in English (P. Elek)', 'MASS'],
+            'elgépelt szentmise'      => ['Szentmsie', 'MASS'],
+            'elgépelt szentmise 2'    => ['Kollégiumi szentmse', 'MASS'],
+            'ragozott mise'           => ['Kollégistáink szentmiséje (P. Szőcs)', 'MASS'],
+            'újmise'                  => ['P. Phamdinh Ngoc József SJ újmiséje', 'MASS'],
+
+            // Ezek TOVÁBBRA IS kategória nélkül maradnak, és ez a helyes: liturgiák, de
+            // egyik sem a négy kategória valamelyike. A „szertartás" önmagában ezért nem
+            // lehet alias — a temetésből is misét csinálna.
+            'temetés'                 => ['BOHAN BÉLA ATYA TEMETÉSE 12 ÓRAKOR', null],
+            'keresztelő'              => ['Keresztelő (P. Vértesaljai)', null],
+            'esküvő'                  => ['Esküvő (Alácsi Ervin atya)', null],
+        ];
     }
 
     /**
@@ -69,7 +106,7 @@ final class MassCategoryDetectionTest extends TestCase
      */
     public function testALiturgicalWeekendIsNotAMass(): void
     {
-        self::assertNotSame('MASS', \IcalEventProperties::detectCategory('Régi rítusú liturgikus hétvége'));
+        self::assertNotSame('MASS', $this->md()->categoryForTitle('Régi rítusú liturgikus hétvége'));
     }
 
     /* ---- A kanonikus címek viselkedése NEM változik ---- */
@@ -96,6 +133,24 @@ final class MassCategoryDetectionTest extends TestCase
     {
         self::assertNull($this->md()->categoryForTitle(''));
         self::assertNull($this->md()->categoryForTitle('   '));
+    }
+
+    /**
+     * #896: a szótár a GENERÁLT adatból jön, nem PHP-konstansból.
+     *
+     * Ez a teszt az egyetlen forrást őrzi: ha valaki visszacsempészné a mintákat egy
+     * osztály konstansába, az `aliasesByCategory()` üresen maradna, és ez elbukna.
+     */
+    public function testTheAliasDictionaryComesFromTheGeneratedData(): void
+    {
+        $szotar = $this->md()->aliasesByCategory();
+
+        self::assertNotEmpty($szotar, 'nincs alias a generált JSON-ban');
+        foreach (['MASS', 'ADORATION', 'CONFESSION', 'OTHER'] as $category) {
+            self::assertNotEmpty($szotar[$category] ?? [], "üres a(z) $category szótára");
+        }
+        self::assertContains('szentmise', $szotar['MASS']);
+        self::assertContains('gyóntat', $szotar['CONFESSION']);
     }
 
     /* ---- A keresési klauzula ---- */

--- a/webapp/tools/mass-category-audit.php
+++ b/webapp/tools/mass-category-audit.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * #895/#896: mennyire pontos a kategória-felismerés — TEMPLOMONKÉNT.
+ *
+ * borazslo a #895-ben: „bár jó átnézni, hogy most miből mennyi van, de ez nagyon nem
+ * releváns adat. Inkább az, hogy olyan templomnál ahol már mindenféle van, ott melyikből
+ * mennyi van. Hiszen ez egy új fícsör és tökre nincs feltöltve adattal."
+ *
+ * Igaza van: az összesített szám a MAI, alig feltöltött állapotról szól. Ez a szkript
+ * ezért templomonként bont, és azokat veszi előre, ahol TÖBBFÉLE kategória is előfordul —
+ * ott derül ki, hogy a felismerő tényleg szét tudja-e választani őket.
+ *
+ * CSAK OLVAS.
+ *
+ *   docker compose exec miserend php /miserend/webapp/tools/mass-category-audit.php
+ *
+ * Kapcsolók:
+ *   --limit=N      hány templomot írjon ki (alapérték: 25)
+ *   --church=ID    csak ez az egy templom, a teljes cím-listájával
+ *   --unknown      csak a besorolatlan címeket listázza, templomonként
+ */
+
+require __DIR__ . '/../load.php';
+
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * Balra igazított kitöltés MEGJELENÍTÉSI szélesség szerint.
+ *
+ * A printf `%-34s`-e bájtot számol, az ékezetes templomnevek pedig többájtosak — a
+ * táblázat oszlopai enélkül elcsúsznak, pont azoknál a soroknál, amiket olvasni akarunk.
+ */
+function szelesRe(string $szoveg, int $szelesseg): string {
+    $vagott = mb_strimwidth($szoveg, 0, $szelesseg, '…');
+
+    return $vagott . str_repeat(' ', max(0, $szelesseg - mb_strwidth($vagott)));
+}
+
+$opciok  = getopt('', ['limit::', 'church::', 'unknown']);
+$limit   = isset($opciok['limit']) ? max(1, (int) $opciok['limit']) : 25;
+$csakEgy = isset($opciok['church']) ? (int) $opciok['church'] : null;
+$csakIsmeretlen = isset($opciok['unknown']);
+
+$md = new \MassDefinitions();
+$kategoriak = array_column($md->categories(), 'key');
+
+$query = DB::table('cal_masses')
+    ->join('templomok', 'templomok.id', '=', 'cal_masses.church_id')
+    ->select('cal_masses.church_id', 'cal_masses.title', 'templomok.nev')
+    ->orderBy('cal_masses.church_id');
+
+if ($csakEgy !== null) {
+    $query->where('cal_masses.church_id', $csakEgy);
+}
+
+$templomok = [];
+$osszes = 0;
+
+foreach ($query->get() as $sor) {
+    $tid = (int) $sor->church_id;
+    $kategoria = $md->categoryForTitle((string) $sor->title) ?? 'NINCS';
+
+    if (!isset($templomok[$tid])) {
+        $templomok[$tid] = ['nev' => $sor->nev, 'db' => [], 'ismeretlen' => []];
+    }
+
+    $templomok[$tid]['db'][$kategoria] = ($templomok[$tid]['db'][$kategoria] ?? 0) + 1;
+    if ($kategoria === 'NINCS') {
+        $cim = (string) $sor->title;
+        $templomok[$tid]['ismeretlen'][$cim] = ($templomok[$tid]['ismeretlen'][$cim] ?? 0) + 1;
+    }
+    $osszes++;
+}
+
+if ($templomok === []) {
+    echo "Nincs egyetlen naptár-esemény sem.\n";
+    exit(0);
+}
+
+/*
+ * A rendezés a lényeg: elöl az a templom, ahol a LEGTÖBBFÉLE kategória van. Az összesített
+ * darabszám félrevezet — egy 10 000 misés templom nem mond semmit a felismerő
+ * pontosságáról, egy 200 eseményes, ötféle alkalmat tartó viszont igen.
+ */
+uasort($templomok, static function (array $a, array $b): int {
+    $aFele = count(array_diff_key($a['db'], ['NINCS' => 1]));
+    $bFele = count(array_diff_key($b['db'], ['NINCS' => 1]));
+
+    return $bFele <=> $aFele ?: array_sum($b['db']) <=> array_sum($a['db']);
+});
+
+if ($csakIsmeretlen) {
+    $db = 0;
+    foreach ($templomok as $tid => $t) {
+        if ($t['ismeretlen'] === []) {
+            continue;
+        }
+        printf("#%d %s\n", $tid, $t['nev']);
+        arsort($t['ismeretlen']);
+        foreach ($t['ismeretlen'] as $cim => $n) {
+            printf("   %3d x %s\n", $n, $cim);
+            $db++;
+        }
+        echo "\n";
+    }
+    printf("Összesen %d különböző besorolatlan cím.\n", $db);
+    exit($db > 0 ? 1 : 0);
+}
+
+$fejlec = array_merge($kategoriak, ['NINCS']);
+
+printf("Naptár-esemény: %d, templom: %d\n\n", $osszes, count($templomok));
+printf("%-6s %s", 'id', szelesRe('templom', 34));
+foreach ($fejlec as $k) {
+    printf("%12s", $k);
+}
+printf("%8s\n", 'félék');
+echo str_repeat('-', 48 + 12 * count($fejlec) + 8), "\n";
+
+$kiirt = 0;
+$osszesites = [];
+
+foreach ($templomok as $tid => $t) {
+    foreach ($t['db'] as $k => $n) {
+        $osszesites[$k] = ($osszesites[$k] ?? 0) + $n;
+    }
+
+    if ($kiirt++ >= $limit) {
+        continue;
+    }
+
+    printf("%-6d %s", $tid, szelesRe((string) $t['nev'], 34));
+    foreach ($fejlec as $k) {
+        printf("%12s", $t['db'][$k] ?? '·');
+    }
+    printf("%8d\n", count(array_diff_key($t['db'], ['NINCS' => 1])));
+}
+
+if (count($templomok) > $limit) {
+    printf("\n… és még %d templom (--limit=N a többiért).\n", count($templomok) - $limit);
+}
+
+printf("\nÖsszesen:\n");
+foreach ($fejlec as $k) {
+    $n = $osszesites[$k] ?? 0;
+    printf("  %-12s %6d (%.1f%%)\n", $k, $n, $osszes > 0 ? 100 * $n / $osszes : 0);
+}
+
+$ismeretlenTemplomok = array_filter($templomok, static fn(array $t): bool => $t['ismeretlen'] !== []);
+if ($ismeretlenTemplomok !== []) {
+    printf("\n%d templomnál van besorolatlan cím. A listájukhoz: --unknown\n", count($ismeretlenTemplomok));
+}


### PR DESCRIPTION
Closes #896

A #896-ra, @borazslo kérdésére a #849-ből: de, tényleg jobb ott.

## Mi volt a baj

A kanonikus címek a `mass-definitions.ts`-ben vannak, a **szabad szöveges alakok és elgépelések** viszont egy PHP-osztály privát konstansában voltak (`IcalEventProperties::CATEGORY_PATTERNS`). A böngésző-oldal így nem is látta őket: a saját, gyengébb heurisztikájával felelt ugyanarra a kérdésre.

És nem ugyanazt felelte. A PHP a szövegben **legkorábban** előforduló mintát vette, az Angular a **kategóriák sorrendjét**:

```
„Gyóntatás a szentmise előtt"   PHP: CONFESSION   Angular: MASS
```

Vagyis a naptár mást színezhetett, mint amit a kereső talált — ugyanarra az eseményre.

## Mi lett belőle

A szótár a definíciók mellé került (`aliases`), tehát **egy helyen szerkeszthető**, és az Angular build ugyanazt exportálja a `webapp/mass-definitions.json`-ba, amit a PHP olvas. Mindkét oldal ugyanazt a szabályt futtatja:

- a szövegben legkorábban kezdődő alias nyer (a magyar címek a főeseményt írják előre);
- azonos pozíciónál a hosszabb — így az eredmény nem függ a kategóriák felsorolási sorrendjétől;
- az illesztés **szó elején** keres.

Az utolsó pont menet közben derült ki: szóhatár nélkül az „UnknownMassTitle"-ből is mise lett (a `mass` alias beleakadt) — ezt egy meglévő Angular-teszt fogta meg. Cserébe a szóösszetételeknek saját alak kell, mert a „újmiséje" végén álló „misé" magától nem illeszkedik. Ez két címbe került az éles adatban; az egyiket („Sztmise") elgépelésként felvettem, a másik a „KIKmise" — arra nem fogok külön aliast írni.

A kategória-felismerés kikerült az `IcalEventProperties`-ből. Az az osztály az ICS-mezőkről szól (nyelv, rítus, típus, lemondás); a kategória nem ICS-tulajdonság, hanem a miserend saját fogalma.

## Mérés

A fejlesztői adatbázis mind a 12 505 során:

| | előtte | utána |
|---|---:|---:|
| MASS | 12 104 | 12 122 |
| OTHER | 227 | 227 |
| ADORATION | 96 | 96 |
| CONFESSION | 17 | 17 |
| **besorolatlan** | **61** | **43** |

A 18 visszanyert sor mind mise volt: `Nagypénteki szertartás (P. Szőcs)`, `Nagycsütörtöki szertartás`, `Húsvét vigíliája`, `Feltámadási szertartás`, `Eastern vigil in English` (elgépelés), `Szentmsie`, `Kollégiumi szentmse`, `Kollégistáink szentmiséje`, `újmiséje`. Egyik kategória sem mozdult el máshová — ez szigorú bővítés.

### Utólag: a keresztelő, esküvő, temetés (borazslo válasza után)

Megkérdeztem a #896-ban, és @borazslo eldöntötte: ezek csak importból kerülnek be, keresni sem fog rájuk senki, a keresőben viszont az „egyéb" jó nekik — a teljes elrejtésük már átverés lenne. A **szerkesztő felületen viszont nem akarunk ilyet állítani.**

A kettő együtt kizárja az új definíciót (BAPTISM, WEDDING): az megjelenne a naptárszerkesztő cím-választójában is. Ezért **kategória-szintű** aliast vezettem be a definíció-szintű mellé — a felismerés tud róluk, a szerkesztő nem. Erre külön teszt van mindkét oldalon.

A mise marad mise: a „10 misén keresztelő" szentmise, mert a korábbi találat nyer.

Ezzel a végleges kép:

| | előtte | utána |
|---|---:|---:|
| MASS | 12 104 | 12 122 |
| OTHER | 227 | 244 |
| **besorolatlan** | **61** | **26** |

A maradék 26 helyesen az: lelkinap, cserkész-továbbképzés, „Pék Mónika 16,35", „Szmesko 9".

Tesztek: PHP 1557 (a két bukó a masteren is bukik, ettől független), Angular 478, mind zöld. Az új esetek az éles adatból való címek, és mindkét oldalon ugyanazok.

## Deploy

Séma-lépés nincs. A `webapp/mass-definitions.json` **generált** fájl — a repóban van, és most újragenerálva került bele, tehát a deploy nem igényel külön build-lépést. Aki a `mass-definitions.ts`-t módosítja, annak viszont ezután is le kell futtatnia a generálást (`npm run build` a `calendar/`-ban), különben a PHP a régi szótárt olvassa.


