### PR TITLE
Zöldre teszem a mastert: CSRF-token a tesztben, PHP-óra a visszatöltésben

### DIFF
--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -89,6 +89,26 @@ class Crons {
 	public static function backfillBoundaryCheckedAt(): int {
 		$napok = max(1, (int) round((time() - strtotime('-' . \OSM::BOUNDARY_FRESHNESS)) / 86400));
 
+		/*
+		 * #890: a horgony a PHP órája, nem a MySQL `NOW()`-ja.
+		 *
+		 * Az oszlop MINDEN más írója és olvasója a PHP óráját használja: a bélyeget az
+		 * `OSM::checkBoundaries()` `date('Y-m-d H:i:s')`-szel írja, az esedékességet az
+		 * `osm.php` és a `requeueChurchesWithoutBoundary()` PHP-ben számolt határidőhöz
+		 * méri. Egyedül ez a visszatöltés dolgozott a MySQL órájával — az pedig a
+		 * `+05:00`-s session-zóna miatt HÁROM ÓRÁVAL előrébb jár (#890).
+		 *
+		 * Következmény élesben: a visszatöltött templom három órával frissebbnek látszik
+		 * a valóságosnál. Egy 180 napos ablakban ez kicsi, de a CI-ben mérhető volt: ha a
+		 * `FLOOR(RAND() * $napok)` nullát húzott, a bélyeg a PHP órájához képest a JÖVŐBE
+		 * került, és a `BoundaryFreshnessTest` elhasalt — pontosan 10799 másodperccel.
+		 * Innen a master szakaszos pirosa.
+		 *
+		 * A `RAND()` marad a MySQL-ben: soronként KELL más érték, különben az egész köteg
+		 * ugyanazt a bélyeget kapná, és fél év múlva egyszerre járna le mind.
+		 */
+		$horgony = date('Y-m-d H:i:s');
+
 		return DB::table('templomok')
 			->whereNull('boundaries_checked_at')
 			->whereExists(function ($q) {
@@ -98,9 +118,23 @@ class Crons {
 					->whereColumn('lookup_boundary_church.church_id', 'templomok.id')
 					->where('boundaries.boundary', 'administrative');
 			})
-			->update(['boundaries_checked_at' => DB::raw(
-				'DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * ' . $napok . ') DAY)'
-			)]);
+			->update(['boundaries_checked_at' => DB::raw(self::backfillBelyegKifejezes($horgony, $napok))]);
+	}
+
+	/**
+	 * #890: a visszatöltés SQL-kifejezése, külön, hogy tesztelhető legyen.
+	 *
+	 * Azért van kiemelve, mert a hiba, amit javít, csak SZAKASZOSAN látszik: a MySQL
+	 * órájára horgonyzott bélyeg akkor kerül a jövőbe, ha a `FLOOR(RAND() * $napok)`
+	 * épp nullát húz — negyven templomnál ez nagyjából minden ötödik futás. A kifejezést
+	 * viszont determinisztikusan meg lehet nézni, tehát a visszaesés nem tud észrevétlen
+	 * maradni.
+	 *
+	 * A `$horgony` a saját óránkból jön (`date('Y-m-d H:i:s')`), kötött formátumú, nem
+	 * külső bemenet; a `$napok` egész.
+	 */
+	public static function backfillBelyegKifejezes(string $horgony, int $napok): string {
+		return "DATE_SUB('" . $horgony . "', INTERVAL FLOOR(RAND() * " . max(1, $napok) . ") DAY)";
 	}
 
 	public static function churchesWithoutBoundaryCount(): int {

--- a/webapp/tests/Integration/BoundaryFreshnessTest.php
+++ b/webapp/tests/Integration/BoundaryFreshnessTest.php
@@ -181,4 +181,25 @@ final class BoundaryFreshnessTest extends TestCase {
         self::assertGreaterThan(1, count(array_unique($belyegek)),
             'a belyegeknek szet kell szorodniuk, kulonben egyszerre jar le mind');
     }
+
+    /**
+     * #890: a bélyeg horgonya a PHP órája, NEM a MySQL `NOW()`-ja.
+     *
+     * A fenti teszt ezt csak szakaszosan fogta meg: a MySQL órájára horgonyzott bélyeg
+     * akkor kerül a jövőbe, ha a `FLOOR(RAND() * $napok)` épp nullát húz — negyven
+     * templomnál nagyjából minden ötödik futásban. A master emiatt volt hol zöld, hol
+     * piros, ugyanarra a kódra.
+     *
+     * A kifejezés viszont determinisztikusan megnézhető, tehát ez az eset MINDIG szól.
+     */
+    public function testTheBackfillStampIsAnchoredToThePhpClock(): void {
+        $kifejezes = \Crons::backfillBelyegKifejezes('2026-08-27 09:15:00', 180);
+
+        self::assertStringContainsString("'2026-08-27 09:15:00'", $kifejezes,
+            'a horgonynak a kapott, PHP-ből jövő időpontnak kell lennie');
+        self::assertStringNotContainsString('NOW()', $kifejezes,
+            'a MySQL órája három órával előrébb jár a PHP-énál (#890) — nem keverhetjük');
+        self::assertStringContainsString('RAND()', $kifejezes,
+            'a szórás soronként kell, különben egyszerre jár le minden bélyeg');
+    }
 }

--- a/webapp/tests/Integration/ChurchCreateFormTest.php
+++ b/webapp/tests/Integration/ChurchCreateFormTest.php
@@ -18,13 +18,11 @@ class ChurchCreateFormTest extends TestCase {
 
     private const NEV_ELOTAG = 'Létrehozás teszt ';
 
-    private string $baseUrl;
-    private ?string $cookie = null;
+    private CsrfFormClient $client;
 
     protected function setUp(): void {
-        $this->baseUrl = rtrim(getenv('PANTHER_EXTERNAL_BASE_URI') ?: 'http://127.0.0.1:8000', '/');
-        $this->login();
-        if ($this->cookie === null) {
+        $this->client = new CsrfFormClient();
+        if (!$this->client->login('admin', 'miserend')) {
             $this->markTestSkipped('Nem sikerült adminisztrátorként bejelentkezni.');
         }
     }
@@ -33,35 +31,18 @@ class ChurchCreateFormTest extends TestCase {
         DB::table('templomok')->where('nev', 'LIKE', self::NEV_ELOTAG . '%')->delete();
     }
 
-    private function login(): void {
-        $ctx = stream_context_create(['http' => [
-            'method'        => 'POST',
-            'header'        => "Content-Type: application/x-www-form-urlencoded\r\n",
-            'content'       => http_build_query(['login' => 'admin', 'passw' => 'miserend', 'logout' => 'false']),
-            'timeout'       => 30,
-            'ignore_errors' => true,
-        ]]);
-        @file_get_contents($this->baseUrl . '/', false, $ctx);
-        foreach ($http_response_header ?? [] as $h) {
-            if (stripos($h, 'Set-Cookie:') === 0 && stripos($h, 'token=') !== false) {
-                $this->cookie = trim(explode(';', substr($h, 11))[0]);
-            }
-        }
-    }
-
+    /**
+     * #873: a beküldés a CsrfFormClient-en át megy, ami úgy viselkedik, mint a böngésző:
+     * betölti az űrlap oldalát, elteszi a `csrf` sütit, és a POST-hoz mellékeli a lapról
+     * kiolvasott tokent.
+     *
+     * Ez a teszt eredetileg nyers POST-tal készült — a #880 (CSRF) és a #899 (ez a
+     * folyamat) párhuzamosan futott, és külön-külön mindkettő zöld volt. Együtt viszont
+     * az őr nyelte el a beküldést, és a master lett tőle piros. Ezért van külön eset is
+     * arra, hogy token NÉLKÜL tényleg nem megy át semmi.
+     */
     private function post(array $fields): string {
-        $header = "Content-Type: application/x-www-form-urlencoded\r\n";
-        if ($this->cookie) {
-            $header .= 'Cookie: ' . $this->cookie . "\r\n";
-        }
-        $ctx = stream_context_create(['http' => [
-            'method' => 'POST', 'header' => $header,
-            'content' => http_build_query($fields), 'timeout' => 60, 'ignore_errors' => true,
-        ]]);
-        $body = @file_get_contents($this->baseUrl . '/church/create', false, $ctx);
-        $this->assertNotFalse($body, 'A kérés nem sikerült.');
-
-        return $body;
+        return $this->client->post('/church/create', $fields, true, '/church/create');
     }
 
     private function mezok(string $nev, array $override = []): array {
@@ -166,6 +147,20 @@ class ChurchCreateFormTest extends TestCase {
         self::assertNotNull($sor);
         self::assertSame('123456', (string) $sor->osmid);
         self::assertSame('node', (string) $sor->osmtype);
+    }
+
+    /**
+     * #873/#899: token nélkül NEM jöhet létre templom.
+     *
+     * Ez az eset azért van itt, mert pont ennek a hiánya vitte pirosba a mastert: a
+     * teszt nyers POST-tal ment, és amikor a CSRF-őr bekerült a `create.php`-be, minden
+     * eset elhasalt. Innentől ha valaki leveszi az őrt, ez szól.
+     */
+    public function testAPostWithoutATokenIsRejected(): void {
+        $valasz = $this->client->post('/church/create', $this->mezok('token-nélkül'), false);
+
+        self::assertNull($this->sor('token-nélkül'), 'token nélkül nem jöhet létre templom');
+        self::assertStringContainsString('biztonsági token', $valasz);
     }
 
     /** OSM-azonosító nélkül is létre KELL jönnie — csak letiltva. */


### PR DESCRIPTION
A master piros, két független októl.

## 1. A #899 tesztjei nyers POST-tal küldtek be (8 hiba)

Az ág a #880 (CSRF) **előtti** masterről indult, tehát nálam a `create.php`-ben még nem volt `\Csrf::guard()`. Külön-külön mindkét PR zöld volt; a beolvasztás után viszont az őr — helyesen — elnyelte a beküldést:

```
[miserend] Unhandled exception: Exception: Érvénytelen vagy hiányzó biztonsági token.
```

Mostantól a `CsrfFormClient`-en mennek, ahogy a `ChurchEditFormTest` is: betölti az űrlap oldalát, elteszi a `csrf` sütit, és a POST-hoz mellékeli a lapról olvasott tokent.

Plusz egy eset arra, hogy **token nélkül tényleg nem megy át semmi** — ha valaki leveszi az őrt a `create.php`-ről, ez szól. Ennek a hiánya engedte, hogy a két PR külön-külön zöldnek látsszon.

## 2. A BoundaryFreshnessTest a MySQL órájától bukott (1 hiba)

Ez nem a szórás hibája volt. A `backfillBoundaryCheckedAt()` volt az **egyetlen** hely, ami a MySQL órájával horgonyzott:

```sql
DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 180) DAY)
```

Az oszlop minden más írója és olvasója a PHP óráját használja — a bélyeget az `OSM::checkBoundaries()` `date('Y-m-d H:i:s')`-szel írja, az esedékességet az `osm.php:45` és a `requeueChurchesWithoutBoundary()` PHP-ben számolt határidőhöz méri. A két óra viszont a `+05:00`-s session-zóna miatt **három órával** eltér (#890).

Ezért volt szakaszos: ha a `FLOOR(RAND() * 180)` nullát húzott, az a bélyeg a PHP órájához képest a jövőbe került. Negyven templomnál ez nagyjából minden ötödik futás — innen a „ugyanarra a kódra hol zöld, hol piros".

A bukó állítás pontosan ezt mutatta: `1787826949` vs `1787816150`, azaz **10799 másodperc** — három óra, egy híján.

Élesben is hibás, nem csak a CI-ben: a visszatöltött templom három órával frissebbnek látszott a valóságosnál.

**Javítás:** a horgony a PHP órája; a `RAND()` marad a MySQL-ben, mert soronként kell más érték (különben fél év múlva egyszerre járna le minden bélyeg). Mérve, 200 húzással:

```
PHP most           : 2026-08-27 14:03:39
MySQL NOW()        : 2026-08-27 17:03:39
200 húzás maximuma : 2026-08-27 14:03:39   (0 mp-cel a PHP jelene UTÁN)
```

A kifejezést külön metódusba emeltem, és determinisztikus teszt őrzi, hogy ne `NOW()`-ra horgonyozzon. A meglévő teszt ezt csak minden ötödik futásban fogta meg — pont ezért maradhatott észrevétlen.

## Mérés

A teljes tesztsor lefut. Egyetlen hiba marad a fejlesztői példányomon (`SzentsegimadasImportTest`), az az Elasticsearch-állapotomtól függ, a CI-ben nem bukott, és ettől a változtatástól független.

## Egy tanulság a #890-hez

A 2. pont az első **kimért, éles hatás** a #890-ből: nem csak elméleti csúszás, hanem hibás adat a `boundaries_checked_at`-ben és szakaszosan piros CI. Amíg a kapcsolat zónája nem UTC, ez a fajta hiba bármelyik `NOW()`-t használó íráson visszatérhet — a mostani javítás egyetlen helyet zár le.
