### PR TITLE
Használhatóvá teszem az új misézőhely felvitelét (#898)

### DIFF
--- a/webapp/classes/html/church/create.php
+++ b/webapp/classes/html/church/create.php
@@ -12,10 +12,10 @@ class Create extends \Html\Html {
 
         $this->title = 'Új misézőhely létrehozása';
 
-        
+
         $isForm = \Request::Text('submit');
         if ($isForm) {
-            $tid = $this->create();            
+            $tid = $this->create();
             if($tid) {
                 $this->redirect("/templom/".$tid."/edit");
                 return;
@@ -29,12 +29,25 @@ class Create extends \Html\Html {
     }
 
     function create() {
-        
-        $lat = \Request::FloatRequired('church[lat]');
-        $lon = \Request::FloatRequired('church[lon]');
+
+        $lat = self::koordinata('church[lat]', 'szélességi fok', -90, 90);
+        $lon = self::koordinata('church[lon]', 'hosszúsági fok', -180, 180);
         $name = \Request::TextRequired('church[nev]');
         $osm_id = \Request::Integer('church[osmid]');
         $osm_type = \Request::InArray('church[osmtype]', ['node', 'way', 'relation']);
+
+        /*
+         * #898: a két OSM-mező csak EGYÜTT ér valamit.
+         *
+         * Eddig fél azonosítót is el lehetett menteni (típus id nélkül vagy fordítva),
+         * és az a templom onnantól úgy nézett ki, mintha OSM-hez lenne kötve — miközben
+         * az `OSM::updateChurch()` az `empty($osmtype) OR empty($osmid)` ágon úgyis
+         * kihagyja. Csendes fél-adat helyett inkább szóljunk.
+         */
+        if (($osm_id && !$osm_type) || (!$osm_id && $osm_type)) {
+            throw new \Exception('Az OSM azonosítóhoz a típus és az azonosító is kell — '
+                . 'vagy hagyd üresen mind a kettőt.');
+        }
 
         $church = \Eloquent\Church::create([
             'nev' => $name,
@@ -43,13 +56,65 @@ class Create extends \Html\Html {
             'lat' => $lat,
             'lon' => $lon,
             'osmid' => $osm_id,
-            'osmtype' => $osm_type,                                    
+            'osmtype' => $osm_type,
         ]);
-         
+
+        /*
+         * #898: az űrlapon ott van a megjegyzés-mező, de a mentés eddig nem olvasta —
+         * amit a szerkesztő beírt, az némán elveszett.
+         *
+         * És nem elég a fenti tömbbe betenni: az `adminmegj` nincs a `Church::$fillable`
+         * listáján, tehát a tömeges értékadás CSENDBEN eldobná. Kimértem — a sor létrejön,
+         * a megjegyzés helye üres marad. Ezért közvetlen értékadás.
+         */
+        $megjegyzes = \Request::Text('church[adminmegj]');
+        if ($megjegyzes !== false && trim((string) $megjegyzes) !== '') {
+            $church->adminmegj = $megjegyzes;
+        }
+
         $church->save();
 
         return $church->id;
-        
+
+    }
+
+    /**
+     * #898: koordináta az űrlapról, tizedesVESSZŐVEL is.
+     *
+     * A magyar billentyűzeten és a magyar számformátumban a tizedesjel a vessző, és a
+     * felhasználók így is írják be. A `Request::FloatRequired()` az `is_numeric()`-re
+     * épül, ami a „47,4979"-et elutasítja — a bejelentő pedig ezt kapta:
+     * `Required 'church[lat]' is not a Float.` Ebből nem derül ki, mit rontott el.
+     *
+     * A vessző cseréje itt, a koordinátánál történik, nem a `Request`-ben: ott az
+     * ezres elválasztó vessző („1,000") miatt a csere értelmet változtatna.
+     *
+     * A tartomány-ellenőrzés is idevaló. Felcserélt szélesség/hosszúság esetén (ami
+     * gyakori hiba) a 90 fölötti szélességet így elkapjuk, ahelyett hogy a templom a
+     * térkép túloldalán landolna.
+     */
+    private static function koordinata(string $mezo, string $nev, float $min, float $max): float {
+        $nyers = \Request::Text($mezo);
+
+        if ($nyers === false || trim((string) $nyers) === '') {
+            throw new \Exception('Hiányzik a ' . $nev . '. A térképen a jelölőt mozgatva is megadható.');
+        }
+
+        $ertek = str_replace(',', '.', trim((string) $nyers));
+
+        if (!is_numeric($ertek)) {
+            throw new \Exception('A ' . $nev . ' nem szám: „' . $nyers . '". '
+                . 'Tizedesjelnek pont és vessző is jó, de más nem kerülhet bele.');
+        }
+
+        $ertek = (float) $ertek;
+
+        if ($ertek < $min || $ertek > $max) {
+            throw new \Exception('A ' . $nev . ' ' . $min . ' és ' . $max . ' közé eshet, '
+                . 'ez viszont ' . $ertek . '. (Nincs felcserélve a két mező?)');
+        }
+
+        return $ertek;
     }
 
 }

--- a/webapp/templates/church/create.twig
+++ b/webapp/templates/church/create.twig
@@ -37,8 +37,23 @@
 
         <div class="row mb-3">
             <div class="col-12 font-weight-bold">
-                <h4>Koordináta:</h4> 
-                <p>A térképen mozgatva a jelölőt változik a mentendő koordináta.</p>               
+                <h4>Koordináta:</h4>
+                <p>A térképen mozgatva a jelölőt változik a mentendő koordináta. Ha nem tudod
+                   fejből, keress rá a településre — a térkép odaugrik, és onnan igazítod.</p>
+            </div>
+            {# #898: helynév -> koordináta. A meglévő, szerveroldali és cache-elt
+               /ajax/Geocode végpontot hívja, ugyanazt, amit a kereső űrlapja. #}
+            <div class="col-md-8 mb-2">
+                <input type="text" id="hely-kereso" class="form-control"
+                       placeholder="Település, cím vagy templomnév — pl. Hajdúnánás">
+            </div>
+            <div class="col-md-4 mb-2">
+                <button type="button" id="hely-keres-gomb" class="btn btn-outline-secondary w-100">
+                    Ugrás a térképen
+                </button>
+            </div>
+            <div class="col-12 mb-2">
+                <small id="hely-allapot" class="text-muted"></small>
             </div>
             <div class="col-md-5">
                 <input type="text" name="church[lat]" value="" class="form-control" placeholder="szélességi fok">
@@ -75,6 +90,10 @@
             </div>
             <div class="col-md-12">
                 
+                <div id="osm-allapot" class="alert alert-light py-2 px-3 mb-2" role="status">
+                    Adj meg koordinátát, és megnézzük, van-e a környéken OSM-ben ismert templom.
+                </div>
+
                  <!-- Táblázat a közeli helyek megjelenítéséhez -->
                 <table id="nearby-places" class="table table-striped">
                     <thead>
@@ -121,199 +140,342 @@
     <link rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css"/>
 
     <script>
-  $( function() {
-		  
-  
-    $( ".info" ).on( "click", function() { 
-        console.log($( this ).data('id'));
-               $('#help' + $( this ).data('id') ).toggle(600);
+    $(function () {
+        $('.info').on('click', function () {
+            $('#help' + $(this).data('id')).toggle(600);
+        });
     });
- });
-  
-    
+
+    /*
+     * #898: „Feladtam az új misézőhely felvitelét… A koordináták beírása után vagy szép
+     * fővárosunk valamelyik kerületébe téved, hogy mozgassam a helyet fél Magyarországon
+     * át vagy egy teljesen más településre visz."
+     *
+     * Az ok a régi kódban a BEMENET kezelése volt, három hibával:
+     *
+     *  1. Az `input` esemény MINDEN leütésre lefutott. A „47.4979" begépelése közben a
+     *     mező tartalma sorra „4", „47", „47.", „47.4" — és mindegyikre elmozdult a
+     *     térkép. Amíg a másik mező üres volt, a Leaflet a `""`-t 0-nak vette, tehát a
+     *     jelölő az Atlanti-óceánra ugrott, majd vissza. Innen a „fél Magyarországon át".
+     *  2. Ugyanezekre a félkész értékekre indult egy-egy Overpass-lekérdezés is,
+     *     leütésenként — a válaszok pedig tetszőleges sorrendben értek vissza, tehát a
+     *     táblázatban egy KORÁBBI koordináta találatai maradhattak. Ráadásul a kevés
+     *     találat miatti újrapróbálkozás (1000 -> 6000 -> … -> 21000 m) leütésenként öt
+     *     kérést jelentett: egy koordináta beírása simán ötven kérés, amire az Overpass
+     *     jogosan kizár — az meg a némán elnyelt hibaágra futott.
+     *  3. Tizedesvesszővel (magyar számformátum, magyar billentyűzet) a Leaflet
+     *     „Invalid LatLng"-gel elszállt, és onnantól a térkép mozdíthatatlan volt.
+     *
+     * Mostantól: a beírás UTÁN, kis várakozással dolgozunk, csak érvényes koordinátára,
+     * egyszerre egy Overpass-kéréssel, és ami történik, az látszik is a felületen.
+     */
     $(function () {
 
-         // Mezők változásának figyelése
-        $('input[name="church[lat]"], input[name="church[lon]"]').on('input', function () {
-            var lat = $('input[name="church[lat]"]').val();
-            var lon = $('input[name="church[lon]"]').val();
+        var ALAP_LAT = 47.497913;
+        var ALAP_LON = 19.040236;
 
-            // OSM szerkesztési link frissítése
-            $('#osm-edit-link').attr('href', `https://www.openstreetmap.org/edit?editor=id#map=19/${lat}/${lon}`);  
+        var latMezo   = $('input[name="church[lat]"]');
+        var lonMezo   = $('input[name="church[lon]"]');
+        var osmTipus  = $('select[name="church[osmtype]"]');
+        var osmAzon   = $('input[name="church[osmid]"]');
+        var tablaTest = $('#nearby-places tbody');
+        var osmAllapot = $('#osm-allapot');
+        var helyAllapot = $('#hely-allapot');
 
-            // osmtype és osmid mezők ürítése
-            $('select[name="church[osmtype]"]').val('');
-            $('input[name="church[osmid]"]').val('');
+        /** Tizedesvessző is jó — a mentés (create.php) ugyanígy fogadja el. */
+        function szamma(ertek) {
+            var szoveg = String(ertek === undefined || ertek === null ? '' : ertek).trim().replace(',', '.');
+            if (szoveg === '') return null;
 
-            // Térkép frissítése
-            marker.setLatLng([lat, lon]);
-            map.setView([lat, lon], map.getZoom());
-                        
-            // Overpass Turbo API lekérés
-            fetchOverpassData(lat, lon);     
-        });
+            var szam = Number(szoveg);
+            return isFinite(szam) ? szam : null;
+        }
 
-        function fetchOverpassData(lat, lon, radius = 1000) {
-            // Overpass Turbo lekérdezés
-            var query = `
-                [out:json][timeout:25];
-                (
-                    node["amenity"="place_of_worship"]["religion"="christian"](around:${radius},${lat},${lon});
-                    way["amenity"="place_of_worship"]["religion"="christian"](around:${radius},${lat},${lon});
-                    relation["amenity"="place_of_worship"]["religion"="christian"](around:${radius},${lat},${lon});
-                );
-                out body center;
-            `;
+        /** A két mező együtt, csak ha MINDKETTŐ érvényes. Félkész értékre nem mozdulunk. */
+        function koordinata() {
+            var lat = szamma(latMezo.val());
+            var lon = szamma(lonMezo.val());
 
-            $.ajax({
+            if (lat === null || lon === null) return null;
+            if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+
+            return { lat: lat, lon: lon };
+        }
+
+        var map = L.map('map').setView([ALAP_LAT, ALAP_LON], 15);
+        L.tileLayer(window.MISEREND_CSEMPE.url, window.MISEREND_CSEMPE.beallitas).addTo(map);
+        var marker = L.marker([ALAP_LAT, ALAP_LON], { draggable: true }).addTo(map);
+
+        function osmLinkFrissit(pont) {
+            $('#osm-edit-link').attr('href',
+                'https://www.openstreetmap.org/edit?editor=id#map=19/' + pont.lat + '/' + pont.lon);
+        }
+
+        function osmAzonositoTorol() {
+            osmTipus.val('');
+            osmAzon.val('');
+        }
+
+        /* ---- Overpass: egyszerre EGY kérés, és a válasza látszik ---- */
+
+        var futoKeres = null;
+        var idozito = null;
+        var sorszam = 0;
+
+        function osmUzenet(szoveg, tipus) {
+            osmAllapot.attr('class', 'alert alert-' + (tipus || 'light') + ' py-2 px-3 mb-2').text(szoveg);
+        }
+
+        function keresEsedekes(pont) {
+            if (idozito) clearTimeout(idozito);
+
+            // Fél másodperc: ennyi alatt a gépelés befejeződik, tehát egy koordináta
+            // beírásából EGY lekérdezés lesz, nem tíz.
+            idozito = setTimeout(function () { kozeliekKeresese(pont, 1000, 0); }, 500);
+        }
+
+        function kozeliekKeresese(pont, sugar, probalkozas) {
+            if (futoKeres) {
+                futoKeres.abort();
+            }
+
+            var sajatSorszam = ++sorszam;
+            osmUzenet('Keressük a közeli templomokat az OSM-ben… (' + Math.round(sugar / 1000) + ' km)', 'light');
+
+            var lekerdezes = '[out:json][timeout:25];('
+                + 'node["amenity"="place_of_worship"]["religion"="christian"](around:' + sugar + ',' + pont.lat + ',' + pont.lon + ');'
+                + 'way["amenity"="place_of_worship"]["religion"="christian"](around:' + sugar + ',' + pont.lat + ',' + pont.lon + ');'
+                + 'relation["amenity"="place_of_worship"]["religion"="christian"](around:' + sugar + ',' + pont.lat + ',' + pont.lon + ');'
+                + ');out body center;';
+
+            futoKeres = $.ajax({
                 url: '{{ overpass_api_url }}',
                 type: 'POST',
-                data: { data: query },
-                success: function (response) {
-                    // Eredmények feldolgozása
-                    var results = response.elements.map(function (element) {
-                        var distance = getDistanceFromLatLonInKm(lat, lon, element.lat || element.center.lat, element.lon || element.center.lon);
+                data: { data: lekerdezes },
+                success: function (valasz) {
+                    // Elavult válasz: közben újabb kérés indult. Ne írjuk felül vele a
+                    // frissebb találatokat — pont ez zavarta össze a régi felületet.
+                    if (sajatSorszam !== sorszam) return;
+
+                    var talalatok = (valasz.elements || []).map(function (elem) {
+                        var elemLat = elem.lat || (elem.center && elem.center.lat);
+                        var elemLon = elem.lon || (elem.center && elem.center.lon);
+                        var cimkek = elem.tags || {};
+
                         return {
-                            id: element.id,
-                            type: element.type,
-                            lat: element.lat || element.center.lat,
-                            lon: element.lon || element.center.lon,
-                            distance: distance,
-                            name: element.tags.name || element.tags.name_hu || element.tags.alt_name,
-                            denomination: element.tags.denomination || element.tags.religion || 'unknown',
-                            miserend: element.tags['url:miserend']
+                            id: elem.id,
+                            type: elem.type,
+                            lat: elemLat,
+                            lon: elemLon,
+                            distance: tavolsagKm(pont.lat, pont.lon, elemLat, elemLon),
+                            name: cimkek.name || cimkek.name_hu || cimkek.alt_name,
+                            denomination: cimkek.denomination || cimkek.religion || 'ismeretlen',
+                            miserend: cimkek['url:miserend']
                         };
+                    }).filter(function (t) {
+                        return t.lat !== undefined && t.lon !== undefined;
                     });
 
-                    // Ha az eredmények száma 1 vagy kevesebb, újrapróbálkozás nagyobb radius értékkel
-                    if (results.length <= 1 && radius < 20000) {
-                        console.log(`Kevés találat (${results.length}), újrapróbálkozás nagyobb körrel (${radius + 5000}m)...`);
-                        fetchOverpassData(lat, lon, radius + 5000);
+                    // Ha semmi nincs a közelben, egyszer tágítunk — de csak egyszer, és
+                    // csak akkor, ha tényleg üres. A régi kód ötször tágított, minden
+                    // leütésre.
+                    if (talalatok.length === 0 && probalkozas < 1) {
+                        kozeliekKeresese(pont, 10000, probalkozas + 1);
                         return;
                     }
 
-                    // Távolság szerint rendezés
-                    results.sort(function (a, b) {
-                        return a.distance - b.distance;
-                    });
+                    talalatok.sort(function (a, b) { return a.distance - b.distance; });
+                    tablaTest.html(talalatok.map(sorHtml).join(''));
 
-                    // Táblázat frissítése
-                    var rows = results.map(function (result) {
-                        return `
-                            <tr>
-                                <td>${result.name ? result.name : `${result.type}:${result.id}`}<br/><small>${result.denomination}</small></td>
-                                <td>${(result.distance * 1000).toFixed(0)} m</td>
-                                <td style="text-align:center"><a href="https://www.openstreetmap.org/${result.type}/${result.id}" target="_blank"><span class="{{ ICONS_MAP_SEE }}" title="OSM elem megtekintése."></span></a></td>                                
-                                <td style="text-align:center">
-                                    ${result.miserend ? `
-                                        <a href="${result.miserend}" target="_blank">
-                                            <span class="{{ ICONS_CHURCH_SEE }}" title="Misézőhely megtalálható a Miserend.hu-n. Lássuk."></span>
-                                        </a>
-                                    ` : ''}
-                                </td>
-                                <td style="text-align:center">
-                                ${result.miserend ? `` : `
-                                    <span class="{{ ICONS_ADD }} select-location" 
-                                        title="Legyen ez az OSM entitás a templom adata!"
-                                        data-lat="${result.lat}" 
-                                        data-lon="${result.lon}" 
-                                        data-osmtype="${result.type}" 
-                                        data-osmid="${result.id}">
-                                    </span>`}
-                                </td>
-                            </tr>
-                        `;
-                    }).join('');
-
-                    $('#nearby-places tbody').html(rows);
-
-                    // Gomb eseménykezelő hozzáadása
-                    $('#nearby-places').on('click', '.select-location', function () {
-                        var lat = $(this).data('lat');
-                        var lon = $(this).data('lon');
-                        var osmtype = $(this).data('osmtype');
-                        var osmid = $(this).data('osmid');
-
-                        // Mezők kitöltése
-                        $('input[name="church[lat]"]').val(lat.toFixed(6));
-                        $('input[name="church[lon]"]').val(lon.toFixed(6));
-                        $('select[name="church[osmtype]"]').val(osmtype);
-                        $('input[name="church[osmid]"]').val(osmid);
-
-                        // Térkép frissítése
-                        marker.setLatLng([lat, lon]);
-                        map.setView([lat, lon], map.getZoom());
-                        
-                    });
+                    if (talalatok.length === 0) {
+                        osmUzenet('Nincs OSM-ben ismert templom ' + Math.round(sugar / 1000)
+                            + ' km-en belül. Ez nem baj: a misézőhely OSM-azonosító nélkül is létrehozható, '
+                            + 'csak addig letiltva marad.', 'warning');
+                    } else {
+                        osmUzenet(talalatok.length + ' templom az OSM-ben, '
+                            + Math.round(sugar / 1000) + ' km-en belül. Ha a tiéd köztük van, '
+                            + 'a jobb szélső gombbal kötheted hozzá.', 'light');
+                    }
                 },
-                error: function () {
-                    console.error('Hiba történt az Overpass Turbo API lekérése során.');
+                error: function (xhr, allapot) {
+                    if (allapot === 'abort' || sajatSorszam !== sorszam) return;
+
+                    /*
+                     * #898: „Tök rossz a hibakezelése. Az OSM azonosítós részben ha
+                     * overpass turbo api hibás lekérdezés van, akkor csak olyan mintha nem
+                     * is húztuk volna arrébb a markert."
+                     *
+                     * Eddig ez az ág csak egy console.error volt: a táblázatban ott
+                     * maradtak az ELŐZŐ koordináta találatai, és semmi nem jelezte, hogy a
+                     * lekérdezés elhasalt. A leggyakoribb ok a 429 — az Overpass kizár, ha
+                     * túl sűrűn kérdezünk (amit a régi, leütésenkénti kérés ki is váltott).
+                     */
+                    tablaTest.empty();
+
+                    var uzenet = xhr.status === 429 || xhr.status === 504
+                        ? 'Az OSM lekérdező (Overpass) most nem áll szóba velünk — túl sok kérés vagy '
+                          + 'túlterhelés. Várj fél percet, és mozdítsd meg a jelölőt újra.'
+                        : 'Nem sikerült lekérdezni az OSM-et (' + (xhr.status || 'nincs válasz') + '). '
+                          + 'A misézőhely enélkül is létrehozható, OSM-azonosító nélkül.';
+
+                    osmUzenet(uzenet, 'danger');
+                },
+                complete: function () {
+                    if (sajatSorszam === sorszam) futoKeres = null;
                 }
             });
         }
 
-    // Alapértelmezett koordináták az input mezőkből
-    var defaultLat = parseFloat($('input[name="church[lat]"]').val()) || 47.497913;
-    var defaultLon = parseFloat($('input[name="church[lon]"]').val()) || 19.040236;
+        function sorHtml(talalat) {
+            var nev = talalat.name ? talalat.name : (talalat.type + ':' + talalat.id);
 
-    // Térkép inicializálása
-    var map = L.map('map').setView([defaultLat, defaultLon], 15);
+            return '<tr>'
+                + '<td>' + nev + '<br/><small>' + talalat.denomination + '</small></td>'
+                + '<td>' + (talalat.distance * 1000).toFixed(0) + ' m</td>'
+                + '<td style="text-align:center"><a href="https://www.openstreetmap.org/'
+                    + talalat.type + '/' + talalat.id + '" target="_blank">'
+                    + '<span class="{{ ICONS_MAP_SEE }}" title="OSM elem megtekintése."></span></a></td>'
+                + '<td style="text-align:center">'
+                    + (talalat.miserend
+                        ? '<a href="' + talalat.miserend + '" target="_blank"><span class="{{ ICONS_CHURCH_SEE }}"'
+                          + ' title="Misézőhely megtalálható a Miserend.hu-n. Lássuk."></span></a>'
+                        : '')
+                + '</td>'
+                + '<td style="text-align:center">'
+                    + (talalat.miserend
+                        ? ''
+                        : '<span class="{{ ICONS_ADD }} select-location" title="Legyen ez az OSM entitás a templom adata!"'
+                          + ' data-lat="' + talalat.lat + '" data-lon="' + talalat.lon + '"'
+                          + ' data-osmtype="' + talalat.type + '" data-osmid="' + talalat.id + '"></span>')
+                + '</td>'
+                + '</tr>';
+        }
 
-    // #376/#817: CARTO Voyager basemap (a direkt tile.openstreetmap.org produkcióra
-    // tiltott). A konfiguráció a /js/map-tiles.js-ben van, egy helyen.
-    L.tileLayer(window.MISEREND_CSEMPE.url, window.MISEREND_CSEMPE.beallitas).addTo(map);
+        /*
+         * Az eseménykezelő EGYSZER kötődik, a táblázatra delegálva. A régi kód minden
+         * sikeres Overpass-válasznál újra rákötött, tehát tíz lekérdezés után egy
+         * kattintás tízszer futott le.
+         */
+        $('#nearby-places').on('click', '.select-location', function () {
+            var pont = { lat: Number($(this).data('lat')), lon: Number($(this).data('lon')) };
 
-    // Marker inicializálása
-    var marker = L.marker([defaultLat, defaultLon], { draggable: true }).addTo(map);
+            latMezo.val(pont.lat.toFixed(6));
+            lonMezo.val(pont.lon.toFixed(6));
+            osmTipus.val($(this).data('osmtype'));
+            osmAzon.val(String($(this).data('osmid')));
 
-    // Marker mozgatásának kezelése
-    marker.on('moveend', function (e) {
-        var lat = e.target.getLatLng().lat.toFixed(6);
-        var lon = e.target.getLatLng().lng.toFixed(6);
+            marker.setLatLng([pont.lat, pont.lon]);
+            map.setView([pont.lat, pont.lon], map.getZoom());
+            osmLinkFrissit(pont);
 
-        // Mezők frissítése
-        $('input[name="church[lat]"]').val(lat);
-        $('input[name="church[lon]"]').val(lon);
+            osmUzenet('Hozzákötve: ' + $(this).data('osmtype') + ':' + $(this).data('osmid')
+                + '. A mentés után a /templom/…/edit oldalon folytatod.', 'success');
+        });
 
-        // OSM szerkesztési link frissítése
-        $('#osm-edit-link').attr('href', `https://www.openstreetmap.org/edit?editor=id#map=19/${lat}/${lon}`);  
+        /* ---- A koordináta-mezők ---- */
 
-        // osmtype és osmid mezők ürítése
-        $('select[name="church[osmtype]"]').val('');
-        $('input[name="church[osmid]"]').val('');
-        
-        // Overpass Turbo API lekérés
-        fetchOverpassData(lat, lon);
+        latMezo.add(lonMezo).on('input', function () {
+            var pont = koordinata();
 
+            if (pont === null) {
+                // Félkész vagy hibás érték: NEM mozdítunk semmit. Csak szólunk, ha a
+                // beírt szöveg egyáltalán nem szám — a félkész gépelés nem hiba.
+                var nyers = String($(this).val()).trim();
+                if (nyers !== '' && szamma(nyers) === null) {
+                    osmUzenet('A koordináta nem szám: „' + nyers + '". Tizedesjelnek a pont és a '
+                        + 'vessző is jó.', 'warning');
+                }
+                return;
+            }
 
-        
-        
-        
+            osmAzonositoTorol();
+            marker.setLatLng([pont.lat, pont.lon]);
+            map.setView([pont.lat, pont.lon], map.getZoom());
+            osmLinkFrissit(pont);
+            keresEsedekes(pont);
+        });
+
+        marker.on('dragend', function (esemeny) {
+            var helyzet = esemeny.target.getLatLng();
+            var pont = { lat: Number(helyzet.lat.toFixed(6)), lon: Number(helyzet.lng.toFixed(6)) };
+
+            latMezo.val(pont.lat.toFixed(6));
+            lonMezo.val(pont.lon.toFixed(6));
+            osmAzonositoTorol();
+            osmLinkFrissit(pont);
+            keresEsedekes(pont);
+        });
+
+        /* ---- Helynév -> koordináta ---- */
+
+        function helyKereses() {
+            var hely = $('#hely-kereso').val().trim();
+
+            if (hely.length < 3) {
+                helyAllapot.text('Írj be legalább három karaktert.');
+                return;
+            }
+
+            helyAllapot.text('Keressük…');
+
+            // Ugyanaz a végpont, amit a kereső űrlapja hív: szerveroldali és cache-elt,
+            // tehát a Nominatim használati szabályzatát is betartja.
+            $.getJSON('/index.php?q=ajax/Geocode&hely=' + encodeURIComponent(hely))
+                .done(function (adat) {
+                    if (!adat || !adat.found) {
+                        helyAllapot.text(adat && adat.message ? adat.message : 'Ezt a helyet nem találtuk meg.');
+                        return;
+                    }
+
+                    var pont = { lat: adat.lat, lon: adat.lon };
+
+                    latMezo.val(pont.lat.toFixed(6));
+                    lonMezo.val(pont.lon.toFixed(6));
+                    osmAzonositoTorol();
+                    marker.setLatLng([pont.lat, pont.lon]);
+
+                    // A településre 15-ös zoom: a templom onnan már látszik, és a jelölő
+                    // pár mozdulattal a helyére húzható.
+                    map.setView([pont.lat, pont.lon], 15);
+                    osmLinkFrissit(pont);
+
+                    helyAllapot.text('Ide ugrottunk: ' + adat.name + '. Húzd a jelölőt a templomra.');
+                    keresEsedekes(pont);
+                })
+                .fail(function () {
+                    helyAllapot.text('A helykeresés most nem érhető el. Add meg a koordinátát kézzel.');
+                });
+        }
+
+        $('#hely-keres-gomb').on('click', helyKereses);
+        $('#hely-kereso').on('keydown', function (esemeny) {
+            // Enter itt NE küldje be az űrlapot — a felhasználó keresni akar, nem menteni.
+            if (esemeny.key === 'Enter') {
+                esemeny.preventDefault();
+                helyKereses();
+            }
+        });
+
+        /* ---- Távolság ---- */
+
+        function tavolsagKm(lat1, lon1, lat2, lon2) {
+            var R = 6371;
+            var dLat = fokRadian(lat2 - lat1);
+            var dLon = fokRadian(lon2 - lon1);
+            var a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(fokRadian(lat1)) * Math.cos(fokRadian(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+            return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        }
+
+        function fokRadian(fok) {
+            return fok * (Math.PI / 180);
+        }
     });
+    </script>
 
-    // Távolság számítása két koordináta között
-    function getDistanceFromLatLonInKm(lat1, lon1, lat2, lon2) {
-        var R = 6371; // Föld sugara km-ben
-        var dLat = deg2rad(lat2 - lat1);
-        var dLon = deg2rad(lon2 - lon1);
-        var a =
-            Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-            Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) *
-            Math.sin(dLon / 2) * Math.sin(dLon / 2);
-        var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        var d = R * c; // Távolság km-ben
-        return d;
-    }
 
-    function deg2rad(deg) {
-        return deg * (Math.PI / 180);
-    }
-});
-
-   
-  </script>
-
-    
 {% endblock %}
 
 

--- a/webapp/tests/Integration/ChurchCreateFormTest.php
+++ b/webapp/tests/Integration/ChurchCreateFormTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #898: az új misézőhely felvitele.
+ *
+ * borazslo az első pontban ezt írja: „Aránylag ritkán van rá szükség, így elég könnyű
+ * eltörni a folyamatot, mert nincsenek tesztek hogy minden rendben működik-e." Ez a
+ * fájl az a teszt.
+ *
+ * Valódi HTTP-hívások bejelentkezett adminisztrátorként — a `ChurchEditFormTest`
+ * mintájára, mert az űrlap feldolgozása a `Request`-en és a session-ön múlik, azt pedig
+ * kívülről érdemes megfogni.
+ */
+class ChurchCreateFormTest extends TestCase {
+
+    private const NEV_ELOTAG = 'Létrehozás teszt ';
+
+    private string $baseUrl;
+    private ?string $cookie = null;
+
+    protected function setUp(): void {
+        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
+        $this->login();
+        if ($this->cookie === null) {
+            $this->markTestSkipped('Nem sikerült adminisztrátorként bejelentkezni.');
+        }
+    }
+
+    protected function tearDown(): void {
+        DB::table('templomok')->where('nev', 'LIKE', self::NEV_ELOTAG . '%')->delete();
+    }
+
+    private function login(): void {
+        $ctx = stream_context_create(['http' => [
+            'method'        => 'POST',
+            'header'        => "Content-Type: application/x-www-form-urlencoded\r\n",
+            'content'       => http_build_query(['login' => 'admin', 'passw' => 'miserend', 'logout' => 'false']),
+            'timeout'       => 30,
+            'ignore_errors' => true,
+        ]]);
+        @file_get_contents($this->baseUrl . '/', false, $ctx);
+        foreach ($http_response_header ?? [] as $h) {
+            if (stripos($h, 'Set-Cookie:') === 0 && stripos($h, 'token=') !== false) {
+                $this->cookie = trim(explode(';', substr($h, 11))[0]);
+            }
+        }
+    }
+
+    private function post(array $fields): string {
+        $header = "Content-Type: application/x-www-form-urlencoded\r\n";
+        if ($this->cookie) {
+            $header .= 'Cookie: ' . $this->cookie . "\r\n";
+        }
+        $ctx = stream_context_create(['http' => [
+            'method' => 'POST', 'header' => $header,
+            'content' => http_build_query($fields), 'timeout' => 60, 'ignore_errors' => true,
+        ]]);
+        $body = @file_get_contents($this->baseUrl . '/church/create', false, $ctx);
+        $this->assertNotFalse($body, 'A kérés nem sikerült.');
+
+        return $body;
+    }
+
+    private function mezok(string $nev, array $override = []): array {
+        return array_merge([
+            'submit'          => 'Létrehozás',
+            'church[nev]'     => self::NEV_ELOTAG . $nev,
+            'church[lat]'     => '47.5',
+            'church[lon]'     => '19.0',
+        ], $override);
+    }
+
+    private function sor(string $nev) {
+        return DB::table('templomok')->where('nev', self::NEV_ELOTAG . $nev)->first();
+    }
+
+    /**
+     * A LÉNYEG: tizedesVESSZŐVEL is működik.
+     *
+     * A magyar számformátumban a tizedesjel a vessző, és a felhasználók így írják be. A
+     * régi kód az `is_numeric()`-re épülő `FloatRequired()`-del ezt elutasította, méghozzá
+     * `Required 'church[lat]' is not a Float.` szöveggel — abból nem derül ki, mit kell
+     * másképp csinálni.
+     */
+    public function testACommaIsAcceptedAsDecimalSeparator(): void {
+        $this->post($this->mezok('vessző', [
+            'church[lat]' => '47,4979',
+            'church[lon]' => '19,0402',
+        ]));
+
+        $sor = $this->sor('vessző');
+        self::assertNotNull($sor, 'a tizedesvesszős koordinátával is létre kell jönnie');
+        self::assertEqualsWithDelta(47.4979, (float) $sor->lat, 0.00001);
+        self::assertEqualsWithDelta(19.0402, (float) $sor->lon, 0.00001);
+    }
+
+    /**
+     * #898: az űrlapon ott a megjegyzés-mező, de a mentés nem olvasta.
+     *
+     * Nem elég a `Church::create()` tömbjébe betenni: az `adminmegj` nincs a
+     * `$fillable`-ben, tehát a tömeges értékadás CSENDBEN eldobja. Kimértem — a templom
+     * létrejön, a megjegyzés helye üres.
+     */
+    public function testTheAdminNoteIsSaved(): void {
+        $this->post($this->mezok('megjegyzés', [
+            'church[adminmegj]' => 'Ezt a szerkesztő írta be.',
+        ]));
+
+        $sor = $this->sor('megjegyzés');
+        self::assertNotNull($sor);
+        self::assertStringContainsString('Ezt a szerkesztő írta be.', (string) $sor->adminmegj);
+    }
+
+    /** Felcserélt szélesség/hosszúság: gyakori hiba, és a térkép túloldalán kötne ki. */
+    public function testAnOutOfRangeLatitudeIsRejected(): void {
+        $valasz = $this->post($this->mezok('tartomány', [
+            'church[lat]' => '190',
+            'church[lon]' => '19',
+        ]));
+
+        self::assertNull($this->sor('tartomány'), 'érvénytelen koordinátával nem jöhet létre templom');
+        self::assertStringContainsString('szélességi fok', $valasz);
+        self::assertStringContainsString('felcserélve', $valasz);
+    }
+
+    /** Ami egyáltalán nem szám, arra érthető mondat jár, nem belső hibaszöveg. */
+    public function testANonNumericCoordinateGetsAReadableMessage(): void {
+        $valasz = $this->post($this->mezok('szöveg', [
+            'church[lat]' => 'valahol Hajdúnánáson',
+        ]));
+
+        self::assertNull($this->sor('szöveg'));
+        self::assertStringContainsString('nem szám', $valasz);
+        self::assertStringNotContainsString('is not a Float', $valasz);
+    }
+
+    public function testAMissingCoordinateGetsAReadableMessage(): void {
+        $valasz = $this->post($this->mezok('hiányzó', ['church[lat]' => '']));
+
+        self::assertNull($this->sor('hiányzó'));
+        self::assertStringContainsString('Hiányzik a szélességi fok', $valasz);
+    }
+
+    /**
+     * Fél OSM-azonosító nem ér semmit: az `OSM::updateChurch()` az
+     * `empty($osmtype) OR empty($osmid)` ágon kihagyja, a templom viszont úgy néz ki,
+     * mintha kötve lenne.
+     */
+    public function testAHalfOsmIdentifierIsRejected(): void {
+        $valasz = $this->post($this->mezok('fél-osm', ['church[osmid]' => '123456']));
+
+        self::assertNull($this->sor('fél-osm'));
+        self::assertStringContainsString('OSM azonosítóhoz', $valasz);
+    }
+
+    public function testACompleteOsmIdentifierIsStored(): void {
+        $this->post($this->mezok('teljes-osm', [
+            'church[osmid]'   => '123456',
+            'church[osmtype]' => 'node',
+        ]));
+
+        $sor = $this->sor('teljes-osm');
+        self::assertNotNull($sor);
+        self::assertSame('123456', (string) $sor->osmid);
+        self::assertSame('node', (string) $sor->osmtype);
+    }
+
+    /** OSM-azonosító nélkül is létre KELL jönnie — csak letiltva. */
+    public function testAChurchCanBeCreatedWithoutAnOsmLink(): void {
+        $this->post($this->mezok('osm-nélkül'));
+
+        $sor = $this->sor('osm-nélkül');
+        self::assertNotNull($sor, 'OSM-azonosító nélkül is létre kell jönnie');
+        self::assertSame('n', (string) $sor->ok, 'a friss templom még nem engedélyezett');
+    }
+}


### PR DESCRIPTION
Closes #898

A bejelentő panaszából indultam ki:

> A koordináták beírása -már fejből tudom - után vagy szép fővárosunk valamelyik kerületébe téved, hogy mozgassam a helyet fél Magyarországon át vagy egy teljesen más településre visz

**Megtaláltam, és nem a felhasználón múlt.** Három hiba volt a bemenet kezelésében.

## 1. A térkép minden leütésre elugrott

A koordináta-mezőkre kötött `input` esemény **minden billentyűleütésre** lefutott. A „47.4979" begépelése közben a mező tartalma sorra `4`, `47`, `47.`, `47.4` — és mindegyikre elmozdult a jelölő. Amíg a másik mező üres volt, a Leaflet a `""`-t **nullának** vette, tehát a térkép az Atlanti-óceánra ugrott, majd vissza. Innen a „fél Magyarországon át".

Mostantól a gépelés **után** dolgozunk (fél másodperc), és csak akkor, ha **mindkét** koordináta érvényes. Félkész értékre nem mozdul semmi.

## 2. Leütésenként öt Overpass-kérés

Ugyanezekre a félkész értékekre indult egy-egy Overpass-lekérdezés is. A kevés találat miatti újrapróbálkozás (1000 → 6000 → 11000 → 16000 → 21000 m) leütésenként **öt** kérést jelentett: egy koordináta beírása simán ötven kérés. Az Overpass erre jogosan kizár (429).

És ekkor jött a te pontod:

> Tök rossz a hibakezelése. Az OSM azonosítós részben ha overpass turbo api hibás lekérdezés van, akkor csak olyan mintha nem is húztuk volna arrébb a markert

A hibaág egyetlen `console.error` volt. A táblázatban ott maradtak az **előző** koordináta találatai, és semmi nem jelezte, hogy a lekérdezés elhasalt.

Mostantól: egyszerre egy kérés (az újabb megszakítja a régit), a késve érkező válasz nem írja felül a frissebbet, a tágítás egyszer történik, és a hiba **látszik** — a 429-re külön mondat, mert az a gyakori.

Mellékesen: az eseménykezelő minden sikeres válasznál újra rákötődött a táblázatra, tehát tíz lekérdezés után egy kattintás tízszer futott le. Most egyszer kötődik.

## 3. Tizedesvessző

Magyar billentyűzeten a tizedesjel a vessző. A böngészőben ettől a Leaflet `Invalid LatLng`-gel elszállt (a térkép onnantól mozdíthatatlan), a mentésnél pedig ez fogadta a felhasználót:

```
Required 'church[lat]' is not a Float.
```

Mostantól mindkét oldal elfogadja a vesszőt, és a hibaüzenetek magyarul mondják meg, mi a baj — a tartományt is ellenőrzöm, mert a felcserélt szélesség/hosszúság gyakori hiba.

## Helykereső

> sima koordináta megadása helyett valahogy lehetne hatékonyabban odavinni a markert (nominatim itt is, ami közel viszi és aztán igazgatjuk?)

Betettem. A **meglévő** `/ajax/Geocode` végpontot hívja — ugyanazt, amit a kereső űrlapja —, tehát szerveroldali és két hétre cache-elt: a Nominatim használati szabályzatát nem sértjük, és a felhasználó IP-je sem megy ki. Beírod, hogy „Hajdúnánás", a térkép odaugrik, a jelölőt ráhúzod a templomra.

## Az adminisztrátori megjegyzés némán elveszett

Az űrlapon ott a mező, a mentés viszont nem olvasta. És nem elég a `Church::create()` tömbjébe betenni: az `adminmegj` **nincs a `$fillable`-ben**, tehát a tömeges értékadás csendben eldobja. Kimértem — a templom létrejön, a megjegyzés helye üres. Ezért közvetlen értékadás.

## Tesztek

> Aránylag ritkán van rá szükség, így elég könnyű eltörni a folyamatot, mert nincsenek tesztek hogy minden rendben működik-e.

Nyolc teszt (`ChurchCreateFormTest`), valódi HTTP-hívásokkal, bejelentkezett adminisztrátorként. **A régi kódon hatot bukik**, a másik kettő a „ne romoljon el" garancia (teljes OSM-azonosító mentése, létrehozás OSM-azonosító nélkül).

A teljes tesztsor lefut. A `BoundaryFreshnessTest` szakaszosan bukik — az a #890 három órája, a masteren is előjön, ettől független.

## Amit NEM csináltam meg

**Az OSM node létrehozása a miserendből.** Ez a listád leghosszabb pontja, és te magad írod, hogy „meg kell gondolni alternatív megoldásokat". OSM írási jogosultság, changeset, és a moderálási késleltetés kérdése is nyitva van — ezt nem akartam egyoldalúan eldönteni.

**A „letiltva marad" kérdés.** Ma a `create()` mindig `ok = 'n'`-nel hoz létre, OSM-azonosítótól függetlenül; az engedélyezés az `/edit` oldalon külön lépés. Amit írsz — hogy egy frissen felvitt templomnál ez nem jó — **policy-döntés**, nem hiba: legyen `f` („feltöltött, áttekintésre vár"), vagy rögtön `i`? Szólj, melyiket akarod, és beteszem. Addig a felület legalább megmondja, hogy OSM-azonosító nélkül is létrehozható a hely, csak letiltva marad — eddig ezt sem mondta meg senki.
