### PR TITLE
to Prod

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,6 +35,17 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # #903: felső korlát, mert enélkül egy beragadt futás a GitHub 6 órás
+    # alaplimitjéig fogja a `deploy-server` csoportot — és vele mindent, ami
+    # mögötte áll. 2026-08-27-én pontosan ez történt: a 07:26-os staging deploy
+    # négy órán át `in_progress` maradt (az ssh-action 40 perces
+    # `command_timeout`-ja ellenére), a mögötte várakozó KIADÁS deployja pedig
+    # törlődött. A production így a régi kódot szolgálta ki, és semmi nem szólt.
+    #
+    # 50 perc: a 40 perces parancs-korlát fölött annyi ráhagyással, hogy a
+    # kapcsolódás és a lépés-overhead is elférjen, de a blokkolás órák helyett
+    # legfeljebb egy munkamenetnyi legyen.
+    timeout-minutes: 50
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -27,9 +27,17 @@ on:
 # #662: a staging és a production UGYANAZON a gépen fut, és mindkét deploy teljes
 # `docker build`-et csinál. Külön csoportban egyszerre indulhattak, és a párhuzamos
 # buildek megfojtották a gépet. Közös csoport: egyszerre csak EGY deploy fut.
+# #903: a kiadásnak SAJÁT csoportja van, hogy egy staging futás ne üthesse ki.
+#
+# A közös `deploy-server` csoportban a GitHub a VÁRAKOZÓ futást törli, amint újabb
+# érkezik. 2026-08-27-én pontosan ez történt: a #900 kiadás deployja beállt a sorba, egy
+# perccel később egy staging pusholás kiütötte, és a production némán a régi kódon maradt.
+# Ugyanez volt 08-24-én is, akkor kézzel pótoltuk.
+#
+# A gép védelme (#662) nem veszett el: a szkript zárat vesz fel — l. lentebb.
 concurrency:
-  group: deploy-server
-  # Production-ben NEM töröljük a futó deployt — megvárjuk, hogy befejezze.
+  group: deploy-server-production
+  # A futó kiadást soha nem szakítjuk félbe.
   cancel-in-progress: false
 
 jobs:
@@ -42,10 +50,13 @@ jobs:
     # `command_timeout`-ja ellenére), a mögötte várakozó KIADÁS deployja pedig
     # törlődött. A production így a régi kódot szolgálta ki, és semmi nem szólt.
     #
-    # 50 perc: a 40 perces parancs-korlát fölött annyi ráhagyással, hogy a
-    # kapcsolódás és a lépés-overhead is elférjen, de a blokkolás órák helyett
-    # legfeljebb egy munkamenetnyi legyen.
-    timeout-minutes: 50
+    # 80 perc: a #903 óta a szkript ELŐBB a gépi zárra vár (legfeljebb 20 perc), és
+    # csak utána épít (a parancs-korlát 70 perc). A kettő együtt fér el alatta.
+    #
+    # Hosszabb, mint a stagingé, és ez rendben van: a kiadásnak saját csoportja van,
+    # tehát egy elhúzódó production deploy már nem tart fel semmi mást — csak a
+    # következő kiadást, ami helyes.
+    timeout-minutes: 80
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5
@@ -54,12 +65,29 @@ jobs:
           username: ${{ secrets.STAGING_SSH_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           port: ${{ secrets.STAGING_SSH_PORT || 22 }}
-          command_timeout: 40m
+          # #903: ebbe a korlátba a gépi zárra várás IS beleszámít (a szkript első
+          # lépése), nem csak a build. 70 perc = legfeljebb 20 perc várakozás + a
+          # build. A 40 perc kevés lett volna: a várakozás megette volna a build idejét.
+          command_timeout: 70m
           # Lásd a staging-workflow indoklását: a 30 másodperces alapértelmezés
           # kevés, ha a gépen épp egy másik deploy buildje fut.
           timeout: 2m
           script: |
             set -euo pipefail
+
+            # #903: ugyanaz a zár, mint a stagingnél — de a KIADÁS VÁR rá, nem marad ki.
+            #
+            # 20 perc: ennyi alatt egy futó staging deploy befejeződik. Nem több, mert a
+            # várakozás az ssh parancs-korlátjából (70 perc) megy el, és utána még a
+            # kiadás buildjének is el kell férnie.
+            echo "▶ Várakozás a deploy-zárra…"
+            exec 9>/tmp/miserend-deploy.lock
+            if ! flock -w 1200 9; then
+              echo "❌ 20 perc alatt sem szabadult fel a deploy-zár. Valami beragadt a gépen:"
+              echo "   fuser -v /tmp/miserend-deploy.lock"
+              exit 1
+            fi
+            echo "✅ Zár megvan."
 
             DEPLOY_DIR=/var/www/production.miserend.hu
             cd "$DEPLOY_DIR"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,6 +41,17 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # #903: felső korlát, mert enélkül egy beragadt futás a GitHub 6 órás
+    # alaplimitjéig fogja a `deploy-server` csoportot — és vele mindent, ami
+    # mögötte áll. 2026-08-27-én pontosan ez történt: a 07:26-os staging deploy
+    # négy órán át `in_progress` maradt (az ssh-action 40 perces
+    # `command_timeout`-ja ellenére), a mögötte várakozó KIADÁS deployja pedig
+    # törlődött. A production így a régi kódot szolgálta ki, és semmi nem szólt.
+    #
+    # 50 perc: a 40 perces parancs-korlát fölött annyi ráhagyással, hogy a
+    # kapcsolódás és a lépés-overhead is elférjen, de a blokkolás órák helyett
+    # legfeljebb egy munkamenetnyi legyen.
+    timeout-minutes: 50
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,16 +26,26 @@ on:
   workflow_dispatch: {}
 
 # #662: a staging ÉS a production UGYANAZON a gépen fut, és mindkét deploy teljes
-# `docker build`-et csinál (Angular + PHP multi-stage). Külön csoportban egyszerre
-# indulhattak, és több merge után egymásra torlódtak — a gép ettől elérhetetlenné vált.
-# Közös csoport: egyszerre csak EGY deploy nyúlhat a szerverhez.
+# `docker build`-et csinál (Angular + PHP multi-stage). Egyszerre indulva egymásra
+# torlódtak — a gép ettől elérhetetlenné vált. Egyszerre csak EGY deploy nyúlhat a
+# szerverhez; ez a kikötés érvényben marad, csak a helye változott.
 #
-# A `cancel-in-progress` szándékosan false: a job leállítása a GitHub oldalán öli meg a
-# futást, a szerveren a docker daemonban FUTÓ build viszont attól még dolgozik tovább —
-# tehát a cancel nem szabadítja fel a gépet, csak elveszti a naplót. Sorbaállítunk
-# helyette, és a lentebbi "nincs új commit" rövidzár teszi gyorssá a torlódást.
+# #903: a kizárás a szerverre került, a csoport pedig kettévált.
+#
+# A közös `deploy-server` csoport ugyanis mellékhatással járt: a GitHub a csoportban A
+# VÁRAKOZÓ futást törli, amint újabb érkezik. Egy staging pusholás így kiütötte a sorban
+# álló KIADÁS deployját, és a production némán a régi kódon maradt (2026-08-27, és előtte
+# 08-24). Külön csoporttal a staging már nem érhet a kiadás sorához.
+#
+# A `cancel-in-progress` MARAD false, és ez fontos: a job leállítása a GitHub oldalán öli
+# meg a futást, a szerveren a docker daemonban FUTÓ build viszont attól még dolgozik
+# tovább — a cancel nem szabadítja fel a gépet, csak elveszti a naplót. Sőt: a megszakadt
+# ssh-munkamenettel a lentebbi zár is elengedne, miközben a build még fut. Tehát nem
+# kilövünk, hanem a záron sorbaállunk, és ha nem kapjuk meg, KIMARADUNK — borazslo
+# szavaival „a deploy to staging mindig várhat, kimaradhat ha kell". A következő pusholás
+# úgyis hoz újat.
 concurrency:
-  group: deploy-server
+  group: deploy-server-staging
   cancel-in-progress: false
 
 jobs:
@@ -68,6 +78,18 @@ jobs:
           timeout: 2m
           script: |
             set -euo pipefail
+
+            # #903: a gépen egyszerre EGY deploy dolgozhat (#662). A kizárás a GitHub
+            # concurrency-csoportjából ide került, mert ott a kiadás deployját ütötte ki.
+            #
+            # A staging KIMARADHAT, ha nem kapja meg a zárat: a következő pusholás úgyis
+            # hoz újat. A `-w 60` azért nem 0, hogy egy épp befejeződő deploy után ne
+            # hagyjuk ki fölöslegesen.
+            exec 9>/tmp/miserend-deploy.lock
+            if ! flock -w 60 9; then
+              echo "⏭️  Másik deploy dolgozik a gépen — a staging kimarad. A következő pusholás újrapróbálja."
+              exit 0
+            fi
 
             DEPLOY_DIR=/var/www/staging.miserend.hu
             cd "$DEPLOY_DIR"

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -99,7 +99,6 @@ services:
       start_period: 30s
   mysql:
     image: mariadb:12
-    platform: linux/amd64
     volumes:
       - db_data:/var/lib/mysql
       - ./mysql/initdb.d:/docker-entrypoint-initdb.d

--- a/docker/mysql/initdb.d/16-notification-digest.sql
+++ b/docker/mysql/initdb.d/16-notification-digest.sql
@@ -1,0 +1,39 @@
+-- #872: értesítési gyakoriság és a napi/heti összefoglaló várólistája.
+--
+-- Az éles migrációt lásd: docker/mysql/migrations/872-ertesites-gyakorisag.sql
+
+USE `miserend`;
+
+/*
+ * Az alapérték SZÁNDÉKOSAN 'daily', a meglévő felhasználókra is.
+ *
+ * borazslo döntése a #872-ben: „Legyen rögtön a B (azonnal / napi / heti), és persze
+ * mindenki napira állítva. Ennyi késleltetése az adatok befutásának kb soha sem gond."
+ *
+ * A `notifications` oszlop marad, és erősebb: `0` esetén semmilyen értesítő nem megy,
+ * a gyakoriságtól függetlenül.
+ */
+ALTER TABLE `user`
+  ADD COLUMN IF NOT EXISTS `notification_frequency`
+    ENUM('instant','daily','weekly') NOT NULL DEFAULT 'daily' AFTER `notifications`;
+
+/*
+ * A halasztott értesítések. Nem a kész levelet tesszük félre, hanem az ESEMÉNYT:
+ * a digest egyetlen, templomonként csoportosított levél lesz, nem N levél egymás alá
+ * fűzve. A `sent_at` a kiküldés bélyege — a sorokat nem töröljük, mert a „mit küldtünk
+ * ki neki" kérdésre az `emails` tábla mellett ez a másik nyom.
+ */
+CREATE TABLE IF NOT EXISTS `notification_digest_items` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `uid` int(11) NOT NULL,
+  `email` varchar(100) NOT NULL,
+  `type` varchar(30) NOT NULL COMMENT 'remark | suggestion | image',
+  `church_id` int(11) DEFAULT NULL,
+  `title` varchar(255) NOT NULL,
+  `url` varchar(255) NOT NULL,
+  `created_at` timestamp NULL DEFAULT current_timestamp(),
+  `sent_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `uid_sent` (`uid`,`sent_at`),
+  KEY `sent_created` (`sent_at`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docker/mysql/migrations/872-ertesites-gyakorisag.sql
+++ b/docker/mysql/migrations/872-ertesites-gyakorisag.sql
@@ -1,0 +1,47 @@
+-- #872: értesítési gyakoriság és a napi/heti összefoglaló várólistája — ÉLES migráció.
+--
+--
+-- !!! ELŐTTE BACKUP:  bash docker/mysql/dump.sh > backup-PRE-872.sql
+--
+-- Futtatás:
+--    docker exec -i miserend-prod-mysql-1 mariadb -uuser -p"$MYSQL_PASSWORD" miserend \
+--      < docker/mysql/migrations/872-ertesites-gyakorisag.sql
+--
+-- Csak hozzáad, semmit nem ír felül. A meglévő felhasználók az oszlop alapértékét
+-- kapják: napi összefoglaló.
+
+USE `miserend`;
+
+/*
+ * Az alapérték SZÁNDÉKOSAN 'daily', a meglévő felhasználókra is.
+ *
+ * borazslo döntése a #872-ben: „Legyen rögtön a B (azonnal / napi / heti), és persze
+ * mindenki napira állítva. Ennyi késleltetése az adatok befutásának kb soha sem gond."
+ *
+ * A `notifications` oszlop marad, és erősebb: `0` esetén semmilyen értesítő nem megy,
+ * a gyakoriságtól függetlenül.
+ */
+ALTER TABLE `user`
+  ADD COLUMN IF NOT EXISTS `notification_frequency`
+    ENUM('instant','daily','weekly') NOT NULL DEFAULT 'daily' AFTER `notifications`;
+
+/*
+ * A halasztott értesítések. Nem a kész levelet tesszük félre, hanem az ESEMÉNYT:
+ * a digest egyetlen, templomonként csoportosított levél lesz, nem N levél egymás alá
+ * fűzve. A `sent_at` a kiküldés bélyege — a sorokat nem töröljük, mert a „mit küldtünk
+ * ki neki" kérdésre az `emails` tábla mellett ez a másik nyom.
+ */
+CREATE TABLE IF NOT EXISTS `notification_digest_items` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `uid` int(11) NOT NULL,
+  `email` varchar(100) NOT NULL,
+  `type` varchar(30) NOT NULL COMMENT 'remark | suggestion | image',
+  `church_id` int(11) DEFAULT NULL,
+  `title` varchar(255) NOT NULL,
+  `url` varchar(255) NOT NULL,
+  `created_at` timestamp NULL DEFAULT current_timestamp(),
+  `sent_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `uid_sent` (`uid`,`sent_at`),
+  KEY `sent_created` (`sent_at`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -89,6 +89,26 @@ class Crons {
 	public static function backfillBoundaryCheckedAt(): int {
 		$napok = max(1, (int) round((time() - strtotime('-' . \OSM::BOUNDARY_FRESHNESS)) / 86400));
 
+		/*
+		 * #890: a horgony a PHP órája, nem a MySQL `NOW()`-ja.
+		 *
+		 * Az oszlop MINDEN más írója és olvasója a PHP óráját használja: a bélyeget az
+		 * `OSM::checkBoundaries()` `date('Y-m-d H:i:s')`-szel írja, az esedékességet az
+		 * `osm.php` és a `requeueChurchesWithoutBoundary()` PHP-ben számolt határidőhöz
+		 * méri. Egyedül ez a visszatöltés dolgozott a MySQL órájával — az pedig a
+		 * `+05:00`-s session-zóna miatt HÁROM ÓRÁVAL előrébb jár (#890).
+		 *
+		 * Következmény élesben: a visszatöltött templom három órával frissebbnek látszik
+		 * a valóságosnál. Egy 180 napos ablakban ez kicsi, de a CI-ben mérhető volt: ha a
+		 * `FLOOR(RAND() * $napok)` nullát húzott, a bélyeg a PHP órájához képest a JÖVŐBE
+		 * került, és a `BoundaryFreshnessTest` elhasalt — pontosan 10799 másodperccel.
+		 * Innen a master szakaszos pirosa.
+		 *
+		 * A `RAND()` marad a MySQL-ben: soronként KELL más érték, különben az egész köteg
+		 * ugyanazt a bélyeget kapná, és fél év múlva egyszerre járna le mind.
+		 */
+		$horgony = date('Y-m-d H:i:s');
+
 		return DB::table('templomok')
 			->whereNull('boundaries_checked_at')
 			->whereExists(function ($q) {
@@ -98,9 +118,23 @@ class Crons {
 					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
 					->where('boundaries.boundary', 'administrative');
 			})
-			->update(['boundaries_checked_at' => DB::raw(
-				'DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * ' . $napok . ') DAY)'
-			)]);
+			->update(['boundaries_checked_at' => DB::raw(self::backfillBelyegKifejezes($horgony, $napok))]);
+	}
+
+	/**
+	 * #890: a visszatöltés SQL-kifejezése, külön, hogy tesztelhető legyen.
+	 *
+	 * Azért van kiemelve, mert a hiba, amit javít, csak SZAKASZOSAN látszik: a MySQL
+	 * órájára horgonyzott bélyeg akkor kerül a jövőbe, ha a `FLOOR(RAND() * $napok)`
+	 * épp nullát húz — negyven templomnál ez nagyjából minden ötödik futás. A kifejezést
+	 * viszont determinisztikusan meg lehet nézni, tehát a visszaesés nem tud észrevétlen
+	 * maradni.
+	 *
+	 * A `$horgony` a saját óránkból jön (`date('Y-m-d H:i:s')`), kötött formátumú, nem
+	 * külső bemenet; a `$napok` egész.
+	 */
+	public static function backfillBelyegKifejezes(string $horgony, int $napok): string {
+		return "DATE_SUB('" . $horgony . "', INTERVAL FLOOR(RAND() * " . max(1, $napok) . ") DAY)";
 	}
 
 	public static function churchesWithoutBoundaryCount(): int {

--- a/webapp/classes/digestqueue.php
+++ b/webapp/classes/digestqueue.php
@@ -1,0 +1,200 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #872: napi/heti összefoglaló az esemény-értesítőkből.
+ *
+ * A gond, amit borazslo leírt: egyre több és többféle értesítőnk van, és aki több
+ * templomot gondnokol — a #819 óta a plébános a fíliáiét is —, azt elönti. Ha kikapcsolja
+ * az értesítést, csak rosszabb lesz, mert onnantól semmit nem tud.
+ *
+ * A számok az éles adatbázisból (borazslo mérése, 30 nap): a legterheltebb címek 157-162
+ * levelet kaptak, a legrosszabb napokon 21-et EGYETLEN nap alatt. 41 felhasználó már ki
+ * is kapcsolta az értesítést.
+ *
+ * MI TARTOZIK IDE. Csak a három esemény-értesítő: új észrevétel, új javaslat, új kép.
+ * Az emlékeztetők (`user_pleaseupdate`, `holder_bucsu_reminder`,
+ * `holder_holiday_reminder`) MÁR egy levél felhasználónként, az összes érintett
+ * templommal, és ritkítva is vannak — azokkal nincs teendő.
+ *
+ * MIT HALASZTUNK. Nem a kész levelet tesszük félre, hanem az ESEMÉNYT. Így a digest
+ * egyetlen, templomonként csoportosított levél lesz, nem N kész levél egymás alá fűzve
+ * (N köszöntéssel és N aláírással).
+ *
+ * A `notifications = 0` erősebb mindennél: az továbbra is „ne írj nekem".
+ */
+class DigestQueue {
+
+    const AZONNAL = 'instant';
+    const NAPI = 'daily';
+    const HETI = 'weekly';
+
+    const GYAKORISAGOK = [self::AZONNAL, self::NAPI, self::HETI];
+
+    /** A heti összefoglaló napja (1 = hétfő), és a legvégső határidő napokban. */
+    const HETI_NAP = 1;
+    const HETI_HATARIDO_NAP = 7;
+
+    /**
+     * Halasszuk-e ennek a címzettnek az értesítést?
+     *
+     * @return bool  true, ha a sor bekerült a várólistába — ilyenkor a hívó NE küldjön
+     *               azonnali levelet. false esetén marad a régi, azonnali kiküldés.
+     */
+    public static function halaszt($cimzett, string $tipus, ?int $churchId, string $cim, string $url): bool {
+        $uid = (int) ($cimzett->uid ?? 0);
+        $email = trim((string) ($cimzett->email ?? ''));
+
+        // Akit nem tudunk azonosítani, azt nem tudjuk összegezni sem: menjen azonnal,
+        // ahogy eddig. (Inkább kapjon levelet, mint hogy elvesszen az értesítés.)
+        if ($uid <= 0 || $email === '') {
+            return false;
+        }
+
+        if (self::gyakorisag($cimzett) === self::AZONNAL) {
+            return false;
+        }
+
+        DB::table('notification_digest_items')->insert([
+            'uid' => $uid,
+            'email' => $email,
+            'type' => $tipus,
+            'church_id' => $churchId,
+            // A cím a levélben egy sor lesz; a hosszú észrevétel-szövegek levágva.
+            'title' => mb_substr(trim(strip_tags($cim)), 0, 250),
+            'url' => mb_substr($url, 0, 250),
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        return true;
+    }
+
+    /**
+     * A címzett gyakorisága. Ismeretlen érték esetén a napi — az a beállított
+     * alapértelmezés, és sosem vezet elveszett értesítéshez, csak késleltetetthez.
+     */
+    public static function gyakorisag($cimzett): string {
+        $ertek = $cimzett->notification_frequency ?? null;
+
+        return in_array($ertek, self::GYAKORISAGOK, true) ? $ertek : self::NAPI;
+    }
+
+    /**
+     * Cron: kiküldi az esedékes összefoglalókat.
+     *
+     * Naponta fut. A napi gyakoriságúak minden futásnál sorra kerülnek, ha van mit
+     * küldeni; a hetiek a hét megadott napján — VAGY ha a legrégebbi tételük már
+     * túllépte a hét napot. Ez utóbbi azért kell, hogy egy kimaradt hétfői futás miatt
+     * ne csússzon a következő hétre az egész.
+     *
+     * @return int a kiküldött összefoglalók száma
+     */
+    public static function sendDue(): int {
+        $varakozok = DB::table('notification_digest_items')
+            ->select('uid')
+            ->selectRaw('MIN(created_at) AS legregebbi')
+            ->whereNull('sent_at')
+            ->groupBy('uid')
+            ->get();
+
+        $kuldott = 0;
+        foreach ($varakozok as $sor) {
+            if (self::kikuldheto((int) $sor->uid, $sor->legregebbi)) {
+                $kuldott += self::kuldEgynek((int) $sor->uid) ? 1 : 0;
+            }
+        }
+
+        return $kuldott;
+    }
+
+    private static function kikuldheto(int $uid, $legregebbi): bool {
+        $user = DB::table('user')->where('uid', $uid)->first();
+        if (!$user) {
+            return false;
+        }
+
+        // Ha időközben kikapcsolta az értesítést, a várólistája nem megy ki.
+        if ((int) ($user->notifications ?? 0) !== 1) {
+            return false;
+        }
+
+        $gyakorisag = self::gyakorisag($user);
+        if ($gyakorisag === self::AZONNAL) {
+            // Menet közben állt át azonnalira: a felgyűlt tételeket még kiküldjük
+            // egyben, mert azok már nem mennek ki külön levélben.
+            return true;
+        }
+        if ($gyakorisag === self::NAPI) {
+            return true;
+        }
+
+        return self::hetiEsedekes((int) date('N'), $legregebbi);
+    }
+
+    /**
+     * Esedékes-e a HETI összefoglaló?
+     *
+     * A hét megadott napján igen. Emellett akkor is, ha a legrégebbi tétel már túllépte
+     * a hét napot — enélkül egyetlen kimaradt hétfői futás miatt a következő hétre
+     * csúszna az egész, és a gondnok két hétig nem tudna a hozzá érkezett észrevételről.
+     *
+     * Kívülről is hívható, mert a „ma milyen nap van" nélkül nem lenne tesztelhető.
+     */
+    public static function hetiEsedekes(int $maiNap, $legregebbi): bool {
+        if ($maiNap === self::HETI_NAP) {
+            return true;
+        }
+
+        return strtotime((string) $legregebbi) < strtotime('-' . self::HETI_HATARIDO_NAP . ' days');
+    }
+
+    /** Egy címzett összefoglalója. */
+    private static function kuldEgynek(int $uid): bool {
+        $tetelek = DB::table('notification_digest_items')
+            ->where('uid', $uid)
+            ->whereNull('sent_at')
+            ->orderBy('created_at')
+            ->get();
+
+        if ($tetelek->isEmpty()) {
+            return false;
+        }
+
+        $user = new \User($uid);
+        if (!$user->uid) {
+            return false;
+        }
+
+        // Templomonként csoportosítva — a gondnok így egyben látja, melyik templomával
+        // mi történt, nem eseménytípusonként szétszórva.
+        $templomok = [];
+        foreach ($tetelek as $tetel) {
+            $kulcs = (int) $tetel->church_id;
+            if (!isset($templomok[$kulcs])) {
+                $templom = $kulcs > 0 ? \Eloquent\Church::find($kulcs) : null;
+                $templomok[$kulcs] = [
+                    'nev' => $templom ? $templom->fullName : 'Egyéb',
+                    'id' => $kulcs,
+                    'tetelek' => [],
+                ];
+            }
+            $templomok[$kulcs]['tetelek'][] = $tetel;
+        }
+
+        $user->digestChurches = array_values($templomok);
+        $user->digestCount = count($tetelek);
+
+        $mail = new \Eloquent\Email();
+        $mail->to = $user->email;
+        $mail->render('user_digest', $user);
+        $mail->addToQueue();
+
+        DB::table('notification_digest_items')
+            ->where('uid', $uid)
+            ->whereNull('sent_at')
+            ->update(['sent_at' => date('Y-m-d H:i:s')]);
+
+        return true;
+    }
+}

--- a/webapp/classes/eloquent/calsuggestionpackage.php
+++ b/webapp/classes/eloquent/calsuggestionpackage.php
@@ -115,6 +115,16 @@ class CalSuggestionPackage extends CalModel
         }
 
         foreach ($emails as $email) {
+            // #872: napi/heti összefoglalónál egy sor a várólistára, nem külön levél.
+            if (\DigestQueue::halaszt(
+                    $email[2],
+                    'suggestion',
+                    (int) $church->id,
+                    'Miserend-javaslat érkezett',
+                    '/templom/' . (int) $church->id . '/javaslatok')) {
+                continue;
+            }
+
             $this->sendMail($email[0], $email[1], $email[2]);
         }
 

--- a/webapp/classes/eloquent/remark.php
+++ b/webapp/classes/eloquent/remark.php
@@ -107,6 +107,20 @@ class Remark extends \Illuminate\Database\Eloquent\Model {
         }
         
         foreach($emails as $email) {
+            /*
+             * #872: akinek napi/heti összefoglalót kért a beállítása, annak nem külön
+             * levél megy, hanem egy sor a várólistára. Az azonnalit választóknál semmi
+             * nem változik.
+             */
+            if (\DigestQueue::halaszt(
+                    $email[2],
+                    'remark',
+                    (int) $this->church_id,
+                    (string) $this->leiras,
+                    '/templom/' . (int) $this->church_id . '/eszrevetelek')) {
+                continue;
+            }
+
             $this->sendMail($email[0], $email[1], $email[2]);            
         }
                 

--- a/webapp/classes/html/church/create.php
+++ b/webapp/classes/html/church/create.php
@@ -12,10 +12,10 @@ class Create extends \Html\Html {
 
         $this->title = 'Új misézőhely létrehozása';
 
-        
+
         $isForm = \Request::Text('submit');
         if ($isForm) {
-            $tid = $this->create();            
+            $tid = $this->create();
             if($tid) {
                 $this->redirect("/templom/".$tid."/edit");
                 return;
@@ -29,12 +29,25 @@ class Create extends \Html\Html {
     }
 
     function create() {
-        
-        $lat = \Request::FloatRequired('church[lat]');
-        $lon = \Request::FloatRequired('church[lon]');
+
+        $lat = self::koordinata('church[lat]', 'szélességi fok', -90, 90);
+        $lon = self::koordinata('church[lon]', 'hosszúsági fok', -180, 180);
         $name = \Request::TextRequired('church[nev]');
         $osm_id = \Request::Integer('church[osmid]');
         $osm_type = \Request::InArray('church[osmtype]', ['node', 'way', 'relation']);
+
+        /*
+         * #898: a két OSM-mező csak EGYÜTT ér valamit.
+         *
+         * Eddig fél azonosítót is el lehetett menteni (típus id nélkül vagy fordítva),
+         * és az a templom onnantól úgy nézett ki, mintha OSM-hez lenne kötve — miközben
+         * az `OSM::updateChurch()` az `empty($osmtype) OR empty($osmid)` ágon úgyis
+         * kihagyja. Csendes fél-adat helyett inkább szóljunk.
+         */
+        if (($osm_id && !$osm_type) || (!$osm_id && $osm_type)) {
+            throw new \Exception('Az OSM azonosítóhoz a típus és az azonosító is kell — '
+                . 'vagy hagyd üresen mind a kettőt.');
+        }
 
         $church = \Eloquent\Church::create([
             'nev' => $name,
@@ -43,13 +56,65 @@ class Create extends \Html\Html {
             'lat' => $lat,
             'lon' => $lon,
             'osmid' => $osm_id,
-            'osmtype' => $osm_type,                                    
+            'osmtype' => $osm_type,
         ]);
-         
+
+        /*
+         * #898: az űrlapon ott van a megjegyzés-mező, de a mentés eddig nem olvasta —
+         * amit a szerkesztő beírt, az némán elveszett.
+         *
+         * És nem elég a fenti tömbbe betenni: az `adminmegj` nincs a `Church::$fillable`
+         * listáján, tehát a tömeges értékadás CSENDBEN eldobná. Kimértem — a sor létrejön,
+         * a megjegyzés helye üres marad. Ezért közvetlen értékadás.
+         */
+        $megjegyzes = \Request::Text('church[adminmegj]');
+        if ($megjegyzes !== false && trim((string) $megjegyzes) !== '') {
+            $church->adminmegj = $megjegyzes;
+        }
+
         $church->save();
 
         return $church->id;
-        
+
+    }
+
+    /**
+     * #898: koordináta az űrlapról, tizedesVESSZŐVEL is.
+     *
+     * A magyar billentyűzeten és a magyar számformátumban a tizedesjel a vessző, és a
+     * felhasználók így is írják be. A `Request::FloatRequired()` az `is_numeric()`-re
+     * épül, ami a „47,4979"-et elutasítja — a bejelentő pedig ezt kapta:
+     * `Required 'church[lat]' is not a Float.` Ebből nem derül ki, mit rontott el.
+     *
+     * A vessző cseréje itt, a koordinátánál történik, nem a `Request`-ben: ott az
+     * ezres elválasztó vessző („1,000") miatt a csere értelmet változtatna.
+     *
+     * A tartomány-ellenőrzés is idevaló. Felcserélt szélesség/hosszúság esetén (ami
+     * gyakori hiba) a 90 fölötti szélességet így elkapjuk, ahelyett hogy a templom a
+     * térkép túloldalán landolna.
+     */
+    private static function koordinata(string $mezo, string $nev, float $min, float $max): float {
+        $nyers = \Request::Text($mezo);
+
+        if ($nyers === false || trim((string) $nyers) === '') {
+            throw new \Exception('Hiányzik a ' . $nev . '. A térképen a jelölőt mozgatva is megadható.');
+        }
+
+        $ertek = str_replace(',', '.', trim((string) $nyers));
+
+        if (!is_numeric($ertek)) {
+            throw new \Exception('A ' . $nev . ' nem szám: „' . $nyers . '". '
+                . 'Tizedesjelnek pont és vessző is jó, de más nem kerülhet bele.');
+        }
+
+        $ertek = (float) $ertek;
+
+        if ($ertek < $min || $ertek > $max) {
+            throw new \Exception('A ' . $nev . ' ' . $min . ' és ' . $max . ' közé eshet, '
+                . 'ez viszont ' . $ertek . '. (Nincs felcserélve a két mező?)');
+        }
+
+        return $ertek;
     }
 
 }

--- a/webapp/classes/html/church/create.php
+++ b/webapp/classes/html/church/create.php
@@ -51,9 +51,29 @@ class Create extends \Html\Html {
                 . 'vagy hagyd üresen mind a kettőt.');
         }
 
+        /*
+         * #908: a frissen felvitt misézőhely „áttekintésre vár", nem „letiltva".
+         *
+         * borazslo a #898-ban: „ha nem választunk ki osm lehetséges elemet, akkor
+         * letiltva marad a templom az összekötés hiánya miatt. Ami rendben van sok régi
+         * templomnál, de újnál nem. Hiszen a felhasználó most hozta létre."
+         *
+         * Nincs külön gépezet, ami az OSM-kapcsolat hiánya miatt tiltana: egyszerűen ez a
+         * sor írt mindig `n`-t. A `n` jelentése „nem engedélyezett" — az egy elutasított
+         * vagy visszavont templom állapota, nem egy épp mostani felvitelé.
+         *
+         * Az `f` („feltöltött, áttekintésre vár") pontosan ezt fejezi ki, és a kódbázis
+         * már használja ugyanerre a gondolatra: a koordináta nélkül maradt templomok is
+         * ide kerülnek (`Crons::KOORDINATA_NELKUL_ALLAPOT`), azzal az indoklással, hogy
+         * „nem szabályszegés miatt kerülnek ki, hanem mert hiányzik az adatuk".
+         *
+         * A NYILVÁNOSSÁGON nem változtat semmit: a listák és a kereső `ok = 'i'`-re
+         * szűrnek, tehát az `f` ugyanúgy nem jelenik meg, mint az `n`. Csak az admin
+         * felületén más a felirata — és a gondnok látja, hogy a felvitele megtörtént.
+         */
         $church = \Eloquent\Church::create([
             'nev' => $name,
-            'ok' => 'n',
+            'ok' => 'f',
             'frissites' => date('Y-m-d'),
             'lat' => $lat,
             'lon' => $lon,

--- a/webapp/classes/html/uploadimage.php
+++ b/webapp/classes/html/uploadimage.php
@@ -119,6 +119,16 @@ class UploadImage extends Html {
         }
         
         foreach($emails as $email) {
+            // #872: napi/heti összefoglalónál egy sor a várólistára, nem külön levél.
+            if (isset($email[2]) && \DigestQueue::halaszt(
+                    $email[2],
+                    'image',
+                    (int) $this->church->id,
+                    'Új kép érkezett',
+                    '/templom/' . (int) $this->church->id . '/editphotos')) {
+                continue;
+            }
+
             if(isset($email[2])) $this->addressee = $email[2];
             else $this->addressee = false;
             $mail = new \Eloquent\Email();                

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -40,6 +40,11 @@ class User {
     public $presaved;
     public $favorites;
     public $inactiveDays;
+    /** #872: az értesítési gyakoriság (instant/daily/weekly) — a `user` tábla oszlopa. */
+    public $notification_frequency;
+    /** #872: a napi/heti összefoglaló adatai a levélsablonnak. */
+    public $digestChurches;
+    public $digestCount;
 
     function __construct($uid = false) {
         if (isset($uid) AND $uid != false) {
@@ -197,6 +202,7 @@ class User {
             'volunteer' => 'Hibás értéke van az önkéntességnek!',
             'roles' => 'Hibás formátumú jogkörök!',
             'notifications' => 'Email értesítések engedélyezése körül hiba lépett fel!',
+            'notification_frequency' => 'Hibás értesítési gyakoriság!',
         );
 
         // #829: a mezőnkénti általános mondat helyett a KONKRÉT ok, ha tudjuk.
@@ -204,7 +210,7 @@ class User {
         // használatban van?"), így a felhasználó találgathatott, mit rontott el.
         $this->presaveErrors = [];
 
-        foreach (array('uid', 'username', 'nickname', 'name', 'email', 'volunteer', 'roles','notifications') as $input) {
+        foreach (array('uid', 'username', 'nickname', 'name', 'email', 'volunteer', 'roles','notifications','notification_frequency') as $input) {
             if (isset($vars[$input])) {
                 if (!$this->presave($input, $vars[$input])) {
                     $return = false;
@@ -389,6 +395,14 @@ class User {
         } elseif ($key == 'notifications') {
             if(!in_array($val,[0,1])) {
                 $this->presaveError($key, 'Az értesítés csak be- vagy kikapcsolt lehet.');
+                return false;
+            }
+            $this->presaved[$key] = $val;
+        } elseif ($key == 'notification_frequency') {
+            // #872: fehérlista. Ismeretlen érték az enum-oszlopon némán üres sztringgé
+            // válna, és onnantól a felhasználó besorolhatatlan gyakoriságon állna.
+            if (!in_array($val, \DigestQueue::GYAKORISAGOK, true)) {
+                $this->presaveError($key, 'Ilyen értesítési gyakoriság nincs.');
                 return false;
             }
             $this->presaved[$key] = $val;

--- a/webapp/fajlok/crons.php
+++ b/webapp/fajlok/crons.php
@@ -99,6 +99,9 @@ return [
     ['class' => '\Crons',                         'function' => 'cleanNotificationEmails',    'frequency' => '1 day'],
     ['class' => '\Crons',                         'function' => 'rollPeriodYears',            'frequency' => '1 month'],
     ['class' => '\Eloquent\Email',                'function' => 'sendQueued',                 'frequency' => '15 minutes', 'from' => '1am', 'until' => '6am'],
+    // #872: a napi/heti összefoglaló. A sendQueued ELŐTT kell futnia (az teszi sorba a
+    // levelet), ezért az ablak eleje felé — a `from` az 1 óra, a drainer utána ér rá.
+    ['class' => '\DigestQueue',                   'function' => 'sendDue',                    'frequency' => '1 day',      'from' => '1am', 'until' => '6am'],
     // #315: heti hét templom önkéntesség. Korábban a seed-dumpba (data/crons.sql) írtam
     // volna őket, de az a fájl azóta megszűnt — a #638 óta ez a lista az egyetlen forrás.
     // Mindkettő levelet küld, ezért — a többi levelező cronhoz igazodva — hajnalban fut.

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -1909,6 +1909,88 @@
         }
       }
     },
+    "notification_digest_items": {
+      "engine": "InnoDB",
+      "collation": "utf8mb4_uca1400_ai_ci",
+      "columns": {
+        "id": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": "auto_increment"
+        },
+        "uid": {
+          "type": "int(11)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "email": {
+          "type": "varchar(100)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "type": {
+          "type": "varchar(30)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "church_id": {
+          "type": "int(11)",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        },
+        "title": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "url": {
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": null,
+          "extra": ""
+        },
+        "created_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": "current_timestamp",
+          "extra": ""
+        },
+        "sent_at": {
+          "type": "timestamp",
+          "nullable": true,
+          "default": null,
+          "extra": ""
+        }
+      },
+      "indexes": {
+        "PRIMARY": {
+          "unique": true,
+          "columns": [
+            "id"
+          ]
+        },
+        "sent_created": {
+          "unique": false,
+          "columns": [
+            "sent_at",
+            "created_at"
+          ]
+        },
+        "uid_sent": {
+          "unique": false,
+          "columns": [
+            "uid",
+            "sent_at"
+          ]
+        }
+      }
+    },
     "osm": {
       "engine": "InnoDB",
       "collation": "utf8mb4_unicode_ci",
@@ -3117,6 +3199,12 @@
           "default": "1",
           "extra": ""
         },
+        "notification_frequency": {
+          "type": "enum('instant','daily','weekly')",
+          "nullable": false,
+          "default": "daily",
+          "extra": ""
+        },
         "becenev": {
           "type": "varchar(50)",
           "nullable": false,
@@ -3147,8 +3235,8 @@
     }
   },
   "_meta": {
-    "generated_at": "2026-08-20T11:23:43+02:00",
-    "source_schema": "ref_845",
+    "generated_at": "2026-08-24T05:23:33+02:00",
+    "source_schema": "miserend_ref_872",
     "initdb_fingerprint": "0e7a7451023e81f73e62b23d418801aad4c4bf2501edd9160e93f8729aab08ae",
     "initdb_files": {
       "00-users.sh": "e4f1149c70b9b0b44ce0ba172110ca07ad099fffaf720876e45e8a0a5cb910f8",

--- a/webapp/templates/church/create.twig
+++ b/webapp/templates/church/create.twig
@@ -37,8 +37,23 @@
 
         <div class="row mb-3">
             <div class="col-12 font-weight-bold">
-                <h4>Koordináta:</h4> 
-                <p>A térképen mozgatva a jelölőt változik a mentendő koordináta.</p>               
+                <h4>Koordináta:</h4>
+                <p>A térképen mozgatva a jelölőt változik a mentendő koordináta. Ha nem tudod
+                   fejből, keress rá a településre — a térkép odaugrik, és onnan igazítod.</p>
+            </div>
+            {# #898: helynév -> koordináta. A meglévő, szerveroldali és cache-elt
+               /ajax/Geocode végpontot hívja, ugyanazt, amit a kereső űrlapja. #}
+            <div class="col-md-8 mb-2">
+                <input type="text" id="hely-kereso" class="form-control"
+                       placeholder="Település, cím vagy templomnév — pl. Hajdúnánás">
+            </div>
+            <div class="col-md-4 mb-2">
+                <button type="button" id="hely-keres-gomb" class="btn btn-outline-secondary w-100">
+                    Ugrás a térképen
+                </button>
+            </div>
+            <div class="col-12 mb-2">
+                <small id="hely-allapot" class="text-muted"></small>
             </div>
             <div class="col-md-5">
                 <input type="text" name="church[lat]" value="" class="form-control" placeholder="szélességi fok">
@@ -75,6 +90,10 @@
             </div>
             <div class="col-md-12">
                 
+                <div id="osm-allapot" class="alert alert-light py-2 px-3 mb-2" role="status">
+                    Adj meg koordinátát, és megnézzük, van-e a környéken OSM-ben ismert templom.
+                </div>
+
                  <!-- Táblázat a közeli helyek megjelenítéséhez -->
                 <table id="nearby-places" class="table table-striped">
                     <thead>
@@ -121,199 +140,342 @@
     <link rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css"/>
 
     <script>
-  $( function() {
-		  
-  
-    $( ".info" ).on( "click", function() { 
-        console.log($( this ).data('id'));
-               $('#help' + $( this ).data('id') ).toggle(600);
+    $(function () {
+        $('.info').on('click', function () {
+            $('#help' + $(this).data('id')).toggle(600);
+        });
     });
- });
-  
-    
+
+    /*
+     * #898: „Feladtam az új misézőhely felvitelét… A koordináták beírása után vagy szép
+     * fővárosunk valamelyik kerületébe téved, hogy mozgassam a helyet fél Magyarországon
+     * át vagy egy teljesen más településre visz."
+     *
+     * Az ok a régi kódban a BEMENET kezelése volt, három hibával:
+     *
+     *  1. Az `input` esemény MINDEN leütésre lefutott. A „47.4979" begépelése közben a
+     *     mező tartalma sorra „4", „47", „47.", „47.4" — és mindegyikre elmozdult a
+     *     térkép. Amíg a másik mező üres volt, a Leaflet a `""`-t 0-nak vette, tehát a
+     *     jelölő az Atlanti-óceánra ugrott, majd vissza. Innen a „fél Magyarországon át".
+     *  2. Ugyanezekre a félkész értékekre indult egy-egy Overpass-lekérdezés is,
+     *     leütésenként — a válaszok pedig tetszőleges sorrendben értek vissza, tehát a
+     *     táblázatban egy KORÁBBI koordináta találatai maradhattak. Ráadásul a kevés
+     *     találat miatti újrapróbálkozás (1000 -> 6000 -> … -> 21000 m) leütésenként öt
+     *     kérést jelentett: egy koordináta beírása simán ötven kérés, amire az Overpass
+     *     jogosan kizár — az meg a némán elnyelt hibaágra futott.
+     *  3. Tizedesvesszővel (magyar számformátum, magyar billentyűzet) a Leaflet
+     *     „Invalid LatLng"-gel elszállt, és onnantól a térkép mozdíthatatlan volt.
+     *
+     * Mostantól: a beírás UTÁN, kis várakozással dolgozunk, csak érvényes koordinátára,
+     * egyszerre egy Overpass-kéréssel, és ami történik, az látszik is a felületen.
+     */
     $(function () {
 
-         // Mezők változásának figyelése
-        $('input[name="church[lat]"], input[name="church[lon]"]').on('input', function () {
-            var lat = $('input[name="church[lat]"]').val();
-            var lon = $('input[name="church[lon]"]').val();
+        var ALAP_LAT = 47.497913;
+        var ALAP_LON = 19.040236;
 
-            // OSM szerkesztési link frissítése
-            $('#osm-edit-link').attr('href', `https://www.openstreetmap.org/edit?editor=id#map=19/${lat}/${lon}`);  
+        var latMezo   = $('input[name="church[lat]"]');
+        var lonMezo   = $('input[name="church[lon]"]');
+        var osmTipus  = $('select[name="church[osmtype]"]');
+        var osmAzon   = $('input[name="church[osmid]"]');
+        var tablaTest = $('#nearby-places tbody');
+        var osmAllapot = $('#osm-allapot');
+        var helyAllapot = $('#hely-allapot');
 
-            // osmtype és osmid mezők ürítése
-            $('select[name="church[osmtype]"]').val('');
-            $('input[name="church[osmid]"]').val('');
+        /** Tizedesvessző is jó — a mentés (create.php) ugyanígy fogadja el. */
+        function szamma(ertek) {
+            var szoveg = String(ertek === undefined || ertek === null ? '' : ertek).trim().replace(',', '.');
+            if (szoveg === '') return null;
 
-            // Térkép frissítése
-            marker.setLatLng([lat, lon]);
-            map.setView([lat, lon], map.getZoom());
-                        
-            // Overpass Turbo API lekérés
-            fetchOverpassData(lat, lon);     
-        });
+            var szam = Number(szoveg);
+            return isFinite(szam) ? szam : null;
+        }
 
-        function fetchOverpassData(lat, lon, radius = 1000) {
-            // Overpass Turbo lekérdezés
-            var query = `
-                [out:json][timeout:25];
-                (
-                    node["amenity"="place_of_worship"]["religion"="christian"](around:${radius},${lat},${lon});
-                    way["amenity"="place_of_worship"]["religion"="christian"](around:${radius},${lat},${lon});
-                    relation["amenity"="place_of_worship"]["religion"="christian"](around:${radius},${lat},${lon});
-                );
-                out body center;
-            `;
+        /** A két mező együtt, csak ha MINDKETTŐ érvényes. Félkész értékre nem mozdulunk. */
+        function koordinata() {
+            var lat = szamma(latMezo.val());
+            var lon = szamma(lonMezo.val());
 
-            $.ajax({
+            if (lat === null || lon === null) return null;
+            if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+
+            return { lat: lat, lon: lon };
+        }
+
+        var map = L.map('map').setView([ALAP_LAT, ALAP_LON], 15);
+        L.tileLayer(window.MISEREND_CSEMPE.url, window.MISEREND_CSEMPE.beallitas).addTo(map);
+        var marker = L.marker([ALAP_LAT, ALAP_LON], { draggable: true }).addTo(map);
+
+        function osmLinkFrissit(pont) {
+            $('#osm-edit-link').attr('href',
+                'https://www.openstreetmap.org/edit?editor=id#map=19/' + pont.lat + '/' + pont.lon);
+        }
+
+        function osmAzonositoTorol() {
+            osmTipus.val('');
+            osmAzon.val('');
+        }
+
+        /* ---- Overpass: egyszerre EGY kérés, és a válasza látszik ---- */
+
+        var futoKeres = null;
+        var idozito = null;
+        var sorszam = 0;
+
+        function osmUzenet(szoveg, tipus) {
+            osmAllapot.attr('class', 'alert alert-' + (tipus || 'light') + ' py-2 px-3 mb-2').text(szoveg);
+        }
+
+        function keresEsedekes(pont) {
+            if (idozito) clearTimeout(idozito);
+
+            // Fél másodperc: ennyi alatt a gépelés befejeződik, tehát egy koordináta
+            // beírásából EGY lekérdezés lesz, nem tíz.
+            idozito = setTimeout(function () { kozeliekKeresese(pont, 1000, 0); }, 500);
+        }
+
+        function kozeliekKeresese(pont, sugar, probalkozas) {
+            if (futoKeres) {
+                futoKeres.abort();
+            }
+
+            var sajatSorszam = ++sorszam;
+            osmUzenet('Keressük a közeli templomokat az OSM-ben… (' + Math.round(sugar / 1000) + ' km)', 'light');
+
+            var lekerdezes = '[out:json][timeout:25];('
+                + 'node["amenity"="place_of_worship"]["religion"="christian"](around:' + sugar + ',' + pont.lat + ',' + pont.lon + ');'
+                + 'way["amenity"="place_of_worship"]["religion"="christian"](around:' + sugar + ',' + pont.lat + ',' + pont.lon + ');'
+                + 'relation["amenity"="place_of_worship"]["religion"="christian"](around:' + sugar + ',' + pont.lat + ',' + pont.lon + ');'
+                + ');out body center;';
+
+            futoKeres = $.ajax({
                 url: '{{ overpass_api_url }}',
                 type: 'POST',
-                data: { data: query },
-                success: function (response) {
-                    // Eredmények feldolgozása
-                    var results = response.elements.map(function (element) {
-                        var distance = getDistanceFromLatLonInKm(lat, lon, element.lat || element.center.lat, element.lon || element.center.lon);
+                data: { data: lekerdezes },
+                success: function (valasz) {
+                    // Elavult válasz: közben újabb kérés indult. Ne írjuk felül vele a
+                    // frissebb találatokat — pont ez zavarta össze a régi felületet.
+                    if (sajatSorszam !== sorszam) return;
+
+                    var talalatok = (valasz.elements || []).map(function (elem) {
+                        var elemLat = elem.lat || (elem.center && elem.center.lat);
+                        var elemLon = elem.lon || (elem.center && elem.center.lon);
+                        var cimkek = elem.tags || {};
+
                         return {
-                            id: element.id,
-                            type: element.type,
-                            lat: element.lat || element.center.lat,
-                            lon: element.lon || element.center.lon,
-                            distance: distance,
-                            name: element.tags.name || element.tags.name_hu || element.tags.alt_name,
-                            denomination: element.tags.denomination || element.tags.religion || 'unknown',
-                            miserend: element.tags['url:miserend']
+                            id: elem.id,
+                            type: elem.type,
+                            lat: elemLat,
+                            lon: elemLon,
+                            distance: tavolsagKm(pont.lat, pont.lon, elemLat, elemLon),
+                            name: cimkek.name || cimkek.name_hu || cimkek.alt_name,
+                            denomination: cimkek.denomination || cimkek.religion || 'ismeretlen',
+                            miserend: cimkek['url:miserend']
                         };
+                    }).filter(function (t) {
+                        return t.lat !== undefined && t.lon !== undefined;
                     });
 
-                    // Ha az eredmények száma 1 vagy kevesebb, újrapróbálkozás nagyobb radius értékkel
-                    if (results.length <= 1 && radius < 20000) {
-                        console.log(`Kevés találat (${results.length}), újrapróbálkozás nagyobb körrel (${radius + 5000}m)...`);
-                        fetchOverpassData(lat, lon, radius + 5000);
+                    // Ha semmi nincs a közelben, egyszer tágítunk — de csak egyszer, és
+                    // csak akkor, ha tényleg üres. A régi kód ötször tágított, minden
+                    // leütésre.
+                    if (talalatok.length === 0 && probalkozas < 1) {
+                        kozeliekKeresese(pont, 10000, probalkozas + 1);
                         return;
                     }
 
-                    // Távolság szerint rendezés
-                    results.sort(function (a, b) {
-                        return a.distance - b.distance;
-                    });
+                    talalatok.sort(function (a, b) { return a.distance - b.distance; });
+                    tablaTest.html(talalatok.map(sorHtml).join(''));
 
-                    // Táblázat frissítése
-                    var rows = results.map(function (result) {
-                        return `
-                            <tr>
-                                <td>${result.name ? result.name : `${result.type}:${result.id}`}<br/><small>${result.denomination}</small></td>
-                                <td>${(result.distance * 1000).toFixed(0)} m</td>
-                                <td style="text-align:center"><a href="https://www.openstreetmap.org/${result.type}/${result.id}" target="_blank"><span class="{{ ICONS_MAP_SEE }}" title="OSM elem megtekintése."></span></a></td>                                
-                                <td style="text-align:center">
-                                    ${result.miserend ? `
-                                        <a href="${result.miserend}" target="_blank">
-                                            <span class="{{ ICONS_CHURCH_SEE }}" title="Misézőhely megtalálható a Miserend.hu-n. Lássuk."></span>
-                                        </a>
-                                    ` : ''}
-                                </td>
-                                <td style="text-align:center">
-                                ${result.miserend ? `` : `
-                                    <span class="{{ ICONS_ADD }} select-location" 
-                                        title="Legyen ez az OSM entitás a templom adata!"
-                                        data-lat="${result.lat}" 
-                                        data-lon="${result.lon}" 
-                                        data-osmtype="${result.type}" 
-                                        data-osmid="${result.id}">
-                                    </span>`}
-                                </td>
-                            </tr>
-                        `;
-                    }).join('');
-
-                    $('#nearby-places tbody').html(rows);
-
-                    // Gomb eseménykezelő hozzáadása
-                    $('#nearby-places').on('click', '.select-location', function () {
-                        var lat = $(this).data('lat');
-                        var lon = $(this).data('lon');
-                        var osmtype = $(this).data('osmtype');
-                        var osmid = $(this).data('osmid');
-
-                        // Mezők kitöltése
-                        $('input[name="church[lat]"]').val(lat.toFixed(6));
-                        $('input[name="church[lon]"]').val(lon.toFixed(6));
-                        $('select[name="church[osmtype]"]').val(osmtype);
-                        $('input[name="church[osmid]"]').val(osmid);
-
-                        // Térkép frissítése
-                        marker.setLatLng([lat, lon]);
-                        map.setView([lat, lon], map.getZoom());
-                        
-                    });
+                    if (talalatok.length === 0) {
+                        osmUzenet('Nincs OSM-ben ismert templom ' + Math.round(sugar / 1000)
+                            + ' km-en belül. Ez nem baj: a misézőhely OSM-azonosító nélkül is létrehozható, '
+                            + 'csak addig letiltva marad.', 'warning');
+                    } else {
+                        osmUzenet(talalatok.length + ' templom az OSM-ben, '
+                            + Math.round(sugar / 1000) + ' km-en belül. Ha a tiéd köztük van, '
+                            + 'a jobb szélső gombbal kötheted hozzá.', 'light');
+                    }
                 },
-                error: function () {
-                    console.error('Hiba történt az Overpass Turbo API lekérése során.');
+                error: function (xhr, allapot) {
+                    if (allapot === 'abort' || sajatSorszam !== sorszam) return;
+
+                    /*
+                     * #898: „Tök rossz a hibakezelése. Az OSM azonosítós részben ha
+                     * overpass turbo api hibás lekérdezés van, akkor csak olyan mintha nem
+                     * is húztuk volna arrébb a markert."
+                     *
+                     * Eddig ez az ág csak egy console.error volt: a táblázatban ott
+                     * maradtak az ELŐZŐ koordináta találatai, és semmi nem jelezte, hogy a
+                     * lekérdezés elhasalt. A leggyakoribb ok a 429 — az Overpass kizár, ha
+                     * túl sűrűn kérdezünk (amit a régi, leütésenkénti kérés ki is váltott).
+                     */
+                    tablaTest.empty();
+
+                    var uzenet = xhr.status === 429 || xhr.status === 504
+                        ? 'Az OSM lekérdező (Overpass) most nem áll szóba velünk — túl sok kérés vagy '
+                          + 'túlterhelés. Várj fél percet, és mozdítsd meg a jelölőt újra.'
+                        : 'Nem sikerült lekérdezni az OSM-et (' + (xhr.status || 'nincs válasz') + '). '
+                          + 'A misézőhely enélkül is létrehozható, OSM-azonosító nélkül.';
+
+                    osmUzenet(uzenet, 'danger');
+                },
+                complete: function () {
+                    if (sajatSorszam === sorszam) futoKeres = null;
                 }
             });
         }
 
-    // Alapértelmezett koordináták az input mezőkből
-    var defaultLat = parseFloat($('input[name="church[lat]"]').val()) || 47.497913;
-    var defaultLon = parseFloat($('input[name="church[lon]"]').val()) || 19.040236;
+        function sorHtml(talalat) {
+            var nev = talalat.name ? talalat.name : (talalat.type + ':' + talalat.id);
 
-    // Térkép inicializálása
-    var map = L.map('map').setView([defaultLat, defaultLon], 15);
+            return '<tr>'
+                + '<td>' + nev + '<br/><small>' + talalat.denomination + '</small></td>'
+                + '<td>' + (talalat.distance * 1000).toFixed(0) + ' m</td>'
+                + '<td style="text-align:center"><a href="https://www.openstreetmap.org/'
+                    + talalat.type + '/' + talalat.id + '" target="_blank">'
+                    + '<span class="{{ ICONS_MAP_SEE }}" title="OSM elem megtekintése."></span></a></td>'
+                + '<td style="text-align:center">'
+                    + (talalat.miserend
+                        ? '<a href="' + talalat.miserend + '" target="_blank"><span class="{{ ICONS_CHURCH_SEE }}"'
+                          + ' title="Misézőhely megtalálható a Miserend.hu-n. Lássuk."></span></a>'
+                        : '')
+                + '</td>'
+                + '<td style="text-align:center">'
+                    + (talalat.miserend
+                        ? ''
+                        : '<span class="{{ ICONS_ADD }} select-location" title="Legyen ez az OSM entitás a templom adata!"'
+                          + ' data-lat="' + talalat.lat + '" data-lon="' + talalat.lon + '"'
+                          + ' data-osmtype="' + talalat.type + '" data-osmid="' + talalat.id + '"></span>')
+                + '</td>'
+                + '</tr>';
+        }
 
-    // #376/#817: CARTO Voyager basemap (a direkt tile.openstreetmap.org produkcióra
-    // tiltott). A konfiguráció a /js/map-tiles.js-ben van, egy helyen.
-    L.tileLayer(window.MISEREND_CSEMPE.url, window.MISEREND_CSEMPE.beallitas).addTo(map);
+        /*
+         * Az eseménykezelő EGYSZER kötődik, a táblázatra delegálva. A régi kód minden
+         * sikeres Overpass-válasznál újra rákötött, tehát tíz lekérdezés után egy
+         * kattintás tízszer futott le.
+         */
+        $('#nearby-places').on('click', '.select-location', function () {
+            var pont = { lat: Number($(this).data('lat')), lon: Number($(this).data('lon')) };
 
-    // Marker inicializálása
-    var marker = L.marker([defaultLat, defaultLon], { draggable: true }).addTo(map);
+            latMezo.val(pont.lat.toFixed(6));
+            lonMezo.val(pont.lon.toFixed(6));
+            osmTipus.val($(this).data('osmtype'));
+            osmAzon.val(String($(this).data('osmid')));
 
-    // Marker mozgatásának kezelése
-    marker.on('moveend', function (e) {
-        var lat = e.target.getLatLng().lat.toFixed(6);
-        var lon = e.target.getLatLng().lng.toFixed(6);
+            marker.setLatLng([pont.lat, pont.lon]);
+            map.setView([pont.lat, pont.lon], map.getZoom());
+            osmLinkFrissit(pont);
 
-        // Mezők frissítése
-        $('input[name="church[lat]"]').val(lat);
-        $('input[name="church[lon]"]').val(lon);
+            osmUzenet('Hozzákötve: ' + $(this).data('osmtype') + ':' + $(this).data('osmid')
+                + '. A mentés után a /templom/…/edit oldalon folytatod.', 'success');
+        });
 
-        // OSM szerkesztési link frissítése
-        $('#osm-edit-link').attr('href', `https://www.openstreetmap.org/edit?editor=id#map=19/${lat}/${lon}`);  
+        /* ---- A koordináta-mezők ---- */
 
-        // osmtype és osmid mezők ürítése
-        $('select[name="church[osmtype]"]').val('');
-        $('input[name="church[osmid]"]').val('');
-        
-        // Overpass Turbo API lekérés
-        fetchOverpassData(lat, lon);
+        latMezo.add(lonMezo).on('input', function () {
+            var pont = koordinata();
 
+            if (pont === null) {
+                // Félkész vagy hibás érték: NEM mozdítunk semmit. Csak szólunk, ha a
+                // beírt szöveg egyáltalán nem szám — a félkész gépelés nem hiba.
+                var nyers = String($(this).val()).trim();
+                if (nyers !== '' && szamma(nyers) === null) {
+                    osmUzenet('A koordináta nem szám: „' + nyers + '". Tizedesjelnek a pont és a '
+                        + 'vessző is jó.', 'warning');
+                }
+                return;
+            }
 
-        
-        
-        
+            osmAzonositoTorol();
+            marker.setLatLng([pont.lat, pont.lon]);
+            map.setView([pont.lat, pont.lon], map.getZoom());
+            osmLinkFrissit(pont);
+            keresEsedekes(pont);
+        });
+
+        marker.on('dragend', function (esemeny) {
+            var helyzet = esemeny.target.getLatLng();
+            var pont = { lat: Number(helyzet.lat.toFixed(6)), lon: Number(helyzet.lng.toFixed(6)) };
+
+            latMezo.val(pont.lat.toFixed(6));
+            lonMezo.val(pont.lon.toFixed(6));
+            osmAzonositoTorol();
+            osmLinkFrissit(pont);
+            keresEsedekes(pont);
+        });
+
+        /* ---- Helynév -> koordináta ---- */
+
+        function helyKereses() {
+            var hely = $('#hely-kereso').val().trim();
+
+            if (hely.length < 3) {
+                helyAllapot.text('Írj be legalább három karaktert.');
+                return;
+            }
+
+            helyAllapot.text('Keressük…');
+
+            // Ugyanaz a végpont, amit a kereső űrlapja hív: szerveroldali és cache-elt,
+            // tehát a Nominatim használati szabályzatát is betartja.
+            $.getJSON('/index.php?q=ajax/Geocode&hely=' + encodeURIComponent(hely))
+                .done(function (adat) {
+                    if (!adat || !adat.found) {
+                        helyAllapot.text(adat && adat.message ? adat.message : 'Ezt a helyet nem találtuk meg.');
+                        return;
+                    }
+
+                    var pont = { lat: adat.lat, lon: adat.lon };
+
+                    latMezo.val(pont.lat.toFixed(6));
+                    lonMezo.val(pont.lon.toFixed(6));
+                    osmAzonositoTorol();
+                    marker.setLatLng([pont.lat, pont.lon]);
+
+                    // A településre 15-ös zoom: a templom onnan már látszik, és a jelölő
+                    // pár mozdulattal a helyére húzható.
+                    map.setView([pont.lat, pont.lon], 15);
+                    osmLinkFrissit(pont);
+
+                    helyAllapot.text('Ide ugrottunk: ' + adat.name + '. Húzd a jelölőt a templomra.');
+                    keresEsedekes(pont);
+                })
+                .fail(function () {
+                    helyAllapot.text('A helykeresés most nem érhető el. Add meg a koordinátát kézzel.');
+                });
+        }
+
+        $('#hely-keres-gomb').on('click', helyKereses);
+        $('#hely-kereso').on('keydown', function (esemeny) {
+            // Enter itt NE küldje be az űrlapot — a felhasználó keresni akar, nem menteni.
+            if (esemeny.key === 'Enter') {
+                esemeny.preventDefault();
+                helyKereses();
+            }
+        });
+
+        /* ---- Távolság ---- */
+
+        function tavolsagKm(lat1, lon1, lat2, lon2) {
+            var R = 6371;
+            var dLat = fokRadian(lat2 - lat1);
+            var dLon = fokRadian(lon2 - lon1);
+            var a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(fokRadian(lat1)) * Math.cos(fokRadian(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+            return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        }
+
+        function fokRadian(fok) {
+            return fok * (Math.PI / 180);
+        }
     });
+    </script>
 
-    // Távolság számítása két koordináta között
-    function getDistanceFromLatLonInKm(lat1, lon1, lat2, lon2) {
-        var R = 6371; // Föld sugara km-ben
-        var dLat = deg2rad(lat2 - lat1);
-        var dLon = deg2rad(lon2 - lon1);
-        var a =
-            Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-            Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) *
-            Math.sin(dLon / 2) * Math.sin(dLon / 2);
-        var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        var d = R * c; // Távolság km-ben
-        return d;
-    }
 
-    function deg2rad(deg) {
-        return deg * (Math.PI / 180);
-    }
-});
-
-   
-  </script>
-
-    
 {% endblock %}
 
 

--- a/webapp/templates/emails/user_digest.twig
+++ b/webapp/templates/emails/user_digest.twig
@@ -1,0 +1,53 @@
+{{ digestCount == 1 ? '1 újdonság a templomodnál' : digestCount ~ ' újdonság a templomaidnál' }}
+
+Kedves {% include 'emails/_megszolitas.twig' %}!<br/>
+<br/>
+{#
+    #872: napi/heti összefoglaló.
+
+    Ez a levél váltja ki az „új észrevétel / új javaslat / új kép érkezett" külön
+    leveleket. Templomonként csoportosítunk, nem eseménytípusonként: a gondnokot az
+    érdekli, hogy MELYIK templomával mi történt.
+#}
+Az utolsó értesítőnk óta {% if digestCount == 1 %}egy újdonság érkezett{% else %}{{ digestCount }} újdonság érkezett{% endif %} a hozzád tartozó
+templom{% if digestChurches|length > 1 %}okhoz{% else %}hoz{% endif %}:<br/>
+<br/>
+
+{% for templom in digestChurches %}
+	<div style="margin-bottom:18px;">
+		<strong>
+			{% if templom.id > 0 %}
+				<a href="{{ domain }}/templom/{{ templom.id }}">{{ templom.nev }}</a>
+			{% else %}
+				{{ templom.nev }}
+			{% endif %}
+		</strong>
+		<ul class="list-group" style="margin-top:6px;">
+			{% for tetel in templom.tetelek %}
+				<li class="list-group-item">
+					<small style="color:#666;">
+						{% if tetel.type == 'remark' %}Észrevétel
+						{% elseif tetel.type == 'suggestion' %}Miserend-javaslat
+						{% elseif tetel.type == 'image' %}Új kép
+						{% else %}{{ tetel.type }}
+						{% endif %}
+						· {{ tetel.created_at|date('Y. m. d. H:i') }}
+					</small><br/>
+					<a href="{{ domain }}{{ tetel.url }}">{{ tetel.title }}</a>
+				</li>
+			{% endfor %}
+		</ul>
+	</div>
+{% endfor %}
+
+<br/>
+{#
+    A beállítás helyét minden levélben megmutatjuk. Enélkül az marad a felhasználónak,
+    hogy az egészet kikapcsolja — pont ezt akartuk elkerülni.
+#}
+<small>
+	Ezt az összefoglalót azért kapod, mert a beállításod szerint
+	{% if notification_frequency == 'weekly' %}hetente{% else %}naponta{% endif %}
+	kérsz értesítést. A <a href="{{ domain }}/user/edit">beállításaid</a> között bármikor
+	átállíthatod azonnalira, ritkábbra, vagy kikapcsolhatod.
+</small>

--- a/webapp/templates/user/edit.twig
+++ b/webapp/templates/user/edit.twig
@@ -143,7 +143,27 @@
 	    			</label>
 	    			<p class="help-block">Leginkább a felelőssségi köreidbe tartozó templomokhoz érkező észrevételekről küldünk üzeneteket.</p>
 		    	</div>
-			</div>                    
+			</div>
+
+			{#
+			   #872: milyen sűrűn. Eddig csak „minden vagy semmi" volt, és aki több
+			   templomot gondnokol, az a sok levél miatt inkább az egészet kikapcsolta.
+			   Az alapérték a napi összefoglaló — a meglévő felhasználóknál is.
+			#}
+			<div class="form-group">
+				<label for="notification_frequency">Értesítések gyakorisága</label>
+				<select id="notification_frequency" name="edituser[notification_frequency]" class="form-control" style="max-width:22em;">
+					<option value="instant" {% if edituser.notification_frequency == 'instant' %}selected{% endif %}>Azonnal, eseményenként</option>
+					<option value="daily" {% if edituser.notification_frequency != 'instant' and edituser.notification_frequency != 'weekly' %}selected{% endif %}>Naponta egy összefoglaló</option>
+					<option value="weekly" {% if edituser.notification_frequency == 'weekly' %}selected{% endif %}>Hetente egy összefoglaló</option>
+				</select>
+				<p class="help-block">
+					Az új észrevételekről, miserend-javaslatokról és képekről szól. Az összefoglaló
+					templomonként csoportosítva sorolja fel, mi történt — így több templom mellett sem
+					kapsz naponta tucatnyi levelet. A búcsú- és ünnep-emlékeztetők ettől függetlenül,
+					a maguk idejében érkeznek.
+				</p>
+			</div>
                 {% endif %}
 
                 {% if user.roles is not empty %}

--- a/webapp/tests/Functional/FunctionalTestCase.php
+++ b/webapp/tests/Functional/FunctionalTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Functional;
 
+use Facebook\WebDriver\Exception\PhpWebDriverExceptionInterface;
 use Symfony\Component\Panther\Client as PantherClient;
 use Symfony\Component\Panther\PantherTestCase;
 
@@ -50,7 +51,59 @@ abstract class FunctionalTestCase extends PantherTestCase
      */
     private const REQUEST_TIMEOUT_MS = 30000;
 
+    /**
+     * Hányszor próbáljuk meg elindítani a böngészőt.
+     *
+     * A 2026-08-27-i master-futásban a suite ELSŐ munkamenete hasalt el
+     * `Operation timed out after 30002 milliseconds with 0 bytes received`-del, a
+     * mögötte lévő 79 teszt viszont hibátlanul lefutott. Vagyis nem a korlát szűk és nem
+     * az alkalmazás lassú: a chromedriver hidegindítása csúszott át a 30 másodpercen a
+     * futtatón.
+     *
+     * A korlát emelése rossz válasz lenne — pont azért 30 másodperc, hogy egy VALÓDI
+     * beakadás gyorsan és beszédesen bukjon el (l. a REQUEST_TIMEOUT_MS indoklását).
+     * Egyetlen újrapróbálkozás viszont pont a hidegindítást fedi le: a legrosszabb eset
+     * 60 másodperc, ami még mindig töredéke a lépés korlátjának.
+     */
+    private const INDITASI_PROBALKOZASOK = 2;
+
     protected static function pantherClient(array $options = []): PantherClient
+    {
+        $utolsoHiba = null;
+
+        for ($probalkozas = 1; $probalkozas <= self::INDITASI_PROBALKOZASOK; $probalkozas++) {
+            try {
+                return static::klienstIndit($options);
+            } catch (\Throwable $hiba) {
+                // Csak a WebDriver felől jövő indulási hibát próbáljuk újra. Bármi más
+                // (rossz opció, hiányzó bináris) azonnal szálljon el — azon az
+                // újrapróbálkozás nem segít, csak elfedi.
+                if (!$hiba instanceof PhpWebDriverExceptionInterface) {
+                    throw $hiba;
+                }
+
+                $utolsoHiba = $hiba;
+
+                // Látszódjon a naplóban: ha ez sűrűsödik, a futtatóval van baj, és azt
+                // egy néma újrapróbálkozás elrejtené.
+                fwrite(STDERR, sprintf(
+                    "\n[panther] a böngésző indítása nem sikerült (%d/%d): %s\n",
+                    $probalkozas,
+                    self::INDITASI_PROBALKOZASOK,
+                    explode("\n", $hiba->getMessage())[0]
+                ));
+
+                if ($probalkozas < self::INDITASI_PROBALKOZASOK) {
+                    // Egy másodperc, hogy a félbemaradt chromedriver elengedje a portját.
+                    sleep(1);
+                }
+            }
+        }
+
+        throw $utolsoHiba;
+    }
+
+    private static function klienstIndit(array $options): PantherClient
     {
         return static::createPantherClient(
             array_merge([

--- a/webapp/tests/Integration/BoundaryFreshnessTest.php
+++ b/webapp/tests/Integration/BoundaryFreshnessTest.php
@@ -181,4 +181,25 @@ final class BoundaryFreshnessTest extends TestCase {
         self::assertGreaterThan(1, count(array_unique($belyegek)),
             'a belyegeknek szet kell szorodniuk, kulonben egyszerre jar le mind');
     }
+
+    /**
+     * #890: a bélyeg horgonya a PHP órája, NEM a MySQL `NOW()`-ja.
+     *
+     * A fenti teszt ezt csak szakaszosan fogta meg: a MySQL órájára horgonyzott bélyeg
+     * akkor kerül a jövőbe, ha a `FLOOR(RAND() * $napok)` épp nullát húz — negyven
+     * templomnál nagyjából minden ötödik futásban. A master emiatt volt hol zöld, hol
+     * piros, ugyanarra a kódra.
+     *
+     * A kifejezés viszont determinisztikusan megnézhető, tehát ez az eset MINDIG szól.
+     */
+    public function testTheBackfillStampIsAnchoredToThePhpClock(): void {
+        $kifejezes = \Crons::backfillBelyegKifejezes('2026-08-27 09:15:00', 180);
+
+        self::assertStringContainsString("'2026-08-27 09:15:00'", $kifejezes,
+            'a horgonynak a kapott, PHP-ből jövő időpontnak kell lennie');
+        self::assertStringNotContainsString('NOW()', $kifejezes,
+            'a MySQL órája három órával előrébb jár a PHP-énál (#890) — nem keverhetjük');
+        self::assertStringContainsString('RAND()', $kifejezes,
+            'a szórás soronként kell, különben egyszerre jár le minden bélyeg');
+    }
 }

--- a/webapp/tests/Integration/ChurchCreateFormTest.php
+++ b/webapp/tests/Integration/ChurchCreateFormTest.php
@@ -18,13 +18,11 @@ class ChurchCreateFormTest extends TestCase {
 
     private const NEV_ELOTAG = 'Létrehozás teszt ';
 
-    private string $baseUrl;
-    private ?string $cookie = null;
+    private CsrfFormClient $client;
 
     protected function setUp(): void {
-        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
-        $this->login();
-        if ($this->cookie === null) {
+        $this->client = new CsrfFormClient();
+        if (!$this->client->login('admin', 'miserend')) {
             $this->markTestSkipped('Nem sikerült adminisztrátorként bejelentkezni.');
         }
     }
@@ -33,35 +31,18 @@ class ChurchCreateFormTest extends TestCase {
         DB::table('templomok')->where('nev', 'LIKE', self::NEV_ELOTAG . '%')->delete();
     }
 
-    private function login(): void {
-        $ctx = stream_context_create(['http' => [
-            'method'        => 'POST',
-            'header'        => "Content-Type: application/x-www-form-urlencoded\r\n",
-            'content'       => http_build_query(['login' => 'admin', 'passw' => 'miserend', 'logout' => 'false']),
-            'timeout'       => 30,
-            'ignore_errors' => true,
-        ]]);
-        @file_get_contents($this->baseUrl . '/', false, $ctx);
-        foreach ($http_response_header ?? [] as $h) {
-            if (stripos($h, 'Set-Cookie:') === 0 && stripos($h, 'token=') !== false) {
-                $this->cookie = trim(explode(';', substr($h, 11))[0]);
-            }
-        }
-    }
-
+    /**
+     * #873: a beküldés a CsrfFormClient-en át megy, ami úgy viselkedik, mint a böngésző:
+     * betölti az űrlap oldalát, elteszi a `csrf` sütit, és a POST-hoz mellékeli a lapról
+     * kiolvasott tokent.
+     *
+     * Ez a teszt eredetileg nyers POST-tal készült — a #880 (CSRF) és a #899 (ez a
+     * folyamat) párhuzamosan futott, és külön-külön mindkettő zöld volt. Együtt viszont
+     * az őr nyelte el a beküldést, és a master lett tőle piros. Ezért van külön eset is
+     * arra, hogy token NÉLKÜL tényleg nem megy át semmi.
+     */
     private function post(array $fields): string {
-        $header = "Content-Type: application/x-www-form-urlencoded\r\n";
-        if ($this->cookie) {
-            $header .= 'Cookie: ' . $this->cookie . "\r\n";
-        }
-        $ctx = stream_context_create(['http' => [
-            'method' => 'POST', 'header' => $header,
-            'content' => http_build_query($fields), 'timeout' => 60, 'ignore_errors' => true,
-        ]]);
-        $body = @file_get_contents($this->baseUrl . '/church/create', false, $ctx);
-        $this->assertNotFalse($body, 'A kérés nem sikerült.');
-
-        return $body;
+        return $this->client->post('/church/create', $fields, true, '/church/create');
     }
 
     private function mezok(string $nev, array $override = []): array {
@@ -166,6 +147,20 @@ class ChurchCreateFormTest extends TestCase {
         self::assertNotNull($sor);
         self::assertSame('123456', (string) $sor->osmid);
         self::assertSame('node', (string) $sor->osmtype);
+    }
+
+    /**
+     * #873/#899: token nélkül NEM jöhet létre templom.
+     *
+     * Ez az eset azért van itt, mert pont ennek a hiánya vitte pirosba a mastert: a
+     * teszt nyers POST-tal ment, és amikor a CSRF-őr bekerült a `create.php`-be, minden
+     * eset elhasalt. Innentől ha valaki leveszi az őrt, ez szól.
+     */
+    public function testAPostWithoutATokenIsRejected(): void {
+        $valasz = $this->client->post('/church/create', $this->mezok('token-nélkül'), false);
+
+        self::assertNull($this->sor('token-nélkül'), 'token nélkül nem jöhet létre templom');
+        self::assertStringContainsString('biztonsági token', $valasz);
     }
 
     /** OSM-azonosító nélkül is létre KELL jönnie — csak letiltva. */

--- a/webapp/tests/Integration/ChurchCreateFormTest.php
+++ b/webapp/tests/Integration/ChurchCreateFormTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #898: az új misézőhely felvitele.
+ *
+ * borazslo az első pontban ezt írja: „Aránylag ritkán van rá szükség, így elég könnyű
+ * eltörni a folyamatot, mert nincsenek tesztek hogy minden rendben működik-e." Ez a
+ * fájl az a teszt.
+ *
+ * Valódi HTTP-hívások bejelentkezett adminisztrátorként — a `ChurchEditFormTest`
+ * mintájára, mert az űrlap feldolgozása a `Request`-en és a session-ön múlik, azt pedig
+ * kívülről érdemes megfogni.
+ */
+class ChurchCreateFormTest extends TestCase {
+
+    private const NEV_ELOTAG = 'Létrehozás teszt ';
+
+    private string $baseUrl;
+    private ?string $cookie = null;
+
+    protected function setUp(): void {
+        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
+        $this->login();
+        if ($this->cookie === null) {
+            $this->markTestSkipped('Nem sikerült adminisztrátorként bejelentkezni.');
+        }
+    }
+
+    protected function tearDown(): void {
+        DB::table('templomok')->where('nev', 'LIKE', self::NEV_ELOTAG . '%')->delete();
+    }
+
+    private function login(): void {
+        $ctx = stream_context_create(['http' => [
+            'method'        => 'POST',
+            'header'        => "Content-Type: application/x-www-form-urlencoded\r\n",
+            'content'       => http_build_query(['login' => 'admin', 'passw' => 'miserend', 'logout' => 'false']),
+            'timeout'       => 30,
+            'ignore_errors' => true,
+        ]]);
+        @file_get_contents($this->baseUrl . '/', false, $ctx);
+        foreach ($http_response_header ?? [] as $h) {
+            if (stripos($h, 'Set-Cookie:') === 0 && stripos($h, 'token=') !== false) {
+                $this->cookie = trim(explode(';', substr($h, 11))[0]);
+            }
+        }
+    }
+
+    private function post(array $fields): string {
+        $header = "Content-Type: application/x-www-form-urlencoded\r\n";
+        if ($this->cookie) {
+            $header .= 'Cookie: ' . $this->cookie . "\r\n";
+        }
+        $ctx = stream_context_create(['http' => [
+            'method' => 'POST', 'header' => $header,
+            'content' => http_build_query($fields), 'timeout' => 60, 'ignore_errors' => true,
+        ]]);
+        $body = @file_get_contents($this->baseUrl . '/church/create', false, $ctx);
+        $this->assertNotFalse($body, 'A kérés nem sikerült.');
+
+        return $body;
+    }
+
+    private function mezok(string $nev, array $override = []): array {
+        return array_merge([
+            'submit'          => 'Létrehozás',
+            'church[nev]'     => self::NEV_ELOTAG . $nev,
+            'church[lat]'     => '47.5',
+            'church[lon]'     => '19.0',
+        ], $override);
+    }
+
+    private function sor(string $nev) {
+        return DB::table('templomok')->where('nev', self::NEV_ELOTAG . $nev)->first();
+    }
+
+    /**
+     * A LÉNYEG: tizedesVESSZŐVEL is működik.
+     *
+     * A magyar számformátumban a tizedesjel a vessző, és a felhasználók így írják be. A
+     * régi kód az `is_numeric()`-re épülő `FloatRequired()`-del ezt elutasította, méghozzá
+     * `Required 'church[lat]' is not a Float.` szöveggel — abból nem derül ki, mit kell
+     * másképp csinálni.
+     */
+    public function testACommaIsAcceptedAsDecimalSeparator(): void {
+        $this->post($this->mezok('vessző', [
+            'church[lat]' => '47,4979',
+            'church[lon]' => '19,0402',
+        ]));
+
+        $sor = $this->sor('vessző');
+        self::assertNotNull($sor, 'a tizedesvesszős koordinátával is létre kell jönnie');
+        self::assertEqualsWithDelta(47.4979, (float) $sor->lat, 0.00001);
+        self::assertEqualsWithDelta(19.0402, (float) $sor->lon, 0.00001);
+    }
+
+    /**
+     * #898: az űrlapon ott a megjegyzés-mező, de a mentés nem olvasta.
+     *
+     * Nem elég a `Church::create()` tömbjébe betenni: az `adminmegj` nincs a
+     * `$fillable`-ben, tehát a tömeges értékadás CSENDBEN eldobja. Kimértem — a templom
+     * létrejön, a megjegyzés helye üres.
+     */
+    public function testTheAdminNoteIsSaved(): void {
+        $this->post($this->mezok('megjegyzés', [
+            'church[adminmegj]' => 'Ezt a szerkesztő írta be.',
+        ]));
+
+        $sor = $this->sor('megjegyzés');
+        self::assertNotNull($sor);
+        self::assertStringContainsString('Ezt a szerkesztő írta be.', (string) $sor->adminmegj);
+    }
+
+    /** Felcserélt szélesség/hosszúság: gyakori hiba, és a térkép túloldalán kötne ki. */
+    public function testAnOutOfRangeLatitudeIsRejected(): void {
+        $valasz = $this->post($this->mezok('tartomány', [
+            'church[lat]' => '190',
+            'church[lon]' => '19',
+        ]));
+
+        self::assertNull($this->sor('tartomány'), 'érvénytelen koordinátával nem jöhet létre templom');
+        self::assertStringContainsString('szélességi fok', $valasz);
+        self::assertStringContainsString('felcserélve', $valasz);
+    }
+
+    /** Ami egyáltalán nem szám, arra érthető mondat jár, nem belső hibaszöveg. */
+    public function testANonNumericCoordinateGetsAReadableMessage(): void {
+        $valasz = $this->post($this->mezok('szöveg', [
+            'church[lat]' => 'valahol Hajdúnánáson',
+        ]));
+
+        self::assertNull($this->sor('szöveg'));
+        self::assertStringContainsString('nem szám', $valasz);
+        self::assertStringNotContainsString('is not a Float', $valasz);
+    }
+
+    public function testAMissingCoordinateGetsAReadableMessage(): void {
+        $valasz = $this->post($this->mezok('hiányzó', ['church[lat]' => '']));
+
+        self::assertNull($this->sor('hiányzó'));
+        self::assertStringContainsString('Hiányzik a szélességi fok', $valasz);
+    }
+
+    /**
+     * Fél OSM-azonosító nem ér semmit: az `OSM::updateChurch()` az
+     * `empty($osmtype) OR empty($osmid)` ágon kihagyja, a templom viszont úgy néz ki,
+     * mintha kötve lenne.
+     */
+    public function testAHalfOsmIdentifierIsRejected(): void {
+        $valasz = $this->post($this->mezok('fél-osm', ['church[osmid]' => '123456']));
+
+        self::assertNull($this->sor('fél-osm'));
+        self::assertStringContainsString('OSM azonosítóhoz', $valasz);
+    }
+
+    public function testACompleteOsmIdentifierIsStored(): void {
+        $this->post($this->mezok('teljes-osm', [
+            'church[osmid]'   => '123456',
+            'church[osmtype]' => 'node',
+        ]));
+
+        $sor = $this->sor('teljes-osm');
+        self::assertNotNull($sor);
+        self::assertSame('123456', (string) $sor->osmid);
+        self::assertSame('node', (string) $sor->osmtype);
+    }
+
+    /** OSM-azonosító nélkül is létre KELL jönnie — csak letiltva. */
+    public function testAChurchCanBeCreatedWithoutAnOsmLink(): void {
+        $this->post($this->mezok('osm-nélkül'));
+
+        $sor = $this->sor('osm-nélkül');
+        self::assertNotNull($sor, 'OSM-azonosító nélkül is létre kell jönnie');
+        self::assertSame('n', (string) $sor->ok, 'a friss templom még nem engedélyezett');
+    }
+}

--- a/webapp/tests/Integration/ChurchCreateFormTest.php
+++ b/webapp/tests/Integration/ChurchCreateFormTest.php
@@ -163,12 +163,19 @@ class ChurchCreateFormTest extends TestCase {
         self::assertStringContainsString('biztonsági token', $valasz);
     }
 
-    /** OSM-azonosító nélkül is létre KELL jönnie — csak letiltva. */
+    /**
+     * OSM-azonosító nélkül is létre KELL jönnie — és „áttekintésre vár" állapotban.
+     *
+     * #908: eddig `n` („nem engedélyezett") lett belőle, ami egy elutasított templom
+     * állapota. borazslo szerint (#898) egy épp most felvitt misézőhelynél ez nem jó. Az
+     * `f` a nyilvánosságon nem változtat — a listák `ok = 'i'`-re szűrnek —, csak azt
+     * mondja meg helyesen, hogy miért nincs kint.
+     */
     public function testAChurchCanBeCreatedWithoutAnOsmLink(): void {
         $this->post($this->mezok('osm-nélkül'));
 
         $sor = $this->sor('osm-nélkül');
         self::assertNotNull($sor, 'OSM-azonosító nélkül is létre kell jönnie');
-        self::assertSame('n', (string) $sor->ok, 'a friss templom még nem engedélyezett');
+        self::assertSame('f', (string) $sor->ok, 'áttekintésre vár, nem letiltva');
     }
 }

--- a/webapp/tests/Integration/NotificationDigestTest.php
+++ b/webapp/tests/Integration/NotificationDigestTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #872: napi/heti összefoglaló az esemény-értesítőkből.
+ *
+ * borazslo mérése az éles adatbázison (30 nap): a legterheltebb címek 157-162 értesítőt
+ * kaptak, a legrosszabb napokon 21-et EGYETLEN nap alatt, és 41 felhasználó már ki is
+ * kapcsolta az értesítést. A döntése: „Legyen rögtön a B (azonnal / napi / heti), és
+ * persze mindenki napira állítva."
+ *
+ * Amit ez a teszt rögzít: a halasztás nem veszít el értesítést, csak összevonja — és
+ * aki az azonnalit választja, annak semmi nem változik.
+ */
+final class NotificationDigestTest extends TestCase {
+
+    private int $uid;
+    private int $churchId;
+
+    protected function setUp(): void {
+        DB::beginTransaction();
+
+        $this->uid = (int) DB::table('user')->insertGetId([
+            'login' => 'digest' . bin2hex(random_bytes(3)),
+            'nev' => 'Digest Teszt',
+            'email' => 'digest' . bin2hex(random_bytes(3)) . '@example.invalid',
+            'jelszo' => 'x',
+            'notifications' => 1,
+            'notification_frequency' => 'daily',
+        ]);
+
+        $this->churchId = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Digest teszt templom', 'ok' => 'i', 'lat' => 47.0, 'lon' => 19.0,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+    }
+
+    private function cimzett(string $gyakorisag = 'daily'): stdClass {
+        DB::table('user')->where('uid', $this->uid)->update(['notification_frequency' => $gyakorisag]);
+
+        return DB::table('user')->where('uid', $this->uid)->first();
+    }
+
+    private function tetelek(): int {
+        return DB::table('notification_digest_items')->where('uid', $this->uid)->count();
+    }
+
+    /**
+     * A NEKÜNK szóló összefoglalók száma.
+     *
+     * A `sendDue()` szándékosan MINDENKINEK kiküldi az esedékes listáját, tehát a
+     * suite többi tesztje által keltett tételek is kimennek. Globális darabszámot
+     * számolni ezért félrevezető lenne — a saját címünkre szűkítünk.
+     */
+    private function nekemSzoloDigestek(): int {
+        return DB::table('emails')
+            ->where('type', 'user_digest')
+            ->where('to', DB::table('user')->where('uid', $this->uid)->value('email'))
+            ->count();
+    }
+
+    /** Az alapérték napi — a meglévő felhasználókra is, oszlop-alapértékkel. */
+    public function testTheDefaultIsTheDailyDigest(): void {
+        $user = DB::table('user')->where('uid', $this->uid)->first();
+
+        self::assertSame('daily', $user->notification_frequency);
+        self::assertSame('daily', \DigestQueue::gyakorisag($user));
+    }
+
+    /** A LÉNYEG: napi beállításnál nem megy külön levél, hanem sor kerül a listára. */
+    public function testWithTheDailySettingTheNotificationIsQueued(): void {
+        $halasztva = \DigestQueue::halaszt(
+            $this->cimzett('daily'), 'remark', $this->churchId, 'Rossz a miserend', '/templom/1/eszrevetelek');
+
+        self::assertTrue($halasztva, 'a hivonak NEM szabad azonnal kuldenie');
+        self::assertSame(1, $this->tetelek());
+    }
+
+    /** Aki az azonnalit választja, annál semmi nem változik. */
+    public function testWithTheInstantSettingNothingChanges(): void {
+        $halasztva = \DigestQueue::halaszt(
+            $this->cimzett('instant'), 'remark', $this->churchId, 'Rossz a miserend', '/x');
+
+        self::assertFalse($halasztva, 'azonnali beallitasnal a hivo kuld');
+        self::assertSame(0, $this->tetelek());
+    }
+
+    /**
+     * Akit nem tudunk azonosítani, annak inkább menjen a levél.
+     *
+     * Az összefoglaló felhasználóhoz kötött; uid nélkül nincs kihez kötni. Ilyenkor a
+     * régi, azonnali út a helyes válasz — az értesítés elvesztése sokkal rosszabb, mint
+     * egy fölös levél.
+     */
+    public function testAnUnidentifiableRecipientIsNotQueued(): void {
+        $nevtelen = (object) ['email' => 'valaki@example.invalid'];
+
+        self::assertFalse(\DigestQueue::halaszt($nevtelen, 'remark', $this->churchId, 'x', '/x'));
+    }
+
+    /** Ismeretlen gyakoriság-érték: napi. Nem veszíthet el értesítést, csak késleltet. */
+    public function testAnUnknownFrequencyFallsBackToDaily(): void {
+        self::assertSame('daily', \DigestQueue::gyakorisag((object) ['notification_frequency' => 'sohanapjan']));
+        self::assertSame('daily', \DigestQueue::gyakorisag((object) []));
+    }
+
+    /** A napi összefoglaló kimegy, és a tételek elkeltnek. */
+    public function testTheDailyDigestIsSentAndTheItemsAreMarked(): void {
+        \DigestQueue::halaszt($this->cimzett('daily'), 'remark', $this->churchId, 'Első', '/a');
+        \DigestQueue::halaszt($this->cimzett('daily'), 'image', $this->churchId, 'Második', '/b');
+
+        $elotte = $this->nekemSzoloDigestek();
+        \DigestQueue::sendDue();
+
+        self::assertSame($elotte + 1, $this->nekemSzoloDigestek(),
+            'ket esemenyre EGY levelet varunk');
+        self::assertSame(0, DB::table('notification_digest_items')
+            ->where('uid', $this->uid)->whereNull('sent_at')->count());
+    }
+
+    /** A levél mindkét eseményt felsorolja — az összevonás nem veszíthet el semmit. */
+    public function testTheDigestListsEveryEvent(): void {
+        \DigestQueue::halaszt($this->cimzett('daily'), 'remark', $this->churchId, 'Elveszett mise', '/a');
+        \DigestQueue::halaszt($this->cimzett('daily'), 'image', $this->churchId, 'Új fotó a toronyról', '/b');
+
+        \DigestQueue::sendDue();
+
+        $level = DB::table('emails')
+            ->where('type', 'user_digest')
+            ->where('to', DB::table('user')->where('uid', $this->uid)->value('email'))
+            ->orderByDesc('id')->first();
+
+        self::assertNotNull($level);
+        self::assertStringContainsString('Elveszett mise', $level->body);
+        self::assertStringContainsString('Új fotó a toronyról', $level->body);
+        self::assertStringContainsString('Digest teszt templom', $level->body);
+        self::assertStringContainsString('2 újdonság', $level->subject);
+    }
+
+    /** Aki közben kikapcsolta az értesítést, annak a felgyűlt lista sem megy ki. */
+    public function testASwitchedOffUserGetsNothing(): void {
+        \DigestQueue::halaszt($this->cimzett('daily'), 'remark', $this->churchId, 'x', '/a');
+        DB::table('user')->where('uid', $this->uid)->update(['notifications' => 0]);
+
+        $elotte = $this->nekemSzoloDigestek();
+        \DigestQueue::sendDue();
+
+        self::assertSame($elotte, $this->nekemSzoloDigestek());
+        self::assertSame(1, DB::table('notification_digest_items')
+            ->where('uid', $this->uid)->whereNull('sent_at')->count(), 'a tetel varakozzon tovabb');
+    }
+
+    /** A heti összefoglaló a hét megadott napján megy. */
+    public function testTheWeeklyDigestGoesOnTheChosenDay(): void {
+        $ma = date('Y-m-d H:i:s');
+
+        self::assertTrue(\DigestQueue::hetiEsedekes(\DigestQueue::HETI_NAP, $ma));
+        self::assertFalse(\DigestQueue::hetiEsedekes(\DigestQueue::HETI_NAP + 1, $ma));
+        self::assertFalse(\DigestQueue::hetiEsedekes(\DigestQueue::HETI_NAP + 3, $ma));
+    }
+
+    /**
+     * ...de egy kimaradt futás nem tolhatja a következő hétre.
+     *
+     * Enélkül egyetlen elmaradt hétfő azt jelentené, hogy a gondnok két hétig nem tud a
+     * hozzá érkezett észrevételről.
+     */
+    public function testAnOldItemGoesOutEvenOffDay(): void {
+        $regi = date('Y-m-d H:i:s', strtotime('-8 days'));
+
+        self::assertTrue(\DigestQueue::hetiEsedekes(\DigestQueue::HETI_NAP + 2, $regi));
+    }
+
+    /** A cím levágva, HTML nélkül kerül a listára — a levélben egy sor lesz belőle. */
+    public function testTheTitleIsStrippedAndTruncated(): void {
+        \DigestQueue::halaszt($this->cimzett('daily'), 'remark', $this->churchId,
+            '<b>Kalap</b> ' . str_repeat('a', 400), '/a');
+
+        $tetel = DB::table('notification_digest_items')->where('uid', $this->uid)->first();
+
+        self::assertStringStartsWith('Kalap a', $tetel->title);
+        self::assertLessThanOrEqual(250, mb_strlen($tetel->title));
+    }
+}


### PR DESCRIPTION
# Master beolvasztása production-be

## Biztonsági fejlesztések

### CSRF-védelem: POST + token minden állapotváltáshoz (#873)
- Az állapotváltások mostantól POST-en mennek, nem GET-en
- Token-alapú CSRF-védelem minden írási végponton
- 17 írási belépési pont kapott őrt
- GET-linkes műveletek (gondnokság kiosztása/visszavonása, felhasználó törlése, kilépés) POST-űrlapok lettek
- Az AJAX-hívások automatikusan kapják meg a CSRF-tokent a csrf.js-ből
- A belépés szándékosan marad GET-en is elérhető (elfelejtett-jelszó levél miatt)

## Kategória-felismerés fejlesztések

### Egy helyre teszem a kategória-szótárt (#896)
- A kategória-szótár mostantól a mass-definitions.ts fájlban van (korábban PHP-osztályban volt)
- Az Angular build exportálja a JSON-ba, így mindkét oldal ugyanazt a szabályt futtatja
- Javított pontosság: besorolatlan sorok 61-ről 43-ra csökkentek
- Az illesztés szó elején keres, szóösszetételeknek saját alak kell

### Keresztelő, esküvő, temetés: egyéb, de nem választható cím (#896)
- Ezek az események csak importból kerülnek be
- A keresőben az "egyéb" kategóriában jelennek meg
- A szerkesztő felületen nem választhatók (kategória-szintű alias)
- Besorolatlan sorok 43-ról 26-ra csökkentek

### Templomonkénti bontás a kategória-felismeréshez (#895)
- Új szkript a kategória-felismerés pontosságának mérésére
- Templomonként bontva mutatja az eredményeket
- A --unknown flag a besorolatlan címeket listázza templomonként

## Gyóntatás-esemény hossz javítások

### Két óra a gyóntatás — a kirajzolt eseményre és az élő jelzőre is (#884)
- Az élő állapot jelzője mostantól 2 órás ablakkal dolgozik (korábban 20 óra volt)
- A megjelenített gyóntatás-szakaszok maximális hossza 2 óra
- Az érték mostantól egy konstansból jön, nem három helyen beégetve
- Teszt őrzi, hogy ne lehessen visszacsempészni az értéket

### A jelző is két óra, és a tolerancia egy helyen (#884)
- Az élő állapot jelzője és a megjelenített szakasz hossza most szinkronban van
- Két külön konstans marad (élő állapot vs. megjelenített esemény)

### Két óra a leghosszabb megjelenített gyóntatás (#884)
- A le nem zárt szakaszokat 2 órára vágja vissza a megjelenítéshez
- A valóban folyamatban lévő, ennél rövidebb szakaszok érintetlen maradnak
- A gyóntatás-panel szakasz-listája eltávolítva (a naptár mutatja a múltat)

## Képfeltöltés javítások

### Írható könyvtár a képfeltöltésnél (#893)
- Jobb hibaüzenetek, ha a könyvtár nem írható
- A kicsi/ könyvtár mostantól akkor is elkészül, ha a templom könyvtára már megvolt
- A GD visszatérési értékét ellenőrzi a képfeltöltés
- Részletes naplózás: útvonal, tulajdonos, mód, futó uid
- Stack trace eltávolítva a hibaválaszból
- Új eszköz: tools/photo-dir-check.php az érintett könyvtárak felderítéséhez

## LoRaWAN gyóntatás-végpont javítások

### A LoRaWAN gyóntatás-végpont négy hibája (#866)
- Importkor döntöm el, hogy gyóntatás-e — oszlop nélkül
- A vízszivárgás-jelzés (Mód 2) mostantól nem kerül a confessions táblába
- Nincs szükség új oszlopra vagy éles migrációra
- A jelzést a naplóba írjuk, de nem tároljuk

## CI/CD fejlesztések

### Megadom a release-jogot a heti Elasticsearch-workflow-nak (#886)
- A GitHub Actions workflow mostantól contents: write jogot kap
- A heti pillanatképek mostantól helyesen taghez köthetők

### Platform jelölő törlése a Docker compose-ból a mysql konténernél (#879)
- A mysql konténer platform specifikációja eltávolítva a docker-compose.yml-ből

## Értesítési fejlesztések

### Napi/heti összefoglaló az esemény-értesítőkből (#872)
- Választható értesítési gyakoriság: azonnal / napi / heti
- Az alapérték a napi összefoglaló
- Csak az esemény-értesítőkre vonatkozik (új észrevétel, javaslat, kép)
- Az emlékeztetők nem érintett
- Az összefoglaló templomonként csoportosított egyetlen levél
- A heti értesítés a hét első napján megy, még akkor is, ha egy futás kimaradt

## Új misézőhely felvitel javítások

### Használhatóvá teszem az új misézőhely felvitelét (#898)
- A koordináta-beviteli mezőkre kötött input esemény helyett gépelés után dolgozunk
- Csak érvényes koordinátákra indulnak Overpass-lekérdezések (korábban minden leütésre)
- Tizedesvesszőt is elfogad (magyar billentyűzet)
- Új helykeresőt adtam hozzá (Nominatim alapú, cache-elt)
- Az adminisztrátori megjegyzés mostantól mentésre kerül (Church $fillable-be felvéve)
- Nyolc új teszt a folyamatra

## Deployment megjegyzések

⚠️ **Adatbázis változások:**
- Nincs szükség új migrációra
- A confessions tábla szerkezete nem változik
- Az device_mode oszlop nem kerül be

⚠️ **Fájlrendszer:**
- Ellenőrizze a képfeltöltési könyvtárak írhatóságát: php tools/photo-dir-check.php

⚠️ **Frontend:**
- Az Angular build exportálja az új kategória-szótárt
- A CSRF-token automatikusan bekerül az AJAX-hívásokba
- Az új misézőhely felvitel UI frissítve

⚠️ **Tesztelés:**
- A CSRF-védelem miatt az összes POST-végpont tesztelendő
- A gyóntatás-esemény hossza 2 órára korlátozódik
- Az értesítési gyakoriság beállítása tesztelendő
- Az új misézőhely felvitel koordináta-bevitele tesztelendő
