### PR TITLE
Felső korlátot adok a deploy-jobokra (#903)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,6 +35,17 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # #903: felső korlát, mert enélkül egy beragadt futás a GitHub 6 órás
+    # alaplimitjéig fogja a `deploy-server` csoportot — és vele mindent, ami
+    # mögötte áll. 2026-08-27-én pontosan ez történt: a 07:26-os staging deploy
+    # négy órán át `in_progress` maradt (az ssh-action 40 perces
+    # `command_timeout`-ja ellenére), a mögötte várakozó KIADÁS deployja pedig
+    # törlődött. A production így a régi kódot szolgálta ki, és semmi nem szólt.
+    #
+    # 50 perc: a 40 perces parancs-korlát fölött annyi ráhagyással, hogy a
+    # kapcsolódás és a lépés-overhead is elférjen, de a blokkolás órák helyett
+    # legfeljebb egy munkamenetnyi legyen.
+    timeout-minutes: 50
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,6 +41,17 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # #903: felső korlát, mert enélkül egy beragadt futás a GitHub 6 órás
+    # alaplimitjéig fogja a `deploy-server` csoportot — és vele mindent, ami
+    # mögötte áll. 2026-08-27-én pontosan ez történt: a 07:26-os staging deploy
+    # négy órán át `in_progress` maradt (az ssh-action 40 perces
+    # `command_timeout`-ja ellenére), a mögötte várakozó KIADÁS deployja pedig
+    # törlődött. A production így a régi kódot szolgálta ki, és semmi nem szólt.
+    #
+    # 50 perc: a 40 perces parancs-korlát fölött annyi ráhagyással, hogy a
+    # kapcsolódás és a lépés-overhead is elférjen, de a blokkolás órák helyett
+    # legfeljebb egy munkamenetnyi legyen.
+    timeout-minutes: 50
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5


### PR DESCRIPTION
Closes #903

> [!IMPORTANT]
> **A CI SZÁNDÉKOSAN piros ezen a PR-en — nem ettől a változtatástól.**
>
> A 9 bukó teszt (`BoundaryFreshnessTest` + 8 `ChurchCreateFormTest`) a master jelenlegi
> állapotából jön; ez az ág onnan indult, tehát örökli. A javításuk a **#902**.
>
> Ebben a PR-ben egyetlen sor változik két workflow-fájlban (`timeout-minutes: 50`), és
> azok a fájlok PR-en nem is futnak — a deployok csak `push`-ra és kézi indításra
> indulnak. A YAML-t ellenőriztem, mindkettő értelmezhető.
>
> **Sorrend:** előbb a #902, utána itt „Re-run all jobs" — akkor zöld lesz. A teljes
> sorrend a #901-ben áll.

A #900 kiadás beolvadt a `production` ágba, a deployja viszont sosem futott le — és semmi nem szólt róla.

```
07:13:00  Deploy to production [production]  → cancelled
07:14:18  Deploy to staging    [master]      → cancelled
07:26:12  Deploy to staging    [master]      → in_progress   ← négy órán át
07:33:32  Deploy to staging    [master]      → pending
```

A 07:26-os staging deploy job-ja 07:31-kor indult, és négy óra múlva is `in_progress` volt — pedig az `ssh-action` `command_timeout`-ja 40 perc. A jobon **nem volt `timeout-minutes`**, tehát a GitHub 6 órás alaplimitjéig foghatta a közös `deploy-server` csoportot. A mögötte várakozó **kiadás** deployja pedig törlődött: a `cancel-in-progress: false` csak a futó futást védi, a várakozót a GitHub kiütteti a következővel.

Ez a PR a **blokkolót** vágja el: 50 perc felső korlát mindkét deploy jobra. A 40 perces parancs-korlát fölött annyi ráhagyás, hogy a kapcsolódás (`timeout: 2m`) és a lépés-overhead is elférjen. A `phpunit.yml` ezt már megkapta korábban, a deployok kimaradtak.

**Amit ez nem old meg**, és nem is akartam egyedül eldönteni: hogy egy staging futás kiüthet-e egy várakozó kiadást. Tiszta GitHub-megoldás nincs rá — ha a production külön csoportot kap, egyszerre futhat a stagingdel ugyanazon a gépen, pont amit a #662 megszüntetett. Három irányt felvázoltam a #903-ban, választani kell köztük. Ez a PR mindhárom mellett érvényes.

**Ettől függetlenül, kézzel:** a production deployt egyszer le kell futtatni (`workflow_dispatch`), különben a #900 tartalma nincs kint. Ehhez nekem nincs jogosultságom.

