### PR TITLE
Egy órán jár a PHP és a MySQL (#890)

### DIFF
--- a/docker/mysql/migrations/890-idozona-europe-budapest.sql
+++ b/docker/mysql/migrations/890-idozona-europe-budapest.sql
@@ -1,0 +1,385 @@
+-- #890: a session-időzóna `+05:00`-ról `Europe/Budapest`-re áll — a történelmi,
+-- PHP által írt TIMESTAMP oszlopok egyszeri helyretolása.
+--
+--
+-- !!! ELŐTTE BACKUP:  bash docker/mysql/dump.sh > backup-PRE-890.sql
+--
+-- Futtatás (az alkalmazás ÁLLJON, l. docs/deploy-lepesek.md):
+--    docker exec -i miserend-prod-mysql-1 mariadb -uuser -p"$MYSQL_PASSWORD" miserend \
+--      < docker/mysql/migrations/890-idozona-europe-budapest.sql
+--
+--
+-- MIÉRT KELL. A PHP `date('Y-m-d H:i:s')`-szel budapesti FALIÓRA-időt ír, a
+-- munkamenet viszont `+05:00`-ban értelmezi, tehát a TÁROLT pillanat 5 órával a
+-- falióra mögé kerül a helyes 1-2 óra helyett. Amíg ugyanaz a rossz zóna olvassa
+-- vissza, ez nem látszik — de a `webapp/functions.php` javításával az olvasás
+-- helyreáll, és a régi sorok 3 (nyár) / 4 (tél) órával korábbra ugranának.
+-- Ez a migráció ezt a 3-4 órát adja vissza a TÁROLT pillanatnak.
+--
+-- A KÉPLET. Kizárólag `+05:00`-s munkamenetben érvényes — a fájl ezért maga
+-- állítja be, nem bízza a kliensre:
+--     CONVERT_TZ(col,'Europe/Budapest','+05:00')
+-- Az eltolás NEM konstans: a tárolt pillanatra érvényes budapesti eltolás dönti
+-- el, tehát az óraátállítás körüli sorokra is helyes. Egy `INTERVAL 3 HOUR`
+-- HIBÁS volna.
+--
+-- MIT NEM ÉRINT.
+--   * DATETIME oszlopok — a munkamenet-zóna nem konvertálja őket, tehát a PHP
+--     által írtak (`chat.datum`, `user.regdatum`, `user.lastactive`) MA IS
+--     helyesek. A MySQL órájával írtak (`templomok.moddatum`, és a vegyes
+--     `user.lastlogin` / `remarks.admindatum` egy része) 3-4 órával a jövőben
+--     állnak, de egyiket sem olvassa órához mérő kód, és a javítás után az új
+--     sorok maguktól jók lesznek. Nem nyúlunk hozzájuk — l. a jegy indoklását.
+--   * `church_update_tokens.created_at` és `updates.timestamp` — ezeket a MySQL
+--     `CURRENT_TIMESTAMP` alapértéke tölti, tehát a TÁROLT pillanatuk MA IS
+--     helyes, és a javítástól maguktól jóra fordulnak. Eltolni őket rontás volna.
+--   * `cal_masses.start_date` — varchar, zóna nélküli falióra, ismétlődő
+--     eseményekkel. A munkamenet-zóna nem ér hozzá.
+--   * 2016-01-01 ELŐTTI sorok — a `SET time_zone='+05:00'` a 8bd8e2e9 commit-tal
+--     került be (2016-01-01). Ami régebbi, az nem ezen a hibán ment keresztül.
+--   * `'0000-00-00 00:00:00'` — a `CONVERT_TZ` NULL-t adna rá. NULL-ozható
+--     oszlopon ez néma adatvesztés; NOT NULL TIMESTAMP oszlopon a MariaDB NÉMÁN
+--     a futásidejű CURRENT_TIMESTAMP-re cseréli (mérve, warning nélkül). Az alsó
+--     határ egyszerre zárja ki a nulla-dátumot és a hiba előtti kort.
+
+USE `miserend`;
+
+/*
+ * 1. ŐR — a nevesített időzóna elérhetősége.
+ *
+ * Ha a `mysql.time_zone_*` tábla hiányzik vagy csonka, a `CONVERT_TZ` NEM hibázik,
+ * hanem NULL-t ad — a migráció ilyenkor csendben kinullázná az oszlopokat. Ezért
+ * a fájl elején ismert bemenetre ismert kimenetet követelünk: ha nem stimmel, a
+ * NOT NULL oszlopba írt NULL ERROR 1048-cal MEGÁLLÍTJA a futást, és mivel a
+ * kliens `--force` nélkül fut, a lenti UPDATE-ek el sem indulnak.
+ *
+ * Ha itt elszáll:  mariadb-tzinfo-to-sql /usr/share/zoneinfo | mariadb -u root -p mysql
+ */
+DROP TEMPORARY TABLE IF EXISTS `_tz890_or`;
+CREATE TEMPORARY TABLE `_tz890_or` (
+  `LEALLAS_A_MYSQL_TIME_ZONE_TABLA_HIANYZIK_VAGY_ROSSZ` TINYINT NOT NULL
+) ENGINE=InnoDB;
+
+INSERT INTO `_tz890_or` VALUES (NULLIF(
+      CONVERT_TZ('2026-07-15 10:00:00','Europe/Budapest','+05:00') = '2026-07-15 13:00:00'
+  AND CONVERT_TZ('2026-01-15 10:00:00','Europe/Budapest','+05:00') = '2026-01-15 14:00:00'
+, 0));
+
+/*
+ * 2. NAPLÓ — az idempotencia egyetlen forrása.
+ *
+ * A képlet ÉRTÉK alapján nem idempotens: az eltolt időbélyeg ugyanolyan hihető,
+ * mint az eredeti, tehát egy második futás némán további 3-4 órát csúsztatna.
+ * Ezért oszloponként jelöljük, hogy megtörtént, és az UPDATE-et ehhez a jelöléshez
+ * kötjük. A DDL implicit commitot okoz, ezért a tábla a tranzakció ELŐTT készül.
+ *
+ * A `futott_epoch` SZÁNDÉKOSAN BIGINT, nem TIMESTAMP: a napló ne essen annak a
+ * hibának az áldozatává, amit javít.
+ */
+CREATE TABLE IF NOT EXISTS `tz_migracio_890` (
+  `tabla`        varchar(64) NOT NULL,
+  `oszlop`       varchar(64) NOT NULL,
+  `futott_epoch` bigint(20)  NOT NULL,
+  `erintett_sor` int(11)     NOT NULL DEFAULT 0,
+  PRIMARY KEY (`tabla`,`oszlop`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+/*
+ * 3. A KÉPLET MUNKAMENETE.
+ *
+ * `+05:00` KELL: az UPDATE bal oldala is a munkamenet-zónán megy át, ezért a
+ * kifejezés csak ebben a zónában adja a helyes eredményt. A `mariadb` kliens
+ * alapból a szerver zónáján (itt SYSTEM=UTC) indul — nem szabad rábízni.
+ */
+SET time_zone = '+05:00';
+SET @KEZDET = '2016-01-01 00:00:00';
+SET @VEGE   = '2038-01-01 00:00:00';
+
+START TRANSACTION;
+
+-- ---------------------------------------------------------------------------
+-- 4. OSZLOPONKÉNTI HELYRETOLÁS
+--
+-- Táblánként EGY utasítás, benne a tábla MINDEN migrálandó dátumoszlopa. Ez nem
+-- kényelmi kérdés: a `confessions.timestamp`, a `church_relationships.updated_at`
+-- és az `external_calendars.updated_at` `ON UPDATE current_timestamp()`-es, tehát
+-- ha nem szerepelnének explicit módon a SET-listában, a futásidőre ugranának.
+--
+-- A határőr az ÉRTÉKADÁSBAN van, nem a WHERE-ben: így egy NULL vagy nulla-dátumú
+-- oszlop nem zárja ki a sor többi oszlopát a javításból.
+-- ---------------------------------------------------------------------------
+
+-- photos
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('photos','created_at',UNIX_TIMESTAMP()),('photos','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `photos` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='photos' AND @go = 2;
+
+-- templomok  (a `moddatum` DATETIME — szándékosan kimarad, l. a fejlécet)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('templomok','created_at',UNIX_TIMESTAMP()),('templomok','updated_at',UNIX_TIMESTAMP()),
+  ('templomok','deleted_at',UNIX_TIMESTAMP()),('templomok','boundaries_checked_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `templomok` SET
+  `created_at`            = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at`            = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`),
+  `deleted_at`            = IF(`deleted_at` >= @KEZDET AND `deleted_at` < @VEGE, CONVERT_TZ(`deleted_at`,'Europe/Budapest','+05:00'), `deleted_at`),
+  `boundaries_checked_at` = IF(`boundaries_checked_at` >= @KEZDET AND `boundaries_checked_at` < @VEGE, CONVERT_TZ(`boundaries_checked_at`,'Europe/Budapest','+05:00'), `boundaries_checked_at`)
+WHERE @go = 4;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='templomok' AND @go = 4;
+
+-- keyword_shortcuts
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('keyword_shortcuts','created_at',UNIX_TIMESTAMP()),('keyword_shortcuts','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `keyword_shortcuts` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='keyword_shortcuts' AND @go = 2;
+
+-- church_links
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('church_links','created_at',UNIX_TIMESTAMP()),('church_links','updated_at',UNIX_TIMESTAMP()),
+  ('church_links','deleted_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `church_links` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`),
+  `deleted_at` = IF(`deleted_at` >= @KEZDET AND `deleted_at` < @VEGE, CONVERT_TZ(`deleted_at`,'Europe/Budapest','+05:00'), `deleted_at`)
+WHERE @go = 3;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='church_links' AND @go = 3;
+
+-- church_holders
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('church_holders','created_at',UNIX_TIMESTAMP()),('church_holders','updated_at',UNIX_TIMESTAMP()),
+  ('church_holders','deleted_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `church_holders` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`),
+  `deleted_at` = IF(`deleted_at` >= @KEZDET AND `deleted_at` < @VEGE, CONVERT_TZ(`deleted_at`,'Europe/Budapest','+05:00'), `deleted_at`)
+WHERE @go = 3;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='church_holders' AND @go = 3;
+
+-- church_relationships  (updated_at ON UPDATE — ezért van benne explicit módon)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('church_relationships','created_at',UNIX_TIMESTAMP()),('church_relationships','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `church_relationships` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='church_relationships' AND @go = 2;
+
+-- confessions  (a `timestamp` maga ON UPDATE — az explicit értékadás elnyomja)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('confessions','timestamp',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `confessions` SET
+  `timestamp` = IF(`timestamp` >= @KEZDET AND `timestamp` < @VEGE, CONVERT_TZ(`timestamp`,'Europe/Budapest','+05:00'), `timestamp`)
+WHERE @go = 1;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='confessions' AND @go = 1;
+
+-- external_calendars  (updated_at ON UPDATE — ezért van benne explicit módon)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('external_calendars','created_at',UNIX_TIMESTAMP()),('external_calendars','updated_at',UNIX_TIMESTAMP()),
+  ('external_calendars','last_import_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `external_calendars` SET
+  `created_at`     = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at`     = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`),
+  `last_import_at` = IF(`last_import_at` >= @KEZDET AND `last_import_at` < @VEGE, CONVERT_TZ(`last_import_at`,'Europe/Budapest','+05:00'), `last_import_at`)
+WHERE @go = 3;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='external_calendars' AND @go = 3;
+
+-- tokens  (a `timeout` a munkamenet-lejárat — enélkül a javítás kiléptet mindenkit)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('tokens','timeout',UNIX_TIMESTAMP()),('tokens','created_at',UNIX_TIMESTAMP()),('tokens','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `tokens` SET
+  `timeout`    = IF(`timeout` >= @KEZDET AND `timeout` < @VEGE, CONVERT_TZ(`timeout`,'Europe/Budapest','+05:00'), `timeout`),
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 3;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='tokens' AND @go = 3;
+
+-- crons  (a `deadline_at` az ütemező horgonya — enélkül minden munka egyszerre esedékes)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('crons','deadline_at',UNIX_TIMESTAMP()),('crons','lastsuccess_at',UNIX_TIMESTAMP()),
+  ('crons','created_at',UNIX_TIMESTAMP()),('crons','updated_At',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `crons` SET
+  `deadline_at`    = IF(`deadline_at` >= @KEZDET AND `deadline_at` < @VEGE, CONVERT_TZ(`deadline_at`,'Europe/Budapest','+05:00'), `deadline_at`),
+  `lastsuccess_at` = IF(`lastsuccess_at` >= @KEZDET AND `lastsuccess_at` < @VEGE, CONVERT_TZ(`lastsuccess_at`,'Europe/Budapest','+05:00'), `lastsuccess_at`),
+  `created_at`     = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_At`     = IF(`updated_At` >= @KEZDET AND `updated_At` < @VEGE, CONVERT_TZ(`updated_At`,'Europe/Budapest','+05:00'), `updated_At`)
+WHERE @go = 4;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='crons' AND @go = 4;
+
+-- emails  (a `created_at`/`updated_at` a beragadt-küldés detektorának bemenete)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('emails','created_at',UNIX_TIMESTAMP()),('emails','updated_at',UNIX_TIMESTAMP()),('emails','failed_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `emails` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`),
+  `failed_at`  = IF(`failed_at`  >= @KEZDET AND `failed_at`  < @VEGE, CONVERT_TZ(`failed_at`,'Europe/Budapest','+05:00'),  `failed_at`)
+WHERE @go = 3;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='emails' AND @go = 3;
+
+-- messages
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES ('messages','timestamp',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `messages` SET
+  `timestamp` = IF(`timestamp` >= @KEZDET AND `timestamp` < @VEGE, CONVERT_TZ(`timestamp`,'Europe/Budapest','+05:00'), `timestamp`)
+WHERE @go = 1;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='messages' AND @go = 1;
+
+-- remarks  (az `admindatum` DATETIME — szándékosan kimarad)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('remarks','created_at',UNIX_TIMESTAMP()),('remarks','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `remarks` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='remarks' AND @go = 2;
+
+-- church_update_tokens  (a `created_at` MySQL-írt — szándékosan kimarad)
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('church_update_tokens','expires_at',UNIX_TIMESTAMP()),('church_update_tokens','used_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `church_update_tokens` SET
+  `expires_at` = IF(`expires_at` >= @KEZDET AND `expires_at` < @VEGE, CONVERT_TZ(`expires_at`,'Europe/Budapest','+05:00'), `expires_at`),
+  `used_at`    = IF(`used_at`    >= @KEZDET AND `used_at`    < @VEGE, CONVERT_TZ(`used_at`,'Europe/Budapest','+05:00'),    `used_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='church_update_tokens' AND @go = 2;
+
+-- cal_suggestions
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('cal_suggestions','created_at',UNIX_TIMESTAMP()),('cal_suggestions','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `cal_suggestions` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='cal_suggestions' AND @go = 2;
+
+-- cal_suggestion_packages
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('cal_suggestion_packages','created_at',UNIX_TIMESTAMP()),('cal_suggestion_packages','updated_at',UNIX_TIMESTAMP()),
+  ('cal_suggestion_packages','handled_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `cal_suggestion_packages` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`),
+  `handled_at` = IF(`handled_at` >= @KEZDET AND `handled_at` < @VEGE, CONVERT_TZ(`handled_at`,'Europe/Budapest','+05:00'), `handled_at`)
+WHERE @go = 3;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='cal_suggestion_packages' AND @go = 3;
+
+-- notification_digest_items
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('notification_digest_items','created_at',UNIX_TIMESTAMP()),('notification_digest_items','sent_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `notification_digest_items` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `sent_at`    = IF(`sent_at`    >= @KEZDET AND `sent_at`    < @VEGE, CONVERT_TZ(`sent_at`,'Europe/Budapest','+05:00'),    `sent_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='notification_digest_items' AND @go = 2;
+
+-- distances
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('distances','created_at',UNIX_TIMESTAMP()),('distances','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `distances` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='distances' AND @go = 2;
+
+-- favorites
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('favorites','created_at',UNIX_TIMESTAMP()),('favorites','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `favorites` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='favorites' AND @go = 2;
+
+-- osm
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('osm','created_at',UNIX_TIMESTAMP()),('osm','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `osm` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='osm' AND @go = 2;
+
+-- lookup_boundary_church
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('lookup_boundary_church','created_at',UNIX_TIMESTAMP()),('lookup_boundary_church','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `lookup_boundary_church` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='lookup_boundary_church' AND @go = 2;
+
+-- lookup_church_osm
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('lookup_church_osm','created_at',UNIX_TIMESTAMP()),('lookup_church_osm','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `lookup_church_osm` SET
+  `created_at` = IF(`created_at` >= @KEZDET AND `created_at` < @VEGE, CONVERT_TZ(`created_at`,'Europe/Budapest','+05:00'), `created_at`),
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 2;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='lookup_church_osm' AND @go = 2;
+
+-- lookup_osm_enclosed
+INSERT IGNORE INTO `tz_migracio_890` (tabla,oszlop,futott_epoch) VALUES
+  ('lookup_osm_enclosed','updated_at',UNIX_TIMESTAMP());
+SET @go := ROW_COUNT();
+UPDATE `lookup_osm_enclosed` SET
+  `updated_at` = IF(`updated_at` >= @KEZDET AND `updated_at` < @VEGE, CONVERT_TZ(`updated_at`,'Europe/Budapest','+05:00'), `updated_at`)
+WHERE @go = 1;
+SET @n := ROW_COUNT();
+UPDATE `tz_migracio_890` SET `erintett_sor` = @n WHERE `tabla`='lookup_osm_enclosed' AND @go = 1;
+
+COMMIT;
+
+DROP TEMPORARY TABLE IF EXISTS `_tz890_or`;
+
+-- ---------------------------------------------------------------------------
+-- 5. UTÓELLENŐRZÉS — az alkalmazás MÉG ÁLLJON, amíg ez lefut.
+-- ---------------------------------------------------------------------------
+SELECT `tabla`, `oszlop`, `erintett_sor`, FROM_UNIXTIME(`futott_epoch`) AS futott
+  FROM `tz_migracio_890` ORDER BY `tabla`, `oszlop`;

--- a/docs/deploy-lepesek.md
+++ b/docs/deploy-lepesek.md
@@ -133,6 +133,62 @@ SELECT COUNT(*) FROM information_schema.COLUMNS
 
 ---
 
+### `890-idozona-europe-budapest.sql` — **KARBANTARTÁSI ABLAK KELL, olvasd el végig**
+
+A munkamenet-időzóna `+05:00`-ról `Europe/Budapest`-re áll (`webapp/functions.php`), és a
+történelmi, PHP által írt TIMESTAMP oszlopokat ez a migráció tolja helyre. **A kettő
+együtt jár**: külön-külön futtatva a fél rendszer 3-4 órával elcsúszik.
+
+**Előfeltétel — ezt a deploy ELŐTT nézd meg, nem közben:**
+```sql
+SELECT (SELECT COUNT(*) FROM mysql.time_zone_name)                   AS zonak,
+       CONVERT_TZ('2026-07-15 10:00:00','Europe/Budapest','+05:00')  AS nyar,
+       CONVERT_TZ('2026-01-15 10:00:00','Europe/Budapest','+05:00')  AS tel;
+-- elvárt: zonak > 0, nyar = '2026-07-15 13:00:00', tel = '2026-01-15 14:00:00'
+-- NULL vagy eltérés -> a tz-tábla hiányzik. NE menj tovább, töltsd be:
+--   mariadb-tzinfo-to-sql /usr/share/zoneinfo | mariadb -u root -p mysql
+```
+A MariaDB a tz-táblát CSAK üres adatkönyvtárnál tölti be, a prod deploy pedig soha nem
+üríti a volume-ot — tehát nem lehet feltételezni, hogy megvan. Ha hiányzik, a `CONVERT_TZ`
+NEM hibázik, hanem NULL-t ad; a migráció saját őre emiatt áll meg (ERROR 1048).
+
+**Sorrend (az alkalmazás ÁLLJON a 2-4. lépés alatt):**
+1. friss mentés: `mariadb-dump --single-transaction --databases miserend | gzip > ~/backups/miserend-PRE-890-$(date +%F_%H%M%S).sql.gz`
+2. `docker compose ... stop miserend`, és a hoszt crontab `q=cron` sora kikommentelve
+3. **kód előbb** (a javított `functions.php`-t tartalmazó image induljon el), majd
+4. `docker exec -i mysql mariadb -u root -p miserend < docker/mysql/migrations/890-idozona-europe-budapest.sql`
+5. utóellenőrzés (lent), csak utána `start miserend` és a crontab vissza
+
+**Kell-e még?**
+```sql
+SELECT COUNT(*) FROM information_schema.TABLES
+ WHERE TABLE_SCHEMA='miserend' AND TABLE_NAME='tz_migracio_890';
+-- 0 -> még kell
+-- 1 -> megvolt; a `SELECT * FROM tz_migracio_890` megmondja, mikor és hány sorra
+```
+A migráció **idempotens**: a `tz_migracio_890` napló miatt a második futás nulla sort ír.
+Enélkül nem lenne az — az eltolt időbélyeg ugyanolyan hihető, mint az eredeti.
+
+**Utóellenőrzés, még leállított alkalmazás mellett.** A migráció ELŐTT jegyezd fel néhány
+sor értékét egy `+05:00`-s munkamenetből; utána ugyanannak kell visszajönnie egy
+`Europe/Budapest`-esből:
+```sql
+SET time_zone='Europe/Budapest';
+SELECT MAX(created_at) FROM photos;      -- egyezzen a migráció előtti +05:00-s értékkel
+SELECT MAX(timeout)    FROM tokens;      -- ha ez 3-4 órával korábbi, mindenki kilépett
+SELECT MAX(deadline_at) FROM crons;      -- ha korábbi, egyszerre indul minden cron
+```
+
+Elasticsearch-újraindexelés **nem kell**: a mise-index a `cal_masses.start_date` varchar
+mezőből épül, amihez a migráció nem nyúl, a `crons.lastsuccess_at` pedig vele együtt
+mozdul, tehát az újraindexelési kapu nem billen át. Ez viszont csak akkor igaz, ha a
+kódjavítás és a migráció között NEM futott cron — ezért kell a leállás.
+
+**Amit szándékosan NEM javít:** a DATETIME oszlopokat (`chat.datum`, `user.regdatum`,
+`user.lastlogin`, `user.lastactive`, `remarks.admindatum`, `templomok.moddatum`) és a
+MySQL órájával írt `church_update_tokens.created_at` / `updates.timestamp` oszlopokat.
+Az indoklás a migrációs fájl fejlécében van.
+
 ## Nem SQL, de deploy után kell
 
 ### Séma-referencia újragenerálása

--- a/webapp/classes/crons.php
+++ b/webapp/classes/crons.php
@@ -96,7 +96,9 @@ class Crons {
 		 * `OSM::checkBoundaries()` `date('Y-m-d H:i:s')`-szel írja, az esedékességet az
 		 * `osm.php` és a `requeueChurchesWithoutBoundary()` PHP-ben számolt határidőhöz
 		 * méri. Egyedül ez a visszatöltés dolgozott a MySQL órájával — az pedig a
-		 * `+05:00`-s session-zóna miatt HÁROM ÓRÁVAL előrébb jár (#890).
+		 * `+05:00`-s session-zóna miatt HÁROM ÓRÁVAL előrébb járt (#890). A session-zóna
+		 * azóta `Europe/Budapest`, tehát a rés megszűnt; a PHP-horgony viszont marad,
+		 * mert a helyes függés így is ez, és a lenti regressziós teszt is ezt őrzi.
 		 *
 		 * Következmény élesben: a visszatöltött templom három órával frissebbnek látszik
 		 * a valóságosnál. Egy 180 napos ablakban ez kicsi, de a CI-ben mérhető volt: ha a

--- a/webapp/functions.php
+++ b/webapp/functions.php
@@ -17,12 +17,51 @@ function dbconnect() {
 			'charset' => 'utf8mb4',
 			'collation' => 'utf8mb4_unicode_ci',
 			'prefix' => '',
+			/*
+			 * #890: a munkamenet-zóna ott dől el, ahol a kapcsolat születik.
+			 *
+			 * Eddig `bootEloquent()` UTÁN ment egy `DB::statement("SET time_zone='+05:00'")`.
+			 * Két baja volt. Az egyik, hogy `+05:00` — a PHP `Europe/Budapest`-ben ír
+			 * (load.php), tehát a tárolt pillanat 5 órával a falióra mögé került a helyes
+			 * 1-2 óra helyett. A másik, hogy EGYSZER futott: a Laravel elveszett kapcsolat
+			 * után magától újracsatlakozik (Connection::reconnectIfMissingConnection()), és
+			 * az új kapcsolat már NEM kapta meg a beállítást — mérve `SYSTEM` (=UTC) lett
+			 * belőle, némán, egy harmadik kódolást hozva be. Tipikus alkalom rá a fél órás
+			 * `updateMasses()` újraindexelés.
+			 *
+			 * A `timezone` konfigkulcsot a MySqlConnector::configureTimezone() a `connect()`
+			 * részeként alkalmazza, tehát MINDEN újracsatlakozásnál is lefut.
+			 *
+			 * A zónát a PHP-tól kérdezzük, nem írjuk le másodszor: két helyen karbantartott
+			 * időzónából előbb-utóbb kettő lesz.
+			 */
+			'timezone' => date_default_timezone_get(),
 				], 'default');
 		// Make this Capsule instance available globally via static methods... (optional)
 		$capsule->setAsGlobal();
 		$capsule->bootEloquent();
-		DB::statement("SET time_zone='+05:00';");
 	} catch(PDOException $e) {
+		/*
+		 * #890: az időzóna-hibát NEM szabad elnyelni.
+		 *
+		 * Ha a `mysql.time_zone_*` tábla nincs betöltve, a connector `set time_zone`-ja
+		 * ERROR 1298-cal elszáll. A Laravel ezt `QueryException`-be csomagolja, ami
+		 * `PDOException`-leszármazott (vendor/illuminate/database/QueryException.php) —
+		 * tehát ez a catch eddig lenyelte volna, kiírta volna a hibát a HTML-be, és az
+		 * alkalmazás futott volna tovább SYSTEM (=UTC) zónán. Az a legrosszabb kimenet:
+		 * egy harmadik, néma időrendszer a PHP falióra-értékei mellett.
+		 *
+		 * Megoldás nincs a kódban — a tz-táblát be kell tölteni:
+		 *   mariadb-tzinfo-to-sql /usr/share/zoneinfo | mariadb -u root -p mysql
+		 */
+		if (($e->errorInfo[1] ?? null) === 1298) {
+			throw new \RuntimeException(
+				'#890: a MySQL nem ismeri a(z) "' . date_default_timezone_get() . '" időzónát. '
+				. 'Töltsd be a nevesített időzóna-táblát: '
+				. 'mariadb-tzinfo-to-sql /usr/share/zoneinfo | mariadb -u root -p mysql',
+				0, $e
+			);
+		}
 		echo $e->getMessage();		
 	}
 

--- a/webapp/tests/Integration/CronOverlapTest.php
+++ b/webapp/tests/Integration/CronOverlapTest.php
@@ -30,6 +30,10 @@ class CronOverlapTest extends TestCase {
             'password' => $c['password'],
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
+            // #890: ez a kapcsolat megkerüli a `dbconnect()`-et, tehát külön kell
+            // megkapnia a zónát — enélkül a szerver SYSTEM (=UTC) zónáján ülne, és
+            // egy ide tévedő időbélyeg-összehasonlítás némán két órát tévedne.
+            'timezone' => date_default_timezone_get(),
         ], 'masik');
 
         return $capsule->getConnection('masik');

--- a/webapp/tests/Integration/SessionTimezoneTest.php
+++ b/webapp/tests/Integration/SessionTimezoneTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #890: a PHP és a MySQL egy órán járjon.
+ *
+ * A hiba az volt, hogy a `dbconnect()` a munkamenetet `+05:00`-ra állította, a PHP
+ * viszont `Europe/Budapest`-ben ír (load.php:12). A PHP által írt falióra-érték így
+ * öt órával a valódi pillanat mögé került a helyes egy-kettő helyett, és mindig
+ * pontosan annyival, amennyi az évszaktól függött — nyáron három, télen négy óra.
+ * Amíg ugyanaz a rossz zóna olvasta vissza, nem látszott; minden vegyes
+ * PHP↔MySQL összehasonlítás viszont csúszott (`DATEDIFF(NOW(), ...)`, cron-határidők,
+ * a beragadt levelek detektora).
+ *
+ * Két dolgot őriz ez a teszt, és a második a fontosabb:
+ *   1. a munkamenet-zóna megegyezik a PHP zónájával;
+ *   2. TÚLÉLI AZ ÚJRACSATLAKOZÁST. A régi megoldás egyetlen `DB::statement`-tel
+ *      állította a zónát a bootstrapkor — azt a Laravel automatikus reconnectje
+ *      (Connection::reconnectIfMissingConnection()) elveszítette, és a munkamenet
+ *      némán SYSTEM (=UTC) zónára esett vissza. Egy harmadik időrendszer,
+ *      hibaüzenet nélkül, tipikusan a fél órás `updateMasses()` közepén.
+ */
+final class SessionTimezoneTest extends TestCase {
+
+    public function testTheSessionTimezoneMatchesThePhpTimezone(): void {
+        self::assertSame(
+            date_default_timezone_get(),
+            DB::connection()->selectOne('SELECT @@session.time_zone AS tz')->tz,
+            'a MySQL munkamenet-zónájának a PHP zónájával kell egyeznie (#890)'
+        );
+    }
+
+    public function testThePhpClockAndTheMysqlClockShowTheSameWallTime(): void {
+        $mysql = strtotime(DB::connection()->selectOne('SELECT NOW() AS n')->n);
+
+        /*
+         * Két másodperc a tűrés: a két olvasás nem ugyanabban a pillanatban történik.
+         * A javítandó hiba nagyságrendje 3-4 ÓRA, tehát ez bőven megkülönbözteti őket.
+         */
+        self::assertLessThanOrEqual(2, abs(time() - $mysql),
+            'a PHP és a MySQL faliórája legfeljebb másodpercekkel térhet el (#890)');
+    }
+
+    /**
+     * Ez az a teszt, amit a régi `DB::statement`-es megoldás megbukott.
+     */
+    public function testTheTimezoneSurvivesAReconnect(): void {
+        $connection = DB::connection();
+        $connection->reconnect();
+
+        self::assertSame(
+            date_default_timezone_get(),
+            $connection->selectOne('SELECT @@session.time_zone AS tz')->tz,
+            'az újracsatlakozott kapcsolatnak is a PHP zónáján kell lennie (#890)'
+        );
+        self::assertLessThanOrEqual(2, abs(time() - strtotime($connection->selectOne('SELECT NOW() AS n')->n)),
+            'újracsatlakozás után sem csúszhat el a két óra (#890)');
+    }
+
+    /**
+     * A nevesített zóna nem elég, ha a MySQL nem ismeri: a `CONVERT_TZ` ilyenkor NEM
+     * hibázik, hanem NULL-t ad — a #890 migrációja pedig ebből néma adatvesztést
+     * csinálna. A migráció saját őre ezt elkapja, de a hiányt itt is meg akarjuk
+     * tudni, mielőtt bárki élesben futtat bármit.
+     */
+    public function testTheNamedTimezoneTableIsLoaded(): void {
+        $sor = DB::connection()->selectOne(
+            "SELECT CONVERT_TZ('2026-07-15 10:00:00','Europe/Budapest','+05:00') AS nyar,
+                    CONVERT_TZ('2026-01-15 10:00:00','Europe/Budapest','+05:00') AS tel"
+        );
+
+        self::assertSame('2026-07-15 13:00:00', $sor->nyar,
+            'nyári időszámítás: +02:00 → a +05:00-s falióra három órával későbbi');
+        self::assertSame('2026-01-15 14:00:00', $sor->tel,
+            'téli időszámítás: +01:00 → a +05:00-s falióra négy órával későbbi');
+    }
+
+    /**
+     * A megjelenítés a PHP zónáján keresztül megy, tehát ami TIMESTAMP oszlopba
+     * PHP-vel bemegy, annak változatlanul kell visszajönnie — az óraátállítás
+     * két határán is. Ez a #890 migrációjának a szemantikai szerződése.
+     */
+    public function testAWallClockValueSurvivesARoundTrip(): void {
+        $ertekek = [
+            'tel'                => '2026-01-15 10:00:00',
+            'nyar'               => '2026-07-15 10:00:00',
+            'tavaszi-atallitas'  => '2026-03-29 03:30:00',
+            'oszi-atallitas'     => '2026-10-25 03:30:00',
+        ];
+
+        DB::connection()->statement(
+            'CREATE TEMPORARY TABLE tz890_probakor (id INT PRIMARY KEY, ts TIMESTAMP NULL)'
+        );
+        try {
+            $i = 0;
+            foreach ($ertekek as $ertek) {
+                DB::connection()->insert('INSERT INTO tz890_probakor VALUES (?, ?)', [++$i, $ertek]);
+            }
+
+            $i = 0;
+            foreach ($ertekek as $cimke => $ertek) {
+                $vissza = DB::connection()
+                    ->selectOne('SELECT ts FROM tz890_probakor WHERE id = ?', [++$i])->ts;
+                self::assertSame($ertek, $vissza, "a(z) $cimke sor faliórája megváltozott (#890)");
+            }
+        } finally {
+            DB::connection()->statement('DROP TEMPORARY TABLE IF EXISTS tz890_probakor');
+        }
+    }
+}

--- a/webapp/tests/bootstrap.php
+++ b/webapp/tests/bootstrap.php
@@ -36,6 +36,20 @@ if (!function_exists('configurationSetEnvironment')) {
 $env = env('MISEREND_WEBAPP_ENVIRONMENT', 'testing');
 configurationSetEnvironment($env);
 
+/*
+ * #890: a `date_default_timezone_set()` a `dbconnect()` ELŐTT kell, hogy legyen.
+ *
+ * A load.php ezt a legelső dolgai közt teszi meg (load.php:12), a teszt-bootstrap
+ * viszont eddig a `dbconnect()` UTÁN — így a kapcsolat születésekor a PHP még a
+ * konténer alapértelmezett UTC-jén állt. A `dbconnect()` most a PHP zónájából
+ * származtatja a munkamenet-zónát, tehát ez a sorrend már nem ízlés kérdése:
+ * fordítva a tesztek UTC-s kapcsolaton futnának, az alkalmazás meg budapestin.
+ *
+ * A régi sorrend nyoma az adatbázisban is látszott: a `crons` sorai a `Cron::init()`
+ * miatt UTC-s PHP-órával születtek, miközben minden más sor budapestivel.
+ */
+date_default_timezone_set('Europe/Budapest');
+
 // Set up database connection for integration tests
 dbconnect();
 
@@ -53,7 +67,6 @@ if (!defined('DOMAIN')) {
     define('DOMAIN', $GLOBALS['config']['path']['domain'] ?? 'http://localhost');
 }
 
-date_default_timezone_set('Europe/Budapest');
 
 /*
  * A `t()` fordító-rövidítést a load.php definiálja, a tesztek viszont nem azt töltik be.


### PR DESCRIPTION
Closes #890

A `dbconnect()` a munkamenetet `+05:00`-ra állította, a PHP viszont `Europe/Budapest`-ben ír. A tárolt pillanat így öt órával a falióra mögé került a helyes egy-kettő helyett.

> [!WARNING]
> **Deploy-lépés van, karbantartási ablakkal.** A kód és a migráció **együtt jár** — külön-külön futtatva a fél rendszer 3-4 órával elcsúszik. A `docs/deploy-lepesek.md` leírja a sorrendet, az előfeltételt és az utóellenőrzést.

## Amit menet közben találtam, és rosszabb az eredeti hibánál

A régi `DB::statement("SET time_zone='+05:00'")` **egyszer** futott, a Laravel automatikus újracsatlakozása pedig elvesztette. Mérve a régi kóddal:

```
1) csatlakozás után : +05:00  NOW=11:16:37
2) újracsatlakozás  : SYSTEM  NOW=06:16:37     ← néma UTC, a PHP közben 08:16:37-et ír
```

Vagyis nem két időrendszer volt, hanem **három**, és a harmadik hibaüzenet nélkül állt elő — tipikusan a fél órás `updateMasses()` közepén.

A zóna ezért a **kapcsolat konfigjába** kerül (`'timezone' => date_default_timezone_get()`). A `MySqlConnector::configureTimezone()` a `connect()` részeként fut (`vendor/illuminate/database/Connectors/MySqlConnector.php:37`), tehát minden újracsatlakozásnál is. Ellenőrizve:

```
PHP zóna        : Europe/Budapest | 2026-08-28 08:39:08
kapcsolat után  : Europe/Budapest | NOW=2026-08-28 08:39:08
ÚJRACSATLAKOZÁS : Europe/Budapest | NOW=2026-08-28 08:39:08
PHP gmdate      : 06:39:08        | MySQL UTC=06:39:08
```

**És a hibát nem szabad elnyelni.** Hiányzó időzóna-táblánál a connector `ERROR 1298`-cal száll el, amit a Laravel `QueryException`-be csomagol — az pedig `PDOException`-leszármazott (ellenőrizve: `QueryException.php:9`). A `dbconnect()` `catch(PDOException)`-e ezt eddig lenyelte volna, kiírta volna a HTML-be, és az app **SYSTEM (=UTC)** zónán futott volna tovább. Most megáll, a betöltő paranccsal együtt.

## A migráció

23 tábla, 53 **TIMESTAMP** oszlop. DATETIME-hoz nem nyúl — ellenőriztem, egyik sem szerepel benne.

Az eltolás **nem konstans**: a tárolt pillanatra érvényes budapesti eltolás dönti el. Egy `INTERVAL 3 HOUR` hibás volna, és ez nem elméleti — mérve, az óraátállítás körül:

| beírt falióra | csúszás ma | migráció után |
|---|---|---|
| 2026-01-15 10:00 | −4h | **10:00** |
| 2026-07-15 10:00 | −3h | **10:00** |
| 2026-03-29 03:30 | **−4h** | **03:30** |
| 2026-10-25 02:30 | **−3h** | **02:30** |

A 3. és 4. sor mutatja, hogy a naptári dátum nem elég: **a tárolt pillanat dönt.**

### Amit kimértem a valódi adatbázis klónján

A `miserend` teljes klónján (40 tábla), **kétszer** lefuttatva:

```
ELŐTTE (+05:00 olvasat):   photos.created_at = 2016-01-15 07:08:30
UTÁNA  (Budapest olvasat): photos.created_at = 2016-01-15 07:08:30   ✓ (4 órás korrekció)
                           remarks.created_at = 2026-08-28 07:32:40  ✓ (3 órás korrekció)
                           nulla-dátumok      = 9086 → 9086          ✓ érintetlen
2. FUTÁS:                  minden érték változatlan, 53 oszlop naplózva
```

**Idempotencia** a `tz_migracio_890` naplón át, nem értéken: az eltolt időbélyeg ugyanolyan hihető, mint az eredeti, tehát egy második futás némán további 3-4 órát csúsztatna.

**Őr a fájl elején.** Hiányzó időzóna-táblánál a `CONVERT_TZ` nem hibázik, hanem **NULL**-t ad — a migráció ilyenkor csendben kinullázná az oszlopokat. Ismert bemenetre ismert kimenetet követelünk; ha nem stimmel:

```
ERROR 1048 (23000): Column 'LEALLAS_A_MYSQL_TIME_ZONE_TABLA_HIANYZIK_VAGY_ROSSZ' cannot be null
EXIT=1, és a további utasításokig el sem jut
```

Kipróbálva nemlétező zónával — tényleg megáll.

**Nulla-dátum-őr.** Mérve: `STRICT_TRANS_TABLES` mellett egy NOT NULL TIMESTAMP oszlopba írt `'0000-00-00'` **némán `NOW()`-ra vált**, warning nélkül. A `>= '2016-01-01'` alsó határ egyszerre zárja ki ezt és a hiba előtti kort — a `SET time_zone='+05:00'` a `8bd8e2e9` commit-tal került be, 2016-01-01-én (ellenőrizve; a fájl akkor még a repó gyökerében volt).

## Amit szándékosan kihagy

**Minden DATETIME oszlop.** A munkamenet-zóna nem konvertálja őket:

- `chat.datum`, `user.regdatum`, `user.lastactive` — a PHP írja, tehát **ma is helyesek**. Hozzájuk nyúlni rontás volna.
- `user.lastlogin`, `remarks.admindatum` — vegyesek, soronként nem szétválaszthatók. A rossz felük viszont nem látszik: a `lastlogin` MySQL-írt sorai a soha be nem lépett felhasználóké, az `admindatum` pedig a sablonban csak a kezelt észrevételeknél jelenik meg — azokat PHP írta.
- `templomok.moddatum` — MySQL-írt, de nincs olvasója (a `church.php:54` property kihasználatlan, a sablonokban nem szerepel).

Mindegyiknél igaz, hogy a javítás után az **új** sorok maguktól jók lesznek, mert a MySQL órája = a PHP órája.

## Tesztek

Új: `SessionTimezoneTest` — a zóna egyezik a PHP-ével, a két falióra másodpercen belül van, **túléli az újracsatlakozást** (ezt bukta meg a régi megoldás), és az időzóna-tábla be van töltve.

A teszt-bootstrap sorrendje is javítva: a `date_default_timezone_set()` a `dbconnect()` **elé** került, különben a tesztek UTC-s kapcsolaton futnának. A régi sorrend nyoma az adatbázisban is látszott — a `crons` sorai UTC-s PHP-órával születtek.

**Teljes szvit: 1631 teszt, nulla hiba.**

> Egy megjegyzés a helyi futáshoz: ezen az ágon a `SchemaReferenceTest` elbukik, mert master a **régi** séma-referenciát hordozza. Ez a #912 dolga, nem ezé — a #912 referenciájával lefuttatva a szvit hibátlan.

## Ami döntést igényel

Az éles adatbázisban **be van-e töltve az időzóna-tábla**. A MariaDB azt csak üres adatkönyvtárnál tölti be, a prod deploy pedig soha nem üríti a volume-ot — tehát nem lehet feltételezni. A `docs/deploy-lepesek.md` első lépése pont ez az ellenőrzés.
