### PR TITLE
Egyszer újrapróbálom a böngésző indítását (#906)

### DIFF
--- a/webapp/tests/Functional/FunctionalTestCase.php
+++ b/webapp/tests/Functional/FunctionalTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Functional;
 
+use Facebook\WebDriver\Exception\PhpWebDriverExceptionInterface;
 use Symfony\Component\Panther\Client as PantherClient;
 use Symfony\Component\Panther\PantherTestCase;
 
@@ -50,7 +51,59 @@ abstract class FunctionalTestCase extends PantherTestCase
      */
     private const REQUEST_TIMEOUT_MS = 30000;
 
+    /**
+     * Hányszor próbáljuk meg elindítani a böngészőt.
+     *
+     * A 2026-08-27-i master-futásban a suite ELSŐ munkamenete hasalt el
+     * `Operation timed out after 30002 milliseconds with 0 bytes received`-del, a
+     * mögötte lévő 79 teszt viszont hibátlanul lefutott. Vagyis nem a korlát szűk és nem
+     * az alkalmazás lassú: a chromedriver hidegindítása csúszott át a 30 másodpercen a
+     * futtatón.
+     *
+     * A korlát emelése rossz válasz lenne — pont azért 30 másodperc, hogy egy VALÓDI
+     * beakadás gyorsan és beszédesen bukjon el (l. a REQUEST_TIMEOUT_MS indoklását).
+     * Egyetlen újrapróbálkozás viszont pont a hidegindítást fedi le: a legrosszabb eset
+     * 60 másodperc, ami még mindig töredéke a lépés korlátjának.
+     */
+    private const INDITASI_PROBALKOZASOK = 2;
+
     protected static function pantherClient(array $options = []): PantherClient
+    {
+        $utolsoHiba = null;
+
+        for ($probalkozas = 1; $probalkozas <= self::INDITASI_PROBALKOZASOK; $probalkozas++) {
+            try {
+                return static::klienstIndit($options);
+            } catch (\Throwable $hiba) {
+                // Csak a WebDriver felől jövő indulási hibát próbáljuk újra. Bármi más
+                // (rossz opció, hiányzó bináris) azonnal szálljon el — azon az
+                // újrapróbálkozás nem segít, csak elfedi.
+                if (!$hiba instanceof PhpWebDriverExceptionInterface) {
+                    throw $hiba;
+                }
+
+                $utolsoHiba = $hiba;
+
+                // Látszódjon a naplóban: ha ez sűrűsödik, a futtatóval van baj, és azt
+                // egy néma újrapróbálkozás elrejtené.
+                fwrite(STDERR, sprintf(
+                    "\n[panther] a böngésző indítása nem sikerült (%d/%d): %s\n",
+                    $probalkozas,
+                    self::INDITASI_PROBALKOZASOK,
+                    explode("\n", $hiba->getMessage())[0]
+                ));
+
+                if ($probalkozas < self::INDITASI_PROBALKOZASOK) {
+                    // Egy másodperc, hogy a félbemaradt chromedriver elengedje a portját.
+                    sleep(1);
+                }
+            }
+        }
+
+        throw $utolsoHiba;
+    }
+
+    private static function klienstIndit(array $options): PantherClient
     {
         return static::createPantherClient(
             array_merge([


### PR DESCRIPTION
Closes #906

A master PHPUnit-futása azért maradt piros a #902 után is, mert a **böngészős suite első munkamenete** nem indult el 30 másodperc alatt:

```
E................................................................ 65 / 80 ( 81%)
Tests: 80, Assertions: 146, Errors: 1, Skipped: 1.
```

Az `E` a **legelső** teszten van, utána 79 hibátlan futás. Tehát nem az alkalmazás lassú és nem a korlát szűk — a chromedriver **hidegindítása** csúszott át a határon a futtatón.

## Miért nem a korlátot emelem

A 30 másodperc szándékos, és a `FunctionalTestCase` külön indoklást hordoz róla: korábban a kliens létrehozása időkorlát nélkül ment, és a CI ettől **némán** beragadt — a lépés 12 perc után bukott el, egyetlen teszteredmény nélkül. A korlát emelése ezt hozná vissza.

## Amit csinál

Egyetlen újrapróbálkozás a böngésző indítására. A hidegindítást lefedi, a legrosszabb eset 60 másodperc (a lépés korlátjának töredéke), egy valódi beakadás pedig továbbra is gyorsan és beszédesen bukik el.

Két dolog, amire ügyeltem:

- **Csak a WebDriver felől jövő indulási hibát** próbálom újra (`PhpWebDriverExceptionInterface` — ezt valósítja meg a `WebDriverCurlException` és a `DriverServerDiedException` is). Bármi más (rossz opció, hiányzó bináris) azonnal elszáll: azon az újrapróbálkozás nem segít, csak elfedi.
- **Látszik a naplóban**, ha kellett a második próbálkozás. Ha ez sűrűsödni kezd, az már a futtatóról szól — és azt egy néma retry elrejtené.

## Mérés

A szintaxist ellenőriztem, a teljes böngészős suite-ot helyben futtatom (a Chromiumos test-image buildjével együtt); az eredményt kommentben pótolom, ha a PR nyitásáig nem ér véget. A CI-ben a hatás úgyis csak statisztikusan látszik: az a hiba minden futásban legfeljebb ~1%-ban jött elő.
