### PR TITLE
A frissen felvitt misézőhely áttekintésre vár, nem letiltva (#908)

### DIFF
--- a/webapp/classes/html/church/create.php
+++ b/webapp/classes/html/church/create.php
@@ -51,9 +51,29 @@ class Create extends \Html\Html {
                 . 'vagy hagyd üresen mind a kettőt.');
         }
 
+        /*
+         * #908: a frissen felvitt misézőhely „áttekintésre vár", nem „letiltva".
+         *
+         * borazslo a #898-ban: „ha nem választunk ki osm lehetséges elemet, akkor
+         * letiltva marad a templom az összekötés hiánya miatt. Ami rendben van sok régi
+         * templomnál, de újnál nem. Hiszen a felhasználó most hozta létre."
+         *
+         * Nincs külön gépezet, ami az OSM-kapcsolat hiánya miatt tiltana: egyszerűen ez a
+         * sor írt mindig `n`-t. A `n` jelentése „nem engedélyezett" — az egy elutasított
+         * vagy visszavont templom állapota, nem egy épp mostani felvitelé.
+         *
+         * Az `f` („feltöltött, áttekintésre vár") pontosan ezt fejezi ki, és a kódbázis
+         * már használja ugyanerre a gondolatra: a koordináta nélkül maradt templomok is
+         * ide kerülnek (`Crons::KOORDINATA_NELKUL_ALLAPOT`), azzal az indoklással, hogy
+         * „nem szabályszegés miatt kerülnek ki, hanem mert hiányzik az adatuk".
+         *
+         * A NYILVÁNOSSÁGON nem változtat semmit: a listák és a kereső `ok = 'i'`-re
+         * szűrnek, tehát az `f` ugyanúgy nem jelenik meg, mint az `n`. Csak az admin
+         * felületén más a felirata — és a gondnok látja, hogy a felvitele megtörtént.
+         */
         $church = \Eloquent\Church::create([
             'nev' => $name,
-            'ok' => 'n',
+            'ok' => 'f',
             'frissites' => date('Y-m-d'),
             'lat' => $lat,
             'lon' => $lon,

--- a/webapp/tests/Integration/ChurchCreateFormTest.php
+++ b/webapp/tests/Integration/ChurchCreateFormTest.php
@@ -163,12 +163,19 @@ class ChurchCreateFormTest extends TestCase {
         self::assertStringContainsString('biztonsági token', $valasz);
     }
 
-    /** OSM-azonosító nélkül is létre KELL jönnie — csak letiltva. */
+    /**
+     * OSM-azonosító nélkül is létre KELL jönnie — és „áttekintésre vár" állapotban.
+     *
+     * #908: eddig `n` („nem engedélyezett") lett belőle, ami egy elutasított templom
+     * állapota. borazslo szerint (#898) egy épp most felvitt misézőhelynél ez nem jó. Az
+     * `f` a nyilvánosságon nem változtat — a listák `ok = 'i'`-re szűrnek —, csak azt
+     * mondja meg helyesen, hogy miért nincs kint.
+     */
     public function testAChurchCanBeCreatedWithoutAnOsmLink(): void {
         $this->post($this->mezok('osm-nélkül'));
 
         $sor = $this->sor('osm-nélkül');
         self::assertNotNull($sor, 'OSM-azonosító nélkül is létre kell jönnie');
-        self::assertSame('n', (string) $sor->ok, 'a friss templom még nem engedélyezett');
+        self::assertSame('f', (string) $sor->ok, 'áttekintésre vár, nem letiltva');
     }
 }


### PR DESCRIPTION
Closes #908

@borazslo a #898-ban: „ha nem választunk ki osm lehetséges elemet, akkor letiltva marad a templom az összekötés hiánya miatt. Ami rendben van sok régi templomnál, de újnál nem. Hiszen a felhasználó most hozta létre."

**Utánanéztem: nincs külön gépezet.** Nem az OSM-kapcsolat hiánya tiltja le — a `create()` írt mindig `ok = 'n'`-t, OSM-azonosítótól függetlenül. Az `n` jelentése „nem engedélyezett", ami egy elutasított vagy visszavont templom állapota.

Egy sor változik: `'n'` → `'f'` („feltöltött, áttekintésre vár"). Ez azt mondja, ami történt, és a kódbázis már ugyanerre a gondolatra használja — a koordináta nélkül maradt templomok is ide kerülnek (`Crons::KOORDINATA_NELKUL_ALLAPOT`), azzal az indoklással, hogy „nem szabályszegés miatt kerülnek ki, hanem mert hiányzik az adatuk".

**A nyilvánosságon nem változtat semmit:** a listák, a kereső és a térkép `ok = 'i'`-re szűrnek, tehát az `f` ugyanúgy nem jelenik meg, mint az `n`. A különbség az admin felületén látszik, és abban, hogy a felvivő látja: a munkája megtörtént.

A `ChurchCreateFormTest` ezt már őrizte (`'n'`-t várt), most `'f'`-et vár — a teszt magyarázata is átírva, hogy miért.

**Ha mégis `i`-t akarsz** (azonnal nyilvános), egy karakter, és megcsinálom. Az `f` a konzervatív választás: nem publikál át nem nézett adatot, de nem is néz ki elutasításnak.

Ami a #898-ból továbbra is nyitva van, és a te döntésedre vár: a kétlépéses felvitel és az OSM node létrehozása. Mindkettőt leírtam a #908-ban.
