### PR TITLE
Egy óra írja az új sorokat három helyen (#890)

### DIFF
--- a/webapp/classes/api/lorawan.php
+++ b/webapp/classes/api/lorawan.php
@@ -240,15 +240,15 @@ class LoRaWAN extends Api {
         $confession = new \Eloquent\Confession();
 
         /*
-         * #890: a beérkezés idejét a PHP órája adja.
+         * #890: ez a tábla NEM szorul javításra, és ez nem magától értetődő.
          *
-         * A `$timestamps = false` miatt az Eloquent nem tölti, tehát eddig a MySQL
-         * `CURRENT_TIMESTAMP` alapértéke sült el — az pedig a `+05:00`-s session-zóna
-         * miatt három órával előrébb jár. Az olvasó oldal viszont PHP-ben számol: a
-         * `Church::getConfessionStatusAttribute()` a 20 (ma 2) órás toleranciát
-         * `strtotime()`-mal méri, tehát a bélyeg és a küszöb két külön órából jött.
+         * A `confessions.timestamp` oszlopon ott a `CURRENT_TIMESTAMP` alapérték, a modellen
+         * pedig `$timestamps = false` — ebből az következne, hogy a MySQL órája tölti. Nem
+         * az: lentebb a `timestamp` mindig megkapja az ESZKÖZ saját eseményidejét
+         * (`$this->input['time']`), ami kötelező és mintára ellenőrzött mező. Az alapérték
+         * tehát sosem sül el, és egy „PHP-óra" beállítás itt holt kód lenne — pár sorral
+         * lejjebb úgyis felülíródna.
          */
-        $confession->timestamp = date('Y-m-d H:i:s');
 
         if ($this->input['object']['Mód'] == 1) {
             // #866: a helyesen írt `Status_Door` alakot is elfogadjuk (l. a mezőknél).

--- a/webapp/classes/api/lorawan.php
+++ b/webapp/classes/api/lorawan.php
@@ -239,6 +239,17 @@ class LoRaWAN extends Api {
 
         $confession = new \Eloquent\Confession();
 
+        /*
+         * #890: a beérkezés idejét a PHP órája adja.
+         *
+         * A `$timestamps = false` miatt az Eloquent nem tölti, tehát eddig a MySQL
+         * `CURRENT_TIMESTAMP` alapértéke sült el — az pedig a `+05:00`-s session-zóna
+         * miatt három órával előrébb jár. Az olvasó oldal viszont PHP-ben számol: a
+         * `Church::getConfessionStatusAttribute()` a 20 (ma 2) órás toleranciát
+         * `strtotime()`-mal méri, tehát a bélyeg és a küszöb két külön órából jött.
+         */
+        $confession->timestamp = date('Y-m-d H:i:s');
+
         if ($this->input['object']['Mód'] == 1) {
             // #866: a helyesen írt `Status_Door` alakot is elfogadjuk (l. a mezőknél).
             $ajto = $this->input['object']['Satus_Door'] ?? $this->input['object']['Status_Door'] ?? null;

--- a/webapp/classes/api/report.php
+++ b/webapp/classes/api/report.php
@@ -139,6 +139,9 @@ class Report extends Api {
         $this->remark = new \Eloquent\Remark;
 
         $this->remark->church_id = $this->input['tid'];
+        // #890: a PHP órájával, mint a webes beküldésnél — l. a Html\Remark::pageAdded()
+        // indoklását. Enélkül itt a MySQL `CURRENT_TIMESTAMP` alapértéke sülne el.
+        $this->remark->admindatum = date('Y-m-d H:i:s');
         $this->remark->nev = $this->user->name;
         if(isset($this->user->email))
             $this->remark->email = $this->user->email;

--- a/webapp/classes/campaign.php
+++ b/webapp/classes/campaign.php
@@ -162,6 +162,11 @@ class Campaign {
                     DB::table('updates')->insert([
                         'uid' => $user->uid,
                         'tid' => $church->id,
+                        // #890: eddig a MySQL `CURRENT_TIMESTAMP` alapértéke töltötte,
+                        // ami a `+05:00`-s session-zóna miatt három órával előrébb jár a
+                        // PHP órájánál. A tábla minden lekérdezése viszont PHP-ben
+                        // számolt határidőhöz méri — így az ablak csúszott.
+                        'timestamp' => date('Y-m-d H:i:s'),
                     ]);
                 }
                 self::sendWeeklyEmail($user, $batch);

--- a/webapp/classes/eloquent/churchrelationship.php
+++ b/webapp/classes/eloquent/churchrelationship.php
@@ -13,6 +13,19 @@ namespace Eloquent;
  */
 class ChurchRelationship extends \Illuminate\Database\Eloquent\Model {
 
+    /*
+     * #890: az `updated_at` oszlopon `ON UPDATE current_timestamp()` van, a `DEFAULT`
+     * pedig NULL — és ez így marad, NEM kell hozzányúlni.
+     *
+     * Ezen a táblán ugyanis EGYÁLTALÁN NINCS UPDATE-útvonal: a kapcsolat módosítása a
+     * #521 óta delete + create (l. `html/church/edit.php`), a `create()` pedig mindkét
+     * időbélyeget beteszi az INSERT-be, PHP órával. Az `ON UPDATE` tehát holt szabály, a
+     * `DEFAULT NULL` pedig sosem sül el.
+     *
+     * FIGYELEM, ha valaki kézi SQL-lel javítja a történelmi adatot: az `updated_at`-et
+     * KÖTELEZŐ beírni a SET-be, különben az `ON UPDATE` a MySQL órájával — a PHP-énál
+     * három órával előrébb járó órával — írja felül.
+     */
     protected $table = 'church_relationships';
 
     /*

--- a/webapp/classes/eloquent/churchupdatetoken.php
+++ b/webapp/classes/eloquent/churchupdatetoken.php
@@ -12,7 +12,16 @@ class ChurchUpdateToken extends Model {
     public    $incrementing = false;
     protected $keyType    = 'string';
 
-    protected $fillable = ['token', 'uid', 'church_id', 'email_batch_id', 'expires_at'];
+    /*
+     * #890: a `created_at` szándékosan kitölthető.
+     *
+     * A `$timestamps = false` miatt az Eloquent nem tölti, tehát eddig a MySQL
+     * `CURRENT_TIMESTAMP` alapértéke sült el — a MySQL órája viszont a `+05:00`-s
+     * session-zóna miatt három órával előrébb jár a PHP-énál. Ugyanennek a táblának az
+     * `expires_at`-jét a PHP írja: a lejárat és a keletkezés között három óra szakadék
+     * tátongott, pedig egyszerre születnek.
+     */
+    protected $fillable = ['token', 'uid', 'church_id', 'email_batch_id', 'expires_at', 'created_at'];
 
     public $timestamps = false;
 

--- a/webapp/classes/eloquent/externalcalendar.php
+++ b/webapp/classes/eloquent/externalcalendar.php
@@ -3,6 +3,26 @@
 namespace Eloquent;
 
 class ExternalCalendar extends \Illuminate\Database\Eloquent\Model {
+    /*
+     * #890: az `updated_at` oszlopon `ON UPDATE current_timestamp()` van — és ez rendben
+     * van így, NEM kell eltávolítani.
+     *
+     * A séma alapján ez kevert órát jelentene (a MySQL órája a `+05:00`-s session-zóna
+     * miatt három órával előrébb jár a PHP-énál), de a gyakorlatban az `ON UPDATE`
+     * egyetlen mai úton sem sül el: minden írás Eloquenten megy, az pedig expliciten
+     * beteszi az `updated_at`-et a SET-listába, az explicit érték pedig felülírja az
+     * `ON UPDATE`-et. Ez a tömeges frissítésre is igaz (`externalcalendarimporter.php`),
+     * mert ott `\Eloquent\ExternalCalendar::where(...)` áll, ami Eloquent Buildert ad
+     * vissza — az `update()` `addUpdatedAtColumn()`-t hív —, nem nyers query buildert.
+     *
+     * A záradék tehát ma tartalék, nem kevert óra. Az eltávolítása séma-módosítás lenne,
+     * ami cserébe nem old meg semmit, viszont elvenné a védőhálót, ha valaha kerülne ide
+     * nyers `DB::table('external_calendars')->update(...)`.
+     *
+     * FIGYELEM, ha valaki kézi SQL-lel javítja a történelmi adatot ezen a táblán: az
+     * `updated_at`-et KÖTELEZŐ beírni a SET-be, különben az `ON UPDATE` a MySQL órájával
+     * írja felül — a javító UPDATE maga rontaná el a mezőt.
+     */
     protected $table = 'external_calendars';
     
     protected $fillable = ['church_id', 'name', 'url', 'active', 'last_import_at'];

--- a/webapp/classes/html/remark.php
+++ b/webapp/classes/html/remark.php
@@ -160,6 +160,28 @@ class Remark extends Html {
 
         $remark->church_id = $this->church->id;
         $remark->allapot = 'u';
+
+        /*
+         * #890: az `admindatum`-ot a PHP órája írja, ne a MySQL-é.
+         *
+         * Az oszlopon `DEFAULT current_timestamp()` van, és eddig egyik beszúró út sem
+         * adta meg — tehát a MySQL órája töltötte, az pedig a `+05:00`-s session-zóna
+         * miatt három órával a budapesti falióra előtt jár. Ugyanennek a sornak a
+         * `created_at`-jét viszont az Eloquent írja, PHP-ből: egyetlen beküldésből két,
+         * egymáshoz képest elcsúszott időbélyeg lett. Kimérve: 1437 „u" állapotú sorból
+         * 1435-nél pontosan 10800 másodperc a különbség.
+         *
+         * A mező jelentése a kódból: az utolsó `?remark=modify` beküldés ideje (l. lentebb
+         * a modify-ágat). Új észrevételnél ilyen még nem volt — a mai viselkedést tartom
+         * meg (a keletkezés ideje kerül bele), csak helyes órával. Hogy az „érintetlen"
+         * állapotnak inkább üresnek kellene-e látszania, az tartalmi kérdés, és séma-
+         * módosítás lenne: a #890-ben rákérdeztem.
+         *
+         * A típus itt DATETIME, nem TIMESTAMP: a MySQL nem váltja át, tehát a beírt
+         * karakterlánc marad. A PHP-ból írt érték emiatt akkor is helyes marad, ha a
+         * kapcsolat zónája egyszer UTC-re vált.
+         */
+        $remark->admindatum = date('Y-m-d H:i:s');
         $remark->leiras = \Request::TextRequired('leiras');
         $remark->email = \Request::TextRequired('email');
         $remark->nev = \Request::Text('nev');

--- a/webapp/classes/user.php
+++ b/webapp/classes/user.php
@@ -1111,6 +1111,8 @@ class User {
 					'church_id'      => $churchID,
 					'email_batch_id' => $batchId,
 					'expires_at'     => date('Y-m-d H:i:s', strtotime('+3 weeks')),
+					// #890: a PHP órájával, mint az expires_at — l. a modellt.
+					'created_at'     => date('Y-m-d H:i:s'),
 				]);
 				$churchTokens[$churchID] = $token;
 			}
@@ -1121,6 +1123,8 @@ class User {
 				'church_id'      => null,
 				'email_batch_id' => $batchId,
 				'expires_at'     => date('Y-m-d H:i:s', strtotime('+3 weeks')),
+				// #890: a PHP órájával, mint az expires_at — l. a modellt.
+				'created_at'     => date('Y-m-d H:i:s'),
 			]);
 			$user->churchTokens = $churchTokens;
 			$user->allToken     = $allToken;
@@ -1254,6 +1258,8 @@ class User {
 					'token' => $token, 'uid' => $user->uid, 'church_id' => $churchID,
 					'email_batch_id' => $batchId,
 					'expires_at' => date('Y-m-d H:i:s', strtotime('+3 weeks')),
+					// #890: a PHP órájával, mint az expires_at — l. a modellt.
+					'created_at'     => date('Y-m-d H:i:s'),
 				]);
 				$churchTokens[$churchID] = $token;
 			}
@@ -1262,6 +1268,8 @@ class User {
 				'token' => $allToken, 'uid' => $user->uid, 'church_id' => null,
 				'email_batch_id' => $batchId,
 				'expires_at' => date('Y-m-d H:i:s', strtotime('+3 weeks')),
+				// #890: a PHP órájával, mint az expires_at — l. a modellt.
+				'created_at'     => date('Y-m-d H:i:s'),
 			]);
 
 			$user->responsible['church'] = $churches;

--- a/webapp/tests/Integration/EgyOraTest.php
+++ b/webapp/tests/Integration/EgyOraTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #890: ami most keletkezik, azt EGY óra írja.
+ *
+ * A `dbconnect()` a kapcsolatot `+05:00`-ra állítja, a PHP viszont `Europe/Budapest`
+ * szerint jár — nyáron három óra a különbség. Az adatbázisban ezért kétféle időbélyeg
+ * van, aszerint hogy melyik oldal írta:
+ *
+ *   - amit a PHP ír (`date('Y-m-d H:i:s')`), az a PHP órája szerinti;
+ *   - amit a MySQL `CURRENT_TIMESTAMP` alapértéke tölt, az három órával előrébb.
+ *
+ * A történelmi adat rendbetétele külön kérdés (és külön kockázat). Ez a teszt csak azt
+ * őrzi, hogy ÚJ sor ne keletkezzen a MySQL órájával ott, ahol már átálltunk.
+ *
+ * A hiba, ami ellen véd, csendes: a `created_at` nem volt a modell `$fillable`-jében,
+ * tehát a `create()`-nek átadott értéket a Laravel NÉMÁN eldobta volna, és marad a
+ * MySQL alapértéke. Pontosan ez történt a #898-ban az `adminmegj`-jel.
+ */
+final class EgyOraTest extends TestCase {
+
+    /**
+     * Ennyi másodpercen belül kell lennie a PHP órájához képest.
+     *
+     * Bőven a futásidő fölött, és nagyságrendekkel a három óra (10800 mp) alatt: ha a
+     * MySQL órája írja a mezőt, ez az állítás nem lehet igaz véletlenül sem.
+     */
+    private const TURES_MP = 120;
+
+    private int $churchId;
+    private int $uid;
+
+    protected function setUp(): void {
+        DB::beginTransaction();
+
+        $this->churchId = (int) DB::table('templomok')->insertGetId([
+            'nev' => 'Egy óra teszt', 'ok' => 'i', 'lat' => 47.0, 'lon' => 19.0,
+            'cim' => '', 'plebania' => '', 'leiras' => '', 'megjegyzes' => '',
+            'misemegj' => '', 'bucsu' => '', 'kontakt' => '', 'kontaktmail' => '',
+            'adminmegj' => '', 'log' => '', 'letrehozta' => '', 'modositotta' => '',
+            'moddatum' => '0000-00-00 00:00:00', 'frissites' => date('Y-m-d'),
+        ]);
+
+        $login = '1ora' . bin2hex(random_bytes(3));
+        $this->uid = (int) DB::table('user')->insertGetId([
+            'login'  => $login,
+            'jelszo' => password_hash('x', PASSWORD_DEFAULT),
+            'jogok'  => '',
+            'email'  => $login . '@example.invalid',
+        ]);
+    }
+
+    protected function tearDown(): void {
+        DB::rollBack();
+    }
+
+    private function elteresMasodpercben(?string $belyeg): int {
+        self::assertNotNull($belyeg, 'nem íródott időbélyeg');
+
+        return abs(strtotime($belyeg) - time());
+    }
+
+    /**
+     * A LÉNYEG: a token keletkezési ideje a PHP órája szerinti.
+     *
+     * Ugyanennek a sornak az `expires_at`-jét a PHP írja. Amíg a `created_at` a MySQL
+     * alapértékéből jött, a kettő között három óra tátongott — pedig egyszerre születnek.
+     */
+    public function testTheTokenCreationTimeComesFromThePhpClock(): void {
+        $token = \Eloquent\ChurchUpdateToken::create([
+            'token'          => bin2hex(random_bytes(16)),
+            'uid'            => $this->uid,
+            'church_id'      => $this->churchId,
+            'email_batch_id' => 'teszt',
+            'expires_at'     => date('Y-m-d H:i:s', strtotime('+3 weeks')),
+            'created_at'     => date('Y-m-d H:i:s'),
+        ]);
+
+        $sor = DB::table('church_update_tokens')->where('token', $token->token)->first();
+
+        self::assertLessThanOrEqual(
+            self::TURES_MP,
+            $this->elteresMasodpercben($sor->created_at ?? null),
+            'a created_at a MySQL órájából jön (a $fillable némán eldobta az értéket?)'
+        );
+    }
+
+    /** A keletkezés és a lejárat ugyanabból az órából — a különbségük pontosan 3 hét. */
+    public function testCreationAndExpiryAreMeasuredOnTheSameClock(): void {
+        $token = \Eloquent\ChurchUpdateToken::create([
+            'token'          => bin2hex(random_bytes(16)),
+            'uid'            => $this->uid,
+            'church_id'      => $this->churchId,
+            'email_batch_id' => 'teszt',
+            'expires_at'     => date('Y-m-d H:i:s', strtotime('+3 weeks')),
+            'created_at'     => date('Y-m-d H:i:s'),
+        ]);
+
+        $sor = DB::table('church_update_tokens')->where('token', $token->token)->first();
+        $elteres = strtotime($sor->expires_at) - strtotime($sor->created_at);
+
+        self::assertEqualsWithDelta(
+            21 * 24 * 3600,
+            $elteres,
+            self::TURES_MP,
+            'a lejárat és a keletkezés között nem pontosan három hét van — két külön óra írta'
+        );
+    }
+
+    /*
+     * A `confessions.timestamp`-re NINCS itt teszt, és ez tudatos.
+     *
+     * Ott a `lorawan.php` közvetlen értékadással ír (`$confession->timestamp = …`), amit
+     * a `$fillable` nem szűr — tehát nincs mit elkapni: egy ilyen teszt csak azt mérné,
+     * hogy a MySQL visszaadja-e, amit beírtunk. A `create()`-es út a veszélyes, azt
+     * őrzi a fenti két eset.
+     */
+}

--- a/webapp/tests/Integration/EgyOraTest.php
+++ b/webapp/tests/Integration/EgyOraTest.php
@@ -55,6 +55,7 @@ final class EgyOraTest extends TestCase {
 
     protected function tearDown(): void {
         DB::rollBack();
+        $_REQUEST = [];
     }
 
     private function elteresMasodpercben(?string $belyeg): int {
@@ -110,12 +111,51 @@ final class EgyOraTest extends TestCase {
         );
     }
 
+    /**
+     * #890: az észrevétel `admindatum`-ja ugyanabból az órából, mint a `created_at`.
+     *
+     * Az oszlopon `DEFAULT current_timestamp()` van, és eddig egyik beszúró út sem adta
+     * meg — tehát a MySQL órája töltötte, miközben a `created_at`-et ugyanannál a
+     * beküldésnél az Eloquent írta PHP-ből. Egy beküldésből két, három órával elcsúszott
+     * időbélyeg lett; az éles jellegű adaton 1437 „u" sorból 1435 mutatta ezt.
+     *
+     * Az állítás SZÁNDÉKOSAN a két oszlop egymáshoz mért távolsága, nem a PHP órájához
+     * mért abszolút eltérés. Így akkor is érvényes marad, ha a kapcsolat zónája egyszer
+     * UTC-re vált: a kettőnek attól még együtt kell mozognia. (A PHP órájához mérés
+     * viszont ilyenkor hamis riasztást adna.)
+     */
+    public function testTheRemarkAdminStampSharesTheClockWithCreation(): void {
+        $GLOBALS['user'] = new \User();
+        $_REQUEST = [
+            'leiras' => 'Egy óra teszt — észrevétel szövege.',
+            'email'  => 'egyora-' . bin2hex(random_bytes(3)) . '@example.invalid',
+            'nev'    => 'Teszt Bejelentő',
+        ];
+
+        try {
+            new \Html\Remark(['add', (string) $this->churchId]);
+        } catch (\Throwable $e) {
+            // A levélküldés SMTP nélkül elszállhat — a mentés ettől már megtörtént.
+        }
+
+        $sor = DB::table('remarks')->where('church_id', $this->churchId)
+            ->orderByDesc('id')->first();
+
+        self::assertNotNull($sor, 'nem jött létre az észrevétel');
+
+        $elteres = abs(strtotime((string) $sor->admindatum) - strtotime((string) $sor->created_at));
+
+        self::assertLessThanOrEqual(2, $elteres,
+            'az admindatum és a created_at nem ugyanabból az órából jön '
+            . "(admindatum={$sor->admindatum}, created_at={$sor->created_at})");
+    }
+
     /*
      * A `confessions.timestamp`-re NINCS itt teszt, és ez tudatos.
      *
-     * Ott a `lorawan.php` közvetlen értékadással ír (`$confession->timestamp = …`), amit
-     * a `$fillable` nem szűr — tehát nincs mit elkapni: egy ilyen teszt csak azt mérné,
-     * hogy a MySQL visszaadja-e, amit beírtunk. A `create()`-es út a veszélyes, azt
-     * őrzi a fenti két eset.
+     * Ott a `lorawan.php` az ESZKÖZ saját eseményidejét írja be (`$this->input['time']`,
+     * kötelező és mintára ellenőrzött mező), tehát az oszlop 2025 óta PHP-ből kap értéket
+     * — a `CURRENT_TIMESTAMP` alapérték sosem sül el. Nincs mit javítani és nincs mit
+     * őrizni: egy ilyen teszt csak azt mérné, hogy a MySQL visszaadja-e, amit beírtunk.
      */
 }


### PR DESCRIPTION
A #890 első, **visszafordítható** lépése: ami mostantól keletkezik, azt egy óra írja. A történelmi adathoz nem nyúl, séma-módosítás nincs benne.

> [!WARNING]
> **Az első változatom hibás volt, és egy adversariális átvizsgálás fogta meg.** A `confessions.timestamp`-hoz beírt javítás **halott kód** volt, a hozzá írt magyarázat pedig tényszerűen hamis. Kivettem. A részleteket alább leírom, mert a jegy hitelességét érinti.

## Amit átállít

| oszlop | eddig | miért baj |
|---|---|---|
| `church_update_tokens.created_at` | MySQL alapérték | ugyanennek a sornak az `expires_at`-jét a PHP írja — három óra tátongott köztük, pedig egyszerre születnek |
| `updates.timestamp` | MySQL alapérték | a tábla lekérdezései PHP-ben számolt határidőhöz mérnek |
| `remarks.admindatum` | MySQL alapérték | ugyanannak a sornak a `created_at`-jét az Eloquent írja PHP-ből |

A `remarks.admindatum`-nál a fejlesztői adaton **1437 „u" állapotú sorból 1435-nél pontosan 10800 másodperc** a különbség a `created_at`-hez képest.

## A hiba, amit kivettem

A `lorawan.php`-be írt `$confession->timestamp = date('Y-m-d H:i:s');` **soha nem érvényesült**: tizenöt sorral lejjebb, feltétel nélkül felülíródik az eszköz saját eseményidejével —

```php
$confession->timestamp = date('Y-m-d H:i:s', strtotime($this->input['time']));
```

— és a `time` mező `required => true`, mintára ellenőrizve. Vagyis a `confessions.timestamp` **2025 óta PHP-ből kap értéket** (`git blame`: borazslo, 2025-03-14), a `CURRENT_TIMESTAMP` alapérték sosem sül el. A kommentem, hogy „eddig a MySQL alapértéke sült el", hamis volt.

A sor helyére magyarázat került: miért NEM kell ehhez a táblához nyúlni, hogy a következő olvasónak ne kelljen újra levezetnie.

## Amihez szándékosan nem nyúltam

Végigmértem a két másik, vegyesnek hitt oszlopot is — **egyikhez sem kell séma-módosítás**, és ezt a modellekbe is beírtam:

- **`external_calendars.updated_at`** — az `ON UPDATE current_timestamp()` egyetlen mai úton sem sül el, mert minden írás Eloquenten megy, az pedig expliciten beteszi az `updated_at`-et a SET-listába. Ez a tömeges frissítésre is igaz (`externalcalendarimporter.php`): ott `\Eloquent\ExternalCalendar::where(...)` áll, ami Eloquent Buildert ad vissza, nem nyers query buildert. Ellenőrizve `pretend()` módban, a futó konténerben:
  ```
  update `external_calendars` set `active` = 0, `updated_at` = '2026-08-28 04:47:41' where …
  ```
  (04:47 a PHP órája; a MySQL ugyanekkor 07:47-et mondott.)

- **`church_relationships.updated_at`** — ezen a táblán **egyáltalán nincs UPDATE-útvonal**: a módosítás a #521 óta delete + create, a `create()` pedig mindkét időbélyeget beteszi az INSERT-be, PHP órával. Az `ON UPDATE` holt szabály, a `DEFAULT NULL` sosem sül el.

Mindkét helyre bekerült egy figyelmeztetés is: ha valaha kézi SQL javítja a történelmi adatot ezeken a táblákon, az `updated_at`-et **kötelező beírni a SET-be**, különben az `ON UPDATE` a MySQL órájával írja felül — a javító UPDATE maga rontaná el a mezőt.

## A csendes csapda, ami majdnem megfogott

A `created_at` **nem volt a `ChurchUpdateToken::$fillable`-jében**. A `create()`-nek átadott értéket a Laravel némán eldobta volna, és a javítás úgy nézett volna ki, mintha megtörtént volna — pontosan úgy, ahogy a #898-ban az `adminmegj`. Ezért van rá teszt. A javítás nélkül:

```
Failed asserting that 10800 is equal to 120 or is less than 120.
Failed asserting that 1803600 matches expected 1814400.
```

Az `admindatum`-teszt szándékosan a **két oszlop egymáshoz mért távolságát** nézi, nem a PHP órájához mért abszolút eltérést: így akkor is érvényes marad, ha a kapcsolat zónája egyszer UTC-re vált. Nélküle ott is 10800 másodperc.

## Mérés

Teljes tesztsor: 1629 teszt. Egy hiba marad a fejlesztői példányomon (`SzentsegimadasImportTest`), az az Elasticsearch-állapotomtól függ és ettől független — a CI-ben nem bukik.

## Deploy

Séma-lépés **nincs**, a `schema-reference.json`-t nem kell újragenerálni, a `SchemaReferenceTest` változatlanul zöld.

## Ami emberi döntést igényel (nem ebben a PR-ben)

A `remarks.admindatum` mai jelentése: „az utolsó `?remark=modify` beküldés ideje". Egy **még nem kezelt** észrevételnél 2026 májusáig `'0000-00-00 00:00:00'` állt itt (az őszinte „senki nem nyúlt hozzá"), a #174-B migráció óta a keletkezés ideje. Ez a PR a **mai viselkedést tartja meg, csak helyes órával**. Ha az a helyes, hogy az érintetlen állapot üresen látsszon, az séma-módosítás — a #890-ben rákérdeztem.
