### PR TITLE
A gépi zár őrzi a deployokat, nem a közös GitHub-csoport (#903)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -27,9 +27,17 @@ on:
 # #662: a staging és a production UGYANAZON a gépen fut, és mindkét deploy teljes
 # `docker build`-et csinál. Külön csoportban egyszerre indulhattak, és a párhuzamos
 # buildek megfojtották a gépet. Közös csoport: egyszerre csak EGY deploy fut.
+# #903: a kiadásnak SAJÁT csoportja van, hogy egy staging futás ne üthesse ki.
+#
+# A közös `deploy-server` csoportban a GitHub a VÁRAKOZÓ futást törli, amint újabb
+# érkezik. 2026-08-27-én pontosan ez történt: a #900 kiadás deployja beállt a sorba, egy
+# perccel később egy staging pusholás kiütötte, és a production némán a régi kódon maradt.
+# Ugyanez volt 08-24-én is, akkor kézzel pótoltuk.
+#
+# A gép védelme (#662) nem veszett el: a szkript zárat vesz fel — l. lentebb.
 concurrency:
-  group: deploy-server
-  # Production-ben NEM töröljük a futó deployt — megvárjuk, hogy befejezze.
+  group: deploy-server-production
+  # A futó kiadást soha nem szakítjuk félbe.
   cancel-in-progress: false
 
 jobs:
@@ -42,10 +50,13 @@ jobs:
     # `command_timeout`-ja ellenére), a mögötte várakozó KIADÁS deployja pedig
     # törlődött. A production így a régi kódot szolgálta ki, és semmi nem szólt.
     #
-    # 50 perc: a 40 perces parancs-korlát fölött annyi ráhagyással, hogy a
-    # kapcsolódás és a lépés-overhead is elférjen, de a blokkolás órák helyett
-    # legfeljebb egy munkamenetnyi legyen.
-    timeout-minutes: 50
+    # 80 perc: a #903 óta a szkript ELŐBB a gépi zárra vár (legfeljebb 20 perc), és
+    # csak utána épít (a parancs-korlát 70 perc). A kettő együtt fér el alatta.
+    #
+    # Hosszabb, mint a stagingé, és ez rendben van: a kiadásnak saját csoportja van,
+    # tehát egy elhúzódó production deploy már nem tart fel semmi mást — csak a
+    # következő kiadást, ami helyes.
+    timeout-minutes: 80
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5
@@ -54,12 +65,29 @@ jobs:
           username: ${{ secrets.STAGING_SSH_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           port: ${{ secrets.STAGING_SSH_PORT || 22 }}
-          command_timeout: 40m
+          # #903: ebbe a korlátba a gépi zárra várás IS beleszámít (a szkript első
+          # lépése), nem csak a build. 70 perc = legfeljebb 20 perc várakozás + a
+          # build. A 40 perc kevés lett volna: a várakozás megette volna a build idejét.
+          command_timeout: 70m
           # Lásd a staging-workflow indoklását: a 30 másodperces alapértelmezés
           # kevés, ha a gépen épp egy másik deploy buildje fut.
           timeout: 2m
           script: |
             set -euo pipefail
+
+            # #903: ugyanaz a zár, mint a stagingnél — de a KIADÁS VÁR rá, nem marad ki.
+            #
+            # 20 perc: ennyi alatt egy futó staging deploy befejeződik. Nem több, mert a
+            # várakozás az ssh parancs-korlátjából (70 perc) megy el, és utána még a
+            # kiadás buildjének is el kell férnie.
+            echo "▶ Várakozás a deploy-zárra…"
+            exec 9>/tmp/miserend-deploy.lock
+            if ! flock -w 1200 9; then
+              echo "❌ 20 perc alatt sem szabadult fel a deploy-zár. Valami beragadt a gépen:"
+              echo "   fuser -v /tmp/miserend-deploy.lock"
+              exit 1
+            fi
+            echo "✅ Zár megvan."
 
             DEPLOY_DIR=/var/www/production.miserend.hu
             cd "$DEPLOY_DIR"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,16 +26,26 @@ on:
   workflow_dispatch: {}
 
 # #662: a staging ÉS a production UGYANAZON a gépen fut, és mindkét deploy teljes
-# `docker build`-et csinál (Angular + PHP multi-stage). Külön csoportban egyszerre
-# indulhattak, és több merge után egymásra torlódtak — a gép ettől elérhetetlenné vált.
-# Közös csoport: egyszerre csak EGY deploy nyúlhat a szerverhez.
+# `docker build`-et csinál (Angular + PHP multi-stage). Egyszerre indulva egymásra
+# torlódtak — a gép ettől elérhetetlenné vált. Egyszerre csak EGY deploy nyúlhat a
+# szerverhez; ez a kikötés érvényben marad, csak a helye változott.
 #
-# A `cancel-in-progress` szándékosan false: a job leállítása a GitHub oldalán öli meg a
-# futást, a szerveren a docker daemonban FUTÓ build viszont attól még dolgozik tovább —
-# tehát a cancel nem szabadítja fel a gépet, csak elveszti a naplót. Sorbaállítunk
-# helyette, és a lentebbi "nincs új commit" rövidzár teszi gyorssá a torlódást.
+# #903: a kizárás a szerverre került, a csoport pedig kettévált.
+#
+# A közös `deploy-server` csoport ugyanis mellékhatással járt: a GitHub a csoportban A
+# VÁRAKOZÓ futást törli, amint újabb érkezik. Egy staging pusholás így kiütötte a sorban
+# álló KIADÁS deployját, és a production némán a régi kódon maradt (2026-08-27, és előtte
+# 08-24). Külön csoporttal a staging már nem érhet a kiadás sorához.
+#
+# A `cancel-in-progress` MARAD false, és ez fontos: a job leállítása a GitHub oldalán öli
+# meg a futást, a szerveren a docker daemonban FUTÓ build viszont attól még dolgozik
+# tovább — a cancel nem szabadítja fel a gépet, csak elveszti a naplót. Sőt: a megszakadt
+# ssh-munkamenettel a lentebbi zár is elengedne, miközben a build még fut. Tehát nem
+# kilövünk, hanem a záron sorbaállunk, és ha nem kapjuk meg, KIMARADUNK — borazslo
+# szavaival „a deploy to staging mindig várhat, kimaradhat ha kell". A következő pusholás
+# úgyis hoz újat.
 concurrency:
-  group: deploy-server
+  group: deploy-server-staging
   cancel-in-progress: false
 
 jobs:
@@ -68,6 +78,18 @@ jobs:
           timeout: 2m
           script: |
             set -euo pipefail
+
+            # #903: a gépen egyszerre EGY deploy dolgozhat (#662). A kizárás a GitHub
+            # concurrency-csoportjából ide került, mert ott a kiadás deployját ütötte ki.
+            #
+            # A staging KIMARADHAT, ha nem kapja meg a zárat: a következő pusholás úgyis
+            # hoz újat. A `-w 60` azért nem 0, hogy egy épp befejeződő deploy után ne
+            # hagyjuk ki fölöslegesen.
+            exec 9>/tmp/miserend-deploy.lock
+            if ! flock -w 60 9; then
+              echo "⏭️  Másik deploy dolgozik a gépen — a staging kimarad. A következő pusholás újrapróbálja."
+              exit 0
+            fi
 
             DEPLOY_DIR=/var/www/staging.miserend.hu
             cd "$DEPLOY_DIR"


### PR DESCRIPTION
A #903 3-as iránya, @borazslo válasza szerint — de **a saját javaslatomat javítottam** két ponton is.

## Amit rosszul javasoltam

**1. „A staging kapjon `cancel-in-progress: true`-t."** A KÖZÖS csoporttal ez veszélyes: a beállítás az érkező futásé, és a csoport egészére hat — egy staging pusholás nem csak a másik stagingot, hanem egy **épp futó production deployt** is kilőtt volna, a build közepén.

**2. A `cancel-in-progress: true` külön csoportban sem jó.** Erre a workflow saját, korábbi megjegyzése figyelmeztetett, és igaza van: a job leállítása a GitHub oldalán öli meg a futást, a szerveren a docker daemonban **futó build viszont attól még dolgozik tovább**. A cancel nem szabadítja fel a gépet, csak elveszti a naplót. Sőt: a megszakadt ssh-munkamenettel az alábbi zár is elengedne, miközben a build még fut — vagyis pont a #662-es torlódás jönne vissza.

Ezért `cancel-in-progress: false` marad mindkét oldalon.

## Ami lett belőle

```
staging:     group: deploy-server-staging      cancel-in-progress: false
production:  group: deploy-server-production   cancel-in-progress: false
```

Külön csoport, tehát a staging **nem érhet a kiadás sorához** — ez szünteti meg a bejelentett hibát.

A #662 kikötése (egy gépen egyszerre egy deploy) nem veszett el, csak a helye változott: a GitHub concurrency-jéből a **szerverre**, egy `flock`-ra.

- **A kiadás VÁR** a zárra, legfeljebb 20 percet. Ha nem kapja meg, hangosan elhasal, és megmondja, mivel lehet megnézni, mi tartja (`fuser -v`).
- **A staging KIMARAD**, ha 60 másodpercen belül nem kapja meg. A te szavaiddal: „a deploy to staging mindig várhat, kimaradhat ha kell." A következő pusholás úgyis hoz újat.

## Egy szám, ami nem stimmelt

A zárra várás ugyanabból a keretből megy el, mint a build: az `ssh-action` `command_timeout`-ja a TELJES távoli szkriptet méri. A production 40 perces korlátja mellett egy 20 perces várakozás megette volna a build idejét. Ezért ott 70 percre emeltem, a job-korlátot pedig 50-ről 80-ra — így a várakozás és a build is elfér.

A stagingé változatlan (40m/50m): ott a várakozás legfeljebb egy perc.

## Amit NEM tudtam ellenőrizni

**A szerver jelenleg nem elérhető** — a mai staging deployok `dial tcp … i/o timeout`-tal halnak el a 2 perces kapcsolódási korlátnál. A `flock` viselkedését tehát élesben nem láttam, csak a YAML-t ellenőriztem. Az első igazi próba az lesz, amikor a gép visszajön.

Egy megfigyelés addig is: a #904 dolgozik. A reggeli futás négy órán át fogta a sort, a maiak két perc alatt elhasalnak, és nem blokkolnak semmit.
