### PR TITLE
Rendbe teszem a séma-referenciát, és a CI is észreveszi, ha elcsúszik (#911)

### DIFF
--- a/docker/compose.coverage.yml
+++ b/docker/compose.coverage.yml
@@ -10,6 +10,17 @@ services:
       - EXTERNAL_APIS_OFFLINE=1
     volumes:
       - ../webapp:/miserend/webapp
+      # #911: a sémafájlok a CHECKOUTBÓL jöjjenek, ne a beégetett image-ből.
+      #
+      # A séma-referencia ujjlenyomata a `/miserend/docker/mysql/initdb.d`-ből számolódik
+      # (`SchemaCheck::initdbDirectory()`). Ha az az image-ből jön, akkor egy TAG-re épült,
+      # hetekkel korábbi image régi sémafájljait hasonlítjuk a szintén régi, beversenyzett
+      # referenciához — a kettő egyezik, a teszt zöld, és az elavulás észrevétlen marad.
+      # Pontosan ez történt: a referencia tíz fájlt ismert a tizennyolcból, és senki nem
+      # szólt, mert mindkét oldal ugyanazt a nyolcat hiányolta.
+      #
+      # Csak olvasásra kell, és nem kerül semmibe: se build-időbe, se image-méretbe.
+      - ./mysql/initdb.d:/miserend/docker/mysql/initdb.d:ro
       - vendor_data:/miserend/webapp/vendor
       - node_modules_data:/miserend/webapp/node_modules
       - ${TEST_RESULTS_PATH:-..}/test-results:/miserend/test-results

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -37,6 +37,17 @@ services:
     # egy PHP fájlt, és azonnal látszik). Élesben pont ez takarta el az image tartalmát.
     volumes:
       - ../webapp:/miserend/webapp
+      # #911: a sémafájlok a CHECKOUTBÓL jöjjenek, ne a beégetett image-ből.
+      #
+      # A séma-referencia ujjlenyomata a `/miserend/docker/mysql/initdb.d`-ből számolódik
+      # (`SchemaCheck::initdbDirectory()`). Ha az az image-ből jön, akkor egy TAG-re épült,
+      # hetekkel korábbi image régi sémafájljait hasonlítjuk a szintén régi, beversenyzett
+      # referenciához — a kettő egyezik, a teszt zöld, és az elavulás észrevétlen marad.
+      # Pontosan ez történt: a referencia tíz fájlt ismert a tizennyolcból, és senki nem
+      # szólt, mert mindkét oldal ugyanazt a nyolcat hiányolta.
+      #
+      # Csak olvasásra kell, és nem kerül semmibe: se build-időbe, se image-méretbe.
+      - ./mysql/initdb.d:/miserend/docker/mysql/initdb.d:ro
       - vendor_data:/miserend/webapp/vendor
       - node_modules_data:/miserend/webapp/node_modules
 volumes:

--- a/webapp/schema-reference.json
+++ b/webapp/schema-reference.json
@@ -3235,20 +3235,28 @@
     }
   },
   "_meta": {
-    "generated_at": "2026-08-24T05:23:33+02:00",
-    "source_schema": "miserend_ref_872",
-    "initdb_fingerprint": "0e7a7451023e81f73e62b23d418801aad4c4bf2501edd9160e93f8729aab08ae",
+    "generated_at": "2026-08-28T07:32:17+02:00",
+    "source_schema": "miserend",
+    "initdb_fingerprint": "bd4127dba86207e7b7d3daf44314890b61caf59eb135dab2abf3ec259ee7dadd",
     "initdb_files": {
       "00-users.sh": "e4f1149c70b9b0b44ce0ba172110ca07ad099fffaf720876e45e8a0a5cb910f8",
       "01-create-database.sql": "dec66da6495a0d5ee007beda9e2be684b104cb4875b12ba0cf21ebae81874385",
-      "02-schema.sql": "40fdcedfd73cc57f8cb24e64c5785c91286de80d22c42700e0704cd42d657b7a",
+      "02-schema.sql": "3afc5a10cfe59d5580ab9ad1f1552f6d72a96dba3cea2e81356cc469f4fe3307",
       "03-migrations.sql": "b17a6da4226a09f95c8249d6886802fe1087b944644f705d75a716a9a562f644",
       "04-attributes-index.sql": "b2cf9ff6b616a8679c944fb6eb09baf6daeaa53793c0395e8d921525a91ea61a",
       "04-mass-languages.sql": "9df189d0de091724f0b3119bd9fc088a5960885e4a35487df11d5a6422c2bcf5",
       "05-data.sh": "5cf4dcd42e89288863792ed219c41937abcca249da22fbbf623d30dcd176874f",
       "06-data-integrity.sql": "d0afff9288b6b7ccd60aae9e9f9e14c903732f4560e7eb7efde299ff946a944a",
       "06-relationship-type-drop.sql": "04ac1538b42e0d9ad1f8106762013c8e9003965b70bc76ae1b27891273da938e",
-      "07-boundaries-iso.sql": "120cd5b6a656e754c8eef74d34415e03d987a09dce6ba998cb5c6ad1604fc03b"
+      "07-boundaries-iso.sql": "120cd5b6a656e754c8eef74d34415e03d987a09dce6ba998cb5c6ad1604fc03b",
+      "08-usage-stats.sql": "f0b63528507eb0edb0caaa309cdbea1278b99ba9f842adfc804a2eda716001bf",
+      "09-suggestion-handler.sql": "f2b92352c0dd219915630f34e77409b97248c6f15400c6add24c7989f80317e0",
+      "10-location-columns-drop.sql": "b096ed0821aa09e1154a2ab8435c3dd2273769b0cede9b9f5b01e7d6e788e732",
+      "11-mass-location.sql": "661365a7fc5adae8892dc7557e6fc3a028e1c0e877110e2e32df252cc1196b4b",
+      "12-mass-external-calendar.sql": "e4cd35ce1096c4f4ca1454aa422b24e8d521f4adfb2fda9be1a1c69c894e8f5c",
+      "13-emails-error-reason.sql": "d104b534204416e523da52989375fda0696d8a4520bd19892664d67d78ab92c0",
+      "15-attributes-unique.sql": "613796ef5bbdc06f736176b57b5e8da288ed40d07ed75858caa8302fb2fbac5b",
+      "16-notification-digest.sql": "3f6e22de9be67f2a753224d108afa56bda1b88d20be26c71f3dbc2c2f20819f2"
     }
   }
 }

--- a/webapp/tests/Integration/SchemaReferenceTest.php
+++ b/webapp/tests/Integration/SchemaReferenceTest.php
@@ -68,9 +68,24 @@ final class SchemaReferenceTest extends TestCase {
         $reference = \SchemaCheck::loadReference();
         $current   = \SchemaCheck::initdbFingerprint();
 
-        if ($current === null) {
-            self::markTestSkipped('az initdb.d nem olvasható ebben a környezetben');
-        }
+        /*
+         * #911: ez korábban `markTestSkipped` volt, és pont ez volt a baj.
+         *
+         * Ha a sémafájlok nem olvashatók, az ellenőrzés NÉMÁN kimaradt — az eredmény
+         * zöld futás, miközben senki nem vetett össze semmit. Az elavulás így hónapokig
+         * észrevétlen maradhatott: a referencia tíz initdb-fájlt ismert a tizennyolcból.
+         *
+         * Minden környezetben, ahol ez a teszt fut, a könyvtárnak ott kell lennie: a
+         * compose becsatolja a forrásfából (`docker/compose.dev.yml`,
+         * `docker/compose.coverage.yml`), élesben pedig a Dockerfile `COPY . .`-ja
+         * teszi be. Ha mégis hiányzik, azt meg kell tudni — nem elhallgatni.
+         */
+        self::assertNotNull(
+            $current,
+            "Nem olvashatók a sémafájlok: " . \SchemaCheck::initdbDirectory() . "\n"
+            . "Enélkül ez az ellenőrzés vakon futna. Hiányzik a becsatolás?\n"
+            . "  - ./mysql/initdb.d:/miserend/docker/mysql/initdb.d:ro"
+        );
 
         self::assertSame(
             $reference['_meta']['initdb_fingerprint'], $current,
@@ -83,6 +98,18 @@ final class SchemaReferenceTest extends TestCase {
         $result = \SchemaCheck::check();
 
         self::assertArrayHasKey('stale', $result);
+
+        /*
+         * #911: a `stale` akkor is HAMIS, ha nem tudtunk összevetni — a `check()` a két
+         * ujjlenyomat egyezését nézi, és a hiányzó oldalt nem tekinti eltérésnek. Az
+         * alábbi állítás nélkül tehát ez a teszt üresen menne át abban a környezetben,
+         * ahol a legnagyobb szükség volna rá.
+         */
+        self::assertNotNull(
+            \SchemaCheck::initdbFingerprint(),
+            'nincs mivel összevetni: a `stale = false` itt nem jelent semmit'
+        );
+
         self::assertFalse($result['stale'], 'a beversenyzett referencia nem lehet elavult. ' . self::REGENERATE);
     }
 


### PR DESCRIPTION
Closes #911

A beversenyzett `schema-reference.json` **tíz initdb-fájlt ismert a tizennyolcból**, és ráadásul egy `miserend_ref_872` nevű **ideiglenes sémából** készült.

## Miért nem tűnt fel

Helyben zöld volt — de csak azért, mert a futó image is régi: mindkét oldal ugyanazt a nyolc fájlt hiányolta, tehát az ujjlenyomat egyezett. A CI-ban az ellenőrzés kimarad (a coverage-image nem tartalmazza a `docker/mysql`-t). Az éles image viszont a teljes repóból épül (`Dockerfile:39` `COPY . .`, és a `.dockerignore` nem zárja ki), tehát ott a `/health` „elavult referenciát" mutatott volna.

## Kimérve, teljes újraépítés után

```bash
docker compose -f docker/compose.yml -f docker/compose.dev.yml down -v
docker compose -f docker/compose.yml -f docker/compose.dev.yml up -d --build
```

A friss stacken (app-image: 18 initdb-fájl, DB: 40 tábla) az ellenőrzés **azonnal elavultnak jelezte magát**, pontosan a jegyben megjósolt módon:

```
available=true  stale=true  findings=0
  megváltozott: 02-schema.sql
  új fájl: 08-usage-stats.sql
  új fájl: 09-suggestion-handler.sql
  új fájl: 10-location-columns-drop.sql
  új fájl: 11-mass-location.sql
  új fájl: 12-mass-external-calendar.sql
  új fájl: 13-emails-error-reason.sql
  új fájl: 15-attributes-unique.sql
  új fájl: 16-notification-digest.sql
```

Újragenerálás után:

```
available=true  stale=false  findings=0
```

## A megnyugtató rész

**A diff CSAK a `_meta`-t érinti** — 13 beszúrt, 5 törölt sor, a `tables` szakasz betűre azonos. Ez volt a jegy nyitott kérdése: a nyolc hiányzó fájl **nem takart el szerkezeti eltérést**. Ha eltakart volna, most több száz sor mozogna.

## Mérés

A teljes tesztsor a friss stacken: **1626 teszt, nulla hiba.** (Mellékesen ezzel eltűnt az a `SzentsegimadasImportTest`-hiba is, ami a gépemen napok óta bukott — tényleg csak elavult Elasticsearch-állapot volt, ahogy gondoltam.)

## És a másik fele: a CI mostantól észreveszi

Ez a jegy nem attól szólt, hogy a referencia elavult, hanem attól, hogy **hónapokig senki nem szólt róla**. Két néma pont miatt — mindkettőt kijavítottam ugyanebben a PR-ben.

**1. Az ujjlenyomat a beégetett image fájljaiból számolódott.** A coverage-image tag-re épül (`app-release.yaml`), tehát hetekkel korábbi lehet. A régi image régi sémafájljait hasonlítottuk a szintén régi, beversenyzett referenciához: a kettő egyezett, a teszt zöld volt.

A forrásfa mostantól be van csatolva, olvasásra:

```yaml
- ./mysql/initdb.d:/miserend/docker/mysql/initdb.d:ro
```

`compose.coverage.yml`-be (CI) és `compose.dev.yml`-be (fejlesztés) is. **Nulla build-idő, nulla image-méret** — a korábbi „külön mérlegelés" indokom nem állt meg, a becsatolás nem kerül semmibe.

**2. Ha a sémafájlok nem olvashatók, az ellenőrzés némán kimaradt.** A `testFingerprintMatchesTheDeployedSchemaFiles` `markTestSkipped`-et hívott, a `testCheckReportsStaleness` pedig **üresen ment át**, mert a `check()` a hiányzó oldalt nem tekinti eltérésnek (`stale = false` akkor is, ha nem volt mivel összevetni). Mindkettő hangos lett: ha nincs mivel összevetni, azt meg kell tudni.

### Kimérve

```
1) alap                                  -> OK (6 teszt)
2) új sémafájl a forrásfába              -> 2 hiba:
     testFingerprintMatchesTheDeployedSchemaFiles
       „A sémafájlok változtak a referencia készítése óta."
     testCheckReportsStaleness
       „a beversenyzett referencia nem lehet elavult."
3) a próbafájl eltávolítva               -> OK
```

A becsatolás nélkül a 2. lépés **zöld maradt volna** — a konténer nem is látta volna az új fájlt. Pontosan ez a hiba, ami miatt a jegy megszületett.

Teljes tesztsor a friss stacken: **1626 teszt, nulla hiba.**
